### PR TITLE
Actor MaxMp, CurrentCp, MaxCp, CurrentGp, MaxGp

### DIFF
--- a/Dalamud/Game/ClientState/Actors/Types/Chara.cs
+++ b/Dalamud/Game/ClientState/Actors/Types/Chara.cs
@@ -42,7 +42,27 @@ namespace Dalamud.Game.ClientState.Actors.Types {
         /// <summary>
         ///     The maximum MP of this Chara.
         /// </summary>
-        public int MaxMp => 10000;  // Currently hardcoded because the value in actorStruct is very questionable.
+        public int MaxMp => this.actorStruct.MaxMp;
+
+        /// <summary>
+        ///     The current GP of this Chara.
+        /// </summary>
+        public int CurrentGp => this.actorStruct.CurrentGp;
+
+        /// <summary>
+        ///     The maximum GP of this Chara.
+        /// </summary>
+        public int MaxGp => this.actorStruct.MaxGp;
+
+        /// <summary>
+        ///     The current CP of this Chara.
+        /// </summary>
+        public int CurrentCp => this.actorStruct.CurrentCp;
+
+        /// <summary>
+        ///     The maximum CP of this Chara.
+        /// </summary>
+        public int MaxCp => this.actorStruct.MaxCp;
 
         /// <summary>
         /// Byte array describing the visual appearance of this Chara. Indexed by <see cref="CustomizeIndex"/>.

--- a/Dalamud/Game/ClientState/Structs/Actor.cs
+++ b/Dalamud/Game/ClientState/Structs/Actor.cs
@@ -11,40 +11,71 @@ namespace Dalamud.Game.ClientState.Structs
 {
     public class ActorOffsets
     {
-        public const int Name = 0x30;
-        public const int ActorId = 116;
-        public const int DataId = 128;
-        public const int OwnerId = 132;
-        public const int ObjectKind = 140;
-        public const int SubKind = 141;
-        public const int IsFriendly = 142;
-        public const int YalmDistanceFromPlayerX = 144;
-        public const int PlayerTargetStatus = 145;
-        public const int YalmDistanceFromPlayerY = 146;
-        public const int Position = 160;
-        public const int Rotation = 176;
-        public const int Customize = 0x17B8;
-        public const int PlayerCharacterTargetActorId = 0x1F0;
-        public const int BattleNpcTargetActorId = 0x17F8;
-        public const int CompanyTag = 0x17D0;
-        public const int NameId = 0x1868;
-        public const int CurrentWorld = 0x1884;
-        public const int HomeWorld = 0x1886;
-        public const int CurrentHp = 0x1898;
-        public const int MaxHp = 0x189C;
-        public const int CurrentMp = 0x18A0;
-        public const int MaxMp = 0x18AA;
-        public const int ClassJob = 0x18DA;
-        public const int Level = 0x18DC;
-        public const int UIStatusEffects = 0x1958;
-    }
+        // ??? Offsets based on https://github.com/FFXIVAPP/sharlayan-resources/blob/master/structures/5.3/x64.json
 
+        public const int Name = 48;                          // 0x0030
+        public const int ActorId = 116;                      // 0x0074
+        // public const int ??? = 120;                       // 0x0078 NPCID1
+        public const int DataId = 128;                       // 0x0080 NPCID2
+        public const int OwnerId = 132;                      // 0x0084
+        public const int ObjectKind = 140;                   // 0x008C Type
+        public const int SubKind = 141;                      // 0x008D
+        public const int IsFriendly = 142;                   // 0x008E
+        public const int YalmDistanceFromPlayerX = 144;      // 0x0090
+        public const int PlayerTargetStatus = 145;           // 0x0091
+        public const int YalmDistanceFromPlayerY = 146;      // 0x0092 Distance
+        // public const int ??? = 148;                       // 0x0094 TargetFlags
+        // public const int ??? = 148;                       // 0x0094 GatheringInvisible
+        public const int Position = 160;                     // 0x00A0 (X,Z,Y)
+        public const int Rotation = 176;                     // 0x00B0 Heading
+        // public const int ??? = 190;                       // 0x00BE EventObjectType
+        // public const int ??? = 192;                       // 0x00C0 HitBoxRadius
+        // public const int ??? = 228;                       // 0x00E4 Fate
+        // public const int ??? = 396;                       // 0x018C IsGM
+        // public const int ??? = 464;                       // 0x01D0 TargetType
+        // public const int ??? = 480;                       // 0x01E0 EntityCount
+        // public const int ??? = 488;                       // 0x01E8 GatheringStatus
+        public const int PlayerCharacterTargetActorId = 496; // 0x01F0 TargetID
+        // public const int ??? = 5297;                      // 0x14B1 Status
+        public const int Customize = 6072;                   // 0x17B8
+        public const int CompanyTag = 6096;                  // 0x17D0
+        public const int BattleNpcTargetActorId = 6136;      // 0x17F8 ClaimedByID
+        public const int NameId = 6248;                      // 0x1868 ModelID
+        public const int CurrentWorld = 6276;                // 0x1884
+        public const int HomeWorld = 6278;                   // 0x1886
+        public const int CurrentHp = 6296;                   // 0x1898 HPCurrent
+        public const int MaxHp = 6300;                       // 0x189C HPMax
+        public const int CurrentMp = 6304;                   // 0x18A0 MPCurrent
+        public const int MaxMp = 6308;                       // 0x18A4 MPMax
+        public const int CurrentGp = 6314;                   // 0x18AA GPCurrent
+        public const int MaxGp = 6316;                       // 0x18AC GPMax
+        public const int CurrentCp = 6318;                   // 0x18AE CPCurrent
+        public const int MaxCp = 6320;                       // 0x18B0 CPMax
+        // public const int ??? = 6326;                      // 0x18B6 Title
+        // public const int ??? = 6354;                      // 0x18D2 Icon
+        // public const int ??? = 6356;                      // 0x18D4 ActionStatus
+        public const int ClassJob = 6362;                    // 0x18DA Job
+        public const int Level = 6364;                       // 0x18DC Level
+        // public const int ??? = 6367;                      // 0x18DF GrandCompany
+        // public const int ??? = 6367;                      // 0x18DF GrandCompanyRank
+        // public const int ??? = 6371;                      // 0x18E3 DifficultyRank
+        // public const int ??? = 6385;                      // 0x18F1 AgroFlags
+        // public const int ??? = 6406;                      // 0x1906 CombatFlags
+        public const int UIStatusEffects = 6488;             // 0x1958 DefaultStatusEffectOffset
+        // public const int ??? = 6880;                      // 0x1AE0 IsCasting1
+        // public const int ??? = 6882;                      // 0x1AE2 IsCasting2
+        // public const int ??? = 6884;                      // 0x1AE4 CastingID
+        // public const int ??? = 6896;                      // 0x1AF0 CastingTargetID
+        // public const int ??? = 6932;                      // 0x1B14 CastingProgress
+        // public const int ??? = 6936;                      // 0x1B18 CastingTime
+    }
     /// <summary>
     /// Native memory representation of a FFXIV actor.
     /// </summary>
     [StructLayout(LayoutKind.Explicit)]
-    public struct Actor {
-        [FieldOffset(ActorOffsets.Name)] [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 30)]
+    public struct Actor
+    {
+        [FieldOffset(ActorOffsets.Name)] [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 30)] 
         public string Name;
 
         [FieldOffset(ActorOffsets.ActorId)] public int ActorId;
@@ -74,13 +105,13 @@ namespace Dalamud.Game.ClientState.Structs
         [FieldOffset(ActorOffsets.CurrentHp)] public int CurrentHp;
         [FieldOffset(ActorOffsets.MaxHp)] public int MaxHp;
         [FieldOffset(ActorOffsets.CurrentMp)] public int CurrentMp;
-        // This value is weird.  It seems to change semi-randomly between 0 and 10k, definitely
-        // in response to mp-using events, but it doesn't often have a value and the changing seems
-        // somewhat arbitrary.
-        [FieldOffset(ActorOffsets.MaxMp)] public int MaxMp;
+        [FieldOffset(ActorOffsets.MaxMp)] public short MaxMp;
+        [FieldOffset(ActorOffsets.CurrentGp)] public short CurrentGp;
+        [FieldOffset(ActorOffsets.MaxGp)] public short MaxGp;
+        [FieldOffset(ActorOffsets.CurrentCp)] public short CurrentCp;
+        [FieldOffset(ActorOffsets.MaxCp)] public short MaxCp;
         [FieldOffset(ActorOffsets.ClassJob)] public byte ClassJob;
         [FieldOffset(ActorOffsets.Level)] public byte Level;
-        [FieldOffset(ActorOffsets.UIStatusEffects)][MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)] public StatusEffect[] UIStatusEffects; 
-        
+        [FieldOffset(ActorOffsets.UIStatusEffects)] [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)] public StatusEffect[] UIStatusEffects;
     }
 }

