### PR TITLE
Separate hiding via toggle, cutscenes, and gpose (Closes #169)

### DIFF
--- a/Dalamud/Configuration/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/DalamudConfiguration.cs
@@ -32,6 +32,8 @@ namespace Dalamud
 
         public float GlobalUiScale { get; set; } = 1.0f;
         public bool ToggleUiHide { get; set; } = true;
+        public bool ToggleUiHideDuringCutscenes { get; set; } = true;
+        public bool ToggleUiHideDuringGpose { get; set; } = true;
 
         [JsonIgnore]
         public string ConfigPath;

--- a/Dalamud/Interface/DalamudSettingsWindow.cs
+++ b/Dalamud/Interface/DalamudSettingsWindow.cs
@@ -21,6 +21,8 @@ namespace Dalamud.Interface
 
             this.globalUiScale = this.dalamud.Configuration.GlobalUiScale;
             this.doToggleUiHide = this.dalamud.Configuration.ToggleUiHide;
+            this.doToggleUiHideDuringCutscenes = this.dalamud.Configuration.ToggleUiHideDuringCutscenes;
+            this.doToggleUiHideDuringGpose = this.dalamud.Configuration.ToggleUiHideDuringGpose;
 
             this.doPluginTest = this.dalamud.Configuration.DoPluginTest;
             this.doDalamudTest = this.dalamud.Configuration.DoDalamudTest;
@@ -45,6 +47,8 @@ namespace Dalamud.Interface
         private const float MaxScale = 2.0f;
         private float globalUiScale;
         private bool doToggleUiHide;
+        private bool doToggleUiHideDuringCutscenes;
+        private bool doToggleUiHideDuringGpose;
 
         #region Experimental
 
@@ -97,10 +101,18 @@ namespace Dalamud.Interface
 
                     ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsGlobalUiScaleHint", "Scale all XIVLauncher UI elements - useful for 4K displays."));
 
-                    ImGui.Dummy(new Vector2(10f, 10f));
+                    ImGui.Dummy(new Vector2(10f, 16f));
 
-                    ImGui.Checkbox(Loc.Localize("DalamudSettingToggleUiHide", "Hide plugin UI when the game UI is hidden and during cutscenes and gpose"), ref this.doToggleUiHide);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleUiHideHint", "Check this box to hide any open windows by plugins when toggling the game overlay, or upon entering gpose or a cutscene."));
+                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleUiHideOptOutNote", "Plugins may independently opt out of the settings below."));
+
+                    ImGui.Checkbox(Loc.Localize("DalamudSettingToggleUiHide", "Hide plugin UI when the game UI is toggled off."), ref this.doToggleUiHide);
+                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleUiHideHint", "Check this box to hide any open windows by plugins when toggling the game overlay."));
+
+                    ImGui.Checkbox(Loc.Localize("DalamudSettingToggleUiHideDuringCutscenes", "Hide plugin UI during cutscenes."), ref this.doToggleUiHideDuringCutscenes);
+                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleUiHideDuringCutscenesHint", "Check this box to hide any open windows by plugins during cutscenes."));
+
+                    ImGui.Checkbox(Loc.Localize("DalamudSettingToggleUiHideDuringGpose", "Hide plugin UI while gpose is active."), ref this.doToggleUiHideDuringGpose);
+                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleUiHideDuringGposeHint", "Check this box to hide any open windows by plugins while gpose is active."));
 
                     ImGui.EndTabItem();
                 }
@@ -150,6 +162,8 @@ namespace Dalamud.Interface
 
             this.dalamud.Configuration.GlobalUiScale = this.globalUiScale;
             this.dalamud.Configuration.ToggleUiHide = this.doToggleUiHide;
+            this.dalamud.Configuration.ToggleUiHideDuringCutscenes = this.doToggleUiHideDuringCutscenes;
+            this.dalamud.Configuration.ToggleUiHideDuringGpose = this.doToggleUiHideDuringGpose;
 
             this.dalamud.Configuration.DoPluginTest = this.doPluginTest;
             this.dalamud.Configuration.DoDalamudTest = this.doDalamudTest;

--- a/Dalamud/Interface/InterfaceManager.cs
+++ b/Dalamud/Interface/InterfaceManager.cs
@@ -1,13 +1,9 @@
 using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
-using CheapLoc;
 using Dalamud.Game;
 using Dalamud.Game.Internal.DXGI;
 using Dalamud.Hooking;

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -35,9 +35,14 @@ namespace Dalamud.Interface
         public event RawDX11Scene.BuildUIDelegate OnBuildUi;
 
         /// <summary>
-        /// Choose if this plugin should hide its UI automatically when the whole game hides its UI (e.g. with Scroll Lock).
+        /// Choose if this plugin should hide its UI automatically when the game's UI is hidden.
         /// </summary>
         public bool DisableAutomaticUiHide { get; set; } = false;
