### PR TITLE
Proposed hook changes

### DIFF
--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -74,6 +74,7 @@
         <PackageReference Include="Serilog" Version="2.10.0" />
         <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+        <PackageReference Include="Reloaded.Hooks" Version="3.2.3" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Dalamud/Hooking/Hook.cs
+++ b/Dalamud/Hooking/Hook.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-using CoreHook;
 using Dalamud.Hooking.Internal;
+using Dalamud.Hooking.Internal.Implementations;
 
 namespace Dalamud.Hooking
 {
@@ -13,13 +10,9 @@ namespace Dalamud.Hooking
     /// This class is basically a thin wrapper around the LocalHook type to provide helper functions.
     /// </summary>
     /// <typeparam name="T">Delegate type to represents a function prototype. This must be the same prototype as original function do.</typeparam>
-    public sealed class Hook<T> : IDisposable, IDalamudHook where T : Delegate
+    public sealed class Hook<T> : IDisposable where T : Delegate
     {
-        private readonly IntPtr address;
-
-        private readonly T original;
-
-        private readonly LocalHook hookInfo;
+        private readonly IDalamudHookImpl<T> hookImpl;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Hook{T}"/> class.
@@ -28,11 +21,8 @@ namespace Dalamud.Hooking
         /// <param name="address">A memory address to install a hook.</param>
         /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
         public Hook(IntPtr address, T detour)
+            : this(address, detour, false)
         {
-            this.hookInfo = LocalHook.Create(address, detour, null); // Installs a hook here
-            this.address = address;
-            this.original = Marshal.GetDelegateForFunctionPointer<T>(this.hookInfo.OriginalAddress);
-            HookManager.TrackedHooks.Add(new HookInfo() { Delegate = detour, Hook = this, Assembly = Assembly.GetCallingAssembly() });
         }
 
         /// <summary>
@@ -41,61 +31,44 @@ namespace Dalamud.Hooking
         /// </summary>
         /// <param name="address">A memory address to install a hook.</param>
         /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
-        /// <param name="callbackParam">A callback object which can be accessed within the detour.</param>
-        [Obsolete("There is no need to specify new YourDelegateType or callbackParam", true)]
-        public Hook(IntPtr address, Delegate detour, object callbackParam = null)
-            : this(address, detour as T)
+        /// <param name="followJmp">Follow any JMPs to the actual method that needs hooking.</param>
+        /// <remarks>
+        /// The followJmp parameter is only used when ReloadedHooks are used, which currently is only for Linux users.
+        /// Generally, this is only necessary when hooking Win32 functions.
+        /// </remarks>
+        public Hook(IntPtr address, T detour, bool followJmp)
         {
+            this.hookImpl = HookManager.DirtyLinuxUser
+                ? new ReloadedHookImpl<T>(address, detour, followJmp)
+                : new CoreHookImpl<T>(address, detour);
         }
 
         /// <summary>
         /// Gets a memory address of the target function.
         /// </summary>
         /// <exception cref="ObjectDisposedException">Hook is already disposed.</exception>
-        public IntPtr Address
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                this.CheckDisposed();
-                return this.address;
-            }
-        }
+        public IntPtr Address => this.hookImpl.Address;
 
         /// <summary>
         /// Gets a delegate function that can be used to call the actual function as if function is not hooked yet.
         /// </summary>
         /// <exception cref="ObjectDisposedException">Hook is already disposed.</exception>
-        public T Original
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                this.CheckDisposed();
-                return this.original;
-            }
-        }
+        public T Original => this.hookImpl.Original;
 
         /// <summary>
         /// Gets a value indicating whether or not the hook is enabled.
         /// </summary>
-        public bool IsEnabled
-        {
-            get
-            {
-                this.CheckDisposed();
-                return this.hookInfo.ThreadACL.IsExclusive;
-            }
-        }
+        public bool IsEnabled => this.hookImpl.IsEnabled;
 
         /// <summary>
         /// Gets a value indicating whether or not the hook has been disposed.
         /// </summary>
