### PR TITLE
feat: Add support for gamepad control of ImGui

### DIFF
--- a/Dalamud/Configuration/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/DalamudConfiguration.cs
@@ -123,6 +123,11 @@ namespace Dalamud.Configuration
         public bool IsDisableViewport { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not navigation via a gamepad should be globally enabled in ImGui.
+        /// </summary>
+        public bool IsGamepadNavigationEnabled { get; set; } = true;
+
+        /// <summary>
         /// Load a configuration from the provided path.
         /// </summary>
         /// <param name="path">The path to load the configuration file from.</param>

--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -98,6 +98,9 @@ namespace Dalamud.Game.ClientState
         /// </summary>
         public KeyState KeyState;
 
+        /// <summary>
+        /// Provides access to the button state of gamepad buttons in game.
+        /// </summary>
         public GamepadState GamepadState;
         
         /// <summary>
@@ -133,7 +136,7 @@ namespace Dalamud.Game.ClientState
 
             this.KeyState = new KeyState(Address, scanner.Module.BaseAddress);
 
-            this.GamepadState = new GamepadState(scanner);
+            this.GamepadState = new GamepadState(this.Address);
 
             this.Condition = new Condition( Address );
 

--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -98,6 +98,8 @@ namespace Dalamud.Game.ClientState
         /// </summary>
         public KeyState KeyState;
 
+        public GamepadState GamepadState;
+        
         /// <summary>
         /// Provides access to client conditions/player state. Allows you to check if a player is in a duty, mounted, etc.
         /// </summary>
@@ -131,6 +133,8 @@ namespace Dalamud.Game.ClientState
 
             this.KeyState = new KeyState(Address, scanner.Module.BaseAddress);
 
+            this.GamepadState = new GamepadState(scanner);
+
             this.Condition = new Condition( Address );
 
             this.Targets = new Targets(dalamud, Address);
@@ -150,6 +154,7 @@ namespace Dalamud.Game.ClientState
         }
 
         public void Enable() {
+            this.GamepadState.Enable();
             this.PartyList.Enable();
             this.setupTerritoryTypeHook.Enable();
         }
@@ -158,6 +163,7 @@ namespace Dalamud.Game.ClientState
             this.PartyList.Dispose();
             this.setupTerritoryTypeHook.Dispose();
             this.Actors.Dispose();
+            this.GamepadState.Dispose();
 
             this.dalamud.Framework.OnUpdateEvent -= FrameworkOnOnUpdateEvent;
             this.dalamud.NetworkHandlers.CfPop += NetworkHandlersOnCfPop;

--- a/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
+++ b/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
@@ -16,7 +16,14 @@ namespace Dalamud.Game.ClientState
         public IntPtr SetupTerritoryType { get; private set; }
         //public IntPtr SomeActorTableAccess { get; private set; }
         //public IntPtr PartyListUpdate { get; private set; }
-        
+
+        /// <summary>
+        /// Game function which polls the gamepads for data.
+        ///
+        /// Called every frame, even when `Enable Gamepad` is off in the settings.
+        /// </summary>
+        public IntPtr GamepadPoll { get; private set; }
+
         public IntPtr ConditionFlags { get; private set; }
 
         protected override void Setup64Bit(SigScanner sig) {
@@ -38,6 +45,8 @@ namespace Dalamud.Game.ClientState
             ConditionFlags = sig.GetStaticAddressFromSig("48 8D 0D ?? ?? ?? ?? BA ?? ?? ?? ?? E8 ?? ?? ?? ?? B0 01 48 83 C4 30");
 
             TargetManager = sig.GetStaticAddressFromSig("48 8B 05 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? FF 50 ?? 48 85 DB", 3);
+
+            this.GamepadPoll = sig.ScanText("40 ?? 57 41 ?? 48 81 EC ?? ?? ?? ?? 44 0F ?? ?? ?? ?? ?? ?? ?? 48 8B");
         }
     }
 }

