### PR TITLE
add isloggedin property

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,9 @@ insert_final_newline = true
 # 4 space indentation
 indent_style = space
 indent_size = 4
+
+# disable redundant style warnings
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent

--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -175,16 +175,23 @@ namespace Dalamud.Game.ClientState
         /// </summary>
         public event EventHandler OnLogout;
 
+        /// <summary>
+        /// Gets a value indicating whether a character is logged in.
+        /// </summary>
+        public bool IsLoggedIn { get; private set; }
+
         private void FrameworkOnOnUpdateEvent(Framework framework) {
             if (this.Condition.Any() && this.lastConditionNone == true) {
                 Log.Debug("Is login");
                 this.lastConditionNone = false;
+                this.IsLoggedIn = true;
                 OnLogin?.Invoke(this, null);
             }
                 
             if (!this.Condition.Any() && this.lastConditionNone == false) {
                 Log.Debug("Is logout");
                 this.lastConditionNone = true;
+                this.IsLoggedIn = false;
                 OnLogout?.Invoke(this, null);
             }
         }


### PR DESCRIPTION
Adds IsLoggedIn property for plugins on ClientState. This can be used to get existing state when you missed a framework event from a fresh install or LPL.
`PluginLog.Log("LoggedIn " + _pi.ClientState.IsLoggedIn);`

Also, suppressed ".this is redundant" dotnet style warnings.