### PR TITLE
temporary party member resolution optimization

### DIFF
--- a/Dalamud/Game/ClientState/Actors/Types/PartyMember.cs
+++ b/Dalamud/Game/ClientState/Actors/Types/PartyMember.cs
@@ -20,7 +20,7 @@ namespace Dalamud.Game.ClientState.Actors.Types
             CharacterName = Marshal.PtrToStringAnsi(rawData.namePtr);
             Unknown = rawData.unknown;
             Actor = null;
-            for (var i = 0; i < table.Length; i++)
+            for (var i = 0; i < 244; i += 2)
             {
                 if (table[i] != null && table[i].ActorId == rawData.actorId)
                 {


### PR DESCRIPTION
The first 244 entries are where PCs and their minions/mounts/etc go. PCs are on even indices, minion etc is on odd indices. This is to reduce the amount of hanging when trying to resolve a party member who is not in your current zone, and thus not in the actor table.