### PR TITLE
Disable plugins with incompatible API level

### DIFF
--- a/Dalamud/Plugin/PluginManager.cs
+++ b/Dalamud/Plugin/PluginManager.cs
@@ -173,6 +173,7 @@ namespace Dalamud.Plugin
 
                     if (pluginDef.DalamudApiLevel < DALAMUD_API_LEVEL) {
                         Log.Error("Incompatible API level: {0}", dllFile.FullName);
+                        disabledFile.Create().Close();
                         return false;
                     }
 


### PR DESCRIPTION
This is "needed" due to #206, not disabling incompatible plugins that were enabled before means that they'll never get cleaned up.