--- a/Dalamud/Game/ClientState/GamepadButtons.cs
+++ b/Dalamud/Game/ClientState/GamepadButtons.cs
@@ -1,24 +1,88 @@
 ﻿namespace Dalamud.Game.ClientState
 {
+    /// <summary>
+    /// Bitmask of the Button ushort used by the game.
+    /// </summary>
     public enum GamepadButtons : ushort
     {
-        XINPUT_GAMEPAD_DPAD_UP = 0x0001,
-        XINPUT_GAMEPAD_DPAD_DOWN = 0x0002,
-        XINPUT_GAMEPAD_DPAD_LEFT = 0x0004,
-        XINPUT_GAMEPAD_DPAD_RIGHT = 0x0008,
-        XINPUT_GAMEPAD_Y = 0x0010,
-        XINPUT_GAMEPAD_A = 0x0020,
-        XINPUT_GAMEPAD_X = 0x0040,
-        XINPUT_GAMEPAD_B = 0x0080,
-        XINPUT_GAMEPAD_LEFT_1 = 0x0100,
-        XINPUT_GAMEPAD_LEFT_2 = 0x0200, // The back one
-        XINPUT_GAMEPAD_LEFT_3 = 0x0400,
-        XINPUT_GAMEPAD_RIGHT_1 = 0x0800,
-        XINPUT_GAMEPAD_RIGHT_2 = 0x1000, // The back one
-        XINPUT_GAMEPAD_RIGHT_3 = 0x2000,
-        XINPUT_GAMEPAD_START = 0x8000,
-        XINPUT_GAMEPAD_SELECT = 0x4000,
+        /// <summary>
+        /// Digipad up.
+        /// </summary>
+        DpadUp = 0x0001,
 
+        /// <summary>
+        /// Digipad down.
+        /// </summary>
+        DpadDown = 0x0002,
 
+        /// <summary>
+        /// Digipad left.
+        /// </summary>
+        DpadLeft = 0x0004,
+
+        /// <summary>
+        /// Digipad right.
+        /// </summary>
+        DpadRight = 0x0008,
+
+        /// <summary>
+        /// North action button. Triangle on PS, Y on Xbox.
+        /// </summary>
+        North = 0x0010,
+
+        /// <summary>
+        /// South action button. Cross on PS, A on Xbox.
+        /// </summary>
+        South = 0x0020,
+
+        /// <summary>
+        /// West action button. Square on PS, X on Xbos.
+        /// </summary>
+        West = 0x0040,
+
+        /// <summary>
+        /// East action button. Circle on PS, B on Xbox.
+        /// </summary>
+        East = 0x0080,
+
+        /// <summary>
+        /// First button on left shoulder side.
+        /// </summary>
+        L1 = 0x0100,
+
+        /// <summary>
+        /// Second button on left shoulder side. Analog input lost in this bitmask.
+        /// </summary>
+        L2 = 0x0200,
+
+        /// <summary>
+        /// Press on left analogue stick.
+        /// </summary>
+        L3 = 0x0400,
+
+        /// <summary>
+        /// First button on right shoulder.
+        /// </summary>
+        R1 = 0x0800,
+
+        /// <summary>
+        /// Second button on right shoulder. Analog input lost in this bitmask.
+        /// </summary>
+        R2 = 0x1000,
+
+        /// <summary>
+        /// Press on right analogue stick.
+        /// </summary>
+        R3 = 0x2000,
+
+        /// <summary>
+        /// Button on the right inner side of the controller. Options on PS, Start on Xbox.
+        /// </summary>
+        Start = 0x8000,
+
+        /// <summary>
+        /// Button on the left inner side of the controller. ??? on PS, Back on Xbox.
+        /// </summary>
+        Select = 0x4000,
     }
 }

--- a/Dalamud/Game/ClientState/GamepadButtons.cs
+++ b/Dalamud/Game/ClientState/GamepadButtons.cs
@@ -1,0 +1,24 @@
+﻿namespace Dalamud.Game.ClientState
+{
+    public enum GamepadButtons : ushort
+    {
+        XINPUT_GAMEPAD_DPAD_UP = 0x0001,
+        XINPUT_GAMEPAD_DPAD_DOWN = 0x0002,
+        XINPUT_GAMEPAD_DPAD_LEFT = 0x0004,
+        XINPUT_GAMEPAD_DPAD_RIGHT = 0x0008,
+        XINPUT_GAMEPAD_Y = 0x0010,
+        XINPUT_GAMEPAD_A = 0x0020,
+        XINPUT_GAMEPAD_X = 0x0040,
+        XINPUT_GAMEPAD_B = 0x0080,
+        XINPUT_GAMEPAD_LEFT_1 = 0x0100,
+        XINPUT_GAMEPAD_LEFT_2 = 0x0200, // The back one
+        XINPUT_GAMEPAD_LEFT_3 = 0x0400,
+        XINPUT_GAMEPAD_RIGHT_1 = 0x0800,
+        XINPUT_GAMEPAD_RIGHT_2 = 0x1000, // The back one
+        XINPUT_GAMEPAD_RIGHT_3 = 0x2000,
+        XINPUT_GAMEPAD_START = 0x8000,
+        XINPUT_GAMEPAD_SELECT = 0x4000,
+
+
+    }
+}

