### PR TITLE
fix: improve SeString integer decoding and encoding

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/Payloads/ItemPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/ItemPayload.cs
@@ -175,40 +175,5 @@ namespace Dalamud.Game.Text.SeStringHandling.Payloads
                 this.displayName = Encoding.UTF8.GetString(itemNameBytes);
             }
         }
-
-        protected override byte[] MakeInteger(uint value, bool withMarker = true, bool incrementSmallInts = true)
-        {
-            // TODO: as part of refactor
-
-            // linking an item id that is a multiple of 256 seemingly *requires* using byte*256 marker encoding
-            // or the link will not display correctly
-            // I am unsure if this applies to other data types as well, so keeping localized here, pending the
-            // refactor of all this integer handling mess
-            if (value % 256 == 0)
-            {
-                value /= 256;
-                // this is no longer a small int, but it was likely converted to that range
-                incrementSmallInts = false;
-            }
-
-            return base.MakeInteger(value, withMarker, incrementSmallInts);
-        }
-
-        protected override byte GetMarkerForIntegerBytes(byte[] bytes)
-        {
-            // custom marker just for hq items?
-            if (bytes.Length == 3 && IsHQ)
-            {
-                return (byte)IntegerType.Int24Special;
-            }
-
-            // TODO: as in the above function
-            if (bytes.Length == 1 && (this.itemId % 256 == 0))
-            {
-                return (byte)IntegerType.ByteTimes256;
-            }
-
-            return base.GetMarkerForIntegerBytes(bytes);
-        }
     }
 }

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/MapLinkPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/MapLinkPayload.cs
@@ -258,18 +258,5 @@ namespace Dalamud.Game.Text.SeStringHandling.Payloads
             return (int)scaledPos;
         }
         #endregion
-
-        protected override byte GetMarkerForIntegerBytes(byte[] bytes)
-        {
-            var type = bytes.Length switch
-            {
-                3 => (byte)IntegerType.Int24Special,                              // used because seen in incoming data
-                2 => (byte)IntegerType.Int16,
-                1 => (byte)IntegerType.None,                                      // single bytes seem to have no prefix at all here
-                _ => base.GetMarkerForIntegerBytes(bytes)
-            };
-
-            return type;
-        }
     }
 }

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/UIForegroundPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/UIForegroundPayload.cs
@@ -109,15 +109,5 @@ namespace Dalamud.Game.Text.SeStringHandling.Payloads
         {
             this.colorKey = (ushort)GetInteger(reader);
         }
-
-        protected override byte GetMarkerForIntegerBytes(byte[] bytes)
-        {
-            return bytes.Length switch
-            {
-                // a single byte of 0x01 is used to 'disable' color, and has no marker
-                1 => (byte)IntegerType.None,
-                _ => base.GetMarkerForIntegerBytes(bytes)
-            };
-        }
     }
 }

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/UIGlowPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/UIGlowPayload.cs
@@ -109,15 +109,5 @@ namespace Dalamud.Game.Text.SeStringHandling.Payloads
         {
             this.colorKey = (ushort)GetInteger(reader);
         }
-
-        protected override byte GetMarkerForIntegerBytes(byte[] bytes)
-        {
-            return bytes.Length switch
-            {
-                // a single byte of 0x01 is used to 'disable' color, and has no marker
-                1 => (byte)IntegerType.None,
-                _ => base.GetMarkerForIntegerBytes(bytes)
-            };
-        }
     }
 }


### PR DESCRIPTION
The marker of encoded bytes is a bitmask, it indicates which `0x00` byte is stripped out from source integer (`0x00` will terminate the cstring, it's unacceptable).

For example,
`0xF0` means `0b0001 + 0xEF`, it indicates the first three(0b**000**1) zero bytes are stripped out and one(0b000**1**) byte is left in the stream, so `F0 EE` should decode into `0x000000EE`.
`0xF1` means `0b0010 + 0xEF`, first two and the last zero bytes stripped out and one byte left, the third bytes, so `F1 EE` should decode into `0x0000EE00`, the "ByteTimes256".
So the difference of "Int24Special" `0xF6 = 0b0111 + 0xEF` and "Int24" `0xFA = 0b1011 + 0xEF` is obvious, `F6 12 34 56` is `0x00123456` and `FA 12 34 56` is `0x12003456`. (yes, the original implement is broken in this case.)
And the "Int16Packed" `0xF4 = 0b0101 + 0xEF`, actually it's not byte+byte, it's packed from short+short, but the first 8bit of them are zero (and stripped).

Besides, there is no no-marker mode or no-increment mode in fact, the packed values are packed into an 32bit integer first then encoded (they are probably done at different logic level), of course there is no marker or increment inside it.