+
+        /// <summary>
+        /// Choose if this plugin should hide its UI automatically when the user toggles the UI.
+        /// </summary>
+        public bool DisableUserUiHide { get; set; } = false;
 
         /// <summary>
         /// Choose if this plugin should hide its UI automatically during cutscenes.
@@ -120,7 +125,7 @@ namespace Dalamud.Interface
         /// Any ImFontPtr objects that you store <strong>can be invalidated</strong> when fonts are rebuilt
         /// (at any time), so you should both reload your custom fonts and restore those
         /// pointers inside this handler.<br/>
-        /// <strong>PLEASE remove this handler inside Dipose, or when you no longer need your fonts!</strong>
+        /// <strong>PLEASE remove this handler inside Dispose, or when you no longer need your fonts!</strong>
         /// </summary>
         public Action OnBuildFonts
         {
@@ -148,9 +153,9 @@ namespace Dalamud.Interface
 
         private void OnDraw() {
 
-            if (this.dalamud.Framework.Gui.GameUiHidden && this.dalamud.Configuration.ToggleUiHide && !DisableAutomaticUiHide ||
-                CutsceneActive && this.dalamud.Configuration.ToggleUiHideDuringCutscenes && !DisableCutsceneUiHide ||
-                GposeActive && this.dalamud.Configuration.ToggleUiHideDuringGpose && !DisableGposeUiHide)
+            if (this.dalamud.Framework.Gui.GameUiHidden && this.dalamud.Configuration.ToggleUiHide && !(DisableUserUiHide || DisableAutomaticUiHide) ||
+                CutsceneActive && this.dalamud.Configuration.ToggleUiHideDuringCutscenes && !(DisableCutsceneUiHide || DisableAutomaticUiHide) ||
+                GposeActive && this.dalamud.Configuration.ToggleUiHideDuringGpose && !(DisableGposeUiHide || DisableAutomaticUiHide))
                 return;
 
             ImGui.PushID(this.namespaceName);

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -35,13 +35,26 @@ namespace Dalamud.Interface
         public event RawDX11Scene.BuildUIDelegate OnBuildUi;
 
         /// <summary>
-        /// Choose if this plugin should hide its UI automatically when the whole game hides its UI.
+        /// Choose if this plugin should hide its UI automatically when the whole game hides its UI (e.g. with Scroll Lock).
         /// </summary>
         public bool DisableAutomaticUiHide { get; set; } = false;
 
-        private bool CutsceneOrGposeActive => this.dalamud.ClientState != null && this.dalamud.ClientState.Condition[ConditionFlag.OccupiedInCutSceneEvent] ||
-                                              this.dalamud.ClientState.Condition[ConditionFlag.WatchingCutscene] ||
-                                              this.dalamud.ClientState.Condition[ConditionFlag.WatchingCutscene78];
+        /// <summary>
+        /// Choose if this plugin should hide its UI automatically during cutscenes.
+        /// </summary>
+        public bool DisableCutsceneUiHide { get; set; } = false;
+
+        /// <summary>
+        /// Choose if this plugin should hide its UI automatically while gpose is active.
+        /// </summary>
+        public bool DisableGposeUiHide { get; set; } = false;
+
+        private bool CutsceneActive => this.dalamud.ClientState != null &&
+                                       this.dalamud.ClientState.Condition[ConditionFlag.OccupiedInCutSceneEvent] ||
+                                       this.dalamud.ClientState.Condition[ConditionFlag.WatchingCutscene78];
+
+        private bool GposeActive => this.dalamud.ClientState != null &&
+                                    this.dalamud.ClientState.Condition[ConditionFlag.WatchingCutscene];
 
         private Dalamud dalamud;
 
@@ -135,7 +148,9 @@ namespace Dalamud.Interface
 
         private void OnDraw() {
 
-            if ((this.dalamud.Framework.Gui.GameUiHidden || CutsceneOrGposeActive) && this.dalamud.Configuration.ToggleUiHide && !DisableAutomaticUiHide)
+            if (this.dalamud.Framework.Gui.GameUiHidden && this.dalamud.Configuration.ToggleUiHide && !DisableAutomaticUiHide ||
+                CutsceneActive && this.dalamud.Configuration.ToggleUiHideDuringCutscenes && !DisableCutsceneUiHide ||
+                GposeActive && this.dalamud.Configuration.ToggleUiHideDuringGpose && !DisableGposeUiHide)
                 return;
 
             ImGui.PushID(this.namespaceName);


### PR DESCRIPTION
I actually tested my change this time ( *´艸｀)

This is backwards-compatible with the existing interface; DisableAutomaticUiHide exists in addition to DisableCutsceneUiHide and DisableGposeUiHide.