### PR TITLE
fix: show installed testing plugins when testing is disabled

### DIFF
--- a/Dalamud/Plugin/PluginInstallerWindow.cs
+++ b/Dalamud/Plugin/PluginInstallerWindow.cs
@@ -383,7 +383,7 @@ namespace Dalamud.Plugin
 
                 if (this.dalamud.Configuration.DoPluginTest && pluginDefinition.IsTestingExclusive)
                     isTestingAvailable = true;
-                else if (!this.dalamud.Configuration.DoPluginTest && pluginDefinition.IsTestingExclusive) continue;
+                else if (!installed && !this.dalamud.Configuration.DoPluginTest && pluginDefinition.IsTestingExclusive) continue;
 
                 var label = string.Empty;
                 if (isInstalled && !installed)


### PR DESCRIPTION
Fixes: https://github.com/goatcorp/FFXIVQuickLauncher/issues/412