### PR TITLE
[BREAKINGish] Simplify hooks

### DIFF
--- a/Dalamud/Game/Addon/DalamudSystemMenu.cs
+++ b/Dalamud/Game/Addon/DalamudSystemMenu.cs
@@ -32,10 +32,7 @@ namespace Dalamud.Game.Addon
 
             var openSystemMenuAddress = this.dalamud.SigScanner.ScanText("E8 ?? ?? ?? ?? 32 C0 4C 8B AC 24 ?? ?? ?? ?? 48 8B 8D ?? ?? ?? ??");
 
-            this.hookAgentHudOpenSystemMenu = new Hook<AgentHudOpenSystemMenuPrototype>(
-                openSystemMenuAddress,
-                new AgentHudOpenSystemMenuPrototype(this.AgentHudOpenSystemMenuDetour),
-                this);
+            this.hookAgentHudOpenSystemMenu = new Hook<AgentHudOpenSystemMenuPrototype>(openSystemMenuAddress, this.AgentHudOpenSystemMenuDetour);
 
             var atkValueChangeTypeAddress =
                 this.dalamud.SigScanner.ScanText("E8 ?? ?? ?? ?? 45 84 F6 48 8D 4C 24 ??");
@@ -47,10 +44,7 @@ namespace Dalamud.Game.Addon
             this.atkValueSetString = Marshal.GetDelegateForFunctionPointer<AtkValueSetString>(atkValueSetStringAddress);
 
             var uiModuleRequestMainCommandAddress = this.dalamud.SigScanner.ScanText("40 53 56 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 8B 01 8B DA 48 8B F1 FF 90 ?? ?? ?? ??");
-            this.hookUiModuleRequestMainCommand = new Hook<UiModuleRequestMainCommand>(
-                uiModuleRequestMainCommandAddress,
-                new UiModuleRequestMainCommand(this.UiModuleRequestMainCommandDetour),
-                this);
+            this.hookUiModuleRequestMainCommand = new Hook<UiModuleRequestMainCommand>(uiModuleRequestMainCommandAddress, this.UiModuleRequestMainCommandDetour);
         }
 
         private delegate void AgentHudOpenSystemMenuPrototype(void* thisPtr, AtkValue* atkValueArgs, uint menuSize);

--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -106,7 +106,7 @@ namespace Dalamud.Game.ClientState
 
             Log.Verbose("SetupTerritoryType address {SetupTerritoryType}", this.address.SetupTerritoryType);
 
-            this.setupTerritoryTypeHook = new Hook<SetupTerritoryTypeDelegate>(this.address.SetupTerritoryType, new SetupTerritoryTypeDelegate(this.SetupTerritoryTypeDetour), this);
+            this.setupTerritoryTypeHook = new Hook<SetupTerritoryTypeDelegate>(this.address.SetupTerritoryType, this.SetupTerritoryTypeDetour);
 
             dalamud.Framework.OnUpdateEvent += this.FrameworkOnOnUpdateEvent;
             dalamud.NetworkHandlers.CfPop += this.NetworkHandlersOnCfPop;

--- a/Dalamud/Game/Internal/Framework.cs
+++ b/Dalamud/Game/Internal/Framework.cs
@@ -159,13 +159,13 @@ namespace Dalamud.Game.Internal
             // .rdata:00000001411F2000 dq offset Xiv__Framework__update
 
             var pUpdate = Marshal.ReadIntPtr(vtable, IntPtr.Size * 4);
-            this.updateHook = new Hook<OnUpdateDetour>(pUpdate, new OnUpdateDetour(this.HandleFrameworkUpdate), this);
+            this.updateHook = new Hook<OnUpdateDetour>(pUpdate, this.HandleFrameworkUpdate);
 
             var pDestroy = Marshal.ReadIntPtr(vtable, IntPtr.Size * 3);
-            this.destroyHook = new Hook<OnDestroyDetour>(pDestroy, new OnDestroyDelegate(this.HandleFrameworkDestroy), this);
+            this.destroyHook = new Hook<OnDestroyDetour>(pDestroy, this.HandleFrameworkDestroy);
 
             var pRealDestroy = Marshal.ReadIntPtr(vtable, IntPtr.Size * 2);