-        public bool IsDisposed { get; private set; }
+        public bool IsDisposed => this.hookImpl.IsDisposed;
+
 
         /// <summary>
         /// Creates a hook. Hooking address is inferred by calling to GetProcAddress() function.
-        /// Hook is not activated until Enable() method is called.
+        /// The hook is not activated until Enable() method is called.
         /// </summary>
         /// <param name="moduleName">A name of the module currently loaded in the memory. (e.g. ws2_32.dll).</param>
         /// <param name="exportName">A name of the exported function name (e.g. send).</param>
@@ -103,65 +76,39 @@ namespace Dalamud.Hooking
         /// <returns>The hook with the supplied parameters.</returns>
         public static Hook<T> FromSymbol(string moduleName, string exportName, T detour)
         {
-            // Get a function address from the symbol name.
-            var address = LocalHook.GetProcAddress(moduleName, exportName);
+            if (HookManager.DirtyLinuxUser)
+            {
+                var moduleHandle = NativeFunctions.GetModuleHandleW(moduleName);
+                if (moduleHandle == IntPtr.Zero)
+                    throw new Exception($"Could not get a handle to module {moduleName}");
 
-            return new Hook<T>(address, detour);
+                var procAddress = NativeFunctions.GetProcAddress(moduleHandle, exportName);
+                if (procAddress == IntPtr.Zero)
+                    throw new Exception($"Could not get the address of {moduleName}::{exportName}");
+
+                return new Hook<T>(procAddress, detour, true);
+            }
+            else
+            {
+                var address = CoreHook.LocalHook.GetProcAddress(moduleName, exportName);
+                return new Hook<T>(address, detour);
+            }
         }
-
-        /// <summary>
-        /// Creates a hook. Hooking address is inferred by calling to GetProcAddress() function.
-        /// Hook is not activated until Enable() method is called.
-        /// </summary>
-        /// <param name="moduleName">A name of the module currently loaded in the memory. (e.g. ws2_32.dll).</param>
-        /// <param name="exportName">A name of the exported function name (e.g. send).</param>
-        /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
-        /// <param name="callbackParam">A callback object which can be accessed within the detour.</param>
-        /// <returns>The hook with the supplied parameters.</returns>
-        [Obsolete("There is no need to specify new YourDelegateType or callbackParam", true)]
-        public static Hook<T> FromSymbol(string moduleName, string exportName, Delegate detour, object callbackParam = null) => FromSymbol(moduleName, exportName, detour as T);
 
         /// <summary>
         /// Remove a hook from the current process.
         /// </summary>
-        public void Dispose()
-        {
-            if (this.IsDisposed)
-            {
-                return;
-            }
-
-            this.IsDisposed = true;
-            this.hookInfo.Dispose();
-        }
+        public void Dispose() => this.hookImpl.Dispose();
 
         /// <summary>
         /// Starts intercepting a call to the function.
         /// </summary>
-        public void Enable()
-        {
-            this.CheckDisposed();
-
-            this.hookInfo.ThreadACL.SetExclusiveACL(null);
-        }
+        public void Enable() => this.hookImpl.Enable();
 
         /// <summary>
         /// Stops intercepting a call to the function.
         /// </summary>
-        public void Disable()
-        {
-            this.CheckDisposed();
+        public void Disable() => this.hookImpl.Disable();
 
-            this.hookInfo.ThreadACL.SetInclusiveACL(null);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void CheckDisposed()
-        {
-            if (this.IsDisposed)
-            {
-                throw new ObjectDisposedException("Hook is already disposed.");
-            }
-        }
     }
 }