--- a/Dalamud/Game/ClientState/GamepadButtons.cs
+++ b/Dalamud/Game/ClientState/GamepadButtons.cs
@@ -1,10 +1,18 @@
-﻿namespace Dalamud.Game.ClientState
+﻿using System;
+
+namespace Dalamud.Game.ClientState
 {
     /// <summary>
     /// Bitmask of the Button ushort used by the game.
     /// </summary>
+    [Flags]
     public enum GamepadButtons : ushort
     {
+        /// <summary>
+        /// No buttons pressed.
+        /// </summary>
+        None = 0,
+
         /// <summary>
         /// Digipad up.
         /// </summary>

--- a/Dalamud/Game/ClientState/GamepadState.cs
+++ b/Dalamud/Game/ClientState/GamepadState.cs
@@ -228,12 +228,13 @@ namespace Dalamud.Game.ClientState
                     // `ButtonPressed` while ImGuiConfigFlags.NavEnableGamepad is set.
                     // This is debatable.
                     // ImGui itself does not care either way as it uses the Raw values and does its own state handling.
-                    input->ButtonsRaw &= (ushort)~GamepadButtons.L2;
-                    input->ButtonsRaw &= (ushort)~GamepadButtons.R2;
-                    input->ButtonsRaw &= (ushort)~GamepadButtons.DpadDown;
-                    input->ButtonsRaw &= (ushort)~GamepadButtons.DpadLeft;
-                    input->ButtonsRaw &= (ushort)~GamepadButtons.DpadUp;
-                    input->ButtonsRaw &= (ushort)~GamepadButtons.DpadRight;
+                    const ushort deletionMask = (ushort)(~GamepadButtons.L2
+                                                         & ~GamepadButtons.R2
+                                                         & ~GamepadButtons.DpadDown
+                                                         & ~GamepadButtons.DpadLeft
+                                                         & ~GamepadButtons.DpadUp
+                                                         & ~GamepadButtons.DpadRight);
+                    input->ButtonsRaw &= deletionMask;
                     input->ButtonsPressed = 0;
                     input->ButtonsReleased = 0;
                     input->ButtonsRepeat = 0;

--- a/Dalamud/Game/ClientState/GamepadState.cs
+++ b/Dalamud/Game/ClientState/GamepadState.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Windows.Forms;
+using Dalamud.Game.ClientState.Structs;
+using Dalamud.Hooking;
+using OpenGL;
+
+namespace Dalamud.Game.ClientState
+{
+    public unsafe class GamepadState
+    {
+
+        public float ButtonSouth => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_A) > 0 ? 1 : 0;
+        public float ButtonEast => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_B) > 0 ? 1 : 0;
+        public float ButtonWest => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_X) > 0 ? 1 : 0;
+        public float ButtonNorth => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_Y) > 0 ? 1 : 0;
+        public float DPadDown => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_DPAD_DOWN) > 0 ? 1 : 0;
+        public float DPadRight => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_DPAD_RIGHT) > 0 ? 1 : 0;
+        public float DPadUp => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_DPAD_UP) > 0 ? 1 : 0;
+        public float DPadLeft => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_DPAD_LEFT) > 0 ? 1 : 0;
+        public float L1 => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_LEFT_1) > 0 ? 1 : 0;
+        public float L2 => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_LEFT_2) > 0 ? 1 : 0;
+        public float L3 => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_LEFT_3) > 0 ? 1 : 0;
+        public float R1 => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_RIGHT_1) > 0 ? 1 : 0;
+        public float R2 => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_RIGHT_2) > 0 ? 1 : 0;
+        public float R3 => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_RIGHT_3) > 0 ? 1 : 0;
+        public float Start => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_START) > 0 ? 1 : 0;
+        public float Select => (this.buttonsTapped & (ushort)GamepadButtons.XINPUT_GAMEPAD_SELECT) > 0 ? 1 : 0;
+        public float LeftStickLeft => this.leftStickX < 0 ? -this.leftStickX / 100f : 0;
+        public float LeftStickRight => this.leftStickX > 0 ? this.leftStickX / 100f : 0;
+        public float LeftStickUp => this.leftStickY > 0 ? this.leftStickY / 100f : 0;
+        public float LeftStickDown => this.leftStickY < 0 ? -this.leftStickY / 100f : 0;
+        public float RightStickLeft => this.rightStickX < 0 ? -this.rightStickX / 100f : 0;
+        public float RightStickRight => this.rightStickX > 0 ? this.rightStickX / 100f : 0;
+        public float RightStickUp => this.rightStickY > 0 ? this.rightStickY / 100f : 0;
+        public float RightStickDown => this.rightStickY < 0 ? -this.rightStickY / 100f : 0;
+        
+        public float Tapped(GamepadButtons button)
+            => (this.buttonsTapped & (ushort)button) > 0 ? 1 : 0;
+        
+        public float Holding(GamepadButtons button)
+            => (this.buttonsHolding & (ushort)button) > 0 ? 1 : 0;
+        
+        public float Released(GamepadButtons button)
+            => (this.buttonsReleased & (ushort)button) > 0 ? 1 : 0;
+        
+        private delegate int ControllerPoll(IntPtr controllerInput);
+
+        private Hook<ControllerPoll> controllerPoll;
+        //private GamepadInput* _gamePadInput;
+        private bool isDisposed;
+
+        private int leftStickX;
+        private int leftStickY;
+        private int rightStickX;
+        private int rightStickY;
+        private ushort buttons;
+        private ushort buttonsTapped;
+        private ushort buttonsReleased;
+        private ushort buttonsHolding;
+        private bool imGuiMode;
+        
+
+        public GamepadState(SigScanner scanner)
+        {
+            const string controllerPollSignature =
+                "40 ?? 57 41 ?? 48 81 EC ?? ?? ?? ?? 44 0F ?? ?? ?? ?? ?? ?? ?? 48 8B";
+            this.controllerPoll = new Hook<ControllerPoll>(
+                scanner.ScanText(controllerPollSignature),
+                (ControllerPoll) ControllerPollDetour);
+        }
+
+
+        private unsafe int ControllerPollDetour(IntPtr gamepadInput)
+        {
+            //this._gamePadInput =(GamepadInput*) gamepadInput;
+            var original = this.controllerPoll.Original(gamepadInput);
+            var input = (GamepadInput*)gamepadInput;
+            if (
+                (input->ButtonFlag_Holding & (ushort)GamepadButtons.XINPUT_GAMEPAD_RIGHT_1) > 0
+                && (input->ButtonFlag & (ushort)GamepadButtons.XINPUT_GAMEPAD_LEFT_1) > 0)
+            {
+                this.imGuiMode = !this.imGuiMode;
+                if (!this.imGuiMode)
+                {
+                    this.leftStickX = 0;
+                    this.leftStickY = 0;
+                    this.rightStickY = 0;
+                    this.rightStickX = 0;
+                    this.buttons = 0;
+                    this.buttonsTapped = 0;
+                    this.buttonsReleased = 0;
+                    this.buttonsHolding = 0;
+                }
+            }
+
+            if (this.imGuiMode)
+            {
+                this.leftStickX = input->LeftStickX;
+                this.leftStickY = input->LeftStickY;
+                this.rightStickX = input->RightStickX;
+                this.rightStickY = input->RightStickY;
+                this.buttons = input->ButtonFlag;
+                this.buttonsTapped = input->ButtonFlag_Tap;
+                this.buttonsReleased = input->ButtonFlag_Release;
+                this.buttonsHolding = input->ButtonFlag_Holding;
+
+                input->LeftStickX = 0;
+                input->LeftStickY = 0;
+                input->RightStickX = 0;
+                input->RightStickY = 0;
+                input->ButtonFlag = 0;
+                input->ButtonFlag_Tap = 0;
+                input->ButtonFlag_Release = 0;
+                input->ButtonFlag_Holding = 0;
+            }
+
+            // Not so sure about the return value, does not seem to matter if we return the
+            // original, zero or do the work adjusting the bits.
+            return original;
+        }
+
+        public void Enable()
+        {
+            this.controllerPoll.Enable();
+        }
+        
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (this.isDisposed) return;
+            if (disposing)
+            {
+                this.controllerPoll?.Disable();
+                this.controllerPoll?.Dispose();
+            }
+
+            this.isDisposed = true;
+        }
+
+        ~GamepadState()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/Dalamud/Game/ClientState/Structs/GamepadInput.cs
+++ b/Dalamud/Game/ClientState/Structs/GamepadInput.cs
@@ -2,37 +2,63 @@
 
 namespace Dalamud.Game.ClientState.Structs
 {
-    // It is bigger, but I dunno how big in real
+    /// <summary>
+    /// Struct which gets populated by polling the gamepads.
+    ///
+    /// Has an array of gamepads, among many other things (here not mapped).
+    /// All we really care about is the final data which the game uses to determine input.
+    ///
+    /// The size is definitely bigger than only the following fields but I do not know how big.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit)]
     public struct GamepadInput
     {
-        // Each stick is -99 till 99
+        /// <summary>
+        /// Left analogue stick's horizontal value, -99 for left, 99 for right.
+        /// </summary>
         [FieldOffset(0x88)]
         public int LeftStickX;
 
+        /// <summary>
+        /// Left analogue stick's vertical value, -99 for down, 99 for up.
+        /// </summary>
         [FieldOffset(0x8C)]
         public int LeftStickY;
 
+        /// <summary>
+        /// Right analogue stick's horizontal value, -99 for left, 99 for right.
+        /// </summary>
         [FieldOffset(0x90)]
         public int RightStickX;
 
+        /// <summary>
+        /// Right analogue stick's vertical value, -99 for down, 99 for up.
+        /// </summary>
         [FieldOffset(0x94)]
         public int RightStickY;
 
-        // Seems to be source of true, instant population, keeps value while hold.
+        /// <summary>
+        /// Raw input, set the whole time while a button is held. See <see cref="GamepadButtons"/> for the mapping.
+        /// </summary>
         [FieldOffset(0x98)]
-        public ushort ButtonFlag; // bitfield
+        public ushort ButtonsRaw; // bitfield
 
-        // Gets populated only if released after a short tick
+        /// <summary>
+        /// Button pressed, set once when the button is pressed. See <see cref="GamepadButtons"/> for the mapping.
+        /// </summary>
         [FieldOffset(0x9C)]
-        public ushort ButtonFlag_Tap; // bitfield
+        public ushort ButtonsPressed; // bitfield
 
-        // Gets populated on button release
+        /// <summary>
+        /// Button released input, set once right after the button is not hold anymore. See <see cref="GamepadButtons"/> for the mapping.
+        /// </summary>
         [FieldOffset(0xA0)]
-        public ushort ButtonFlag_Release; // bitfield
+        public ushort ButtonsReleased; // bitfield
 
-        // Gets populated after a tick and keeps being set while button is held
+        /// <summary>
+        /// Repeatedly emits the held button input in fixed intervals. See <see cref="GamepadButtons"/> for the mapping.
+        /// </summary>
         [FieldOffset(0xA4)]
-        public ushort ButtonFlag_Holding; // bitfield
+        public ushort ButtonsRepeat; // bitfield
     }
 }

