### PR TITLE
Add chat text when updating plugins

### DIFF
--- a/Dalamud/Game/ChatHandlers.cs
+++ b/Dalamud/Game/ChatHandlers.cs
@@ -218,19 +218,9 @@ namespace Dalamud.Game {
                 } else {
                     var updatedPlugins = t.Result.UpdatedPlugins;
 
-                    if (updatedPlugins.Count != 0) {
+                    if (updatedPlugins != null && updatedPlugins.Any()) {
                         if (this.dalamud.Configuration.AutoUpdatePlugins) {
-                            this.dalamud.Framework.Gui.Chat.Print(string.Format(Loc.Localize("DalamudPluginUpdateSuccessful", "Auto-update:")));
-                            foreach (var plugin in updatedPlugins) {
-                                if (plugin.WasUpdated) {
-                                    this.dalamud.Framework.Gui.Chat.Print(string.Format(Loc.Localize("DalamudPluginUpdateSuccessful", "    》 {0} updated to v{1}."), plugin.Name, plugin.Version));
-                                } else {
-                                    this.dalamud.Framework.Gui.Chat.PrintChat(new XivChatEntry {
-                                        MessageBytes = Encoding.UTF8.GetBytes(string.Format(Loc.Localize("DalamudPluginUpdateFailed", "    》 {0} update to v{1} failed."), plugin.Name, plugin.Version)),
-                                        Type = XivChatType.Urgent
-                                    });
-                                }
-                            }
+                            this.dalamud.PluginRepository.PrintUpdatedPlugins(updatedPlugins, Loc.Localize("DalamudPluginAutoUpdate", "Auto-update:"));
                         } else {
                             this.dalamud.Framework.Gui.Chat.PrintChat(new XivChatEntry {
                                 MessageBytes = Encoding.UTF8.GetBytes(Loc.Localize("DalamudPluginUpdateRequired", "One or more of your plugins needs to be updated. Please use the /xlplugins command in-game to update them!")),

--- a/Dalamud/Plugin/PluginInstallerWindow.cs
+++ b/Dalamud/Plugin/PluginInstallerWindow.cs
@@ -201,6 +201,8 @@ namespace Dalamud.Plugin
 
                             this.errorModalDrawing = this.installStatus == PluginInstallStatus.Fail;
                             this.errorModalOnNextFrame = this.installStatus == PluginInstallStatus.Fail;
+
+                            this.dalamud.PluginRepository.PrintUpdatedPlugins(updatedPlugins, Loc.Localize("DalamudPluginUpdates", "Updates:"));
                         });
                     }
                 }

--- a/Dalamud/Plugin/PluginRepository.cs
+++ b/Dalamud/Plugin/PluginRepository.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using CheapLoc;
+using Dalamud.Game.Chat;
 using Newtonsoft.Json;
 using Serilog;
 
@@ -287,6 +289,22 @@ namespace Dalamud.Plugin
             Log.Information("Plugin update OK.");
 
             return (!hasError, updatedList);
+        }
+
+        public void PrintUpdatedPlugins(List<PluginRepository.PluginUpdateStatus> updatedPlugins, string header) {
+            if (updatedPlugins != null && updatedPlugins.Any()) {
+                this.dalamud.Framework.Gui.Chat.Print(header);
+                foreach (var plugin in updatedPlugins) {
+                    if (plugin.WasUpdated) {
+                        this.dalamud.Framework.Gui.Chat.Print(string.Format(Loc.Localize("DalamudPluginUpdateSuccessful", "    》 {0} updated to v{1}."), plugin.Name, plugin.Version));
+                    } else {
+                        this.dalamud.Framework.Gui.Chat.PrintChat(new XivChatEntry {
+                            MessageBytes = Encoding.UTF8.GetBytes(string.Format(Loc.Localize("DalamudPluginUpdateFailed", "    》 {0} update to v{1} failed."), plugin.Name, plugin.Version)),
+                            Type = XivChatType.Urgent
+                        });
+                    }
+                }
+            }
         }
 
         public void CleanupPlugins() {


### PR DESCRIPTION
With the number of plugins, probably easier to get a summary of what got updated in chat. 
![](https://i.imgur.com/YNgXohs.png)
Not sure if PluginRepository was the correct place for the method.