### PR TITLE
Update ActorTable offsets for hp/mp, add ui (display-only.. probably) status effects

### DIFF
--- a/Dalamud/Game/ClientState/Actors/Types/Actor.cs
+++ b/Dalamud/Game/ClientState/Actors/Types/Actor.cs
@@ -35,6 +35,12 @@ namespace Dalamud.Game.ClientState.Actors.Types {
         public Position3 Position => this.actorStruct.Position;
 
         /// <summary>
+        /// Rotation of this <see cref="Actor"/>.<br/>
+        /// This ranges from -pi to pi radians.
+        /// </summary>
+        public float Rotation => this.actorStruct.Rotation;
+
+        /// <summary>
         ///     Displayname of this <see cref="Actor">Actor</see>.
         /// </summary>
         public string Name => this.actorStruct.Name;

--- a/Dalamud/Game/ClientState/Actors/Types/Chara.cs
+++ b/Dalamud/Game/ClientState/Actors/Types/Chara.cs
@@ -42,7 +42,7 @@ namespace Dalamud.Game.ClientState.Actors.Types {
         /// <summary>
         ///     The maximum MP of this Chara.
         /// </summary>
-        public int MaxMp => this.actorStruct.MaxMp;
+        public int MaxMp => 10000;  // Currently hardcoded because the value in actorStruct is very questionable.
 
         /// <summary>
         /// Byte array describing the visual appearance of this Chara. Indexed by <see cref="CustomizeIndex"/>.

--- a/Dalamud/Game/ClientState/Structs/Actor.cs
+++ b/Dalamud/Game/ClientState/Structs/Actor.cs
@@ -26,6 +26,7 @@ namespace Dalamud.Game.ClientState.Structs
         [FieldOffset(145)] public byte PlayerTargetStatus; // This is some kind of enum
         [FieldOffset(146)] public byte YalmDistanceFromPlayerY; // and the other is z distance
         [FieldOffset(160)] public Position3 Position;
+        [FieldOffset(176)] public float Rotation; // Rotation around the vertical axis (yaw), from -pi to pi radians     
 
         [FieldOffset(0x17B8)] [MarshalAs(UnmanagedType.ByValArray, SizeConst = 28)] public byte[] Customize;
 

--- a/Dalamud/Game/ClientState/Structs/Actor.cs
+++ b/Dalamud/Game/ClientState/Structs/Actor.cs
@@ -38,12 +38,16 @@ namespace Dalamud.Game.ClientState.Structs
         [FieldOffset(0x1868)] public int NameId;
         [FieldOffset(0x1884)] public byte CurrentWorld;
         [FieldOffset(0x1886)] public byte HomeWorld;
-        [FieldOffset(6328)] public int CurrentHp;
-        [FieldOffset(6332)] public int MaxHp;
-        [FieldOffset(6336)] public int CurrentMp;
-        [FieldOffset(6340)] public int MaxMp;
+        [FieldOffset(0x1898)] public int CurrentHp;
+        [FieldOffset(0x189C)] public int MaxHp;
+        [FieldOffset(0x18A0)] public int CurrentMp;
+        // This value is weird.  It seems to change semi-randomly between 0 and 10k, definitely
+        // in response to mp-using events, but it doesn't often have a value and the changing seems
+        // somewhat arbitrary.
+        [FieldOffset(0x18AA)] public int MaxMp;
         [FieldOffset(6358)] public byte ClassJob;
         [FieldOffset(6360)] public byte Level;
+        [FieldOffset(0x1958)][MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)] public StatusEffect[] UIStatusEffects; 
         
     }
 }

--- a/Dalamud/Game/ClientState/Structs/StatusEffect.cs
+++ b/Dalamud/Game/ClientState/Structs/StatusEffect.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Dalamud.Game.ClientState.Structs
+{
+    /// <summary>
+    /// Native memory representation of a FFXIV status effect.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct StatusEffect
+    {
+        public short EffectId;
+        public byte StackCount;
+        public byte Param;
+        public float Duration;
+        public int OwnerId;
+    }
+}

--- a/Dalamud/Interface/DalamudDataWindow.cs
+++ b/Dalamud/Interface/DalamudDataWindow.cs
@@ -98,7 +98,7 @@ namespace Dalamud.Interface
                                     continue;
 
                                 stateString +=
-                                    $"{actor.Address.ToInt64():X}:{actor.ActorId:X}[{i}] - {actor.ObjectKind} - {actor.Name} - X{actor.Position.X} Y{actor.Position.Y} Z{actor.Position.Z} D{actor.YalmDistanceX}\n";
+                                    $"{actor.Address.ToInt64():X}:{actor.ActorId:X}[{i}] - {actor.ObjectKind} - {actor.Name} - X{actor.Position.X} Y{actor.Position.Y} Z{actor.Position.Z} D{actor.YalmDistanceX} R{actor.Rotation}\n";
 
                                 if (actor is Npc npc)
                                     stateString += $"       DataId: {npc.DataId}  NameId:{npc.NameId}\n";


### PR DESCRIPTION
I didn't expose the status effects on Chara/etc since I wasn't sure if we cared yet, and I wasn't sure if you wanted raw struct accessors there (since the current way is kind of a wrapper)