### PR TITLE
fix: component demo icon display

### DIFF
--- a/Dalamud/Interface/Components/ComponentDemoWindow.cs
+++ b/Dalamud/Interface/Components/ComponentDemoWindow.cs
@@ -71,9 +71,8 @@ namespace Dalamud.Interface.Components
             if (ImGui.BeginPopup("IconButtonDemoPopup"))
             {
                 ImGui.Text("You clicked!");
+                ImGui.EndPopup();
             }
-
-            ImGui.EndPopup();
         }
 
         private static void TextWithLabelDemo()


### PR DESCRIPTION
Fix display issue on Components Demo. 
https://discord.com/channels/581875019861328007/584827243617058816/840502137968525312

I thought this was working fine before, but doesn't seem to like the end popup outside of the if statement now.