### PR TITLE
[BREAKING] Use SeString for XivChatEntry

### DIFF
--- a/Dalamud/Game/ChatHandlers.cs
+++ b/Dalamud/Game/ChatHandlers.cs
@@ -88,7 +88,7 @@ namespace Dalamud.Game {
 
         public ChatHandlers(Dalamud dalamud) {
             this.dalamud = dalamud;
-            
+
             dalamud.Framework.Gui.Chat.OnCheckMessageHandled += OnCheckMessageHandled;
             dalamud.Framework.Gui.Chat.OnChatMessage += OnChatMessage;
 
@@ -118,10 +118,10 @@ namespace Dalamud.Game {
             }
         }
 
-        private void OnChatMessage(XivChatType type, uint senderId, ref SeString sender, 
+        private void OnChatMessage(XivChatType type, uint senderId, ref SeString sender,
             ref SeString message, ref bool isHandled) {
 
-            if (type == XivChatType.Notice && !this.hasSeenLoadingMsg) 
+            if (type == XivChatType.Notice && !this.hasSeenLoadingMsg)
                 PrintWelcomeMessage();
 
             // For injections while logged in
@@ -207,7 +207,7 @@ namespace Dalamud.Game {
 
             if (string.IsNullOrEmpty(this.dalamud.Configuration.LastVersion) || !assemblyVersion.StartsWith(this.dalamud.Configuration.LastVersion)) {
                 this.dalamud.Framework.Gui.Chat.PrintChat(new XivChatEntry {
-                    MessageBytes = Encoding.UTF8.GetBytes(Loc.Localize("DalamudUpdated", "The In-Game addon has been updated or was reinstalled successfully! Please check the discord for a full changelog.")),
+                    Message = Loc.Localize("DalamudUpdated", "The In-Game addon has been updated or was reinstalled successfully! Please check the discord for a full changelog."),
                     Type = XivChatType.Notice
                 });
 
@@ -228,7 +228,7 @@ namespace Dalamud.Game {
                             this.dalamud.PluginRepository.PrintUpdatedPlugins(updatedPlugins, Loc.Localize("DalamudPluginAutoUpdate", "Auto-update:"));
                         } else {
                             this.dalamud.Framework.Gui.Chat.PrintChat(new XivChatEntry {
-                                MessageBytes = new SeString(new List<Payload>() {
+                                Message = new SeString(new List<Payload>() {
                                     new TextPayload(Loc.Localize("DalamudPluginUpdateRequired", "One or more of your plugins needs to be updated. Please use the /xlplugins command in-game to update them!")),
                                     new TextPayload("  ["),
                                     new UIForegroundPayload(this.dalamud.Data, 500),
@@ -237,7 +237,7 @@ namespace Dalamud.Game {
                                     RawPayload.LinkTerminator,
                                     new UIForegroundPayload(this.dalamud.Data, 0),
                                     new TextPayload("]"),
-                                }).Encode(),
+                                }),
                                 Type = XivChatType.Urgent
                             });
                         }

--- a/Dalamud/Game/Internal/Gui/ChatGui.cs
+++ b/Dalamud/Game/Internal/Gui/ChatGui.cs
@@ -166,7 +166,7 @@ namespace Dalamud.Game.Internal.Gui {
                     Log.Verbose("SeString was edited, taking precedence over StdString edit.");
                     message.RawData = newEdited;
                     Log.Debug($"\nOLD: {BitConverter.ToString(originalMessageData)}\nNEW: {BitConverter.ToString(newEdited)}");
-                } 
+                }
 
                 var messagePtr = pMessage;
                 OwnedStdString allocatedString = null;
@@ -305,7 +305,7 @@ namespace Dalamud.Game.Internal.Gui {
         public void Print(string message) {
             Log.Verbose("[CHATGUI PRINT]{0}", message);
             PrintChat(new XivChatEntry {
-                MessageBytes = Encoding.UTF8.GetBytes(message),
+                Message = message,
                 Type = this.dalamud.Configuration.GeneralChatType
             });
         }
@@ -313,7 +313,7 @@ namespace Dalamud.Game.Internal.Gui {
         public void PrintError(string message) {
             Log.Verbose("[CHATGUI PRINT ERROR]{0}", message);
             PrintChat(new XivChatEntry {
-                MessageBytes = Encoding.UTF8.GetBytes(message),
+                Message = message,
                 Type = XivChatType.Urgent
             });
         }
@@ -329,10 +329,10 @@ namespace Dalamud.Game.Internal.Gui {
                     continue;
                 }
 
-                var senderRaw = Encoding.UTF8.GetBytes(chat.Name ?? "");
+                var senderRaw = chat.Name?.Encode() ?? new byte[0];
                 using var senderOwned = framework.Libc.NewString(senderRaw);
 
-                var messageRaw = chat.MessageBytes ?? new byte[0];
+                var messageRaw = chat.Message?.Encode() ?? new byte[0];
                 using var messageOwned = framework.Libc.NewString(messageRaw);
 
                 this.HandlePrintMessageDetour(this.baseAddress, chat.Type, senderOwned.Address, messageOwned.Address, chat.SenderId, chat.Parameters);

--- a/Dalamud/Game/Text/XivChatEntry.cs
+++ b/Dalamud/Game/Text/XivChatEntry.cs
@@ -1,4 +1,5 @@
 using System;
+using Dalamud.Game.Text.SeStringHandling;
 
 namespace Dalamud.Game.Text
 {
@@ -7,9 +8,9 @@ namespace Dalamud.Game.Text
 
         public uint SenderId { get; set; }
 
-        public string Name { get; set; } = string.Empty;
+        public SeString Name { get; set; } = string.Empty;
 
-        public byte[] MessageBytes { get; set; }
+        public SeString Message { get; set; }
 
         public IntPtr Parameters { get; set; }
     }

--- a/Dalamud/Plugin/PluginRepository.cs
+++ b/Dalamud/Plugin/PluginRepository.cs
@@ -16,7 +16,7 @@ using Serilog;
 
 namespace Dalamud.Plugin
 {
-    internal class PluginRepository { 
+    internal class PluginRepository {
         private string PluginMasterUrl => "https://raw.githubusercontent.com/goatcorp/DalamudPlugins/api3/pluginmaster.json";
 
         private readonly Dalamud dalamud;
@@ -57,7 +57,7 @@ namespace Dalamud.Plugin
                     var repoNumber = 0;
                     foreach (var repo in repos) {
                         Log.Information("[PLUGINR] Fetching repo: {0}", repo);
-                        
+
                         var data = client.DownloadString(repo);
 
                         var unsortedPluginMaster = JsonConvert.DeserializeObject<List<PluginDefinition>>(data);
@@ -238,7 +238,7 @@ namespace Dalamud.Plugin
                             Version.TryParse(remoteInfo.TestingAssemblyVersion, out var testingAssemblyVer);
                             testingAvailable = testingAssemblyVer > localAssemblyVer && this.dalamud.Configuration.DoPluginTest;
                         }
-                        
+
                         if (remoteAssemblyVer > localAssemblyVer || testingAvailable) {
                             Log.Information("Eligible for update: {0}", remoteInfo.InternalName);
 
@@ -322,7 +322,7 @@ namespace Dalamud.Plugin
                         this.dalamud.Framework.Gui.Chat.Print(string.Format(Loc.Localize("DalamudPluginUpdateSuccessful", "    》 {0} updated to v{1}."), plugin.Name, plugin.Version));
                     } else {
                         this.dalamud.Framework.Gui.Chat.PrintChat(new XivChatEntry {
-                            MessageBytes = Encoding.UTF8.GetBytes(string.Format(Loc.Localize("DalamudPluginUpdateFailed", "    》 {0} update to v{1} failed."), plugin.Name, plugin.Version)),
+                            Message = string.Format(Loc.Localize("DalamudPluginUpdateFailed", "    》 {0} update to v{1} failed."), plugin.Name, plugin.Version),
                             Type = XivChatType.Urgent
                         });
                     }


### PR DESCRIPTION
I'm not sure why `XivChatEntry` was laid out like it was, but it's clunky. This change would remove `MessageBytes` and replace it with `Message`, which takes an `SeString`. Since `string`s implicitly convert into `SeString`s, users can just specify a `string` here.

This would also change the `Name` property to use an `SeString`, which is more correct.

This is a **breaking** change, as it changes the public API and will cause compilation errors for anyone who uses `XivChatEntry`.

---

Also Rider fixed some space issues and I'm too lazy to go back and force-push only my relevant changes.