### PR TITLE
Send strings instead of ulongs to Universalis

### DIFF
--- a/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisHistoryEntry.cs
+++ b/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisHistoryEntry.cs
@@ -18,10 +18,10 @@ namespace Dalamud.Game.Network.MarketBoardUploaders.Universalis {
         public bool OnMannequin { get; set; }
 
         [JsonProperty("sellerID")]
-        public ulong SellerId { get; set; }
+        public string SellerId { get; set; }
 
         [JsonProperty("buyerID")]
-        public ulong BuyerId { get; set; }
+        public string BuyerId { get; set; }
 
         [JsonProperty("timestamp")]
         public long Timestamp { get; set; }

--- a/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisHistoryUploadRequest.cs
+++ b/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisHistoryUploadRequest.cs
@@ -13,6 +13,6 @@ namespace Dalamud.Game.Network.MarketBoardUploaders.Universalis {
         public List<UniversalisHistoryEntry> Entries { get; set; }
 
         [JsonProperty("uploaderID")]
-        public ulong UploaderId { get; set; }
+        public string UploaderId { get; set; }
     }
 }

--- a/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisItemListingsEntry.cs
+++ b/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisItemListingsEntry.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Dalamud.Game.Network.MarketBoardUploaders.Universalis {
     internal class UniversalisItemListingsEntry {
         [JsonProperty("listingID")]
-        public ulong ListingId { get; set; }
+        public string ListingId { get; set; }
 
         [JsonProperty("hq")]
         public bool Hq { get; set; }
@@ -19,7 +19,7 @@ namespace Dalamud.Game.Network.MarketBoardUploaders.Universalis {
         public string RetainerName { get; set; }
 
         [JsonProperty("retainerID")]
-        public ulong RetainerId { get; set; }
+        public string RetainerId { get; set; }
 
         [JsonProperty("creatorName")]
         public string CreatorName { get; set; }
@@ -28,10 +28,10 @@ namespace Dalamud.Game.Network.MarketBoardUploaders.Universalis {
         public bool OnMannequin { get; set; }
 
         [JsonProperty("sellerID")]
-        public ulong SellerId { get; set; }
+        public string SellerId { get; set; }
 
         [JsonProperty("creatorID")]
-        public ulong CreatorId { get; set; }
+        public string CreatorId { get; set; }
 
         [JsonProperty("stainID")]
         public int StainId { get; set; }

--- a/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisItemListingsUploadRequest.cs
+++ b/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisItemListingsUploadRequest.cs
@@ -13,6 +13,6 @@ namespace Dalamud.Game.Network.MarketBoardUploaders.Universalis {
         public List<UniversalisItemListingsEntry> Listings { get; set; }
 
         [JsonProperty("uploaderID")]
-        public ulong UploaderId { get; set; }
+        public string UploaderId { get; set; }
     }
 }

--- a/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
+++ b/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
@@ -29,17 +29,17 @@ namespace Dalamud.Game.Network.Universalis.MarketBoardUploaders {
 
                 var listingsRequestObject = new UniversalisItemListingsUploadRequest();
                 listingsRequestObject.WorldId = this.dalamud.ClientState.LocalPlayer?.CurrentWorld.Id ?? 0;
-                listingsRequestObject.UploaderId = uploader;
+                listingsRequestObject.UploaderId = uploader.ToString();
                 listingsRequestObject.ItemId = request.CatalogId;
 
                 listingsRequestObject.Listings = new List<UniversalisItemListingsEntry>();
                 foreach (var marketBoardItemListing in request.Listings) {
                     var universalisListing = new UniversalisItemListingsEntry {
                         Hq = marketBoardItemListing.IsHq,
-                        SellerId = marketBoardItemListing.RetainerOwnerId,
+                        SellerId = marketBoardItemListing.RetainerOwnerId.ToString(),
                         RetainerName = marketBoardItemListing.RetainerName,
-                        RetainerId = marketBoardItemListing.RetainerId,
-                        CreatorId = marketBoardItemListing.ArtisanId,
+                        RetainerId = marketBoardItemListing.RetainerId.ToString(),
+                        CreatorId = marketBoardItemListing.ArtisanId.ToString(),
                         CreatorName = marketBoardItemListing.PlayerName,
                         OnMannequin = marketBoardItemListing.OnMannequin,
                         LastReviewTime = ((DateTimeOffset) marketBoardItemListing.LastReviewTime).ToUnixTimeSeconds(),
@@ -64,7 +64,7 @@ namespace Dalamud.Game.Network.Universalis.MarketBoardUploaders {
 
                 var historyRequestObject = new UniversalisHistoryUploadRequest();
                 historyRequestObject.WorldId = this.dalamud.ClientState.LocalPlayer?.CurrentWorld.Id ?? 0;
-                historyRequestObject.UploaderId = uploader;
+                historyRequestObject.UploaderId = uploader.ToString();
                 historyRequestObject.ItemId = request.CatalogId;
 
                 historyRequestObject.Entries = new List<UniversalisHistoryEntry>();
@@ -93,7 +93,7 @@ namespace Dalamud.Game.Network.Universalis.MarketBoardUploaders {
             {
                 var taxRatesRequest = new UniversalisTaxUploadRequest();
                 taxRatesRequest.WorldId = this.dalamud.ClientState.LocalPlayer?.CurrentWorld.Id ?? 0;
-                taxRatesRequest.UploaderId = this.dalamud.ClientState.LocalContentId;
+                taxRatesRequest.UploaderId = this.dalamud.ClientState.LocalContentId.ToString();
 
                 taxRatesRequest.TaxData = new UniversalisTaxData {
                     LimsaLominsa = taxRates.LimsaLominsaTax,

--- a/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisTaxUploadRequest.cs
+++ b/Dalamud/Game/Network/MarketBoardUploaders/Universalis/UniversalisTaxUploadRequest.cs
@@ -10,7 +10,7 @@ namespace Dalamud.Game.Network.MarketBoardUploaders.Universalis
     class UniversalisTaxUploadRequest
     {
         [JsonProperty("uploaderID")]
-        public ulong UploaderId { get; set; }
+        public string UploaderId { get; set; }
 
         [JsonProperty("worldID")]
         public uint WorldId { get; set; }


### PR DESCRIPTION
JavaScript does not play nice when deserializing `ulong`s.
The only reason nobody's noticed until now is because it's taken this long for someone to actually try using them as IDs, or because Teamcraft fixed this earlier.