### PR TITLE
Make some payload fields public

### DIFF
--- a/Dalamud/Game/Chat/SeStringHandling/Payloads/RawPayload.cs
+++ b/Dalamud/Game/Chat/SeStringHandling/Payloads/RawPayload.cs
@@ -8,10 +8,10 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
     {
         public override PayloadType Type => PayloadType.Unknown;
 
-        public byte ChunkType { get; private set; }
-        public byte[] Data { get; private set; }
+        public byte ChunkType { get; set; }
+        public byte[] Data { get; set; }
 
-        public RawPayload(byte chunkType)
+        public RawPayload(byte chunkType = 0)
         {
             ChunkType = chunkType;
         }

--- a/Dalamud/Game/Chat/SeStringHandling/Payloads/UIForegroundPayload.cs
+++ b/Dalamud/Game/Chat/SeStringHandling/Payloads/UIForegroundPayload.cs
@@ -8,7 +8,7 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
     {
         public override PayloadType Type => PayloadType.UIForeground;
 
-        public ushort RawColor { get; private set; }
+        public ushort RawColor { get; set; }
 
         //public int Red { get; private set; }
         //public int Green { get; private set; }

--- a/Dalamud/Game/Chat/SeStringHandling/Payloads/UIGlowPayload.cs
+++ b/Dalamud/Game/Chat/SeStringHandling/Payloads/UIGlowPayload.cs
@@ -8,7 +8,7 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
     {
         public override PayloadType Type => PayloadType.UIGlow;
 
-        public ushort RawColor { get; private set; }
+        public ushort RawColor { get; set; }
 
         //public int Red { get; private set; }
         //public int Green { get; private set; }


### PR DESCRIPTION
Some changes making some payload fields (specifically raw ones) setters public, and also allowing for the RawPayload to be instantiated directly.