### PR TITLE
BGM and Injection

### DIFF
--- a/Dalamud.Injector/Program.cs
+++ b/Dalamud.Injector/Program.cs
@@ -24,8 +24,12 @@ namespace Dalamud.Injector {
                 Environment.Exit(0);
             };
 #endif
-
-            var pid = int.Parse(args[0]);
+           var pid = -1;
+            if (args.Count() > 0)
+            {
+                pid = int.Parse(args[0]);
+                args[0] = pid.ToString();
+            }
 
             Process process = null;
 
@@ -45,7 +49,7 @@ namespace Dalamud.Injector {
             }
 
             DalamudStartInfo startInfo;
-            if (args.Length == 1) {
+            if (args.Length < 2) {
                 startInfo = GetDefaultStartInfo();
                 Console.WriteLine("\nA Dalamud start info was not found in the program arguments. One has been generated for you.");
                 Console.WriteLine("\nCopy the following contents into the program arguments:");

--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -304,7 +304,7 @@ namespace Dalamud {
 
             CommandManager.AddHandler("/xlbgmset", new CommandInfo(OnBgmSetCommand)
             {
-                HelpMessage = "Set the Game background music. Usage: /xlbgmset <BGM ID>"
+                HelpMessage = "Set the Game background music. Usage: /xlbgmset <BGM ID>. A list of IDs is available at https://bit.ly/2xb5p1B. Use 0 to return to the default BGM."
             });
 
             CommandManager.AddHandler("/xlitem", new CommandInfo(OnItemLinkCommand)
@@ -460,6 +460,7 @@ namespace Dalamud {
 
         private void OnBgmSetCommand(string command, string arguments)
         {
+            if (arguments == "0") arguments = "9999"; //Revert to the original BGM by specifying an invalid BGM
             Framework.Gui.SetBgm(ushort.Parse(arguments));
         }
 


### PR DESCRIPTION
- /xlbgmset 0 now restores the default BGM (kind of hacky I guess?)
- Added the BGM list (technically a link to the wiki question so we can update it if need be without a dalamud commit) to the ingame command
- Dalamud Injector no longer needs a PID specified and can be run without one to determine it automatically

Please look over the Dalamud Injector code - It seems to work fine but then in random weird cases it threw an error code 15, which could very well just be EasyHook being, well, EasyHook.