### PR TITLE
Add batch number to PF listing args

### DIFF
--- a/Dalamud/Game/Internal/Gui/PartyFinderGui.cs
+++ b/Dalamud/Game/Internal/Gui/PartyFinderGui.cs
@@ -80,7 +80,7 @@ namespace Dalamud.Game.Internal.Gui {
                 }
 
                 var listing = new PartyFinderListing(packet.listings[i], Dalamud.Data, Dalamud.SeStringManager);
-                var args = new PartyFinderListingEventArgs();
+                var args = new PartyFinderListingEventArgs(packet.batchNumber);
                 ReceiveListing?.Invoke(listing, args);
 
                 if (args.Visible) {
@@ -112,6 +112,12 @@ namespace Dalamud.Game.Internal.Gui {
     }
 
     public class PartyFinderListingEventArgs {
+        public int BatchNumber { get; }
+
         public bool Visible { get; set; } = true;
+
+        internal PartyFinderListingEventArgs(int batchNumber) {
+            BatchNumber = batchNumber;
+        }
     }
 }

--- a/Dalamud/Game/Internal/Gui/Structs/PartyFinder.cs
+++ b/Dalamud/Game/Internal/Gui/Structs/PartyFinder.cs
@@ -16,7 +16,7 @@ namespace Dalamud.Game.Internal.Gui.Structs {
 
         [StructLayout(LayoutKind.Sequential)]
         public readonly struct Packet {
-            private readonly int unk0;
+            public readonly int batchNumber;
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
             private readonly byte[] padding1;


### PR DESCRIPTION
Useful for detecting when to invalidate a cache of previously-received listings. The batch number increments by one each time a batch of PF listing packets are sent.