### PR TITLE
fix: Injector pid arg(arg[0]) will not be used when args' length greater than 1

### DIFF
--- a/Dalamud.Injector/Program.cs
+++ b/Dalamud.Injector/Program.cs
@@ -33,7 +33,7 @@ namespace Dalamud.Injector {
 
 
             var pid = -1;
-            if (args.Length == 1) {
+            if (args.Length >= 1) {
                 pid = int.Parse(args[0]);
             }
 


### PR DESCRIPTION
*fix: when program args more than 1, the pid (arg[0]) will not be used.
#137 