--- a/Dalamud/Game/ClientState/Structs/GamepadInput.cs
+++ b/Dalamud/Game/ClientState/Structs/GamepadInput.cs
@@ -1,0 +1,38 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Dalamud.Game.ClientState.Structs
+{
+    // It is bigger, but I dunno how big in real
+    [StructLayout(LayoutKind.Explicit)]
+    public struct GamepadInput
+    {
+        // Each stick is -99 till 99
+        [FieldOffset(0x88)]
+        public int LeftStickX;
+
+        [FieldOffset(0x8C)]
+        public int LeftStickY;
+
+        [FieldOffset(0x90)]
+        public int RightStickX;
+
+        [FieldOffset(0x94)]
+        public int RightStickY;
+
+        // Seems to be source of true, instant population, keeps value while hold.
+        [FieldOffset(0x98)]
+        public ushort ButtonFlag; // bitfield
+
+        // Gets populated only if released after a short tick
+        [FieldOffset(0x9C)]
+        public ushort ButtonFlag_Tap; // bitfield
+
+        // Gets populated on button release
+        [FieldOffset(0xA0)]
+        public ushort ButtonFlag_Release; // bitfield
+
+        // Gets populated after a tick and keeps being set while button is held
+        [FieldOffset(0xA4)]
+        public ushort ButtonFlag_Holding; // bitfield
+    }
+}

