### PR TITLE
Fix plugin version sorting logic

### DIFF
--- a/Dalamud/Plugin/PluginRepository.cs
+++ b/Dalamud/Plugin/PluginRepository.cs
@@ -139,7 +139,12 @@ namespace Dalamud.Plugin
                             continue;
                         }
 
-                        var sortedVersions = versions.OrderBy(x => int.Parse(x.Name.Replace(".", "")));
+                        var sortedVersions = versions.OrderBy(dirInfo =>
+                        {
+                            var success = Version.TryParse(dirInfo.Name, out Version version);
+                            if (!success) { Log.Debug("Unparseable version: {0}", dirInfo.Name); }
+                            return version;
+                        });
                         var latest = sortedVersions.Last();
 
                         var localInfoFile = new FileInfo(Path.Combine(latest.FullName, $"{installed.Name}.json"));


### PR DESCRIPTION
Title.

This is a pretty selfish PR, fixes update issues caused by `BrowserHost`, hah.

Current behaviour:
- Non-numeric folders in the plugin directory will cause a hard update failure (e.g. `cef`, `cef-cache`).
- Due to the string replace, multi-digit versions will sort incorrectly: (`1.0.0.10` -> `10010`) > (`2.0.0.0` -> `2000`).

This PR attempts to fix both issues through the use of the `System.Version` class. It implements proper sorting logic for version numbers, and `TryParse` returns a version of `0.0.0.0` on failure, which will always sort last.