### PR TITLE
Added a label and a warning for dev plugins in the installer window

### DIFF
--- a/Dalamud/Plugin/PluginLoadReason.cs
+++ b/Dalamud/Plugin/PluginLoadReason.cs
@@ -9,21 +9,34 @@ namespace Dalamud.Plugin
     /// <summary>
     /// This enum reflects reasons for loading a plugin.
     /// </summary>
-    public enum PluginLoadReason
+    [Flags]
+    public enum PluginLoadReason 
     {
+        None = 0,
+
         /// <summary>
         /// We don't know why this plugin was loaded.
         /// </summary>
-        Unknown,
+        Unknown = 1,
 
         /// <summary>
         /// This plugin was loaded because it was installed with the plugin installer.
         /// </summary>
-        Installer,
+        Installer = 2,
 
         /// <summary>
         /// This plugin was loaded because the game was started or Dalamud was reinjected.
         /// </summary>
-        Boot
+        Boot = 4,
+
+        /// <summary>
+        /// This plugin was loaded from the installedPlugins folder.
+        /// </summary>
+        Installed = 8,
+
+        /// <summary>
+        /// This plugin was loaded from the devPlugins folder.
+        /// </summary>
+        Dev = 16
     }
 }

--- a/Dalamud/Plugin/PluginManager.cs
+++ b/Dalamud/Plugin/PluginManager.cs
@@ -200,7 +200,7 @@ namespace Dalamud.Plugin
 
                 foreach (var dllFile in pluginDlls) {
                     try {
-                        LoadPluginFromAssembly(dllFile, raw, PluginLoadReason.Boot);
+                        LoadPluginFromAssembly(dllFile, raw, PluginLoadReason.Boot | (raw ? PluginLoadReason.Dev : PluginLoadReason.Installed));
                     } catch (Exception ex) {
                         Log.Error(ex, $"Plugin load for {dllFile.FullName} failed.");
                     }

--- a/Dalamud/Plugin/PluginRepository.cs
+++ b/Dalamud/Plugin/PluginRepository.cs
@@ -81,7 +81,7 @@ namespace Dalamud.Plugin
                     if (disabledFile.Exists)
                         disabledFile.Delete();
 
-                    return this.dalamud.PluginManager.LoadPluginFromAssembly(dllFile, false, PluginLoadReason.Installer);
+                    return this.dalamud.PluginManager.LoadPluginFromAssembly(dllFile, false, PluginLoadReason.Installer | PluginLoadReason.Installed);
                 }
 
                 if (dllFile.Exists && !enableAfterInstall) {
@@ -128,7 +128,7 @@ namespace Dalamud.Plugin
                         testingFile.Delete();
                 }
 
-                return this.dalamud.PluginManager.LoadPluginFromAssembly(dllFile, false, PluginLoadReason.Installer);
+                return this.dalamud.PluginManager.LoadPluginFromAssembly(dllFile, false, PluginLoadReason.Installer | PluginLoadReason.Installed);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
When a plugin is loaded raw from the devPlugins folder AND is in the installer window, display a label and a warning concerning the installed location. This also removes the "Disable" button, as it's not possible to disable a dev plugins and it just produces an error.
This is what it looks like in game:
![chrome_2020-11-01_17-59-08](https://user-images.githubusercontent.com/33433913/97809348-96624380-1c6c-11eb-8492-0f3f88726667.png)
~~It detects dev plugins when they have a dummy configuration, as they usually don't have one when a user try/install a dev plugin.
For it to work with all dev plugins, it would be easy to add a property when loading it in LoadPluginFromAssembly(), but I wasn't sure on how to do it without breaking things.
Another option would be to force raw plugins to load the dummy config.~~
The string isn't localized either as it's pretty advanced, not sure what is the "usual" rule on this.