### PR TITLE
Fix the xllanguage en command

### DIFF
--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -743,7 +743,7 @@ namespace Dalamud {
 
         private void OnSetLanguageCommand(string command, string arguments)
         {
-            if (Localization.ApplicableLangCodes.Contains(arguments.ToLower())) {
+            if (Localization.ApplicableLangCodes.Contains(arguments.ToLower()) || arguments.ToLower() == "en") {
                 this.LocalizationManager.SetupWithLangCode(arguments.ToLower());
                 this.Configuration.LanguageOverride = arguments.ToLower();
 


### PR DESCRIPTION
It was impossible to set the language to English when you're using a localized version of Dalamud. "/xllanguage en" used the default UI culture.