### PR TITLE
Add implicit SeString construction

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -37,6 +37,13 @@ namespace Dalamud.Game.Text.SeStringHandling
         }
 
         /// <summary>
+        /// Implicitly convert a string into a SeString containing a <see cref="TextPayload"/>.
+        /// </summary>
+        /// <param name="str">string to convert</param>
+        /// <returns>Equivalent SeString</returns>
+        public static implicit operator SeString(string str) => new SeString(new Payload[] { new TextPayload(str) });
+
+        /// <summary>
         /// Creates a new SeString from an ordered list of payloads.
         /// </summary>
         /// <param name="payloads">The Payload objects to make up this string.</param>


### PR DESCRIPTION
This is useful for any case where you would like to accept an `SeString` or a `string`. Functions can now request just an `SeString` and users will be able to pass in a simple `string` or a full-fledged `SeString`.