### PR TITLE
Remove SharpDX.Desktop

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "lib/FFXIVClientStructs"]
 	path = lib/FFXIVClientStructs
 	url = https://github.com/goatcorp/FFXIVClientStructs.git
-[submodule "lib/SharpDX.Desktop"]
-	path = lib/SharpDX.Desktop
-	url = https://github.com/goatcorp/SharpDX.Desktop.git


### PR DESCRIPTION
This was only used for RenderForm to detect the d3d11 vtbl. It is no longer required.