### PR TITLE
Sort PluginMaster alphabetically

### DIFF
--- a/Dalamud/Plugin/PluginRepository.cs
+++ b/Dalamud/Plugin/PluginRepository.cs
@@ -50,7 +50,9 @@ namespace Dalamud.Plugin
 
                     var data = client.DownloadString(PluginMasterUrl);
 
-                    this.PluginMaster = JsonConvert.DeserializeObject<ReadOnlyCollection<PluginDefinition>>(data);
+                    var unsortedPluginMaster = JsonConvert.DeserializeObject<List<PluginDefinition>>(data);
+                    unsortedPluginMaster.Sort((a, b) => a.Name.CompareTo(b.Name));
+                    this.PluginMaster = unsortedPluginMaster.AsReadOnly();
 
                     State = InitializationState.Success;
                 }


### PR DESCRIPTION
Currently, testing exclusive plugins are not sorted and are at the bottom of the installer window. This is odd as testing plugins with a stable version are sorted.