### PR TITLE
The ultimate fix (for actor names)

### DIFF
--- a/Dalamud/Game/ClientState/Actors/Types/Actor.cs
+++ b/Dalamud/Game/ClientState/Actors/Types/Actor.cs
@@ -1,6 +1,7 @@
 using System;
-
+using System.Text;
 using Dalamud.Game.ClientState.Structs;
+using Serilog;
 
 namespace Dalamud.Game.ClientState.Actors.Types
 {
@@ -11,6 +12,8 @@ namespace Dalamud.Game.ClientState.Actors.Types
     {
         private readonly Structs.Actor actorStruct;
         private readonly Dalamud dalamud;
+
+        private string name;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Actor"/> class.
@@ -40,7 +43,33 @@ namespace Dalamud.Game.ClientState.Actors.Types
         /// <summary>
         /// Gets the displayname of this <see cref="Actor" />.
         /// </summary>
-        public string Name => this.ActorStruct.Name;
+        public string Name
+        {
+            get
+            {
+                if (this.name == null)
+                {
+                    var i = 0;
+                    for (; i < this.actorStruct.Name.Length; i++)
+                    {
+                        if (this.actorStruct.Name[i] == 0)
+                            break;
+                    }
+
+                    if (i == this.actorStruct.Name.Length)
+                    {
+                        this.name = Encoding.UTF8.GetString(this.actorStruct.Name);
+                        Log.Warning($"Warning: Actor name exceeds underlying struct array length (name={this.name})");
+                    }
+                    else
+                    {
+                        this.name = Encoding.UTF8.GetString(this.actorStruct.Name, 0, i);
+                    }
+                }
+
+                return this.name;
+            }
+        }
 
         /// <summary>
         /// Gets the actor ID of this <see cref="Actor" />.

--- a/Dalamud/Game/ClientState/Actors/Types/Actor.cs
+++ b/Dalamud/Game/ClientState/Actors/Types/Actor.cs
@@ -43,33 +43,7 @@ namespace Dalamud.Game.ClientState.Actors.Types
         /// <summary>
         /// Gets the displayname of this <see cref="Actor" />.
         /// </summary>
-        public string Name
-        {
-            get
-            {
-                if (this.name == null)
-                {
-                    var i = 0;
-                    for (; i < this.actorStruct.Name.Length; i++)
-                    {
-                        if (this.actorStruct.Name[i] == 0)
-                            break;
-                    }
-
-                    if (i == this.actorStruct.Name.Length)
-                    {
-                        this.name = Encoding.UTF8.GetString(this.actorStruct.Name);
-                        Log.Warning($"Warning: Actor name exceeds underlying struct array length (name={this.name})");
-                    }
-                    else
-                    {
-                        this.name = Encoding.UTF8.GetString(this.actorStruct.Name, 0, i);
-                    }
-                }
-
-                return this.name;
-            }
-        }
+        public string Name => this.name ??= Util.GetUTF8String(this.actorStruct.Name);
 
         /// <summary>
         /// Gets the actor ID of this <see cref="Actor" />.

--- a/Dalamud/Game/ClientState/Structs/Actor.cs
+++ b/Dalamud/Game/ClientState/Structs/Actor.cs
@@ -14,8 +14,8 @@ namespace Dalamud.Game.ClientState.Structs
         /// The actor name.
         /// </summary>
         [FieldOffset(ActorOffsets.Name)]
-        [MarshalAs(UnmanagedType.LPUTF8Str, SizeConst = 30)]
-        public string Name;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 30)]
+        public byte[] Name;
 
         /// <summary>
         /// The actor's internal id.

--- a/Dalamud/Util.cs
+++ b/Dalamud/Util.cs
@@ -165,5 +165,36 @@ namespace Dalamud
             NativeFunctions.MessageBox(Process.GetCurrentProcess().MainWindowHandle, message, caption, flags);
             Environment.Exit(-1);
         }
+
+        /// <summary>
+        /// Retrieve a UTF8 string from a null terminated byte array.
+        /// </summary>
+        /// <param name="array">A null terminated UTF8 byte array.</param>
+        /// <returns>A UTF8 encoded string.</returns>
+        public static string GetUTF8String(byte[] array)
+        {
+            var count = 0;
+            for (; count < array.Length; count++)
+            {
+                if (array[count] == 0)
+                    break;
+            }
+
+            string text;
+            if (count == array.Length)
+            {
+                text = Encoding.UTF8.GetString(array);
+                Log.Warning($"Warning: text exceeds underlying array length ({text})");
+            }
+            else
+            {
+                text = Encoding.UTF8.GetString(array, 0, count);
+            }
+
+            return text;
+        }
+
+        // TODO: Someone implement GetUTF8String with some IntPtr overloads.
+        // while(Marshal.ReadByte(0, sz) != 0) { sz++; }
     }
 }


### PR DESCRIPTION
Read the conversation [here](https://discord.com/channels/581875019861328007/653504487352303619/854685863002243092)

In .NET5 the previous band-aid actually causes an access violation, because LPUTF8Str will first attempt to read a pointer. It is an LP after all. Why this works in net472 at all is a mystery. Ultimately, Cara's fix was the correct one to begin with. I've added some caching of the name on top of that and an "oh-no" incase there is no `\0` in the byte array.