### PR TITLE
Fixed directory assembly version when installing plugins

### DIFF
--- a/Dalamud/Plugin/PluginRepository.cs
+++ b/Dalamud/Plugin/PluginRepository.cs
@@ -68,7 +68,7 @@ namespace Dalamud.Plugin
         public bool InstallPlugin(PluginDefinition definition, bool enableAfterInstall = true, bool isUpdate = false, bool fromTesting = false) {
             try
             {
-                var outputDir = new DirectoryInfo(Path.Combine(this.pluginDirectory, definition.InternalName, definition.AssemblyVersion));
+                var outputDir = new DirectoryInfo(Path.Combine(this.pluginDirectory, definition.InternalName, fromTesting ? definition.TestingAssemblyVersion : definition.AssemblyVersion));
                 var dllFile = new FileInfo(Path.Combine(outputDir.FullName, $"{definition.InternalName}.dll"));
                 var disabledFile = new FileInfo(Path.Combine(outputDir.FullName, ".disabled"));
                 var testingFile = new FileInfo(Path.Combine(outputDir.FullName, ".testing"));


### PR DESCRIPTION
When Dalamud installs a plugin, it does not take into account if testing is enabled or not for the output directory.
This means that a disabled plugin will always be "updatable", when it goes to the update function, it just returns (because there's already a .dll in the stable version) without doing anything.