### PR TITLE
ActorTable performance improvements

### DIFF
--- a/Dalamud/Game/ClientState/Actors/ActorTable.cs
+++ b/Dalamud/Game/ClientState/Actors/ActorTable.cs
@@ -57,7 +57,13 @@ namespace Dalamud.Game.ClientState.Actors {
             Address = addressResolver;
             this.dalamud = dalamud;
 
+            dalamud.Framework.OnUpdateEvent += Framework_OnUpdateEvent;
+
             Log.Verbose("Actor table address {ActorTable}", Address.ActorTable);
+        }
+
+        private void Framework_OnUpdateEvent(Internal.Framework framework) {
+            this.ResetCache();
         }
 
         /// <summary>
@@ -140,6 +146,7 @@ namespace Dalamud.Game.ClientState.Actors {
         private void Dispose(bool disposing)
         {
             if (disposed) return;
+            this.dalamud.Framework.OnUpdateEvent -= Framework_OnUpdateEvent;
             Marshal.FreeHGlobal(actorMem);
             disposed = true;
         }

--- a/Dalamud/Game/ClientState/Actors/ActorTable.cs
+++ b/Dalamud/Game/ClientState/Actors/ActorTable.cs
@@ -73,14 +73,7 @@ namespace Dalamud.Game.ClientState.Actors {
         private Actor ReadActorFromMemory(IntPtr offset)
         {
             try {
-                // FIXME: hack workaround for trying to access the player on logout, after the main object has been deleted
-                if (!ReadProcessMemory(Process.GetCurrentProcess().Handle, offset, actorMem, actorMemSize, out _))
-                {
-                    Log.Debug("ActorTable - ReadProcessMemory failed: likely player deletion during logout");
-                    return null;
-                }
-
-                var actorStruct = Marshal.PtrToStructure<Structs.Actor>(actorMem);
+                var actorStruct = Marshal.PtrToStructure<Structs.Actor>(offset);
 
                 switch (actorStruct.ObjectKind) {
                     case ObjectKind.Player: return new PlayerCharacter(offset, actorStruct, this.dalamud);

--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -138,6 +138,7 @@ namespace Dalamud.Game.ClientState
         public void Dispose() {
             this.PartyList.Dispose();
             this.setupTerritoryTypeHook.Dispose();
+            this.Actors.Dispose();
         }
 
         private void FrameworkOnOnUpdateEvent(Framework framework) {

--- a/Dalamud/Game/Internal/Framework.cs
+++ b/Dalamud/Game/Internal/Framework.cs
@@ -23,6 +23,7 @@ namespace Dalamud.Game.Internal {
         public event OnUpdateDelegate OnUpdateEvent;
         
         private Hook<OnUpdateDetour> updateHook;
+        private Dalamud dalamud;
         
         
         /// <summary>
@@ -49,6 +50,8 @@ namespace Dalamud.Game.Internal {
         #endregion
         
         public Framework(SigScanner scanner, Dalamud dalamud) {
+            this.dalamud = dalamud;
+
             Address = new FrameworkAddressResolver();
             Address.Setup(scanner);
             
@@ -101,6 +104,7 @@ namespace Dalamud.Game.Internal {
 
         private bool HandleFrameworkUpdate(IntPtr framework) {
             try {
+                dalamud.ClientState.Actors.ResetCache();
                 Gui.Chat.UpdateQueue(this);
                 Network.UpdateQueue(this);
             } catch (Exception ex) {

--- a/Dalamud/Game/Internal/Framework.cs
+++ b/Dalamud/Game/Internal/Framework.cs
@@ -104,7 +104,6 @@ namespace Dalamud.Game.Internal {
 
         private bool HandleFrameworkUpdate(IntPtr framework) {
             try {
-                dalamud.ClientState.Actors.ResetCache();
                 Gui.Chat.UpdateQueue(this);
                 Network.UpdateQueue(this);
             } catch (Exception ex) {

--- a/Dalamud/Game/Internal/Framework.cs
+++ b/Dalamud/Game/Internal/Framework.cs
@@ -23,7 +23,6 @@ namespace Dalamud.Game.Internal {
         public event OnUpdateDelegate OnUpdateEvent;
         
         private Hook<OnUpdateDetour> updateHook;
-        private Dalamud dalamud;
         
         
         /// <summary>
@@ -50,8 +49,6 @@ namespace Dalamud.Game.Internal {
         #endregion
         
         public Framework(SigScanner scanner, Dalamud dalamud) {
-            this.dalamud = dalamud;
-
             Address = new FrameworkAddressResolver();
             Address.Setup(scanner);
             


### PR DESCRIPTION
**Changes summary**:
- Adds `IDisposable` pattern to free `actorMem` (which I forgot in my previous PR) and added the appropiate call in `ClientState`.
- Added `GetPointerTable()` which retrieves all actor pointers in a single Marshal call.
- Added `GetActorTable()` which retrieves all actors from the pointer table.
- Separated away the Actor memory reading function into its own function (`ReadActorFromMemory`).
- Added a cache to speed up reading the Actors Table when read multiple times. This cache needs to be reset every frame, adjustment changes have been made to do so before emitting the `Framework.OnUpdateEvent`.
- Updated all functions to reflect the usage of the new Actors Table cache.

**Performance regressions**:
- Fetching `ClientState.LocalPlayer` will cause the entire Actor Table to be constructed. (A workaround would be to fetch it the original way as a special case)

**Performance Metrics (approximates)**:
- Without this PR: `450ms`
- With this PR (no cache): `110ms`
- With this PR (with caching): `2ms`

Performance Metrics taken at my Mansion with the following code (inside the Data window)
```csharp
System.Diagnostics.Stopwatch sw = new Stopwatch();
this.dalamud.ClientState.Actors.ResetCache();
sw.Start();
for (int i = 0; i < 256; i++)
    var actors = this.dalamud.ClientState.Actors.ToList();
    //this.dalamud.ClientState.Actors.ResetCache();
}
sw.Stop();
stateString += $"Time taken: {sw.Elapsed.TotalMilliseconds}ms\n\n";
```
**Additional remarks**:
- Care is taken to avoid changing the visible API, which means nulls are preserved in `this[i]` and nulls are skipped in `GetEnumerator`.
- The `ReadProcessMemory` code if removed can recduce the no cache metric by half. I did some testing without it and had no crash but decided to preserve it, is this really needed?