### PR TITLE
feat: refresh plugin tabs after an update

### DIFF
--- a/Dalamud/Plugin/PluginInstallerWindow.cs
+++ b/Dalamud/Plugin/PluginInstallerWindow.cs
@@ -218,6 +218,8 @@ namespace Dalamud.Plugin
                             this.errorModalOnNextFrame = this.installStatus == PluginInstallStatus.Fail;
 
                             this.dalamud.PluginRepository.PrintUpdatedPlugins(this.updatedPlugins, Loc.Localize("DalamudPluginUpdates", "Updates:"));
+
+                            this.RefetchPlugins();
                         });
                     }
                 }


### PR DESCRIPTION
This keeps the non-refreshing behavior when installing a plugin manually.