### PR TITLE
Expose ITextProvider

### DIFF
--- a/Dalamud/Game/Chat/SeStringHandling/ITextProvider.cs
+++ b/Dalamud/Game/Chat/SeStringHandling/ITextProvider.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Dalamud.Game.Chat.SeStringHandling
 {
-    interface ITextProvider
+    public interface ITextProvider
     {
         string Text { get; }
     }


### PR DESCRIPTION
Working with payloads is extremely tedious without this being exposed.