### PR TITLE
Fix #322: persist log level when set through menu

### DIFF
--- a/Dalamud/Configuration/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/DalamudConfiguration.cs
@@ -5,6 +5,7 @@ using System.IO;
 using Dalamud.Game.Text;
 using Newtonsoft.Json;
 using Serilog;
+using Serilog.Events;
 
 namespace Dalamud.Configuration
 {
@@ -12,7 +13,7 @@ namespace Dalamud.Configuration
     /// Class containing Dalamud settings.
     /// </summary>
     [Serializable]
-    internal class DalamudConfiguration
+    public class DalamudConfiguration
     {
         [JsonIgnore]
         private string configPath;
@@ -112,6 +113,11 @@ namespace Dalamud.Configuration
         /// Gets or sets a value indicating whether or not Dalamud should add buttons to the system menu.
         /// </summary>
         public bool DoButtonsSystemMenu { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the default Dalamud debug log level on startup.
+        /// </summary>
+        public LogEventLevel LogLevel { get; set; } = LogEventLevel.Information;
 
         /// <summary>
         /// Gets or sets a value indicating whether or not the debug log should scroll automatically.

--- a/Dalamud/Configuration/ThirdRepoSetting.cs
+++ b/Dalamud/Configuration/ThirdRepoSetting.cs
@@ -3,7 +3,7 @@ namespace Dalamud.Configuration
     /// <summary>
     /// Third party repository for dalamud plugins.
     /// </summary>
-    internal class ThirdRepoSetting
+    public class ThirdRepoSetting
     {
         /// <summary>
         /// Gets or sets the third party repo url.

--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -43,10 +43,12 @@ namespace Dalamud
         /// <param name="info">DalamudStartInfo instance.</param>
         /// <param name="loggingLevelSwitch">LoggingLevelSwitch to control Serilog level.</param>
         /// <param name="finishSignal">Signal signalling shutdown.</param>
-        public Dalamud(DalamudStartInfo info, LoggingLevelSwitch loggingLevelSwitch, ManualResetEvent finishSignal)
+        /// <param name="configuration">The Dalamud configuration.</param>
+        public Dalamud(DalamudStartInfo info, LoggingLevelSwitch loggingLevelSwitch, ManualResetEvent finishSignal, DalamudConfiguration configuration)
         {
             this.StartInfo = info;
             this.LogLevelSwitch = loggingLevelSwitch;
+            this.Configuration = configuration;
 
             this.baseDirectory = info.WorkingDirectory;
 
@@ -226,8 +228,6 @@ namespace Dalamud
         {
             try
             {
-                this.Configuration = DalamudConfiguration.Load(this.StartInfo.ConfigurationPath);
-
                 this.AntiDebug = new AntiDebug(this.SigScanner);
                 if (this.Configuration.IsAntiAntiDebugEnabled)
                     this.AntiDebug.Enable();

--- a/Dalamud/Interface/DalamudInterface.cs
+++ b/Dalamud/Interface/DalamudInterface.cs
@@ -190,6 +190,8 @@ namespace Dalamud.Interface
                                 if (ImGui.MenuItem(logLevel + "##logLevelSwitch", string.Empty, this.dalamud.LogLevelSwitch.MinimumLevel == logLevel))
                                 {
                                     this.dalamud.LogLevelSwitch.MinimumLevel = logLevel;
+                                    this.dalamud.Configuration.LogLevel = logLevel;
+                                    this.dalamud.Configuration.Save();
                                 }
                             }
 


### PR DESCRIPTION
Fixes #322. Saw this freebie in https://github.com/orgs/goatcorp/projects/1 and decided to do it. 

Potentially controversial parts: making the configuration public and loading it in the entry point. I could've set the log level in the tier2 load, but figured you'd really want the persisted log level as early as possible.