### PR TITLE
Require protocol for URL match

### DIFF
--- a/Dalamud/Game/ChatHandlers.cs
+++ b/Dalamud/Game/ChatHandlers.cs
@@ -79,7 +79,7 @@ namespace Dalamud.Game {
         };
 
         private readonly Regex urlRegex =
-            new Regex(@"((http|ftp|https)://)?([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?",
+            new Regex(@"(http|ftp|https)://([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?",
                       RegexOptions.Compiled);
 
         private bool hasSeenLoadingMsg;


### PR DESCRIPTION
Reverting the previous change. Without the protocol this regex matches too many things like `26.2` in map flags. There's probably a better one out there, but it seems to be a bit of a fiesta.