### PR TITLE
Update lumina, enables an option which will stop some sheets failing

### DIFF
--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -38,7 +38,7 @@
     <ItemGroup>
         <PackageReference Include="CheapLoc" Version="1.1.3" />
         <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
-        <PackageReference Include="Lumina" Version="1.1.1" />
+        <PackageReference Include="Lumina" Version="1.1.4" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
         <PackageReference Include="PropertyChanged.Fody" Version="2.6.1" />
         <PackageReference Include="Serilog" Version="2.6.0" />


### PR DESCRIPTION
Updates Lumina to 1.1.4
* 'fixes' the issue where sheets would fail to parse via `LuminaOptions.ExcelSheetStrictCastingEnabled`. Defaults to on, which I assume is generally more helpful than having it throwing exceptions
* Updated excel definitions