### PR TITLE
feat: update loc to allow use by plugins

### DIFF
--- a/Dalamud.Test/LocalizationTests.cs
+++ b/Dalamud.Test/LocalizationTests.cs
@@ -9,7 +9,7 @@ namespace Dalamud.Test {
         
         public LocalizationTests() {
             var workingDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            this.localization = new Localization(workingDir);
+            this.localization = new Localization(workingDir, "dalamud_");
             this.localization.OnLocalizationChanged += code => this.currentLangCode = code;
         }
 

--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -218,7 +218,7 @@ namespace Dalamud
 
                 Log.Verbose("[START] CS OK!");
 
-                this.LocalizationManager = new Localization(this.AssetDirectory.FullName);
+                this.LocalizationManager = new Localization(Path.Combine(this.AssetDirectory.FullName, "UIRes", "loc", "dalamud"), "dalamud_");
                 if (!string.IsNullOrEmpty(this.Configuration.LanguageOverride))
                     this.LocalizationManager.SetupWithLangCode(this.Configuration.LanguageOverride);
                 else

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -189,6 +189,12 @@ namespace Dalamud.Plugin
         /// <returns>directory with path of AppData/XIVLauncher/pluginConfig/PluginInternalName.</returns>
         public string GetPluginConfigDirectory() => this.configs.GetDirectory(this.pluginName);
 
+        /// <summary>
+        /// Get the loc directory.
+        /// </summary>
+        /// <returns>directory with path of AppData/XIVLauncher/pluginConfig/PluginInternalName/loc.</returns>
+        public string GetPluginLocDirectory() => this.configs.GetDirectory(Path.Combine(this.pluginName, "loc"));
+
         #region Chat Links
 
         /// <summary>


### PR DESCRIPTION
Updated Localization class to be usable by plugins.
- Removed hard-coded dalamud loc file references.
- Updated to use CheapLoc methods with assembly param rather than assuming calling assembly.
- Added Localize method (wrapper for CheapLoc method)
- Added ExportLocalizable (wrapper for CheapLoc method)
- Added GetPluginLocDirectory() method (i.e. AppData/XIVLauncher/pluginConfig/PluginInternalName/loc)
- Added error handling to SetupWithLangCode (can be invoked independently).

Plugins can create their own instance of Localization and set language like this.
var localization = new Localization(pluginInterface.GetPluginLocDirectory());
localization.SetupWithLangCode("de");

They could then use CheapLoc directly...
ImGui.Text(Loc.Localize("Label", "Meaingful Text"));

Or could avoid importing CheapLoc and use the Localization.Localize method.
ImGui.Text(localization.Localize("Label", "Meaingful Text"));
			