--- a/Dalamud/Interface/DalamudDataWindow.cs
+++ b/Dalamud/Interface/DalamudDataWindow.cs
@@ -36,7 +36,7 @@ namespace Dalamud.Interface
         private string[] dataKinds = new[]
         {
             "ServerOpCode", "Address", "Actor Table", "Font Test", "Party List", "Plugin IPC", "Condition",
-            "Gauge", "Command", "Addon", "Addon Inspector", "StartInfo", "Target", "Toast", "ImGui", "Tex",
+            "Gauge", "Command", "Addon", "Addon Inspector", "StartInfo", "Target", "Toast", "ImGui", "Tex", "Gamepad",
         };
 
         private bool drawActors = false;
@@ -390,6 +390,60 @@ namespace Dalamud.Interface
                                 Util.ShowObject(this.debugTex);
                             }
 
+                            break;
+
+                        // Gamepad
+                        case 16:
+                            Action<string, uint, Func<GamepadButtons, float>> helper = (text, mask, resolve) =>
+                            {
+                                ImGui.Text($"{text} {mask:X4}");
+                                ImGui.Text($"DPadLeft {resolve(GamepadButtons.DpadLeft)} " +
+                                           $"DPadUp {resolve(GamepadButtons.DpadUp)} " +
+                                           $"DPadRight {resolve(GamepadButtons.DpadRight)} " +
+                                           $"DPadDown {resolve(GamepadButtons.DpadDown)} ");
+                                ImGui.Text($"West {resolve(GamepadButtons.West)} " +
+                                           $"North {resolve(GamepadButtons.North)} " +
+                                           $"East {resolve(GamepadButtons.East)} " +
+                                           $"South {resolve(GamepadButtons.South)} ");
+                                ImGui.Text($"L1 {resolve(GamepadButtons.L1)} " +
+                                           $"L2 {resolve(GamepadButtons.L2)} " +
+                                           $"R1 {resolve(GamepadButtons.R1)} " +
+                                           $"R2 {resolve(GamepadButtons.R2)} ");
+                                ImGui.Text($"Select {resolve(GamepadButtons.Select)} " +
+                                           $"Start {resolve(GamepadButtons.Start)} " +
+                                           $"L3 {resolve(GamepadButtons.L3)} " +
+                                           $"R3 {resolve(GamepadButtons.R3)} ");
+                            };
+#if DEBUG
+                            ImGui.Text($"GamepadInput {this.dalamud.ClientState.GamepadState.GamepadInput.ToString("X")}");
+                            if (ImGui.IsItemHovered()) ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
+                            if (ImGui.IsItemClicked()) ImGui.SetClipboardText($"{this.dalamud.ClientState.GamepadState.GamepadInput.ToString("X")}");
+#endif
+
+                            helper(
+                                "Buttons Raw",
+                                this.dalamud.ClientState.GamepadState.ButtonsRaw,
+                                this.dalamud.ClientState.GamepadState.Raw);
+                            helper(
+                                "Buttons Pressed",
+                                this.dalamud.ClientState.GamepadState.ButtonsPressed,
+                                this.dalamud.ClientState.GamepadState.Pressed);
+                            helper(
+                                "Buttons Repeat",
+                                this.dalamud.ClientState.GamepadState.ButtonsRepeat,
+                                this.dalamud.ClientState.GamepadState.Repeat);
+                            helper(
+                                "Buttons Released",
+                                this.dalamud.ClientState.GamepadState.ButtonsReleased,
+                                this.dalamud.ClientState.GamepadState.Released);
+                            ImGui.Text($"LeftStickLeft {this.dalamud.ClientState.GamepadState.LeftStickLeft:0.00} " +
+                                       $"LeftStickUp {this.dalamud.ClientState.GamepadState.LeftStickUp:0.00} " +
+                                       $"LeftStickRight {this.dalamud.ClientState.GamepadState.LeftStickRight:0.00} " +
+                                       $"LeftStickDown {this.dalamud.ClientState.GamepadState.LeftStickDown:0.00} ");
+                            ImGui.Text($"RightStickLeft {this.dalamud.ClientState.GamepadState.RightStickLeft:0.00} " +
+                                       $"RightStickUp {this.dalamud.ClientState.GamepadState.RightStickUp:0.00} " +
+                                       $"RightStickRight {this.dalamud.ClientState.GamepadState.RightStickRight:0.00} " +
+                                       $"RightStickDown {this.dalamud.ClientState.GamepadState.RightStickDown:0.00} ");
                             break;
                     }
                 }

--- a/Dalamud/Interface/DalamudInterface.cs
+++ b/Dalamud/Interface/DalamudInterface.cs
@@ -35,6 +35,7 @@ namespace Dalamud.Interface
         private readonly ComponentDemoWindow componentDemoWindow;
         private readonly ColorDemoWindow colorDemoWindow;
         private readonly ScratchpadWindow scratchpadWindow;
+        private readonly GamepadModeNotifierWindow gamepadModeNotifierWindow;
 
         private readonly WindowSystem windowSystem = new WindowSystem("DalamudCore");
 
@@ -115,6 +116,9 @@ namespace Dalamud.Interface
                 IsOpen = false,
             };
             this.windowSystem.AddWindow(this.scratchpadWindow);
