### PR TITLE
Plugin Config Directories

### DIFF
--- a/Dalamud/Configuration/PluginConfigurations.cs
+++ b/Dalamud/Configuration/PluginConfigurations.cs
@@ -42,6 +42,18 @@ namespace Dalamud.Configuration
                                                                        });
         }
 
+        public string GetDirectory(string pluginName) {
+            try {
+                var path = GetDirectoryPath(pluginName);
+                if (!path.Exists) {
+                    path.Create();
+                }
+                return path.FullName;
+            } catch {
+                return string.Empty;
+            }
+        }
+
         // Parameterized deserialization
         // Currently this is called via reflection from DalamudPluginInterface.GetPluginConfig()
         // Eventually there may be an additional pluginInterface method that can call this directly
@@ -59,5 +71,7 @@ namespace Dalamud.Configuration
         }
 
         private FileInfo GetPath(string pluginName) => new FileInfo(Path.Combine(this.configDirectory.FullName, $"{pluginName}.json"));
+        private DirectoryInfo GetDirectoryPath(string pluginName) => new DirectoryInfo(Path.Combine(this.configDirectory.FullName, pluginName));
+
     }
 }

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -131,6 +131,12 @@ namespace Dalamud.Plugin
             return this.configs.Load(this.pluginName);
         }
 
+        /// <summary>
+        /// Get the config directory
+        /// </summary>
+        /// <returns>directory with path of AppData/XIVLauncher/pluginConfig/PluginInternalName </returns>
+        public string GetPluginConfigDirectory() => this.configs.GetDirectory(this.pluginName);
+
         #region Chat Links
 
         /// <summary>


### PR DESCRIPTION
Allow plugins to get a directory in the pluginConfig folder
creates the folder when requested if it doesn't exist.