### PR TITLE
Avoid exception log when updating a plugin that is not installed

### DIFF
--- a/Dalamud/Plugin/PluginRepository.cs
+++ b/Dalamud/Plugin/PluginRepository.cs
@@ -216,11 +216,14 @@ namespace Dalamud.Plugin
                                 Log.Verbose("wasEnabled: {0}", wasEnabled);
 
                                 // Try to disable plugin if it is loaded
-                                try {
-                                    this.dalamud.PluginManager.DisablePlugin(info);
-                                } catch (Exception ex) {
-                                    Log.Error(ex, "Plugin disable failed");
-                                    //hasError = true;
+                                if (wasEnabled) {
+                                    try {
+                                        this.dalamud.PluginManager.DisablePlugin(info);
+                                    }
+                                    catch (Exception ex) {
+                                        Log.Error(ex, "Plugin disable failed");
+                                        //hasError = true;
+                                    }
                                 }
 
                                 try {


### PR DESCRIPTION
If wasEnabled is false, it'll always trigger an exception with "Plugin disable failed". Which is a bit confusing, it shouldn't even try to disable it.