+
+            this.gamepadModeNotifierWindow = new GamepadModeNotifierWindow();
+            this.windowSystem.AddWindow(this.gamepadModeNotifierWindow);
 
             Log.Information("[DUI] Windows added");
 
@@ -552,6 +556,14 @@ namespace Dalamud.Interface
         internal void ToggleScratchpadWindow()
         {
             this.scratchpadWindow.IsOpen ^= true;
+        }
+
+        /// <summary>
+        /// Toggle the gamepad notifier window window.
+        /// </summary>
+        internal void ToggleGamePadNotifierWindow()
+        {
+            this.gamepadModeNotifierWindow.IsOpen ^= true;
         }
     }
 }

--- a/Dalamud/Interface/DalamudSettingsWindow.cs
+++ b/Dalamud/Interface/DalamudSettingsWindow.cs
@@ -23,7 +23,7 @@ namespace Dalamud.Interface
         {
             this.dalamud = dalamud;
 
-            this.Size = new Vector2(740, 500);
+            this.Size = new Vector2(740, 525);
             this.SizeCondition = ImGuiCond.FirstUseEver;
 
             this.dalamudMessagesChatType = this.dalamud.Configuration.GeneralChatType;
@@ -38,6 +38,7 @@ namespace Dalamud.Interface
 
             this.doDocking = this.dalamud.Configuration.IsDocking;
             this.doViewport = !this.dalamud.Configuration.IsDisableViewport;
+            this.doGamepad = this.dalamud.Configuration.IsGamepadNavigationEnabled;
 
             this.doPluginTest = this.dalamud.Configuration.DoPluginTest;
             this.thirdRepoList = this.dalamud.Configuration.ThirdRepoList.Select(x => x.Clone()).ToList();
@@ -133,6 +134,7 @@ namespace Dalamud.Interface
         private bool doToggleUiHideDuringGpose;
         private bool doDocking;
         private bool doViewport;
+        private bool doGamepad;
         private List<ThirdRepoSetting> thirdRepoList;
 
         private bool printPluginsWelcomeMsg;
@@ -227,6 +229,9 @@ namespace Dalamud.Interface
 
                     ImGui.Checkbox(Loc.Localize("DalamudSettingToggleDocking", "Enable window docking"), ref this.doDocking);
                     ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleDockingHint", "This will allow you to fuse and tab plugin windows."));
+
+                    ImGui.Checkbox(Loc.Localize("DalamudSettingToggleGamepadNavigation", "Enable navigation of ImGui windows via gamepad."), ref this.doGamepad);
+                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleGamepadNavigationHint", "This will allow you to toggle between game and ImGui navigation via L1+L3."));
 
                     ImGui.EndTabItem();
                 }
@@ -378,6 +383,7 @@ namespace Dalamud.Interface
             this.dalamud.Configuration.ToggleUiHideDuringGpose = this.doToggleUiHideDuringGpose;
 
             this.dalamud.Configuration.IsDocking = this.doDocking;
+            this.dalamud.Configuration.IsGamepadNavigationEnabled = this.doGamepad;
 
             // This is applied every frame in InterfaceManager::CheckViewportState()
             this.dalamud.Configuration.IsDisableViewport = !this.doViewport;
@@ -390,6 +396,18 @@ namespace Dalamud.Interface
             else
             {
                 ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.DockingEnable;
+            }
+
+            // NOTE (Chiv) Toggle gamepad navigation via setting
+            if (!this.dalamud.Configuration.IsGamepadNavigationEnabled)
+            {
+                ImGui.GetIO().BackendFlags &= ~ImGuiBackendFlags.HasGamepad;
+                ImGui.GetIO().ConfigFlags &= ~ImGuiConfigFlags.NavEnableSetMousePos;
+            }
+            else
+            {
+                ImGui.GetIO().BackendFlags |= ImGuiBackendFlags.HasGamepad;
+                ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.NavEnableSetMousePos;
             }
 
             this.dalamud.Configuration.DoPluginTest = this.doPluginTest;

--- a/Dalamud/Interface/DalamudSettingsWindow.cs
+++ b/Dalamud/Interface/DalamudSettingsWindow.cs
@@ -23,7 +23,7 @@ namespace Dalamud.Interface
         {
             this.dalamud = dalamud;
 
-            this.Size = new Vector2(740, 525);
+            this.Size = new Vector2(740, 550);
             this.SizeCondition = ImGuiCond.FirstUseEver;
 
             this.dalamudMessagesChatType = this.dalamud.Configuration.GeneralChatType;
@@ -231,7 +231,7 @@ namespace Dalamud.Interface
                     ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleDockingHint", "This will allow you to fuse and tab plugin windows."));
 
                     ImGui.Checkbox(Loc.Localize("DalamudSettingToggleGamepadNavigation", "Enable navigation of ImGui windows via gamepad."), ref this.doGamepad);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleGamepadNavigationHint", "This will allow you to toggle between game and ImGui navigation via L1+L3."));
+                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleGamepadNavigationHint", "This will allow you to toggle between game and ImGui navigation via L1+L3.\nToggle the PluginInstaller window via R3 if ImGui navigation is enabled."));
 
                     ImGui.EndTabItem();
                 }

--- a/Dalamud/Interface/GamepadModeNotifierWindow.cs
+++ b/Dalamud/Interface/GamepadModeNotifierWindow.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 
+using CheapLoc;
 using Dalamud.Interface.Windowing;
 using ImGuiNET;
 
