### PR TITLE
Add an auto-updater for plugins

### DIFF
--- a/Dalamud/Configuration/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/DalamudConfiguration.cs
@@ -32,6 +32,7 @@ namespace Dalamud
         public bool ToggleUiHideDuringGpose { get; set; } = true;
 
         public bool PrintPluginsWelcomeMsg { get; set; } = true;
+        public bool AutoUpdatePlugins { get; set; } = false;
 
         [JsonIgnore]
         public string ConfigPath;

--- a/Dalamud/Interface/DalamudSettingsWindow.cs
+++ b/Dalamud/Interface/DalamudSettingsWindow.cs
@@ -30,6 +30,7 @@ namespace Dalamud.Interface
             this.doDalamudTest = this.dalamud.Configuration.DoDalamudTest;
 
             this.printPluginsWelcomeMsg = this.dalamud.Configuration.PrintPluginsWelcomeMsg;
+            this.autoUpdatePlugins = this.dalamud.Configuration.AutoUpdatePlugins;
 
             this.languages = Localization.ApplicableLangCodes.Prepend("en").ToArray();
             try {
@@ -87,6 +88,7 @@ namespace Dalamud.Interface
         private bool doToggleUiHideDuringGpose;
 
         private bool printPluginsWelcomeMsg;
+        private bool autoUpdatePlugins;
 
         #region Experimental
 
@@ -131,6 +133,9 @@ namespace Dalamud.Interface
 
                     ImGui.Checkbox(Loc.Localize("DalamudSettingsPrintPluginsWelcomeMsg", "Display loaded plugins in the welcome message"), ref this.printPluginsWelcomeMsg);
                     ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsPrintPluginsWelcomeMsgHint", "Display loaded plugins in FFXIV chat when logging in with a character."));
+
+                    ImGui.Checkbox(Loc.Localize("DalamudSettingsAutoUpdatePlugins", "Auto-update plugins"), ref this.autoUpdatePlugins);
+                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsAutoUpdatePluginsMsgHint", "Automatically update plugins when logging in with a character."));
 
                     ImGui.EndTabItem();
                 }
@@ -218,6 +223,7 @@ namespace Dalamud.Interface
             this.dalamud.Configuration.DoDalamudTest = this.doDalamudTest;
 
             this.dalamud.Configuration.PrintPluginsWelcomeMsg = this.printPluginsWelcomeMsg;
+            this.dalamud.Configuration.AutoUpdatePlugins = this.autoUpdatePlugins;
 
             this.dalamud.Configuration.Save();
         }

--- a/Dalamud/Plugin/PluginRepository.cs
+++ b/Dalamud/Plugin/PluginRepository.cs
@@ -140,6 +140,8 @@ namespace Dalamud.Plugin
 
         internal class PluginUpdateStatus {
             public string InternalName { get; set; }
+            public string Name { get; set; }
+            public string Version { get; set; }
             public bool WasUpdated { get; set; }
         }
 
@@ -244,11 +246,15 @@ namespace Dalamud.Plugin
 
                                 updatedList.Add(new PluginUpdateStatus {
                                     InternalName = remoteInfo.InternalName,
+                                    Name = remoteInfo.Name,
+                                    Version = testingAvailable ? remoteInfo.TestingAssemblyVersion : remoteInfo.AssemblyVersion,
                                     WasUpdated = installSuccess
                                 });
                             } else {
                                 updatedList.Add(new PluginUpdateStatus {
                                     InternalName = remoteInfo.InternalName,
+                                    Name = remoteInfo.Name,
+                                    Version = testingAvailable ? remoteInfo.TestingAssemblyVersion : remoteInfo.AssemblyVersion,
                                     WasUpdated = true
                                 });
                             }


### PR DESCRIPTION
Off by default, it auto-updates plugins when logging in with a character.

I moved everything in a task, tested it with various scenarios, but please verify that it is satisfactory.

Setting and in-game message:
![ffxiv_dx11_2020-12-13_04-10-01](https://user-images.githubusercontent.com/33433913/102002589-1fee4200-3cfe-11eb-9a63-89c0e89452a3.png)
