### PR TITLE
Change sig method log level and add session delimiter in logs

### DIFF
--- a/Dalamud/EntryPoint.cs
+++ b/Dalamud/EntryPoint.cs
@@ -20,6 +20,7 @@ namespace Dalamud {
             Log.Logger = logger;
 
             try {
+                Log.Information(new string('-', 200));
                 Log.Information("Initializing a session..");
 
                 // This is due to GitHub not supporting TLS 1.0, so we enable all TLS versions globally

--- a/Dalamud/Interface/InterfaceManager.cs
+++ b/Dalamud/Interface/InterfaceManager.cs
@@ -73,7 +73,7 @@ namespace Dalamud.Interface
                 Address = sigResolver;
             } catch (Exception ex) {
                 // The SigScanner method fails on wine/proton since DXGI is not a real DLL. We fall back to vtable to detect our Present function address.
-                Log.Error(ex, "Could not get SwapChain address via sig method, falling back to vtable...");
+                Log.Debug(ex, "Could not get SwapChain address via sig method, falling back to vtable...");
 
                 var vtableResolver = new SwapChainVtableResolver();
                 vtableResolver.Setup(scanner);


### PR DESCRIPTION
The exception is confusing for some and is not really useful as it happens every time. Added a line at the start of a session, in order to be able to easily tell different sessions at a glance.