### PR TITLE
Ignore updates for most disabled plugins

### DIFF
--- a/Dalamud/Plugin/PluginRepository.cs
+++ b/Dalamud/Plugin/PluginRepository.cs
@@ -184,6 +184,10 @@ namespace Dalamud.Plugin
                         });
                         var latest = sortedVersions.Last();
 
+                        if (File.Exists(Path.Combine(latest.FullName, ".disabled")) && !File.Exists(Path.Combine(latest.FullName, ".testing"))) {
+                            continue;
+                        }
+
                         var localInfoFile = new FileInfo(Path.Combine(latest.FullName, $"{installed.Name}.json"));
 
                         if (!localInfoFile.Exists) {


### PR DESCRIPTION
Don't update disabled plugins as long as they're not a testing version.
This exception is needed because you can have this situation:
- Plugin
  - Version 1.0.0.1 (Testing): Disabled.
  - Version 1.0.0.0: Enabled.

And the update method only checks the latest version. This should still remove most unwanted updates.
I'm pretty confident there are no cases where this could lead to issues, but not 100% sure.
