### PR TITLE
fix payload parsing to not use PeekChar() when it actually wants a by…

### DIFF
--- a/Dalamud/Game/Chat/SeStringHandling/Payload.cs
+++ b/Dalamud/Game/Chat/SeStringHandling/Payload.cs
@@ -30,7 +30,10 @@ namespace Dalamud.Game.Chat.SeStringHandling
         public static Payload Process(BinaryReader reader)
         {
             Payload payload = null;
-            if ((byte)reader.PeekChar() != START_BYTE)
+
+            var initialByte = reader.ReadByte();
+            reader.BaseStream.Position--;
+            if (initialByte != START_BYTE)
             {
                 payload = ProcessText(reader);
             }

--- a/Dalamud/Game/Chat/SeStringHandling/Payloads/TextPayload.cs
+++ b/Dalamud/Game/Chat/SeStringHandling/Payloads/TextPayload.cs
@@ -58,11 +58,15 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
 
             while (reader.BaseStream.Position < endOfStream)
             {
-                if ((byte)reader.PeekChar() == START_BYTE)
+                var nextByte = reader.ReadByte();
+                if (nextByte == START_BYTE)
+                {
+                    // rewind since this byte isn't part of this payload
+                    reader.BaseStream.Position--;
                     break;
+                }
 
-                // not the most efficient, but the easiest
-                text.Add(reader.ReadByte());
+                text.Add(nextByte);
             }
 
             if (text.Count > 0)


### PR DESCRIPTION
…te (breaks in some non-ascii cases)