### PR TITLE
Framework OnUpdate stats and Hook tracking

### DIFF
--- a/Dalamud/Hooking/HookInfo.cs
+++ b/Dalamud/Hooking/HookInfo.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Dalamud.Hooking {
+    internal class HookInfo {
+
+        internal static List<HookInfo> TrackedHooks = new List<HookInfo>();
+
+        internal IDalamudHook Hook { get; set; }
+        internal Delegate Delegate { get; set; }
+        internal Assembly Assembly { get; set; }
+
+        private ulong? inProcessMemory = 0;
+        internal ulong? InProcessMemory {
+            get {
+                if (Hook.IsDisposed) return 0;
+                if (this.inProcessMemory == null) return null;
+                if (this.inProcessMemory.Value > 0) return this.inProcessMemory.Value;
+                var p = Process.GetCurrentProcess().MainModule;
+                var begin = (ulong) p.BaseAddress.ToInt64();
+                var end = begin + (ulong) p.ModuleMemorySize;
+                var hookAddr = (ulong) Hook.Address.ToInt64();
+                if (hookAddr >= begin && hookAddr <= end) {
+                    this.inProcessMemory = hookAddr - begin;
+                    return this.inProcessMemory.Value;
+                } else {
+                    this.inProcessMemory = null;
+                    return null;
+                }
+            }
+        }
+
+    }
+}

--- a/Dalamud/Hooking/IDalamudHook.cs
+++ b/Dalamud/Hooking/IDalamudHook.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Dalamud.Hooking {
+    internal interface IDalamudHook {
+        public IntPtr Address { get; }
+        public bool IsEnabled { get; }
+        public bool IsDisposed { get; }
+    }
+}

--- a/Dalamud/Interface/DalamudPluginStatWindow.cs
+++ b/Dalamud/Interface/DalamudPluginStatWindow.cs
@@ -147,7 +147,6 @@ namespace Dalamud.Interface {
                 foreach (var trackedHook in HookInfo.TrackedHooks) {
                     try {
                         if (!this.showDalamudHooks && trackedHook.Assembly == Assembly.GetExecutingAssembly()) continue;
-                        
 
                         ImGui.Text($"{trackedHook.Delegate.Target} :: {trackedHook.Delegate.Method.Name}");
                         ImGui.TextDisabled(trackedHook.Assembly.FullName);
@@ -187,8 +186,6 @@ namespace Dalamud.Interface {
             if (ImGui.IsWindowAppearing()) {
                 HookInfo.TrackedHooks.RemoveAll(h => h.Hook.IsDisposed);
             }
-
-
 
             ImGui.EndTabBar();
 

--- a/Dalamud/Interface/DalamudPluginStatWindow.cs
+++ b/Dalamud/Interface/DalamudPluginStatWindow.cs
@@ -1,14 +1,15 @@
 using System;
 using System.Linq;
+using Dalamud.Game.Internal;
 using Dalamud.Plugin;
 using ImGuiNET;
 
 namespace Dalamud.Interface {
-    class DalamudPluginStatWindow : IDisposable {
+    internal class DalamudPluginStatWindow : IDisposable {
 
-        private PluginManager pm;
-        public DalamudPluginStatWindow(PluginManager pm) {
-            this.pm = pm;
+        private readonly PluginManager pluginManager;
+        public DalamudPluginStatWindow(PluginManager pluginManager) {
+            this.pluginManager = pluginManager;
         }
 
         public bool Draw() {
@@ -29,7 +30,7 @@ namespace Dalamud.Interface {
 
                     ImGui.SameLine();
                     if (ImGui.Button("Reset")) {
-                        foreach (var a in this.pm.Plugins) {
+                        foreach (var a in this.pluginManager.Plugins) {
                             a.PluginInterface.UiBuilder.lastDrawTime = -1;
                             a.PluginInterface.UiBuilder.maxDrawTime = -1;
                             a.PluginInterface.UiBuilder.drawTimeHistory.Clear();
@@ -51,7 +52,7 @@ namespace Dalamud.Interface {
                     ImGui.Text("Average");
                     ImGui.NextColumn();
                     ImGui.Separator();
-                    foreach (var a in this.pm.Plugins) {
+                    foreach (var a in this.pluginManager.Plugins) {
                         ImGui.Text(a.Definition.Name);
                         ImGui.NextColumn();
                         ImGui.Text($"{a.PluginInterface.UiBuilder.lastDrawTime/10000f:F4}ms");
@@ -67,6 +68,59 @@ namespace Dalamud.Interface {
                     }
 
                     ImGui.Columns(1);
+
+                }
+                ImGui.EndTabItem();
+            }
+
+            if (ImGui.BeginTabItem("Framework times")) {
+
+                var doStats = Framework.StatsEnabled;
+
+                if (ImGui.Checkbox("Enable Framework Update Tracking", ref doStats)) {
+                    Framework.StatsEnabled = doStats;
+                }
+
+                if (doStats) {
+                    ImGui.SameLine();
+                    if (ImGui.Button("Reset")) {
+                        Framework.StatsHistory.Clear();
+                    }
+                    
+                    ImGui.Columns(4);
+                    ImGui.SetColumnWidth(0, ImGui.GetWindowContentRegionWidth() - 300);
+                    ImGui.SetColumnWidth(1, 100f);
+                    ImGui.SetColumnWidth(2, 100f);
+                    ImGui.SetColumnWidth(3, 100f);
+                    ImGui.Text("Method");
+                    ImGui.NextColumn();
+                    ImGui.Text("Last");
+                    ImGui.NextColumn();
+                    ImGui.Text("Longest");
+                    ImGui.NextColumn();
+                    ImGui.Text("Average");
+                    ImGui.NextColumn();
+                    ImGui.Separator();
+                    ImGui.Separator();
+
+                    foreach (var handlerHistory in Framework.StatsHistory) {
+                        if (handlerHistory.Value.Count == 0) continue;
+                        ImGui.SameLine();
+                        ImGui.Text($"{handlerHistory.Key}");
+                        ImGui.NextColumn();
+                        ImGui.Text($"{handlerHistory.Value.Last():F4}ms");
+                        ImGui.NextColumn();
+                        ImGui.Text($"{handlerHistory.Value.Max():F4}ms");
+                        ImGui.NextColumn();
+                        ImGui.Text($"{handlerHistory.Value.Average():F4}ms");
+                        ImGui.NextColumn();
+                        ImGui.Separator();
+                    }
+                    ImGui.Columns(0);
+                }
+
+                ImGui.EndTabItem();
+            }
 
                 }
                 


### PR DESCRIPTION
Framework OnUpdate
- Tab in the Plugin Stats window for measuring the time plugins spend performing their Framework.OnUpdate handlers
- Allows plugin developers to detect issues in their plugins easier if framework is taking an abnormally long time to update.
![image](https://user-images.githubusercontent.com/11886749/102107803-0e35a780-3e82-11eb-9610-e93e436bfd4f.png)


Hook Tracking
- Track and display hooks and their current status in the Plugin Stats window.
![image](https://user-images.githubusercontent.com/11886749/102108007-4c32cb80-3e82-11eb-8a4d-3dc178212b7f.png)
