### PR TITLE
Add a fallback when .disabled file creation fails

### DIFF
--- a/Dalamud/Plugin/PluginManager.cs
+++ b/Dalamud/Plugin/PluginManager.cs
@@ -80,8 +80,15 @@ namespace Dalamud.Plugin
 
             // Need to do it with Open so the file handle gets closed immediately
             // TODO: Don't use the ".disabled" crap, do it in a config
-            var disabledFile = File.Open(Path.Combine(outputDir.FullName, ".disabled"), FileMode.Create);
-            disabledFile.Close();
+            try {
+                File.Open(Path.Combine(outputDir.FullName, ".disabled"), FileMode.Create).Close();
+            } catch (Exception ex) {
+                Log.Error(ex, "Could not create the .disabled file, disabling all versions...");
+                foreach (var version in outputDir.Parent.GetDirectories()) {
+                    if (!File.Exists(Path.Combine(version.FullName, ".disabled")))
+                        File.Open(Path.Combine(version.FullName, ".disabled"), FileMode.Create).Close();
+                }
+            }
 
             thisPlugin.Plugin.Dispose();
 


### PR DESCRIPTION
If the .disabled file creation fails, it fallbacks to try to disable all versions.

If the issue comes from the path (assembly version mismatch), this will avoid the impossibility of updating/disabling the plugin.
If the issue comes from something else, it'll still fail on the fallback.

> // TODO: Don't use the ".disabled" crap, do it in a config

Truuuue!