### PR TITLE
Plugin cleanup should respect LoadAllApiLevels

### DIFF
--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -514,7 +514,7 @@ namespace Dalamud.Plugin.Internal
                             if (!isVersion)
                             {
                                 Log.Debug($"Not a version, cleaning up {dir.FullName}");
-                                dir.Delete();
+                                dir.Delete(true);
                             }
 
                             return version;

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -558,7 +558,7 @@ namespace Dalamud.Plugin.Internal
                                     continue;
                                 }
 
-                                if (manifest.DalamudApiLevel < DalamudApiLevel)
+                                if (manifest.DalamudApiLevel < DalamudApiLevel && !this.dalamud.Configuration.LoadAllApiLevels)
                                 {
                                     Log.Information($"Lower API: cleaning up {versionDir.FullName}");
                                     versionDir.Delete(true);


### PR DESCRIPTION
#400 

Also fix a minor bug where the "not a version folder" does not delete recursively.