### PR TITLE
fix dupe plugin listings

### DIFF
--- a/Dalamud/Plugin/PluginInstallerWindow.cs
+++ b/Dalamud/Plugin/PluginInstallerWindow.cs
@@ -71,7 +71,8 @@ namespace Dalamud.Plugin
                                                return this.dalamud.PluginManager.Plugins.Where(x => x.Definition != null).Any(
                                                    x => x.Definition.InternalName == def.InternalName);
                                            })
-                                           .ToList();
+                                           .GroupBy(x => new {x.InternalName, x.AssemblyVersion})
+                                           .Select(y => y.First()).ToList();
             this.pluginListInstalled.AddRange(hiddenPlugins);
             this.pluginListInstalled.Sort((x, y) => x.Name.CompareTo(y.Name));
 
@@ -80,7 +81,9 @@ namespace Dalamud.Plugin
 
         private void ResortPlugins() {
             var availableDefs = this.dalamud.PluginRepository.PluginMaster.Where(
-                x => this.pluginListInstalled.All(y => x.InternalName != y.InternalName)).ToList();
+                x => this.pluginListInstalled.All(y => x.InternalName != y.InternalName))
+                                    .GroupBy(x => new {x.InternalName, x.AssemblyVersion})
+                                    .Select(y => y.First()).ToList();
 
             switch (this.sortKind) {
                 case PluginSortKind.Alphabetical:


### PR DESCRIPTION
Bit of an edge case. This avoids duplicate plugin listings with the same InternalName+AssemblyVersion due to multiple repos (e.g. official + custom).
**Before**
![Before](https://user-images.githubusercontent.com/35899782/112785154-59368d80-9021-11eb-8d34-f7a0feb6c5f8.PNG)
**After**
![After](https://user-images.githubusercontent.com/35899782/112785218-7f5c2d80-9021-11eb-88c3-5c3606e7748a.PNG)

