### PR TITLE
Avoid crashing when clicking Choose with no item selected

### DIFF
--- a/Dalamud/Interface/ItemSearchWindow.cs
+++ b/Dalamud/Interface/ItemSearchWindow.cs
@@ -186,14 +186,22 @@ namespace Dalamud.Interface
 
             ImGui.EndChild();
 
-            if (ImGui.Button(Loc.Localize("Choose", "Choose"))) {
-                OnItemChosen?.Invoke(this, this.searchTask.Result[this.selectedItemIndex]);
+            // Darken choose button if it shouldn't be clickable
+            ImGui.PushStyleVar(ImGuiStyleVar.Alpha, this.selectedItemIndex < 0 ? 0.25f : 1);
 
-                if (this.closeOnChoose) {
-                    this.selectedItemTex?.Dispose();
-                    isOpen = false;
+            if (ImGui.Button(Loc.Localize("Choose", "Choose"))) {
+                try {
+                    OnItemChosen?.Invoke(this, this.searchTask.Result[this.selectedItemIndex]);
+                    if (this.closeOnChoose) {
+                        this.selectedItemTex?.Dispose();
+                        isOpen = false;
+                    }
+                } catch (Exception ex) {
+                    Log.Error($"Exception in Choose: {ex.Message}");
                 }
             }
+
+            ImGui.PopStyleVar();
 
             if (!this.closeOnChoose) {
                 ImGui.SameLine();


### PR DESCRIPTION
Also "Disabled" (darkened) the choose button if no item is selected.