### PR TITLE
Fix ActorTable Enumerator

### DIFF
--- a/Dalamud/Game/ClientState/Actors/ActorTable.cs
+++ b/Dalamud/Game/ClientState/Actors/ActorTable.cs
@@ -87,7 +87,9 @@ namespace Dalamud.Game.ClientState.Actors {
 
         public IEnumerator<Actor> GetEnumerator() {
             for (int i=0;i<Length;i++){
-                yield return this[i];
+                if (this[i] != null) {
+                    yield return this[i];
+                }
             }
         }
 

--- a/Dalamud/Game/ClientState/Actors/ActorTable.cs
+++ b/Dalamud/Game/ClientState/Actors/ActorTable.cs
@@ -85,34 +85,10 @@ namespace Dalamud.Game.ClientState.Actors {
             }
         }
 
-        private class ActorTableEnumerator : IEnumerator<Actor> {
-            private readonly ActorTable table;
-
-            private int currentIndex;
-
-            public ActorTableEnumerator(ActorTable table) {
-                this.table = table;
-            }
-
-            public bool MoveNext() {
-                this.currentIndex++;
-                return this.currentIndex != this.table.Length;
-            }
-
-            public void Reset() {
-                this.currentIndex = 0;
-            }
-
-            public Actor Current => this.table[this.currentIndex];
-
-            object IEnumerator.Current => Current;
-
-            // Required by IEnumerator<T> even though we have nothing we want to dispose here.
-            public void Dispose() {}
-        }
-
         public IEnumerator<Actor> GetEnumerator() {
-            return new ActorTableEnumerator(this);
+            for (int i=0;i<Length;i++){
+                yield return this[i];
+            }
         }
 
         IEnumerator IEnumerable.GetEnumerator() {

--- a/Dalamud/Game/ClientState/PartyList.cs
+++ b/Dalamud/Game/ClientState/PartyList.cs
@@ -73,36 +73,13 @@ namespace Dalamud.Game.ClientState
             }
         }
 
-        private class PartyListEnumerator : IEnumerator<PartyMember>
-        {
-            private readonly PartyList party;
-            private int currentIndex;
-
-            public PartyListEnumerator(PartyList list)
-            {
-                this.party = list;
+        public IEnumerator<PartyMember> GetEnumerator() {
+            for (var i = 0; i < Length; i++) {
+                if (this[i] != null) {
+                    yield return this[i];
+                }
             }
-
-            public bool MoveNext()
-            {
-                this.currentIndex++;
-                return this.currentIndex != this.party.Length;
-            }
-
-            public void Reset()
-            {
-                this.currentIndex = 0;
-            }
-
-            public PartyMember Current => this.party[this.currentIndex];
-
-            object IEnumerator.Current => Current;
-
-            // Required by IEnumerator<T> even though we have nothing we want to dispose here.
-            public void Dispose() {}
         }
-
-        public IEnumerator<PartyMember> GetEnumerator() => new PartyListEnumerator(this);
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 


### PR DESCRIPTION
The current implementation of the ActorTable enumerator skips the first element.

simplified it and just used a yield pattern to resolve the issue.