-            this.realDestroyHook = new Hook<OnRealDestroyDelegate>(pRealDestroy, new OnRealDestroyDelegate(this.HandleRealDestroy), this);
+            this.realDestroyHook = new Hook<OnRealDestroyDelegate>(pRealDestroy, this.HandleRealDestroy);
         }
 
         private bool HandleFrameworkUpdate(IntPtr framework)

--- a/Dalamud/Game/Internal/Gui/ChatGui.cs
+++ b/Dalamud/Game/Internal/Gui/ChatGui.cs
@@ -45,9 +45,9 @@ namespace Dalamud.Game.Internal.Gui
 
             Log.Verbose("Chat manager address {ChatManager}", this.address.BaseAddress);
 
-            this.printMessageHook = new Hook<PrintMessageDelegate>(this.address.PrintMessage, new PrintMessageDelegate(this.HandlePrintMessageDetour), this);
-            this.populateItemLinkHook = new Hook<PopulateItemLinkDelegate>(this.address.PopulateItemLinkObject, new PopulateItemLinkDelegate(this.HandlePopulateItemLinkDetour), this);
-            this.interactableLinkClickedHook = new Hook<InteractableLinkClickedDelegate>(this.address.InteractableLinkClicked, new InteractableLinkClickedDelegate(this.InteractableLinkClickedDetour));
+            this.printMessageHook = new Hook<PrintMessageDelegate>(this.address.PrintMessage, this.HandlePrintMessageDetour);
+            this.populateItemLinkHook = new Hook<PopulateItemLinkDelegate>(this.address.PopulateItemLinkObject, this.HandlePopulateItemLinkDetour);
+            this.interactableLinkClickedHook = new Hook<InteractableLinkClickedDelegate>(this.address.InteractableLinkClicked, this.InteractableLinkClickedDetour);
         }
 
         /// <summary>

--- a/Dalamud/Game/Internal/Gui/GameGui.cs
+++ b/Dalamud/Game/Internal/Gui/GameGui.cs
@@ -67,13 +67,13 @@ namespace Dalamud.Game.Internal.Gui
             this.PartyFinder = new PartyFinderGui(scanner, dalamud);
             this.Toast = new ToastGui(scanner, dalamud);
 
-            this.setGlobalBgmHook = new Hook<SetGlobalBgmDelegate>(this.address.SetGlobalBgm, new SetGlobalBgmDelegate(this.HandleSetGlobalBgmDetour), this);
-            this.handleItemHoverHook = new Hook<HandleItemHoverDelegate>(this.address.HandleItemHover, new HandleItemHoverDelegate(this.HandleItemHoverDetour), this);
+            this.setGlobalBgmHook = new Hook<SetGlobalBgmDelegate>(this.address.SetGlobalBgm, this.HandleSetGlobalBgmDetour);
+            this.handleItemHoverHook = new Hook<HandleItemHoverDelegate>(this.address.HandleItemHover, this.HandleItemHoverDetour);
 
-            this.handleItemOutHook = new Hook<HandleItemOutDelegate>(this.address.HandleItemOut, new HandleItemOutDelegate(this.HandleItemOutDetour), this);
+            this.handleItemOutHook = new Hook<HandleItemOutDelegate>(this.address.HandleItemOut, this.HandleItemOutDetour);
 
-            this.handleActionHoverHook = new Hook<HandleActionHoverDelegate>(this.address.HandleActionHover, new HandleActionHoverDelegate(this.HandleActionHoverDetour), this);
-            this.handleActionOutHook = new Hook<HandleActionOutDelegate>(this.address.HandleActionOut, new HandleActionOutDelegate(this.HandleActionOutDetour), this);
+            this.handleActionHoverHook = new Hook<HandleActionHoverDelegate>(this.address.HandleActionHover, this.HandleActionHoverDetour);
+            this.handleActionOutHook = new Hook<HandleActionOutDelegate>(this.address.HandleActionOut, this.HandleActionOutDetour);
 
             this.getUIObject = Marshal.GetDelegateForFunctionPointer<GetUIObjectDelegate>(this.address.GetUIObject);
 
@@ -81,7 +81,7 @@ namespace Dalamud.Game.Internal.Gui
 
             this.screenToWorldNative = Marshal.GetDelegateForFunctionPointer<ScreenToWorldNativeDelegate>(this.address.ScreenToWorld);
 