@@ -34,7 +35,12 @@ namespace Dalamud.Interface
             var drawList = ImGui.GetBackgroundDrawList();
             drawList.PushClipRectFullScreen();
             drawList.AddRectFilled(Vector2.Zero, ImGuiHelpers.MainViewport.Size, 0x661A1A1A);
-            drawList.AddText(Vector2.One, 0xFFFFFFFF, "Gamepad mode is ON. Press R1+L3 to deactivate, press R3 to toggle PluginInstaller.");
+            drawList.AddText(
+                Vector2.One,
+                0xFFFFFFFF,
+                Loc.Localize(
+                    "DalamudGamepadModeNotifierText",
+                    "Gamepad mode is ON. Press R1+L3 to deactivate, press R3 to toggle PluginInstaller."));
             drawList.PopClipRect();
         }
     }

--- a/Dalamud/Interface/GamepadModeNotifierWindow.cs
+++ b/Dalamud/Interface/GamepadModeNotifierWindow.cs
@@ -1,0 +1,41 @@
+﻿using System.Numerics;
+
+using Dalamud.Interface.Windowing;
+using ImGuiNET;
+
+namespace Dalamud.Interface
+{
+    /// <summary>
+    /// Class responsible for drawing a notifier on screen that gamepad mode is active.
+    /// </summary>
+    internal class GamepadModeNotifierWindow : Window
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GamepadModeNotifierWindow"/> class.
+        /// </summary>
+        public GamepadModeNotifierWindow()
+            : base(
+                "###DalamudGamepadModeNotifier",
+                ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoMouseInputs
+                | ImGuiWindowFlags.NoFocusOnAppearing | ImGuiWindowFlags.NoBackground | ImGuiWindowFlags.NoNav
+                | ImGuiWindowFlags.NoInputs | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoSavedSettings,
+                true)
+        {
+            this.Size = Vector2.Zero;
+            this.SizeCondition = ImGuiCond.Always;
+            this.IsOpen = false;
+        }
+
+        /// <summary>
+        /// Draws a light grey-ish, main-viewport-big filled rect in the background draw list alongside a text indicating gamepad mode.
+        /// </summary>
+        public override void Draw()
+        {
+            var drawList = ImGui.GetBackgroundDrawList();
+            drawList.PushClipRectFullScreen();
+            drawList.AddRectFilled(Vector2.Zero, ImGuiHelpers.MainViewport.Size, 0x661A1A1A);
+            drawList.AddText(Vector2.One, 0xFFFFFFFF, "Gamepad mode is ON. Press R1+L3 to deactivate, press R3 to toggle PluginInstaller.");
+            drawList.PopClipRect();
+        }
+    }
+}

--- a/Dalamud/Interface/InterfaceManager.cs
+++ b/Dalamud/Interface/InterfaceManager.cs
@@ -291,6 +291,9 @@ namespace Dalamud.Interface
                     ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.DockingEnable;
                 }
 
+                //TODO (Chiv) Addition
+                ImGui.GetIO().BackendFlags |= ImGuiBackendFlags.HasGamepad;
+                
                 ImGuiHelpers.MainViewport = ImGui.GetMainViewport();
 
                 Log.Information("[IM] Scene & ImGui setup OK!");
@@ -460,6 +463,23 @@ namespace Dalamud.Interface
                 this.dalamud.ClientState.KeyState.ClearAll();
             }
 
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.Activate] = this.dalamud.ClientState.GamepadState.ButtonSouth;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.Cancel] = this.dalamud.ClientState.GamepadState.ButtonEast;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.Input] = this.dalamud.ClientState.GamepadState.ButtonNorth;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.Menu] = this.dalamud.ClientState.GamepadState.ButtonWest;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.DpadLeft] = this.dalamud.ClientState.GamepadState.DPadLeft;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.DpadRight] = this.dalamud.ClientState.GamepadState.DPadRight;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.DpadUp] = this.dalamud.ClientState.GamepadState.DPadUp;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.DpadDown] = this.dalamud.ClientState.GamepadState.DPadDown;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.LStickLeft] = this.dalamud.ClientState.GamepadState.LeftStickLeft;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.LStickRight] = this.dalamud.ClientState.GamepadState.LeftStickRight;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.LStickUp] = this.dalamud.ClientState.GamepadState.LeftStickUp;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.LStickDown] = this.dalamud.ClientState.GamepadState.LeftStickDown;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.FocusPrev] = this.dalamud.ClientState.GamepadState.L1;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.FocusNext] = this.dalamud.ClientState.GamepadState.R1;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.TweakSlow] = this.dalamud.ClientState.GamepadState.L2;
+            ImGui.GetIO().NavInputs[(int)ImGuiNavInput.TweakFast] = this.dalamud.ClientState.GamepadState.R2;
+            
             // TODO: mouse state?
         }
 

--- a/Dalamud/Interface/InterfaceManager.cs
+++ b/Dalamud/Interface/InterfaceManager.cs
@@ -478,7 +478,7 @@ namespace Dalamud.Interface
             var gamepadEnabled = (ImGui.GetIO().BackendFlags & ImGuiBackendFlags.HasGamepad) > 0;
 
             // NOTE (Chiv) Activate ImGui navigation  via L1+L3 press
