### PR TITLE
Fix update behavior for testing and outdated plugins

### DIFF
--- a/Dalamud/Plugin/PluginManager.cs
+++ b/Dalamud/Plugin/PluginManager.cs
@@ -256,7 +256,6 @@ namespace Dalamud.Plugin
 
                     if (pluginDef.DalamudApiLevel < DALAMUD_API_LEVEL) {
                         Log.Error("Incompatible API level: {0}", dllFile.FullName);
-                        disabledFile.Create().Close();
                         return false;
                     }
 


### PR DESCRIPTION
Fixes 2 things:

1. Testing plugins are no longer updated if they're disabled.
2. Plugins that were enabled, but not loaded are correctly enabled after being updated.

Removed the .disabled file due to API level, to match the game version behavior. When it gets an update, the plugin is enabled automatically.
During the plugin update, all versions are disabled, therefore the lack of .disabled is not an issue for the cleanup process.