-            this.toggleUiHideHook = new Hook<ToggleUiHideDelegate>(this.address.ToggleUiHide, new ToggleUiHideDelegate(this.ToggleUiHideDetour), this);
+            this.toggleUiHideHook = new Hook<ToggleUiHideDelegate>(this.address.ToggleUiHide, this.ToggleUiHideDetour);
 
             this.GetBaseUIObject = Marshal.GetDelegateForFunctionPointer<GetBaseUIObjectDelegate>(this.address.GetBaseUIObject);
             this.getUIObjectByName = Marshal.GetDelegateForFunctionPointer<GetUIObjectByNameDelegate>(this.address.GetUIObjectByName);

--- a/Dalamud/Game/Internal/Network/GameNetwork.cs
+++ b/Dalamud/Game/Internal/Network/GameNetwork.cs
@@ -37,9 +37,8 @@ namespace Dalamud.Game.Internal.Network
             Log.Verbose("ProcessZonePacketDown address {ProcessZonePacketDown}", this.address.ProcessZonePacketDown);
             Log.Verbose("ProcessZonePacketUp address {ProcessZonePacketUp}", this.address.ProcessZonePacketUp);
 
-            this.processZonePacketDownHook = new Hook<ProcessZonePacketDownDelegate>(this.address.ProcessZonePacketDown, new ProcessZonePacketDownDelegate(this.ProcessZonePacketDownDetour), this);
-
-            this.processZonePacketUpHook = new Hook<ProcessZonePacketUpDelegate>(this.address.ProcessZonePacketUp, new ProcessZonePacketUpDelegate(this.ProcessZonePacketUpDetour), this);
+            this.processZonePacketDownHook = new Hook<ProcessZonePacketDownDelegate>(this.address.ProcessZonePacketDown, this.ProcessZonePacketDownDetour);
+            this.processZonePacketUpHook = new Hook<ProcessZonePacketUpDelegate>(this.address.ProcessZonePacketUp, this.ProcessZonePacketUpDetour);
         }
 
         /// <summary>

--- a/Dalamud/Game/Internal/Resource/ResourceManager.cs
+++ b/Dalamud/Game/Internal/Resource/ResourceManager.cs
@@ -35,9 +35,8 @@ namespace Dalamud.Game.Internal.File
             Log.Verbose("GetResourceAsync address {GetResourceAsync}", this.address.GetResourceAsync);
             Log.Verbose("GetResourceSync address {GetResourceSync}", this.address.GetResourceSync);
 
-            this.getResourceAsyncHook = new Hook<GetResourceAsyncDelegate>(this.address.GetResourceAsync, new GetResourceAsyncDelegate(this.GetResourceAsyncDetour), this);
-
-            this.getResourceSyncHook = new Hook<GetResourceSyncDelegate>(this.address.GetResourceSync, new GetResourceSyncDelegate(this.GetResourceSyncDetour), this);
+            this.getResourceAsyncHook = new Hook<GetResourceAsyncDelegate>(this.address.GetResourceAsync, this.GetResourceAsyncDetour);
+            this.getResourceSyncHook = new Hook<GetResourceSyncDelegate>(this.address.GetResourceSync, this.GetResourceSyncDetour);
         }
 
         [UnmanagedFunctionPointer(CallingConvention.ThisCall)]

--- a/Dalamud/Hooking/Hook.cs
+++ b/Dalamud/Hooking/Hook.cs
@@ -26,13 +26,25 @@ namespace Dalamud.Hooking
         /// </summary>
         /// <param name="address">A memory address to install a hook.</param>
         /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