--- a/Dalamud/Game/ClientState/Structs/Actor.cs
+++ b/Dalamud/Game/ClientState/Structs/Actor.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using Dalamud.Game.ClientState.Actors;
 #pragma warning disable 1591
 
@@ -75,8 +70,7 @@ namespace Dalamud.Game.ClientState.Structs
     [StructLayout(LayoutKind.Explicit)]
     public struct Actor
     {
-        [FieldOffset(ActorOffsets.Name)] [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 30)] 
-        public string Name;
+        [FieldOffset(ActorOffsets.Name)] [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 30)] public string Name;
 
         [FieldOffset(ActorOffsets.ActorId)] public int ActorId;
         [FieldOffset(ActorOffsets.DataId)] public int DataId;
@@ -96,8 +90,7 @@ namespace Dalamud.Game.ClientState.Structs
         [FieldOffset(ActorOffsets.BattleNpcTargetActorId)] public int BattleNpcTargetActorId;
 
         // This field can't be correctly aligned, so we have to cut it manually.
-        [FieldOffset(ActorOffsets.CompanyTag)] [MarshalAs(UnmanagedType.ByValArray, SizeConst = 7)]
-        public byte[] CompanyTag;
+        [FieldOffset(ActorOffsets.CompanyTag)] [MarshalAs(UnmanagedType.ByValArray, SizeConst = 7)] public byte[] CompanyTag;
 
         [FieldOffset(ActorOffsets.NameId)] public int NameId;
         [FieldOffset(ActorOffsets.CurrentWorld)] public ushort CurrentWorld;


### PR DESCRIPTION
To get things to build I had to...
- bump ImGuiScene to the top of the external dx_11_testing branch as the git submodule link would not checkout properly and does not build on the master branch. 
- Remove a ref keyword in PluginInstallerWindow as ImGui.InputTextWithHint does not allow it.

Based on the offsets in https://github.com/FFXIVAPP/sharlayan-resources/blob/master/structures/5.3/x64.json, I've added CurrentGp, CurrentCp, MaxGp, MaxCp to the Dalamud.Game.ClientState.Structs.Actor struct and public accessors to the Dalamud.Game.ClientState.Actors.Types.Chara class. 

CurrentGp gets some odd values while as a battle class, but its not used so  ¯\\_(ツ)_/¯

MaxMp has several comments as to unreliableness, however after changing it to a short and fixing the offset from what it was currently (CurrentGp) I'm getting 10000 as expected while smacking around the target dummy. There's certainly no risk to just leaving it hardcoded though, let me know. 

Otherwise, I left the rest of the offsets from the Sharlayan file as comments for reference and let the auto-formatter do some work.

