### PR TITLE
Lumina 2.0

### DIFF
--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -197,6 +197,8 @@ namespace Dalamud {
             this.WinSock2.Dispose();
 
             this.SigScanner.Dispose();
+            
+            this.Data.Dispose();
         }
 
 #region Interface

--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -38,7 +38,8 @@
     <ItemGroup>
         <PackageReference Include="CheapLoc" Version="1.1.3" />
         <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
-        <PackageReference Include="Lumina" Version="1.1.4" />
+        <PackageReference Include="Lumina" Version="2.0.0" />
+        <PackageReference Include="Lumina.Generated" Version="5.25.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
         <PackageReference Include="PropertyChanged.Fody" Version="2.6.1" />
         <PackageReference Include="Serilog" Version="2.6.0" />

--- a/Dalamud/Data/TransientSheet/Completion.cs
+++ b/Dalamud/Data/TransientSheet/Completion.cs
@@ -24,8 +24,8 @@ namespace Dalamud.Data.TransientSheet
         public ushort Key;
 
 
-        public int RowId { get; set; }
-        public int SubRowId { get; set; }
+        public uint RowId { get; set; }
+        public uint SubRowId { get; set; }
 
         public void PopulateData( RowParser parser, Lumina.Lumina lumina )
         {

--- a/Dalamud/Data/TransientSheet/ContentFinderCondition.cs
+++ b/Dalamud/Data/TransientSheet/ContentFinderCondition.cs
@@ -592,8 +592,8 @@ namespace Dalamud.Data.TransientSheet
         public bool unknown62_40 => (packed62 & 0x40) == 0x40;
 
 
-        public int RowId { get; set; }
-        public int SubRowId { get; set; }
+        public uint RowId { get; set; }
+        public uint SubRowId { get; set; }
 
         public void PopulateData(RowParser parser, Lumina.Lumina lumina)
         {

--- a/Dalamud/Data/TransientSheet/Item.cs
+++ b/Dalamud/Data/TransientSheet/Item.cs
@@ -239,8 +239,8 @@ namespace Dalamud.Data.TransientSheet
         public bool AlwaysCollectable => (packeda0 & 0x1) == 0x1;
 
 
-        public int RowId { get; set; }
-        public int SubRowId { get; set; }
+        public uint RowId { get; set; }
+        public uint SubRowId { get; set; }
 
         public void PopulateData(RowParser parser, global::Lumina.Lumina lumina)
         {

--- a/Dalamud/Data/TransientSheet/PetMirage.cs
+++ b/Dalamud/Data/TransientSheet/PetMirage.cs
@@ -198,8 +198,8 @@ namespace Dalamud.Data.TransientSheet
         public ushort unknown80;
 
 
-        public int RowId { get; set; }
-        public int SubRowId { get; set; }
+        public uint RowId { get; set; }
+        public uint SubRowId { get; set; }
 
         public void PopulateData( RowParser parser, Lumina.Lumina lumina )
         {

--- a/Dalamud/Game/Chat/SeStringHandling/Payloads/AutoTranslatePayload.cs
+++ b/Dalamud/Game/Chat/SeStringHandling/Payloads/AutoTranslatePayload.cs
@@ -98,7 +98,7 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
                 // try to get the row in the Completion table itself, because this is 'easiest'
                 // The row may not exist at all (if the Key is for another table), or it could be the wrong row
                 // (again, if it's meant for another table)
-                row = sheet.GetRow((int)this.key);
+                row = sheet.GetRow(this.key);
             }
             catch { }    // don't care, row will be null
 
@@ -117,28 +117,26 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
                     // many of the names contain valid id ranges after the table name, but we don't need those
                     var actualTableName = row.LookupTable.Split('[')[0];
 
-                    var ikey = (int)this.key;
-
                     var name = actualTableName switch
                     {
-                        "Action" => this.dataResolver.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(ikey).Name,
-                        "ActionComboRoute" => this.dataResolver.GetExcelSheet<ActionComboRoute>().GetRow(ikey).Name,
-                        "BuddyAction" => this.dataResolver.GetExcelSheet<BuddyAction>().GetRow(ikey).Name,
-                        "ClassJob" => this.dataResolver.GetExcelSheet<ClassJob>().GetRow(ikey).Name,
-                        "Companion" => this.dataResolver.GetExcelSheet<Companion>().GetRow(ikey).Singular,
-                        "CraftAction" => this.dataResolver.GetExcelSheet<CraftAction>().GetRow(ikey).Name,
-                        "GeneralAction" => this.dataResolver.GetExcelSheet<GeneralAction>().GetRow(ikey).Name,
-                        "GuardianDeity" => this.dataResolver.GetExcelSheet<GuardianDeity>().GetRow(ikey).Name,
-                        "MainCommand" => this.dataResolver.GetExcelSheet<MainCommand>().GetRow(ikey).Name,
-                        "Mount" => this.dataResolver.GetExcelSheet<Mount>().GetRow(ikey).Singular,
-                        "Pet" => this.dataResolver.GetExcelSheet<Pet>().GetRow(ikey).Name,
-                        "PetAction" => this.dataResolver.GetExcelSheet<PetAction>().GetRow(ikey).Name,
-                        "PetMirage" => this.dataResolver.GetExcelSheet<PetMirage>().GetRow(ikey).Name,
-                        "PlaceName" => this.dataResolver.GetExcelSheet<PlaceName>().GetRow(ikey).Name,
-                        "Race" => this.dataResolver.GetExcelSheet<Race>().GetRow(ikey).Masculine,
-                        "TextCommand" => this.dataResolver.GetExcelSheet<TextCommand>().GetRow(ikey).Command,
-                        "Tribe" => this.dataResolver.GetExcelSheet<Tribe>().GetRow(ikey).Masculine,
-                        "Weather" => this.dataResolver.GetExcelSheet<Weather>().GetRow(ikey).Name,
+                        "Action" => this.dataResolver.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(this.key).Name,
+                        "ActionComboRoute" => this.dataResolver.GetExcelSheet<ActionComboRoute>().GetRow(this.key).Name,
+                        "BuddyAction" => this.dataResolver.GetExcelSheet<BuddyAction>().GetRow(this.key).Name,
+                        "ClassJob" => this.dataResolver.GetExcelSheet<ClassJob>().GetRow(this.key).Name,
+                        "Companion" => this.dataResolver.GetExcelSheet<Companion>().GetRow(this.key).Singular,
+                        "CraftAction" => this.dataResolver.GetExcelSheet<CraftAction>().GetRow(this.key).Name,
+                        "GeneralAction" => this.dataResolver.GetExcelSheet<GeneralAction>().GetRow(this.key).Name,
+                        "GuardianDeity" => this.dataResolver.GetExcelSheet<GuardianDeity>().GetRow(this.key).Name,
+                        "MainCommand" => this.dataResolver.GetExcelSheet<MainCommand>().GetRow(this.key).Name,
+                        "Mount" => this.dataResolver.GetExcelSheet<Mount>().GetRow(this.key).Singular,
+                        "Pet" => this.dataResolver.GetExcelSheet<Pet>().GetRow(this.key).Name,
+                        "PetAction" => this.dataResolver.GetExcelSheet<PetAction>().GetRow(this.key).Name,
+                        "PetMirage" => this.dataResolver.GetExcelSheet<PetMirage>().GetRow(this.key).Name,
+                        "PlaceName" => this.dataResolver.GetExcelSheet<PlaceName>().GetRow(this.key).Name,
+                        "Race" => this.dataResolver.GetExcelSheet<Race>().GetRow(this.key).Masculine,
+                        "TextCommand" => this.dataResolver.GetExcelSheet<TextCommand>().GetRow(this.key).Command,
+                        "Tribe" => this.dataResolver.GetExcelSheet<Tribe>().GetRow(this.key).Masculine,
+                        "Weather" => this.dataResolver.GetExcelSheet<Weather>().GetRow(this.key).Name,
                         _ => throw new Exception(actualTableName)
                     };
 

--- a/Dalamud/Game/Chat/SeStringHandling/Payloads/ItemPayload.cs
+++ b/Dalamud/Game/Chat/SeStringHandling/Payloads/ItemPayload.cs
@@ -25,7 +25,7 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
         {
             get
             {
-                this.item ??= this.dataResolver.GetExcelSheet<Item>().GetRow((int)this.itemId);
+                this.item ??= this.dataResolver.GetExcelSheet<Item>().GetRow(this.itemId);
                 return this.item;
             }
         }

--- a/Dalamud/Game/Chat/SeStringHandling/Payloads/MapLinkPayload.cs
+++ b/Dalamud/Game/Chat/SeStringHandling/Payloads/MapLinkPayload.cs
@@ -23,7 +23,7 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
         {
             get
             {
-                this.map ??= this.dataResolver.GetExcelSheet<Map>().GetRow((int)this.mapId);
+                this.map ??= this.dataResolver.GetExcelSheet<Map>().GetRow(this.mapId);
                 return this.map;
             }
         }
@@ -39,7 +39,7 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
         {
             get
             {
-                this.territoryType ??= this.dataResolver.GetExcelSheet<TerritoryType>().GetRow((int)this.territoryTypeId);
+                this.territoryType ??= this.dataResolver.GetExcelSheet<TerritoryType>().GetRow(this.territoryTypeId);
                 return this.territoryType;
             }
         }
@@ -105,7 +105,7 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
         {
             get
             {
-                this.placeNameRegion ??= this.dataResolver.GetExcelSheet<PlaceName>().GetRow(TerritoryType.PlaceNameRegion).Name;
+                this.placeNameRegion ??= TerritoryType.PlaceNameRegion.Value?.Name;
                 return this.placeNameRegion;
             }
         }
@@ -118,7 +118,7 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
         {
             get
             {
-                this.placeName ??= this.dataResolver.GetExcelSheet<PlaceName>().GetRow(TerritoryType.PlaceName).Name;
+                this.placeName ??= TerritoryType.PlaceName.Value?.Name;
                 return this.placeName;
             }
         }

--- a/Dalamud/Game/Chat/SeStringHandling/Payloads/PlayerPayload.cs
+++ b/Dalamud/Game/Chat/SeStringHandling/Payloads/PlayerPayload.cs
@@ -38,7 +38,7 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
         {
             get
             {
-                this.world ??= this.dataResolver.GetExcelSheet<World>().GetRow((int)this.serverId);
+                this.world ??= this.dataResolver.GetExcelSheet<World>().GetRow(this.serverId);
                 return this.world;
             }
         }

--- a/Dalamud/Game/Chat/SeStringHandling/Payloads/StatusPayload.cs
+++ b/Dalamud/Game/Chat/SeStringHandling/Payloads/StatusPayload.cs
@@ -23,7 +23,7 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
         {
             get
             {
-                status ??= this.dataResolver.GetExcelSheet<Status>().GetRow((int)this.statusId);
+                status ??= this.dataResolver.GetExcelSheet<Status>().GetRow(this.statusId);
                 return status;
             }
         }

--- a/Dalamud/Game/Chat/SeStringHandling/SeStringUtils.cs
+++ b/Dalamud/Game/Chat/SeStringHandling/SeStringUtils.cs
@@ -22,7 +22,7 @@ namespace Dalamud.Game.Chat.SeStringHandling
         /// <returns>An SeString containing all the payloads necessary to display an item link in the chat log.</returns>
         public static SeString CreateItemLink(uint itemId, bool isHQ, string displayNameOverride = null)
         {
-            string displayName = displayNameOverride ?? SeString.Dalamud.Data.GetExcelSheet<DalamudItem>().GetRow((int)itemId).Name;
+            string displayName = displayNameOverride ?? SeString.Dalamud.Data.GetExcelSheet<DalamudItem>().GetRow(itemId).Name;
             if (isHQ)
             {
                 displayName += $" {(char)SeIconChar.HighQuality}";
@@ -118,10 +118,10 @@ namespace Dalamud.Game.Chat.SeStringHandling
 
             foreach (var place in matches)
             {
-                var map = mapSheet.GetRows().FirstOrDefault(row => row.PlaceName == place.RowId);
+                var map = mapSheet.GetRows().FirstOrDefault(row => row.PlaceName.Row == place.RowId);
                 if (map != null)
                 {
-                    return CreateMapLink(map.TerritoryType, (uint)map.RowId, xCoord, yCoord);
+                    return CreateMapLink(map.TerritoryType.Row, (uint)map.RowId, xCoord, yCoord);
                 }
             }
 

--- a/Dalamud/Game/ClientState/Actors/Resolvers/ClassJob.cs
+++ b/Dalamud/Game/ClientState/Actors/Resolvers/ClassJob.cs
@@ -13,7 +13,7 @@ namespace Dalamud.Game.ClientState.Actors.Resolvers
         /// <summary>
         /// ID of the ClassJob.
         /// </summary>
-        public readonly int Id;
+        public readonly uint Id;
 
         /// <summary>
         /// GameData linked to this ClassJob.

--- a/Dalamud/Game/ClientState/Actors/Resolvers/World.cs
+++ b/Dalamud/Game/ClientState/Actors/Resolvers/World.cs
@@ -13,7 +13,7 @@ namespace Dalamud.Game.ClientState.Actors.Resolvers
         /// <summary>
         /// ID of the world.
         /// </summary>
-        public readonly int Id;
+        public readonly uint Id;
 
         /// <summary>
         /// GameData linked to this world.

--- a/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisHistoryUploadRequest.cs
+++ b/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisHistoryUploadRequest.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Dalamud.Game.Network.MarketBoardUploaders.Universalis {
     internal class UniversalisHistoryUploadRequest {
         [JsonProperty("worldID")]
-        public int WorldId { get; set; }
+        public uint WorldId { get; set; }
 
         [JsonProperty("itemID")]
         public uint ItemId { get; set; }

--- a/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisItemListingsUploadRequest.cs
+++ b/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisItemListingsUploadRequest.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Dalamud.Game.Network.MarketBoardUploaders.Universalis {
     internal class UniversalisItemListingsUploadRequest {
         [JsonProperty("worldID")]
-        public int WorldId { get; set; }
+        public uint WorldId { get; set; }
 
         [JsonProperty("itemID")]
         public uint ItemId { get; set; }

--- a/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
+++ b/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
@@ -28,7 +28,7 @@ namespace Dalamud.Game.Network.Universalis.MarketBoardUploaders {
                 var uploader = this.dalamud.ClientState.LocalContentId;
 
                 var listingsRequestObject = new UniversalisItemListingsUploadRequest();
-                listingsRequestObject.WorldId = this.dalamud.ClientState.LocalPlayer.CurrentWorld.Id;
+                listingsRequestObject.WorldId = this.dalamud.ClientState.LocalPlayer?.CurrentWorld.Id ?? 0;
                 listingsRequestObject.UploaderId = uploader;
                 listingsRequestObject.ItemId = request.CatalogId;
 
@@ -63,7 +63,7 @@ namespace Dalamud.Game.Network.Universalis.MarketBoardUploaders {
                 Log.Verbose(upload);
 
                 var historyRequestObject = new UniversalisHistoryUploadRequest();
-                historyRequestObject.WorldId = this.dalamud.ClientState.LocalPlayer.CurrentWorld.Id;
+                historyRequestObject.WorldId = this.dalamud.ClientState.LocalPlayer?.CurrentWorld.Id ?? 0;
                 historyRequestObject.UploaderId = uploader;
                 historyRequestObject.ItemId = request.CatalogId;
 
@@ -92,7 +92,7 @@ namespace Dalamud.Game.Network.Universalis.MarketBoardUploaders {
             using (var client = new WebClient())
             {
                 var taxRatesRequest = new UniversalisTaxUploadRequest();
-                taxRatesRequest.WorldId = this.dalamud.ClientState.LocalPlayer.CurrentWorld.Id;
+                taxRatesRequest.WorldId = this.dalamud.ClientState.LocalPlayer?.CurrentWorld.Id ?? 0;
                 taxRatesRequest.UploaderId = this.dalamud.ClientState.LocalContentId;
 
                 taxRatesRequest.TaxData = new UniversalisTaxData {

--- a/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisTaxUploadRequest.cs
+++ b/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisTaxUploadRequest.cs
@@ -13,7 +13,7 @@ namespace Dalamud.Game.Network.MarketBoardUploaders.Universalis
         public ulong UploaderId { get; set; }
 
         [JsonProperty("worldID")]
-        public int WorldId { get; set; }
+        public uint WorldId { get; set; }
 
         [JsonProperty("marketTaxRates")]
         public UniversalisTaxData TaxData { get; set; }


### PR DESCRIPTION
This is a breaking change for any plugin that does anything with Lumina's generated sheets, sorry not sorry, but kind of unavoidable because the original setup was dumb

* New sheets with more reliable output and more features!!
  * Primitive group support
  * Lazy row loading
  * More reliable array and bool reading
* [Background file loading](https://lumina.xiv.dev/docs/guides/file-handles.html)
* Performance enhancing ~~drugs~~ code

In most cases, fixing the break will just be a matter of adding a reference to Lumina.Generated in the plugins and it'll start working again. The only exception to this is that a number of referential fields have been replaced with an object that will fetch rows for you, which adds some indirection to accessing the underlying value now:

before 2.0:
 ```
        public uint ItemUICategory;
        public uint ItemSearchCategory;
        public uint EquipSlotCategory;
```   

now:
```
        public LazyRow< ItemUICategory > ItemUICategory;
        public LazyRow< ItemSearchCategory > ItemSearchCategory;
        public LazyRow< EquipSlotCategory > EquipSlotCategory;
```

Also, there's documentation now too: https://lumina.xiv.dev/docs/guides/basic-usage.html