--- a/Dalamud/Hooking/Internal/HookManager.cs
+++ b/Dalamud/Hooking/Internal/HookManager.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using Dalamud.Memory;
+
 namespace Dalamud.Hooking.Internal
 {
     /// <summary>
@@ -8,16 +10,35 @@ namespace Dalamud.Hooking.Internal
     /// </summary>
     internal class HookManager : IDisposable
     {
-        // private readonly Dalamud dalamud;
+        private static readonly ModuleLog Log = new("HM");
+        private static bool checkLinuxOnce = true;
+        private static bool isRunningLinux = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HookManager"/> class.
         /// </summary>
         /// <param name="dalamud">Dalamud instance.</param>
-        public HookManager(Dalamud dalamud)
+        internal HookManager(Dalamud dalamud)
         {
             _ = dalamud;
-            // this.dalamud = dalamud;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the client is running under Linux Wine.
+        /// </summary>
+        /// <returns>A value indicating whether the game is running under Wine.</returns>
+        internal static bool DirtyLinuxUser
+        {
+            get
+            {
+                if (checkLinuxOnce)
+                {
+                    var value = Environment.GetEnvironmentVariable("XL_WINEONLINUX");
+                    isRunningLinux = value is not null;
+                }
+
+                return isRunningLinux;
+            }
         }
 
         /// <summary>
@@ -25,9 +46,43 @@ namespace Dalamud.Hooking.Internal
         /// </summary>
         internal static List<HookInfo> TrackedHooks { get; } = new();
 
+        /// <summary>
+        /// Gets a static list of original code for a hooked address.
+        /// </summary>
+        internal static List<(IntPtr Address, byte[] Original)> Originals { get; } = new();
+
         /// <inheritdoc/>
         public void Dispose()
         {
+            RevertHooks();
+            TrackedHooks.Clear();
+            Originals.Clear();
+        }
+
+        private static unsafe void RevertHooks()
+        {
+            foreach (var (address, originalBytes) in Originals)
+            {
+                var i = 0;
+                var current = (byte*)address;
+                // Find how many bytes have been modified by comparing to the saved original
+                for (; i < originalBytes.Length; i++)
+                {
+                    if (current[i] == originalBytes[i])
+                        break;
+                }
+
+                if (i > 0)
+                {
+                    Log.Debug($"Reverting hook at 0x{address.ToInt64():X}");
+                    fixed (byte* original = originalBytes)
+                    {
+                        MemoryHelper.ChangePermission(address, i, MemoryProtection.ExecuteReadWrite, out var oldPermissions);
+                        MemoryHelper.WriteRaw(address, originalBytes);
+                        MemoryHelper.ChangePermission(address, i, oldPermissions);
+                    }
+                }
+            }
         }
     }
 }

--- a/Dalamud/Hooking/Internal/Implementations/CoreHookImpl.cs
+++ b/Dalamud/Hooking/Internal/Implementations/CoreHookImpl.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Dalamud.Hooking.Internal.Implementations
+{
+    /// <summary>
+    /// Manages a hook which can be used to intercept a call to native function.
+    /// This class is basically a thin wrapper around the LocalHook type to provide helper functions.
+    /// </summary>
+    /// <typeparam name="T">Delegate type to represents a function prototype. This must be the same prototype as original function do.</typeparam>
+    internal sealed class CoreHookImpl<T> : IDisposable, IDalamudHookImpl<T> where T : Delegate
+    {
+        private readonly IntPtr address;
+
+        private readonly CoreHook.LocalHook hookImpl;
+        private readonly T original;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CoreHookImpl{T}"/> class.
+        /// Hook is not activated until Enable() method is called.
+        /// </summary>
+        /// <param name="address">A memory address to install a hook.</param>
+        /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
+        public CoreHookImpl(IntPtr address, T detour)
+        {
+            this.address = address;
+
+            this.hookImpl = CoreHook.LocalHook.Create(address, detour, null);
+            this.original = Marshal.GetDelegateForFunctionPointer<T>(this.hookImpl.OriginalAddress);
+
+            HookManager.TrackedHooks.Add(new HookInfo(this, detour, Assembly.GetCallingAssembly()));
+        }
+
+        /// <summary>
+        /// Gets a memory address of the target function.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">Hook is already disposed.</exception>
+        public IntPtr Address
+        {
+            get
+            {
+                this.CheckDisposed();
+                return this.address;
+            }
+        }
+
+        /// <summary>
+        /// Gets a delegate function that can be used to call the actual function as if function is not hooked yet.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">Hook is already disposed.</exception>
+        public T Original
+        {
+            get
+            {
+                this.CheckDisposed();
+                return this.original;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether or not the hook is enabled.
+        /// </summary>
+        public bool IsEnabled
+        {
+            get
+            {
+                this.CheckDisposed();
+                return this.hookImpl.ThreadACL.IsExclusive;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether or not the hook has been disposed.
+        /// </summary>
+        public bool IsDisposed { get; private set; }
+
+        /// <summary>
+        /// Creates a hook. Hooking address is inferred by calling to GetProcAddress() function.
+        /// The hook is not activated until Enable() method is called.
+        /// </summary>
+        /// <param name="moduleName">A name of the module currently loaded in the memory. (e.g. ws2_32.dll).</param>
+        /// <param name="exportName">A name of the exported function name (e.g. send).</param>
+        /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
+        /// <returns>The hook with the supplied parameters.</returns>
+        public static IDalamudHookImpl<T> FromSymbol(string moduleName, string exportName, T detour)
+        {
+            var address = CoreHook.LocalHook.GetProcAddress(moduleName, exportName);
+            return new CoreHookImpl<T>(address, detour);
+        }
+
+        /// <summary>
+        /// Remove a hook from the current process.
+        /// </summary>
+        public void Dispose()
+        {
+            if (this.IsDisposed)
+                return;
+
+            this.IsDisposed = true;
+            this.hookImpl.Dispose();
+        }
+
+        /// <summary>
+        /// Starts intercepting a call to the function.
+        /// </summary>
+        public void Enable()
+        {
+            this.CheckDisposed();
+            this.hookImpl.ThreadACL.SetExclusiveACL(null);
+        }
+
+        /// <summary>
+        /// Stops intercepting a call to the function.
+        /// </summary>
+        public void Disable()
+        {
+            this.CheckDisposed();
+            this.hookImpl.ThreadACL.SetExclusiveACL(null);
+        }
+
+        /// <summary>
+        /// Check if this object has been disposed already.
+        /// </summary>
+        private void CheckDisposed()
+        {
+            if (this.IsDisposed)
+            {
+                throw new ObjectDisposedException("Hook is already disposed.");
+            }
+        }
+    }
+}

--- a/Dalamud/Hooking/Internal/Implementations/IDalamudHookImpl.cs
+++ b/Dalamud/Hooking/Internal/Implementations/IDalamudHookImpl.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Dalamud.Hooking.Internal.Implementations
+{
+    /// <summary>
+    /// Manages a hook which can be used to intercept a call to native function.
+    /// This class is basically a thin wrapper around the LocalHook type to provide helper functions.
+    /// </summary>
+    /// <typeparam name="T">Delegate type to represents a function prototype. This must be the same prototype as original function do.</typeparam>
+    internal interface IDalamudHookImpl<T> : IDisposable, IDalamudHook where T : Delegate
+    {
+        /// <summary>
+        /// Gets a delegate function that can be used to call the actual function as if function is not hooked yet.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">Hook is already disposed.</exception>
+        public T Original { get; }
+
+        /// <summary>
+        /// Starts intercepting a call to the function.
+        /// </summary>
+        public void Enable();
+
+        /// <summary>
+        /// Stops intercepting a call to the function.
+        /// </summary>
+        public void Disable();
+    }
+}

--- a/Dalamud/Hooking/Internal/Implementations/ReloadedHookImpl.cs
+++ b/Dalamud/Hooking/Internal/Implementations/ReloadedHookImpl.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+using Dalamud.Memory;
+
+namespace Dalamud.Hooking.Internal.Implementations
+{
+    /// <summary>
+    /// Manages a hook which can be used to intercept a call to native function.
+    /// This class is basically a thin wrapper around the LocalHook type to provide helper functions.
+    /// </summary>
+    /// <typeparam name="T">Delegate type to represents a function prototype. This must be the same prototype as original function do.</typeparam>
+    internal sealed class ReloadedHookImpl<T> : IDalamudHookImpl<T> where T : Delegate
+    {
+        private readonly IntPtr address;
+        private readonly Reloaded.Hooks.Definitions.IHook<T> hookImpl;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReloadedHookImpl{T}"/> class.
+        /// Hook is not activated until Enable() method is called.
+        /// </summary>
+        /// <param name="address">A memory address to install a hook.</param>
+        /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
+        public ReloadedHookImpl(IntPtr address, T detour)
+            : this(address, detour, false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReloadedHookImpl{T}"/> class.
+        /// Hook is not activated until Enable() method is called.
+        /// </summary>
+        /// <param name="address">A memory address to install a hook.</param>
+        /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
+        /// <param name="followJmp">Follow any JMPs to the actual method that needs hooking.</param>
+        public ReloadedHookImpl(IntPtr address, T detour, bool followJmp)
+        {
+            if (followJmp)
+            {
+                // This is horrible hackery to follow various types of JMP.
+                // It likely needs to stop when entering a reloaded hook trampoline.
+                // I would much rather use Iced to check against a Instruction type.
+                while (true)
+                {
+                    var b1 = Marshal.ReadByte(address);
+                    if (b1 == 0xE9)
+                    {
+                        var jumpOffset = Marshal.ReadInt32(address + 1);
+                        address += jumpOffset + 5;
+                        continue;
+                    }
+
+                    var b2 = Marshal.ReadByte(address, 1);
+                    if (b1 == 0xFF && b2 == 0x25)
+                    {
+                        address = Marshal.ReadIntPtr(address + 6);
+                        continue;
+                    }
+
+                    break;
+                }
+            }
+
+            var otherHook = HookManager.Originals.FirstOrDefault(o => o.Address == address);
+            if (otherHook == default)
+            {
+                MemoryHelper.ReadRaw(address, 50, out var original);
+                HookManager.Originals.Add((address, original));
+            }
+
+            this.address = address;
+            this.hookImpl = Reloaded.Hooks.ReloadedHooks.Instance.CreateHook<T>(detour, address.ToInt64());
+
+            HookManager.TrackedHooks.Add(new HookInfo(this, detour, Assembly.GetCallingAssembly()));
+        }
+
+        /// <summary>
+        /// Gets a memory address of the target function.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">Hook is already disposed.</exception>
+        public IntPtr Address
+        {
+            get
+            {
+                this.CheckDisposed();
+                return this.address;
+            }
+        }
+
+        /// <summary>
+        /// Gets a delegate function that can be used to call the actual function as if function is not hooked yet.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">Hook is already disposed.</exception>
+        public T Original
+        {
+            get
+            {
+                this.CheckDisposed();
+                return this.hookImpl.OriginalFunction;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether or not the hook is enabled.
+        /// </summary>
+        public bool IsEnabled
+        {
+            get
+            {
+                this.CheckDisposed();
+                return this.hookImpl.IsHookEnabled;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether or not the hook has been disposed.
+        /// </summary>
+        public bool IsDisposed { get; private set; }
+
+        /// <summary>
+        /// Creates a hook. Hooking address is inferred by calling to GetProcAddress() function.
+        /// The hook is not activated until Enable() method is called.
+        /// </summary>
+        /// <param name="moduleName">A name of the module currently loaded in the memory. (e.g. ws2_32.dll).</param>
+        /// <param name="exportName">A name of the exported function name (e.g. send).</param>
+        /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
+        /// <returns>The hook with the supplied parameters.</returns>
+        public static IDalamudHookImpl<T> FromSymbol(string moduleName, string exportName, T detour)
+        {
+            var moduleHandle = NativeFunctions.GetModuleHandleW(moduleName);
+            if (moduleHandle == IntPtr.Zero)
+                throw new Exception($"Could not get a handle to module {moduleName}");
+
+            var procAddress = NativeFunctions.GetProcAddress(moduleHandle, exportName);
+            if (procAddress == IntPtr.Zero)
+                throw new Exception($"Could not get the address of {moduleName}::{exportName}");
+
+            return new ReloadedHookImpl<T>(procAddress, detour, true);
+        }
+
+        /// <summary>
+        /// Remove a hook from the current process.
+        /// </summary>
+        public void Dispose()
+        {
+            if (this.IsDisposed)
+                return;
+
+            this.IsDisposed = true;
+
+            if (this.hookImpl.IsHookEnabled)
+                this.hookImpl.Disable();
+        }
+
+        /// <summary>
+        /// Starts intercepting a call to the function.
+        /// </summary>
+        public void Enable()
+        {
+            this.CheckDisposed();
+
+            if (!this.hookImpl.IsHookActivated)
+                this.hookImpl.Activate();
+
+            if (!this.hookImpl.IsHookEnabled)
+                this.hookImpl.Enable();
+        }
+
+        /// <summary>
+        /// Stops intercepting a call to the function.
+        /// </summary>
+        public void Disable()
+        {
+            this.CheckDisposed();
+
+            if (!this.hookImpl.IsHookActivated)
+                return;
+
+            if (this.hookImpl.IsHookEnabled)
+                this.hookImpl.Disable();
+        }
+
+        /// <summary>
+        /// Check if this object has been disposed already.
+        /// </summary>
+        private void CheckDisposed()
+        {
+            if (this.IsDisposed)
+            {
+                throw new ObjectDisposedException("Hook is already disposed.");
+            }
+        }
+    }
+}

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -10,6 +10,7 @@ using Dalamud.Game;
 using Dalamud.Game.ClientState;
 using Dalamud.Game.Internal.DXGI;
 using Dalamud.Hooking;
+using Dalamud.Hooking.Internal;
 using ImGuiNET;
 using ImGuiScene;
 using Serilog;
@@ -101,17 +102,17 @@ namespace Dalamud.Interface.Internal
                 Log.Error(e, "RTSS Free failed");
             }
 
-            var user32 = NativeFunctions.GetModuleHandleW("user32.dll");
-            var setCursorAddr = NativeFunctions.GetProcAddress(user32, "SetCursor");
+            this.setCursorHook = HookManager.DirtyLinuxUser ? null
+                : Hook<SetCursorDelegate>.FromSymbol("user32.dll", "SetCursor", this.SetCursorDetour);
+            this.presentHook = new Hook<PresentDelegate>(this.address.Present, this.PresentDetour, true);
+            this.resizeBuffersHook = new Hook<ResizeBuffersDelegate>(this.address.ResizeBuffers, this.ResizeBuffersDetour, true);
+
+            var setCursorAddress = this.setCursorHook?.Address ?? IntPtr.Zero;
 
             Log.Verbose("===== S W A P C H A I N =====");
-            Log.Verbose($"SetCursor address 0x{setCursorAddr.ToInt64():X}");
-            Log.Verbose($"Present address 0x{this.address.Present.ToInt64():X}");
-            Log.Verbose($"ResizeBuffers address 0x{this.address.ResizeBuffers.ToInt64():X}");
-
-            this.setCursorHook = new Hook<SetCursorDelegate>(setCursorAddr, this.SetCursorDetour);
-            this.presentHook = new Hook<PresentDelegate>(this.address.Present, this.PresentDetour);
-            this.resizeBuffersHook = new Hook<ResizeBuffersDelegate>(this.address.ResizeBuffers, this.ResizeBuffersDetour);
+            Log.Verbose($"SetCursor address 0x{setCursorAddress.ToInt64():X}");
+            Log.Verbose($"Present address 0x{this.presentHook.Address.ToInt64():X}");
+            Log.Verbose($"ResizeBuffers address 0x{this.resizeBuffersHook.Address.ToInt64():X}");
         }
 
         [UnmanagedFunctionPointer(CallingConvention.ThisCall)]


### PR DESCRIPTION
As mentioned in #445, this proposes a dual track of hooks. If XL_WINEONLINUX is defined, reloaded is used which works well enough with some slight modifications, namely following JMP statements in Win32 style hooks. However as of right now win32 hooks don't work in general, so the 2 that Dalamud uses are disabled, seemingly without penalty. If the variable is NOT defined, CoreHook is used, which while slightly outdated, works exactly as we've come to expect with EasyHook.