### PR TITLE
Catch universalis uploader errors

### DIFF
--- a/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
+++ b/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
@@ -59,7 +59,15 @@ namespace Dalamud.Game.Network.Universalis.MarketBoardUploaders {
                 }
 
                 var upload = JsonConvert.SerializeObject(listingsRequestObject);
-                client.UploadString(ApiBase + $"/upload/{ApiKey}", "POST", upload);
+                try
+                {
+                    client.UploadString(ApiBase + $"/upload/{ApiKey}", "POST", upload);
+                }
+                catch (WebException ex)
+                {
+                    int statusCode = (int)(ex.Response as HttpWebResponse).StatusCode;
+                    Log.Error(ex, $"Universalis returned an HTTP {statusCode}");
+                }
                 Log.Verbose(upload);
 
                 var historyRequestObject = new UniversalisHistoryUploadRequest();
@@ -81,7 +89,15 @@ namespace Dalamud.Game.Network.Universalis.MarketBoardUploaders {
                 client.Headers.Add(HttpRequestHeader.ContentType, "application/json");
 
                 var historyUpload = JsonConvert.SerializeObject(historyRequestObject);
-                client.UploadString(ApiBase + $"/upload/{ApiKey}", "POST", historyUpload);
+                try
+                {
+                    client.UploadString(ApiBase + $"/upload/{ApiKey}", "POST", historyUpload);
+                }
+                catch (WebException ex)
+                {
+                    int statusCode = (int)(ex.Response as HttpWebResponse).StatusCode;
+                    Log.Error(ex, $"Universalis returned an HTTP {statusCode}");
+                }
                 Log.Verbose(historyUpload);
 
                 Log.Verbose("Universalis data upload for item#{0} completed.", request.CatalogId);


### PR DESCRIPTION
Haven't tested it, don't really know when the uploader actually fires off. 

See https://github.com/goatcorp/Dalamud/issues/188.

If there's a better way of handling this, I can throw it together.