### PR TITLE
Expose ChatHandler.MakeItalics as a little helper method

### DIFF
--- a/Dalamud/Game/ChatHandlers.cs
+++ b/Dalamud/Game/ChatHandlers.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -11,7 +10,6 @@ using CheapLoc;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
-using Dalamud.Interface.Internal.Windows;
 using Serilog;
 
 namespace Dalamud.Game
@@ -121,24 +119,21 @@ namespace Dalamud.Game
         /// </summary>
         public string LastLink { get; private set; }
 
-        // /// <summary>
-        // /// Convert a string to SeString and wrap in italics payloads.
-        // /// </summary>
-        // /// <param name="text">Text to convert.</param>
-        // /// <returns>SeString payload of italicized text.</returns>
-        // private static SeString MakeItalics(string text)
-        // {
-        //     // TODO: when the code OnCharMessage is switched to SeString, this can be a straight insertion of the
-        //     // italics payloads only, and be a lot cleaner
-        //     var italicString = new SeString(new List<Payload>(new Payload[]
-        //     {
-        //         EmphasisItalicPayload.ItalicsOn,
-        //         new TextPayload(text),
-        //         EmphasisItalicPayload.ItalicsOff,
-        //     }));
-        //
-        //     return italicString;
-        // }
+        /// <summary>
+        /// Convert a TextPayload to SeString and wrap in italics payloads.
+        /// </summary>
+        /// <param name="text">Text to convert.</param>
+        /// <returns>SeString payload of italicized text.</returns>
+        public static SeString MakeItalics(string text)
+            => MakeItalics(new TextPayload(text));
+
+        /// <summary>
+        /// Convert a TextPayload to SeString and wrap in italics payloads.
+        /// </summary>
+        /// <param name="text">Text to convert.</param>
+        /// <returns>SeString payload of italicized text.</returns>
+        public static SeString MakeItalics(TextPayload text)
+            => new(EmphasisItalicPayload.ItalicsOn, text, EmphasisItalicPayload.ItalicsOff);
 
         private void OnCheckMessageHandled(XivChatType type, uint senderid, ref SeString sender, ref SeString message, ref bool isHandled)
         {

--- a/Dalamud/Game/Text/SeStringHandling/Payload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payload.cs
@@ -300,7 +300,7 @@ namespace Dalamud.Game.Text.SeStringHandling
             EmphasisItalic = 0x1A,
 
             /// <summary>
-            /// See the <see cref="NewLinePayload"/>
+            /// See the <see cref="NewLinePayload"/>.
             /// </summary>
             NewLine = 0x10,
 

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/NewLinePayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/NewLinePayload.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 
 namespace Dalamud.Game.Text.SeStringHandling.Payloads
@@ -16,7 +16,7 @@ namespace Dalamud.Game.Text.SeStringHandling.Payloads
         public static NewLinePayload Payload => new();
 
         /// <summary>
-        /// Gets the text of this payload, evaluates to <c>Environment.NewLine</c>
+        /// Gets the text of this payload, evaluates to <c>Environment.NewLine</c>.
         /// </summary>
         public string Text => Environment.NewLine;
 

--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -29,7 +29,7 @@ namespace Dalamud.Game.Text.SeStringHandling
         /// Creates a new SeString from an ordered list of payloads.
         /// </summary>
         /// <param name="payloads">The Payload objects to make up this string.</param>
-        public SeString(Payload[] payloads)
+        public SeString(params Payload[] payloads)
         {
             this.Payloads = new List<Payload>(payloads);
         }
@@ -61,7 +61,7 @@ namespace Dalamud.Game.Text.SeStringHandling
         /// </summary>
         /// <param name="str">string to convert.</param>
         /// <returns>Equivalent SeString.</returns>
-        public static implicit operator SeString(string str) => new(new Payload[] { new TextPayload(str) });
+        public static implicit operator SeString(string str) => new(new TextPayload(str));
 
         /// <summary>
         /// Creates a SeString from a json. (For testing - not recommended for production use.)


### PR DESCRIPTION
Also add a `params` to the SeString ctor, to allow for `new SeString(payload1, payload2, ...)` without using an explicit array or list.