### PR TITLE
AntiDebug: persist state in config

### DIFF
--- a/Dalamud/Configuration/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/DalamudConfiguration.cs
@@ -139,6 +139,11 @@ namespace Dalamud.Configuration
         public bool IsGamepadNavigationEnabled { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not the anti-anti-debug check is enabled on startup.
+        /// </summary>
+        public bool IsAntiAntiDebugEnabled { get; set; } = false;
+
+        /// <summary>
         /// Load a configuration from the provided path.
         /// </summary>
         /// <param name="path">The path to load the configuration file from.</param>

--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -229,8 +229,11 @@ namespace Dalamud
                 this.Configuration = DalamudConfiguration.Load(this.StartInfo.ConfigurationPath);
 
                 this.AntiDebug = new AntiDebug(this.SigScanner);
+                if (this.Configuration.IsAntiAntiDebugEnabled)
+                    this.AntiDebug.Enable();
 #if DEBUG
-                this.AntiDebug.Enable();
+                if (!this.AntiDebug.IsEnabled)
+                    this.AntiDebug.Enable();
 #endif
 
                 Log.Information("[T2] AntiDebug OK!");

--- a/Dalamud/Game/Internal/AntiDebug.cs
+++ b/Dalamud/Game/Internal/AntiDebug.cs
@@ -35,7 +35,7 @@ namespace Dalamud.Game.Internal
         /// <summary>
         /// Gets a value indicating whether the anti-debugging is enabled.
         /// </summary>
-        public bool IsEnabled { get; private set; }
+        public bool IsEnabled { get; private set; } = false;
 
         /// <summary>
         /// Enables the anti-debugging by overwriting code in memory.

--- a/Dalamud/Interface/DalamudInterface.cs
+++ b/Dalamud/Interface/DalamudInterface.cs
@@ -198,7 +198,14 @@ namespace Dalamud.Interface
 
                         if (ImGui.MenuItem("Enable AntiDebug", null, this.dalamud.AntiDebug.IsEnabled))
                         {
-                            this.dalamud.AntiDebug.Enable();
+                            var newEnabled = !this.dalamud.AntiDebug.IsEnabled;
+                            if (newEnabled)
+                                this.dalamud.AntiDebug.Enable();
+                            else
+                                this.dalamud.AntiDebug.Disable();
+
+                            this.dalamud.Configuration.IsAntiAntiDebugEnabled = newEnabled;
+                            this.dalamud.Configuration.Save();
                         }
 
                         ImGui.Separator();


### PR DESCRIPTION
You have to manually re-enable anti-debug each time you restart the game with a release version of Dalamud. This fixes that by persisting the setting, which makes people like me who repeatedly crash the game at the title screen very happy