### PR TITLE
C++ std string length fix

### DIFF
--- a/Dalamud/Game/Internal/Libc/LibcFunction.cs
+++ b/Dalamud/Game/Internal/Libc/LibcFunction.cs
@@ -31,8 +31,8 @@ namespace Dalamud.Game.Internal.Libc {
             var pString = Marshal.AllocHGlobal(256);
             
             // Initialize a string
-            var npos = new IntPtr(0xFFFFFFFF); // assumed to be -1 (0xFFFFFFFF in x86, 0xFFFFFFFF_FFFFFFFF in amd64)
-            var pReallocString = this.stdStringCtorCString(pString, content, npos);
+            var size = new IntPtr(content.Length);
+            var pReallocString = this.stdStringCtorCString(pString, content, size);
             
             //Log.Verbose("Prev: {Prev} Now: {Now}", pString, pReallocString);
             


### PR DESCRIPTION
Send the correct string size to stdStringCtorCString

This happen to fix the map links running over multiple lines
*(There still the encoding issue with the payloads so this is not a 100% fix but it does fix the annoyance)*

Please do test a bit before merging, I only did some basic testing and I'm not sure if this can break something. I also think the real fix should go to where the raw y and y integers are encoded for MapLinkPayload.

I made this change based from what I read from here: http://www.cplusplus.com/reference/string/string/string/ (5th constructor)