-        /// <param name="callbackParam">A callback object which can be accessed within the detour.</param>
-        public Hook(IntPtr address, Delegate detour, object callbackParam = null)
+        public Hook(IntPtr address, T detour)
         {
-            this.hookInfo = LocalHook.Create(address, detour, callbackParam); // Installs a hook here
+            this.hookInfo = LocalHook.Create(address, detour, null); // Installs a hook here
             this.address = address;
             this.original = Marshal.GetDelegateForFunctionPointer<T>(this.hookInfo.HookBypassAddress);
             HookInfo.TrackedHooks.Add(new HookInfo() { Delegate = detour, Hook = this, Assembly = Assembly.GetCallingAssembly() });
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Hook{T}"/> class.
+        /// Hook is not activated until Enable() method is called.
+        /// </summary>
+        /// <param name="address">A memory address to install a hook.</param>
+        /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
+        /// <param name="callbackParam">A callback object which can be accessed within the detour.</param>
+        [Obsolete("There is no need to specify new YourDelegateType or callbackParam", true)]
+        public Hook(IntPtr address, Delegate detour, object callbackParam = null)
+            : this(address, detour as T)
+        {
         }
 
         /// <summary>
@@ -87,15 +99,26 @@ namespace Dalamud.Hooking
         /// <param name="moduleName">A name of the module currently loaded in the memory. (e.g. ws2_32.dll).</param>
         /// <param name="exportName">A name of the exported function name (e.g. send).</param>
         /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
-        /// <param name="callbackParam">A callback object which can be accessed within the detour.</param>
         /// <returns>The hook with the supplied parameters.</returns>
-        public static Hook<T> FromSymbol(string moduleName, string exportName, Delegate detour, object callbackParam = null)
+        public static Hook<T> FromSymbol(string moduleName, string exportName, T detour)
         {
             // Get a function address from the symbol name.
             var address = LocalHook.GetProcAddress(moduleName, exportName);
 
-            return new Hook<T>(address, detour, callbackParam);
+            return new Hook<T>(address, detour);
         }
+
+        /// <summary>
+        /// Creates a hook. Hooking address is inferred by calling to GetProcAddress() function.
+        /// Hook is not activated until Enable() method is called.
+        /// </summary>
+        /// <param name="moduleName">A name of the module currently loaded in the memory. (e.g. ws2_32.dll).</param>
+        /// <param name="exportName">A name of the exported function name (e.g. send).</param>
+        /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
+        /// <param name="callbackParam">A callback object which can be accessed within the detour.</param>
+        /// <returns>The hook with the supplied parameters.</returns>
+        [Obsolete("There is no need to specify new YourDelegateType or callbackParam", true)]
+        public static Hook<T> FromSymbol(string moduleName, string exportName, Delegate detour, object callbackParam = null) => FromSymbol(moduleName, exportName, detour as T);
 
         /// <summary>
         /// Remove a hook from the current process.

--- a/Dalamud/Interface/InterfaceManager.cs
+++ b/Dalamud/Interface/InterfaceManager.cs
@@ -120,11 +120,11 @@ namespace Dalamud.Interface
             Log.Verbose("Present address {Present}", this.address.Present);
             Log.Verbose("ResizeBuffers address {ResizeBuffers}", this.address.ResizeBuffers);
 
-            this.setCursorHook = new Hook<SetCursorDelegate>(setCursorAddr, new SetCursorDelegate(this.SetCursorDetour), this);
+            this.setCursorHook = new Hook<SetCursorDelegate>(setCursorAddr, this.SetCursorDetour);
 
-            this.presentHook = new Hook<PresentDelegate>(this.address.Present, new PresentDelegate(this.PresentDetour), this);
+            this.presentHook = new Hook<PresentDelegate>(this.address.Present, this.PresentDetour);
 
-            this.resizeBuffersHook = new Hook<ResizeBuffersDelegate>(this.address.ResizeBuffers, new ResizeBuffersDelegate(this.ResizeBuffersDetour), this);
+            this.resizeBuffersHook = new Hook<ResizeBuffersDelegate>(this.address.ResizeBuffers, this.ResizeBuffersDetour);
         }
 
         [UnmanagedFunctionPointer(CallingConvention.ThisCall)]


### PR DESCRIPTION
This simplifies hooks and is already implemented in the net5 branch.  It is currently breaking for NEW COMPILATION ONLY via  `[Obsolete("<reason>", true)]`. The true makes the obsolete attribute throw an error on compilation. So existing plugins won't break, but if anyone wants to compile, they'll need to update. If you would prefer to make this change later I'll take it out.

Our `Hook{T}` type already knows the delegate type. There is no need to have arg2 be of type `Delegate` when it could be of type `T`. 

In addition, arg3, the callbackParam is not even exposed in our API. It sets hookinfo.Callback, so remove it. You can already access `this` or anything else from within the hooked method context.

I tested this briefly on net472. Combo works as expected and Dalamud didn't blow up. 