### PR TITLE
Fix Actor's HitboxRadius' offset

### DIFF
--- a/Dalamud/Game/ClientState/Structs/Actor.cs
+++ b/Dalamud/Game/ClientState/Structs/Actor.cs
@@ -20,7 +20,7 @@ namespace Dalamud.Game.ClientState.Structs
         public const int YalmDistanceFromPlayerY = 146;      // 0x0092 Distance
         public const int Position = 160;                     // 0x00A0 (X,Z,Y)
         public const int Rotation = 176;                     // 0x00B0 Heading
-        public const int HitboxRadius = 190;
+        public const int HitboxRadius = 192;
         public const int CurrentHp = 452;                    // 0x01C4 HPCurrent
         public const int MaxHp = 456;                        // 0x01C8 HPMax
         public const int CurrentMp = 460;                    // 0x01CC MPCurrent

--- a/Dalamud/Game/ClientState/Structs/Actor.cs
+++ b/Dalamud/Game/ClientState/Structs/Actor.cs
@@ -20,7 +20,7 @@ namespace Dalamud.Game.ClientState.Structs
         public const int YalmDistanceFromPlayerY = 146;      // 0x0092 Distance
         public const int Position = 160;                     // 0x00A0 (X,Z,Y)
         public const int Rotation = 176;                     // 0x00B0 Heading
-        public const int HitboxRadius = 192;
+        public const int HitboxRadius = 192;                 // 0x00C0
         public const int CurrentHp = 452;                    // 0x01C4 HPCurrent
         public const int MaxHp = 456;                        // 0x01C8 HPMax
         public const int CurrentMp = 460;                    // 0x01CC MPCurrent


### PR DESCRIPTION
According to [FFXIVAPP](https://github.com/FFXIVAPP/sharlayan-resources/blob/master/structures/5.4/x64.json) the proper offset for an Actor's HitboxRadius is 192 (or 0xC0)