-            // (mimicking to how mouse navigation is activated via L1+R3 press in game).
+            // (mimicking how mouse navigation is activated via L1+R3 press in game).
             if (gamepadEnabled
                 && this.dalamud.ClientState.GamepadState.Raw(GamepadButtons.L1) > 0
                 && this.dalamud.ClientState.GamepadState.Pressed(GamepadButtons.L3) > 0)

--- a/Dalamud/Interface/InterfaceManager.cs
+++ b/Dalamud/Interface/InterfaceManager.cs
@@ -488,6 +488,7 @@ namespace Dalamud.Interface
             {
                 ImGui.GetIO().ConfigFlags ^= ImGuiConfigFlags.NavEnableGamepad;
                 this.dalamud.ClientState.GamepadState.NavEnableGamepad ^= true;
+                this.dalamud.DalamudUi.ToggleGamePadNotifierWindow();
             }
 
             if (gamepadEnabled

--- a/Dalamud/Interface/InterfaceManager.cs
+++ b/Dalamud/Interface/InterfaceManager.cs
@@ -304,6 +304,9 @@ namespace Dalamud.Interface
                     ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.NavEnableSetMousePos;
                 }
 
+                // NOTE (Chiv) Explicitly deactivate on dalamud boot
+                ImGui.GetIO().ConfigFlags &= ~ImGuiConfigFlags.NavEnableGamepad;
+
                 ImGuiHelpers.MainViewport = ImGui.GetMainViewport();
 
                 Log.Information("[IM] Scene & ImGui setup OK!");
@@ -484,7 +487,7 @@ namespace Dalamud.Interface
                 && this.dalamud.ClientState.GamepadState.Pressed(GamepadButtons.L3) > 0)
             {
                 ImGui.GetIO().ConfigFlags ^= ImGuiConfigFlags.NavEnableGamepad;
-                this.dalamud.DalamudUi.TogglePluginInstaller();
+                this.dalamud.ClientState.GamepadState.NavEnableGamepad ^= true;
             }
 
             if (gamepadEnabled

--- a/Dalamud/Interface/InterfaceManager.cs
+++ b/Dalamud/Interface/InterfaceManager.cs
@@ -509,6 +509,11 @@ namespace Dalamud.Interface
                 ImGui.GetIO().NavInputs[(int)ImGuiNavInput.FocusNext] = this.dalamud.ClientState.GamepadState.Raw(GamepadButtons.R1);
                 ImGui.GetIO().NavInputs[(int)ImGuiNavInput.TweakSlow] = this.dalamud.ClientState.GamepadState.Raw(GamepadButtons.L2);
                 ImGui.GetIO().NavInputs[(int)ImGuiNavInput.TweakFast] = this.dalamud.ClientState.GamepadState.Raw(GamepadButtons.R2);
+
+                if (this.dalamud.ClientState.GamepadState.Pressed(GamepadButtons.R3) > 0)
+                {
+                    this.dalamud.DalamudUi.TogglePluginInstaller();
+                }
             }
         }
 


### PR DESCRIPTION
- Alongside a settings option and the ability for plugins to query gamepad state.
  Plugins cannot, however, as of now set an input as 'handled' and block it for the game.
- Switch between letting the game or ImGui handling input via L1+L3 
  (mimicking how mouse navigation is activated via L1+R3 press in game)
- Control ImGui windows via the gamepad in accordance to the proposed button mapping
  https://www.dearimgui.org/controls_sheets/imgui%20controls%20v6%20-%20Xbox.png
- Whether game or ImGui is receiving gamepad input can be be checked via
  `(ImGui.GetIO().ConfigFlags & ImGuiConfigFlags.NavEnableGamepad) > 0`

Potential points of discussion:
- Buttom combo for activating ImGui gamepad control and blocking game gamepad is not configureable
- Plugins can query button state but not subsribe to e.g. an event to e.g. 'handle'
  and supress a button to the game.
  I was not sure whether that is a desireable feature and how to got about
  implementing it so I left it out for now
- Upon activating gamepad control for ImGui, the plugin installer window is _toggled_.
  This allows the user to access almost all relevant settings and plugin configs.
  I think that intead of a toggle an explicit show/hide would be better, however, 
  there is only a ShowPluginInstaller() method, no hide, and I did not want to introduce
  such a big API change.
- There are some quirks with blocking the games input and some decisions with different
  drawbacks needs to be made. Please have a look at the comment starting `GamepadState.cs:197`
  For convenience sake, it is copied down below.

// NOTE (Chiv) Zeroing `ButtonsRaw` destroys `ButtonPressed`, `ButtonReleased`
// and `ButtonRepeat` as the game uses the RAW input to determine those (apparently).
// It does block, however, all input to the game.
// Leaving `ButtonsRaw` as it is and only zeroing the other leaves e.g. long-hold L2/R2
// and the digipad (in some situations, but thankfully not in menus) functional.
// We can either:
// (a) Explicitly only set L2/R2/Digipad to 0 (and destroy their `ButtonPressed` field) => Needs to be documented, or
// (b) ignore it as so far it seems only a 'visual' error
//      (L2/R2 being held down activates CrossHotBar but activating an ability is impossible because of the others blocked input,
//      Digipad is ignored in menus but without any menu's  one still switches target or party members, but cannot interact with them
//      because of the other blocked input)
// `ButtonPressed` is pretty useful so we opt-in to (b).
// This is debatable.
// ImGui itself does not care either way as it uses the Raw values and does its own state handling.
