### PR TITLE
Fix 3rd party install button not working if also on main repo

### DIFF
--- a/Dalamud/Configuration/Internal/ThirdPartyRepoSettings.cs
+++ b/Dalamud/Configuration/Internal/ThirdPartyRepoSettings.cs
@@ -16,11 +16,6 @@ namespace Dalamud.Configuration
         public bool IsEnabled { get; set; }
 
         /// <summary>
-        /// Gets or sets a short name for the repo url.
-        /// </summary>
-        public string Name { get; set; }
-
-        /// <summary>
         /// Clone this object.
         /// </summary>
         /// <returns>A shallow copy of this object.</returns>

--- a/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
@@ -523,7 +523,8 @@ namespace Dalamud.Interface.Internal.Windows
                 }
                 else
                 {
-                    if (ImGui.Button(Locs.PluginButton_InstallVersion(versionString)))
+                    var buttonText = Locs.PluginButton_InstallVersion(versionString);
+                    if (ImGui.Button($"{buttonText}##{buttonText}{index}"))
                     {
                         this.installStatus = OperationStatus.InProgress;
 

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -198,9 +198,10 @@ namespace Dalamud.Plugin.Internal
                     {
                         // Not a plugin
                     }
-                    catch (Exception ex)
+                    catch
                     {
-                        Log.Error(ex, "During boot plugin load, an unexpected error occurred");
+                        // The error should already be printed. This is just to signify which DLL it came from.
+                        Log.Error($"During boot plugin load, an unexpected error occurred: {pluginDef.DllFile}");
                     }
                 }
             }

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -493,6 +493,7 @@ namespace Dalamud.Plugin.Internal
             this.installedPlugins.Remove(plugin);
             PluginLocations.Remove(plugin.AssemblyName.FullName);
 
+            this.NotifyAvailablePluginsChanged();
             this.NotifyInstalledPluginsChanged();
         }
 

--- a/Dalamud/Troubleshooting.cs
+++ b/Dalamud/Troubleshooting.cs
@@ -52,7 +52,7 @@ namespace Dalamud
             public PluginManifest[] LoadedPlugins { get; set; }
 
             public string DalamudVersion { get; set; }
-            
+
             public string DalamudGitHash { get; set; }
 
             public string GameVersion { get; set; }


### PR DESCRIPTION
Fixes #399 

Also:
- after uninstall, plugins should show as available again
- Remove unused property in 3rd party plugin object
- Double stacktrace on plugin load during boot
- Excess whitespace linter complained about

EDIT
Committed on top of the fix plugin cleanup PR, will wait for that to be merged to I can rebase.