### PR TITLE
Dev plugin bugs

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -85,9 +85,12 @@ namespace Dalamud.Configuration.Internal
         public List<string> HiddenPluginInternalName { get; set; } = new();
 
         /// <summary>
-        /// Gets or sets a list of additional settings for devPlugins.
+        /// Gets or sets a list of additional settings for devPlugins. The key is the absolute path
+        /// to the plugin DLL. This is automatically generated for any plugins in the devPlugins folder.
+        /// However by specifiying this value manually, you can add arbitrary files outside the normal
+        /// file paths.
         /// </summary>
-        public List<DevPluginSettings> DevPluginSettings { get; set; } = new();
+        public Dictionary<string, DevPluginSettings> DevPluginSettings { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the global UI scale.

--- a/Dalamud/Configuration/Internal/DevPluginSettings.cs
+++ b/Dalamud/Configuration/Internal/DevPluginSettings.cs
@@ -6,21 +6,6 @@ namespace Dalamud.Configuration.Internal
     internal sealed class DevPluginSettings
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DevPluginSettings"/> class.
-        /// </summary>
-        /// <param name="dllFile">Filename of the DLL representing this plugin.</param>
-        public DevPluginSettings(string dllFile)
-        {
-            this.DllFile = dllFile;
-        }
-
-        /// <summary>
-        /// Gets or sets the path to a plugin DLL. This is automatically generated for any plugins in the devPlugins folder. However by
-        /// specifiying this value manually, you can add arbitrary files outside the normal file paths.
-        /// </summary>
-        public string DllFile { get; set; }
-
-        /// <summary>
         /// Gets or sets a value indicating whether this plugin should automatically start when Dalamud boots up.
         /// </summary>
         public bool StartOnBoot { get; set; } = true;

--- a/Dalamud/Plugin/Internal/LocalDevPlugin.cs
+++ b/Dalamud/Plugin/Internal/LocalDevPlugin.cs
@@ -33,17 +33,11 @@ namespace Dalamud.Plugin.Internal
         public LocalDevPlugin(Dalamud dalamud, FileInfo dllFile, LocalPluginManifest manifest)
             : base(dalamud, dllFile, manifest)
         {
-            // base is called first, ensuring that this is a valid plugin assembly
-            var devSettings = dalamud.Configuration.DevPluginSettings.FirstOrDefault(cfg => cfg.DllFile == dllFile.FullName);
-
-            if (devSettings == default)
+            if (!dalamud.Configuration.DevPluginSettings.TryGetValue(dllFile.FullName, out this.devSettings))
             {
-                devSettings = new DevPluginSettings(dllFile.FullName);
-                dalamud.Configuration.DevPluginSettings.Add(devSettings);
+                dalamud.Configuration.DevPluginSettings[dllFile.FullName] = this.devSettings = new DevPluginSettings();
                 dalamud.Configuration.Save();
             }
-
-            this.devSettings = devSettings;
 
             if (this.AutomaticReload)
             {

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -455,6 +455,10 @@ namespace Dalamud.Plugin.Internal
                 var devPlugin = new LocalDevPlugin(this.dalamud, dllFile, manifest);
                 loadPlugin &= !isBoot || devPlugin.StartOnBoot;
 
+                // If we're not loading it, make sure it's disabled
+                if (!loadPlugin && !devPlugin.IsDisabled)
+                    devPlugin.Disable();
+
                 plugin = devPlugin;
             }
             else
@@ -479,14 +483,17 @@ namespace Dalamud.Plugin.Internal
                 }
                 catch (Exception ex)
                 {
-                    // Dev plugins always get added to the list so they can be fiddled with in the UI
                     if (plugin.IsDev)
                     {
+                        // Dev plugins always get added to the list so they can be fiddled with in the UI
                         Log.Information(ex, $"Dev plugin failed to load, adding anyways:  {dllFile.Name}");
+                        plugin.Disable(); // Disable here, otherwise you can't enable+load later
                     }
                     else if (plugin.Manifest.DalamudApiLevel < DalamudApiLevel)
                     {
+                        // Out of date plugins get added so they can be updated.
                         Log.Information(ex, $"Plugin was outdated, adding anyways:  {dllFile.Name}");
+                        // plugin.Disable(); // Don't disable, or it gets deleted next boot.
                     }
                     else
                     {


### PR DESCRIPTION
Dev plugins if they were configured to not load at boot, or failed, would be in a not-loaded not-disabled state where they would fail manual loading later because "enabling" would fail.

Dev plugin settings in the dalamud config were not updating. Maybe the ref was broken. Changed to a dictionary of dll-path : devSettings.