### PR TITLE
Swap plugins and settings in aers menu thingy

### DIFF
--- a/Dalamud/Game/Addon/DalamudSystemMenu.cs
+++ b/Dalamud/Game/Addon/DalamudSystemMenu.cs
@@ -114,15 +114,15 @@ namespace Dalamud.Game.Addon
             atkValueChangeType(secondStringEntry, ValueType.String);
 
             // do this the most terrible way possible since im lazy
-            var bytes = stackalloc byte[17];
-            Marshal.Copy(System.Text.Encoding.ASCII.GetBytes("Dalamud Settings"), 0, new IntPtr(bytes), 16);
-            bytes[16] = 0x0;
+            var bytes = stackalloc byte[16];
+            Marshal.Copy(System.Text.Encoding.ASCII.GetBytes("Dalamud Plugins"), 0, new IntPtr(bytes), 15);
+            bytes[15] = 0x0;
 
             atkValueSetString(firstStringEntry, bytes); // this allocs the string properly using the game's allocators and copies it, so we dont have to worry about memory fuckups
 
-            var bytes2 = stackalloc byte[16];
-            Marshal.Copy(System.Text.Encoding.ASCII.GetBytes("Dalamud Plugins"), 0, new IntPtr(bytes2), 15);
-            bytes2[15] = 0x0;
+            var bytes2 = stackalloc byte[17];
+            Marshal.Copy(System.Text.Encoding.ASCII.GetBytes("Dalamud Settings"), 0, new IntPtr(bytes2), 16);
+            bytes2[16] = 0x0;
 
             atkValueSetString(secondStringEntry, bytes2);
 
@@ -137,11 +137,11 @@ namespace Dalamud.Game.Addon
         {
             if (commandId == 69420)
             {
-                this.dalamud.DalamudUi.OpenSettings();
+                this.dalamud.DalamudUi.OpenPluginInstaller();
             }
             else if (commandId == 69421)
             {
-                this.dalamud.DalamudUi.OpenPluginInstaller();
+                this.dalamud.DalamudUi.OpenSettings();
             }
             else
             {


### PR DESCRIPTION
Hello,

I would like to present my suggestion: swapping plugins and settings in aers menu thingy!
You would probably ask: "Why, does it even matter?". Yes, it does!

See, you usually open the plugins window more often than the settings window.
This swap will save you ONE key press (huge!) Esc => num 0 instead of Esc => num 2 => num 0.
Settings are also typically the last menu; therefore, it makes sense to place it second instead of first.

Bonus goat picture if you're not convinced yet:
![Trust in me](https://cdn.drawception.com/images/panels/2012/4-30/6e5QTgXnga-16.png)

Best regards,
Aireil