### PR TITLE
Plugins, bugs, utility

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -93,6 +93,13 @@ namespace Dalamud.Configuration.Internal
         public Dictionary<string, DevPluginSettings> DevPluginSettings { get; set; } = new();
 
         /// <summary>
+        /// Gets or sets a list of additional locations that dev plugins should be loaded from. This can
+        /// be either a DLL or folder, but should be the absolute path, or a path relative to the currently
+        /// injected Dalamud instance.
+        /// </summary>
+        public List<DevPluginLocationSettings> DevPluginLoadLocations { get; set; } = new();
+
+        /// <summary>
         /// Gets or sets the global UI scale.
         /// </summary>
         public float GlobalUiScale { get; set; } = 1.0f;

--- a/Dalamud/Configuration/Internal/DevPluginLocationSettings.cs
+++ b/Dalamud/Configuration/Internal/DevPluginLocationSettings.cs
@@ -1,0 +1,24 @@
+namespace Dalamud.Configuration
+{
+    /// <summary>
+    /// Additional locations to load dev plugins from.
+    /// </summary>
+    internal sealed class DevPluginLocationSettings
+    {
+        /// <summary>
+        /// Gets or sets the dev pluign path.
+        /// </summary>
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the third party repo is enabled.
+        /// </summary>
+        public bool IsEnabled { get; set; }
+
+        /// <summary>
+        /// Clone this object.
+        /// </summary>
+        /// <returns>A shallow copy of this object.</returns>
+        public DevPluginLocationSettings Clone() => this.MemberwiseClone() as DevPluginLocationSettings;
+    }
+}

--- a/Dalamud/Data/DataManager.cs
+++ b/Dalamud/Data/DataManager.cs
@@ -5,9 +5,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 
-using Dalamud.Data.LuminaExtensions;
-using Dalamud.Interface;
 using Dalamud.Interface.Internal;
+using Dalamud.Utility;
 using ImGuiScene;
 using JetBrains.Annotations;
 using Lumina;

--- a/Dalamud/Game/GameVersion.cs
+++ b/Dalamud/Game/GameVersion.cs
@@ -209,6 +209,32 @@ namespace Dalamud.Game
             return v2 <= v1;
         }
 
+        public static GameVersion operator +(GameVersion v1, TimeSpan v2)
+        {
+            if (v1 == null)
+                throw new ArgumentNullException(nameof(v1));
+
+            if (v1.Year == -1 || v1.Month == -1 || v1.Day == -1)
+                return v1;
+
+            var date = new DateTime(v1.Year, v1.Month, v1.Day) + v2;
+
+            return new GameVersion(date.Year, date.Month, date.Day, v1.Major, v1.Minor);
+        }
+
+        public static GameVersion operator -(GameVersion v1, TimeSpan v2)
+        {
+            if (v1 == null)
+                throw new ArgumentNullException(nameof(v1));
+
+            if (v1.Year == -1 || v1.Month == -1 || v1.Day == -1)
+                return v1;
+
+            var date = new DateTime(v1.Year, v1.Month, v1.Day) - v2;
+
+            return new GameVersion(date.Year, date.Month, date.Day, v1.Major, v1.Minor);
+        }
+
         /// <summary>
         /// Parse a version string. YYYY.MM.DD.majr.minr or "any".
         /// </summary>

--- a/Dalamud/Hooking/Internal/HookInfo.cs
+++ b/Dalamud/Hooking/Internal/HookInfo.cs
@@ -67,7 +67,7 @@ namespace Dalamud.Hooking.Internal
         internal Delegate Delegate { get; }
 
         /// <summary>
-        /// Gets the hooked assembly.
+        /// Gets the assembly implementing the hook.
         /// </summary>
         internal Assembly Assembly { get; }
     }

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -9,6 +9,7 @@ using Dalamud.Interface.Windowing;
 using Dalamud.Logging;
 using Dalamud.Logging.Internal;
 using Dalamud.Plugin.Internal;
+using Dalamud.Utility;
 using ImGuiNET;
 using Serilog.Events;
 

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -11,6 +11,7 @@ using Dalamud.Game.ClientState;
 using Dalamud.Game.Internal.DXGI;
 using Dalamud.Hooking;
 using Dalamud.Hooking.Internal;
+using Dalamud.Utility;
 using ImGuiNET;
 using ImGuiScene;
 using Serilog;
@@ -322,9 +323,7 @@ namespace Dalamud.Interface.Internal
 
         private static void ShowFontError(string path)
         {
-            Util.Fatal(
-                $"One or more files required by XIVLauncher were not found.\nPlease restart and report this error if it occurs again.\n\n{path}",
-                "Error");
+            Util.Fatal($"One or more files required by XIVLauncher were not found.\nPlease restart and report this error if it occurs again.\n\n{path}", "Error");
         }
 
         private IntPtr PresentDetour(IntPtr swapChain, uint syncInterval, uint presentFlags)

--- a/Dalamud/Interface/Internal/Scratchpad/ScratchExecutionManager.cs
+++ b/Dalamud/Interface/Internal/Scratchpad/ScratchExecutionManager.cs
@@ -83,7 +83,7 @@ namespace Dalamud.Interface.Internal.Scratchpad
             {
                 var script = CSharpScript.Create(code, options);
 
-                var pi = new DalamudPluginInterface(this.dalamud, "Scratch-" + doc.Id, null, PluginLoadReason.Unknown);
+                var pi = new DalamudPluginInterface(this.dalamud, "Scratch-" + doc.Id, PluginLoadReason.Unknown);
                 var plugin = script.ContinueWith<IDalamudPlugin>("return new ScratchPlugin() as IDalamudPlugin;")
                     .RunAsync().GetAwaiter().GetResult().ReturnValue;
 

--- a/Dalamud/Interface/Internal/Scratchpad/ScratchMacroProcessor.cs
+++ b/Dalamud/Interface/Internal/Scratchpad/ScratchMacroProcessor.cs
@@ -131,7 +131,7 @@ public class ScratchPlugin : IDalamudPlugin {
                         case ParseContext.Dispose:
                             break;
                         default:
-                            throw new ArgumentOutOfRangeException();
+                            throw new ArgumentOutOfRangeException(paramName: nameof(input));
                     }
 
                     ctx = ParseContext.None;
@@ -156,7 +156,7 @@ public class ScratchPlugin : IDalamudPlugin {
                         disposeBody += line + "\n";
                         break;
                     default:
-                        throw new ArgumentOutOfRangeException();
+                        throw new ArgumentOutOfRangeException(paramName: nameof(input));
                 }
             }
 

--- a/Dalamud/Interface/Internal/Windows/ChangelogWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ChangelogWindow.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 
 using Dalamud.Interface.Windowing;
+using Dalamud.Utility;
 using ImGuiNET;
 
 namespace Dalamud.Interface.Internal.Windows

--- a/Dalamud/Interface/Internal/Windows/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/DataWindow.cs
@@ -14,6 +14,7 @@ using Dalamud.Game.Internal.Gui.Toast;
 using Dalamud.Game.Text;
 using Dalamud.Interface.Windowing;
 using Dalamud.Plugin;
+using Dalamud.Utility;
 using ImGuiNET;
 using ImGuiScene;
 using Newtonsoft.Json;

--- a/Dalamud/Interface/Internal/Windows/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/DataWindow.cs
@@ -468,8 +468,8 @@ namespace Dalamud.Interface.Internal.Windows
         private void DrawPluginIPC()
         {
 #pragma warning disable CS0618 // Type or member is obsolete
-            var i1 = new DalamudPluginInterface(this.dalamud, "DalamudTestSub", null, PluginLoadReason.Unknown);
-            var i2 = new DalamudPluginInterface(this.dalamud, "DalamudTestPub", null, PluginLoadReason.Unknown);
+            var i1 = new DalamudPluginInterface(this.dalamud, "DalamudTestSub", PluginLoadReason.Unknown);
+            var i2 = new DalamudPluginInterface(this.dalamud, "DalamudTestPub", PluginLoadReason.Unknown);
 
             if (ImGui.Button("Add test sub"))
             {

--- a/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
@@ -484,7 +484,9 @@ namespace Dalamud.Interface.Internal.Windows
                 label += Locs.PluginTitleMod_TestingVersion;
             }
 
-            if (ImGui.CollapsingHeader($"{label}###Header{index}{manifest.InternalName}"))
+            ImGui.PushID($"available{index}{manifest.InternalName}");
+
+            if (ImGui.CollapsingHeader($"{label}###Header"))
             {
                 ImGui.Indent();
 
@@ -579,6 +581,8 @@ namespace Dalamud.Interface.Internal.Windows
 
                 ImGui.EndPopup();
             }
+
+            ImGui.PopID();
         }
 
         private void DrawInstalledPlugin(LocalPlugin plugin, int index, bool showInstalled = false)
@@ -646,7 +650,9 @@ namespace Dalamud.Interface.Internal.Windows
                 label += Locs.PluginTitleMod_OutdatedError;
             }
 
-            if (ImGui.CollapsingHeader($"{label}###Header{index}{plugin.Manifest.InternalName}"))
+            ImGui.PushID($"installed{index}{plugin.Manifest.InternalName}");
+
+            if (ImGui.CollapsingHeader($"{label}###Header"))
             {
                 var manifest = plugin.Manifest;
 
@@ -736,6 +742,8 @@ namespace Dalamud.Interface.Internal.Windows
 
                 ImGui.EndPopup();
             }
+
+            ImGui.PopID();
         }
 
         private void DrawPluginControlButton(LocalPlugin plugin)

--- a/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
@@ -18,6 +18,7 @@ using Dalamud.Plugin;
 using Dalamud.Plugin.Internal;
 using Dalamud.Plugin.Internal.Exceptions;
 using Dalamud.Plugin.Internal.Types;
+using Dalamud.Utility;
 using ImGuiNET;
 
 namespace Dalamud.Interface.Internal.Windows
@@ -662,7 +663,9 @@ namespace Dalamud.Interface.Internal.Windows
                 ImGui.Text(manifest.Name);
 
                 // Download count
-                var downloadText = manifest.DownloadCount > 0
+                var downloadText = plugin.IsDev
+                    ? Locs.PluginBody_AuthorWithoutDownloadCount(manifest.Author)
+                    : manifest.DownloadCount > 0
                     ? Locs.PluginBody_AuthorWithDownloadCount(manifest.Author, manifest.DownloadCount)
                     : Locs.PluginBody_AuthorWithDownloadCountUnavailable(manifest.Author);
 
@@ -670,10 +673,18 @@ namespace Dalamud.Interface.Internal.Windows
                 ImGui.TextColored(ImGuiColors.DalamudGrey3, downloadText);
 
                 // Installed from
-                if (!string.IsNullOrEmpty(manifest.InstalledFromUrl))
+                if (plugin.IsDev)
                 {
-                    var repoText = Locs.PluginBody_Plugin3rdPartyRepo(manifest.InstalledFromUrl);
-                    ImGui.TextColored(ImGuiColors.DalamudGrey3, repoText);
+                    var fileText = Locs.PluginBody_DevPluginPath(plugin.DllFile.FullName);
+                    ImGui.TextColored(ImGuiColors.DalamudGrey3, fileText);
+                }
+                else
+                {
+                    if (!string.IsNullOrEmpty(manifest.InstalledFromUrl))
+                    {
+                        var repoText = Locs.PluginBody_Plugin3rdPartyRepo(manifest.InstalledFromUrl);
+                        ImGui.TextColored(ImGuiColors.DalamudGrey3, repoText);
+                    }
                 }
 
                 // Description
@@ -1185,9 +1196,13 @@ namespace Dalamud.Interface.Internal.Windows
 
             #region Plugin body
 
+            public static string PluginBody_AuthorWithoutDownloadCount(string author) => Loc.Localize("InstallerAuthorWithoutDownloadCount", " by {0}").Format(author);
+
             public static string PluginBody_AuthorWithDownloadCount(string author, long count) => Loc.Localize("InstallerAuthorWithDownloadCount", " by {0}, {1} downloads").Format(author, count);
 
             public static string PluginBody_AuthorWithDownloadCountUnavailable(string author) => Loc.Localize("InstallerAuthorWithDownloadCountUnavailable", " by {0}, download count unavailable").Format(author);
+
+            public static string PluginBody_DevPluginPath(string path) => Loc.Localize("InstallerDevPluginPath", "From {0}").Format(path);
 
             public static string PluginBody_Plugin3rdPartyRepo(string url) => Loc.Localize("InstallerPlugin3rdPartyRepo", "From custom plugin repository {0}").Format(url);
 

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -117,7 +117,7 @@ namespace Dalamud.Plugin
         public Framework Framework { get; private set; }
 
         /// <summary>
-        /// Gets the <see cref="UiBuilder">UiBuilder</see> instance which allows you to draw UI into the game via ImGui draw calls.
+        /// Gets the <see cref="UiBuilder"/> instance which allows you to draw UI into the game via ImGui draw calls.
         /// </summary>
         public UiBuilder UiBuilder { get; private set; }
 
@@ -164,6 +164,8 @@ namespace Dalamud.Plugin
         /// Gets the action that should be executed when any plugin sends a message.
         /// </summary>
         internal Action<string, ExpandoObject> AnyPluginIpcAction { get; private set; }
+
+        #region Configuration
 
         /// <summary>
         /// Save a plugin configuration(inheriting IPluginConfiguration).
@@ -215,6 +217,8 @@ namespace Dalamud.Plugin
         /// </summary>
         /// <returns>directory with path of AppData/XIVLauncher/pluginConfig/PluginInternalName/loc.</returns>
         public string GetPluginLocDirectory() => this.configs.GetDirectory(Path.Combine(this.pluginName, "loc"));
+
+        #endregion
 
         #region Chat Links
 

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -35,9 +35,8 @@ namespace Dalamud.Plugin
         /// </summary>
         /// <param name="dalamud">The dalamud instance to expose.</param>
         /// <param name="pluginName">The internal name of the plugin.</param>
-        /// <param name="assemblyLocation">The equivalent of what Assembly.GetExecutingAssembly().Location should return.</param>
         /// <param name="reason">The reason the plugin was loaded.</param>
-        internal DalamudPluginInterface(Dalamud dalamud, string pluginName, string assemblyLocation, PluginLoadReason reason)
+        internal DalamudPluginInterface(Dalamud dalamud, string pluginName, PluginLoadReason reason)
         {
             this.CommandManager = dalamud.CommandManager;
             this.Framework = dalamud.Framework;
@@ -50,7 +49,6 @@ namespace Dalamud.Plugin
             this.dalamud = dalamud;
             this.pluginName = pluginName;
             this.configs = dalamud.PluginManager.PluginConfigs;
-            this.AssemblyLocation = assemblyLocation;
             this.Reason = reason;
 
             this.GeneralChatType = this.dalamud.Configuration.GeneralChatType;
@@ -87,11 +85,6 @@ namespace Dalamud.Plugin
         /// Gets the reason this plugin was loaded.
         /// </summary>
         public PluginLoadReason Reason { get; }
-
-        /// <summary>
-        /// Gets the plugin assembly location.
-        /// </summary>
-        public string AssemblyLocation { get; private set; }
 
         /// <summary>
         /// Gets the directory Dalamud assets are stored in.

--- a/Dalamud/Plugin/Internal/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/LocalPlugin.cs
@@ -272,7 +272,7 @@ namespace Dalamud.Plugin.Internal
                     this.Manifest.Save(this.manifestFile);
                 }
 
-                this.DalamudInterface = new DalamudPluginInterface(this.dalamud, this.pluginAssembly.GetName().Name, this.DllFile.FullName, reason);
+                this.DalamudInterface = new DalamudPluginInterface(this.dalamud, this.pluginAssembly.GetName().Name, reason);
 
                 if (this.IsDev)
                 {

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -359,16 +359,17 @@ namespace Dalamud.Plugin.Internal
                 // ignored, since the plugin may be loaded already
             }
 
-            using var client = new WebClient();
-
             var tempZip = new FileInfo(Path.GetTempFileName());
 
             try
             {
                 Log.Debug($"Downloading plugin to {tempZip} from {downloadUrl}");
-                client.DownloadFile(downloadUrl, tempZip.FullName);
+                using var client = new HttpClient();
+                var response = client.GetAsync(downloadUrl).Result;
+                using var fs = new FileStream(tempZip.FullName, FileMode.CreateNew);
+                response.Content.CopyToAsync(fs).GetAwaiter().GetResult();
             }
-            catch (WebException ex)
+            catch (HttpRequestException ex)
             {
                 Log.Error(ex, $"Download of plugin {repoManifest.Name} failed unexpectedly.");
                 throw;

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -185,7 +185,22 @@ namespace Dalamud.Plugin.Internal
             }
 
             // devPlugins are more freeform. Look for any dll and hope to get lucky.
-            var devDllFiles = this.devPluginDirectory.GetFiles("*.dll", SearchOption.AllDirectories);
+            var devDllFiles = this.devPluginDirectory.GetFiles("*.dll", SearchOption.AllDirectories).ToList();
+
+            foreach (var setting in this.dalamud.Configuration.DevPluginLoadLocations)
+            {
+                if (!setting.IsEnabled)
+                    continue;
+
+                if (Directory.Exists(setting.Path))
+                {
+                    devDllFiles.AddRange(new DirectoryInfo(setting.Path).GetFiles("*.dll", SearchOption.AllDirectories));
+                }
+                else if (File.Exists(setting.Path))
+                {
+                    devDllFiles.Add(new FileInfo(setting.Path));
+                }
+            }
 
             foreach (var dllFile in devDllFiles)
             {
@@ -298,7 +313,22 @@ namespace Dalamud.Plugin.Internal
                 this.devPluginDirectory.Create();
 
             // devPlugins are more freeform. Look for any dll and hope to get lucky.
-            var devDllFiles = this.devPluginDirectory.GetFiles("*.dll", SearchOption.AllDirectories);
+            var devDllFiles = this.devPluginDirectory.GetFiles("*.dll", SearchOption.AllDirectories).ToList();
+
+            foreach (var setting in this.dalamud.Configuration.DevPluginLoadLocations)
+            {
+                if (!setting.IsEnabled)
+                    continue;
+
+                if (Directory.Exists(setting.Path))
+                {
+                    devDllFiles.AddRange(new DirectoryInfo(setting.Path).GetFiles("*.dll", SearchOption.AllDirectories));
+                }
+                else if (File.Exists(setting.Path))
+                {
+                    devDllFiles.Add(new FileInfo(setting.Path));
+                }
+            }
 
             var listChanged = false;
 

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -978,26 +978,21 @@ namespace Dalamud.Plugin.Internal
         [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1313:Parameter names should begin with lower-case letter", Justification = "Enforced naming for special injected parameters")]
         private static void AssemblyLocationPatch(Assembly __instance, ref string __result)
         {
-            // Assembly.GetExecutingAssembly can return this.
-            // Check for it as a special case and find the plugin.
-            if (__result.EndsWith("System.Private.CoreLib.dll", StringComparison.InvariantCultureIgnoreCase))
+            if (string.IsNullOrEmpty(__result))
             {
                 foreach (var assemblyName in GetStackFrameAssemblyNames())
                 {
                     if (PluginLocations.TryGetValue(assemblyName, out var data))
                     {
                         __result = data.Location;
-                        return;
+                        break;
                     }
                 }
             }
-            else if (string.IsNullOrEmpty(__result))
-            {
-                if (PluginLocations.TryGetValue(__instance.FullName, out var data))
-                {
-                    __result = data.Location;
-                }
-            }
+
+            __result ??= string.Empty;
+
+            Log.Verbose($"Assembly.Location // {__instance.FullName} // {__result}");
         }
 
         /// <summary>
@@ -1010,26 +1005,21 @@ namespace Dalamud.Plugin.Internal
         [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1313:Parameter names should begin with lower-case letter", Justification = "Enforced naming for special injected parameters")]
         private static void AssemblyCodeBasePatch(Assembly __instance, ref string __result)
         {
-            // Assembly.GetExecutingAssembly can return this.
-            // Check for it as a special case and find the plugin.
-            if (__result.EndsWith("System.Private.CoreLib.dll"))
+            if (string.IsNullOrEmpty(__result))
             {
                 foreach (var assemblyName in GetStackFrameAssemblyNames())
                 {
                     if (PluginLocations.TryGetValue(assemblyName, out var data))
                     {
-                        __result = data.Location;
-                        return;
+                        __result = data.CodeBase;
+                        break;
                     }
                 }
             }
-            else if (string.IsNullOrEmpty(__result))
-            {
-                if (PluginLocations.TryGetValue(__instance.FullName, out var data))
-                {
-                    __result = data.Location;
-                }
-            }
+
+            __result ??= string.Empty;
+
+            Log.Verbose($"Assembly.CodeBase // {__instance.FullName} // {__result}");
         }
 
         private static IEnumerable<string> GetStackFrameAssemblyNames()

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -6,17 +6,19 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
 using CheapLoc;
 using Dalamud.Configuration;
+using Dalamud.Game;
 using Dalamud.Game.Text;
 using Dalamud.Logging.Internal;
 using Dalamud.Plugin.Internal.Exceptions;
 using Dalamud.Plugin.Internal.Types;
+using Dalamud.Utility;
 using HarmonyLib;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
@@ -624,7 +626,7 @@ namespace Dalamud.Plugin.Internal
                                     continue;
                                 }
 
-                                if (manifest.ApplicableVersion < this.dalamud.StartInfo.GameVersion)
+                                if (manifest.ApplicableVersion < this.dalamud.StartInfo.GameVersion - TimeSpan.FromDays(90))
                                 {
                                     Log.Information($"Inapplicable version: cleaning up {versionDir.FullName}");
                                     versionDir.Delete(true);

--- a/Dalamud/Plugin/Internal/PluginRepository.cs
+++ b/Dalamud/Plugin/Internal/PluginRepository.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 using Dalamud.Logging.Internal;
@@ -74,11 +74,10 @@ namespace Dalamud.Plugin.Internal
 
             return Task.Run(() =>
             {
-                using var client = new WebClient();
-
                 Log.Information($"Fetching repo: {this.PluginMasterUrl}");
-
-                var data = client.DownloadString(this.PluginMasterUrl);
+                using var client = new HttpClient();
+                using var response = client.GetAsync(this.PluginMasterUrl).Result;
+                var data = response.Content.ReadAsStringAsync().Result;
 
                 var pluginMaster = JsonConvert.DeserializeObject<List<RemotePluginManifest>>(data);
                 pluginMaster.Sort((pm1, pm2) => pm1.Name.CompareTo(pm2.Name));

--- a/Dalamud/Troubleshooting.cs
+++ b/Dalamud/Troubleshooting.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Dalamud.Configuration;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Internal.Types;
+using Dalamud.Utility;
 using Newtonsoft.Json;
 using Serilog;
 

--- a/Dalamud/Utility/EnumExtensions.cs
+++ b/Dalamud/Utility/EnumExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+
+namespace Dalamud.Utility
+{
+    /// <summary>
+    /// Extension methods for enums.
+    /// </summary>
+    public static class EnumExtensions
+    {
+        /// <summary>
+        /// Gets an attribute on an enum.
+        /// </summary>
+        /// <typeparam name="TAttribute">The type of attribute to get.</typeparam>
+        /// <param name="value">The enum value that has an attached attribute.</param>
+        /// <returns>The attached attribute, if any.</returns>
+        public static TAttribute GetAttribute<TAttribute>(this Enum value)
+            where TAttribute : Attribute
+        {
+            var type = value.GetType();
+            var name = Enum.GetName(type, value);
+            return type.GetField(name) // I prefer to get attributes this way
+                       .GetCustomAttributes(false)
+                       .OfType<TAttribute>()
+                       .SingleOrDefault();
+        }
+    }
+}

--- a/Dalamud/Utility/StringExtensions.cs
+++ b/Dalamud/Utility/StringExtensions.cs
@@ -1,0 +1,16 @@
+namespace Dalamud.Utility
+{
+    /// <summary>
+    /// Extension methods for strings.
+    /// </summary>
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// An extension method to chain usage of string.Format.
+        /// </summary>
+        /// <param name="format">Format string.</param>
+        /// <param name="args">Format arguments.</param>
+        /// <returns>Formatted string.</returns>
+        public static string Format(this string format, params object[] args) => string.Format(format, args);
+    }
+}

--- a/Dalamud/Utility/TexFileExtensions.cs
+++ b/Dalamud/Utility/TexFileExtensions.cs
@@ -1,7 +1,7 @@
 using ImGuiScene;
 using Lumina.Data.Files;
 
-namespace Dalamud.Data.LuminaExtensions
+namespace Dalamud.Utility
 {
     /// <summary>
     /// Extensions to <see cref="TexFile"/>.

--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -7,10 +7,11 @@ using System.Text;
 using Dalamud.Game;
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
+using Dalamud.Logging.Internal;
 using ImGuiNET;
 using Serilog;
 
-namespace Dalamud
+namespace Dalamud.Utility
 {
     /// <summary>
     /// Class providing various helper methods for use in Dalamud and plugins.
@@ -196,13 +197,5 @@ namespace Dalamud
 
         // TODO: Someone implement GetUTF8String with some IntPtr overloads.
         // while(Marshal.ReadByte(0, sz) != 0) { sz++; }
-
-        /// <summary>
-        /// An extension method to chain usage of string.Format.
-        /// </summary>
-        /// <param name="format">Format string.</param>
-        /// <param name="args">Format arguments.</param>
-        /// <returns>Formatted string.</returns>
-        public static string Format(this string format, params object[] args) => string.Format(format, args);
     }
 }

--- a/Dalamud/Utility/VectorExtensions.cs
+++ b/Dalamud/Utility/VectorExtensions.cs
@@ -1,0 +1,52 @@
+using System.Numerics;
+
+namespace Dalamud.Utility
+{
+    /// <summary>
+    /// Extension methods for System.Numerics.VectorN and SharpDX.VectorN.
+    /// </summary>
+    public static class VectorExtensions
+    {
+        /// <summary>
+        /// Converts a SharpDX vector to System.Numerics.
+        /// </summary>
+        /// <param name="vec">Vector to convert.</param>
+        /// <returns>A converted vector.</returns>
+        public static Vector2 ToSystem(this SharpDX.Vector2 vec) => new(x: vec.X, y: vec.Y);
+
+        /// <summary>
+        /// Converts a SharpDX vector to System.Numerics.
+        /// </summary>
+        /// <param name="vec">Vector to convert.</param>
+        /// <returns>A converted vector.</returns>
+        public static Vector3 ToSystem(this SharpDX.Vector3 vec) => new(x: vec.X, y: vec.Y, z: vec.Z);
+
+        /// <summary>
+        /// Converts a SharpDX vector to System.Numerics.
+        /// </summary>
+        /// <param name="vec">Vector to convert.</param>
+        /// <returns>A converted vector.</returns>
+        public static Vector4 ToSystem(this SharpDX.Vector4 vec) => new(x: vec.X, y: vec.Y, z: vec.Z, w: vec.W);
+
+        /// <summary>
+        /// Converts a System.Numerics vector to SharpDX.
+        /// </summary>
+        /// <param name="vec">Vector to convert.</param>
+        /// <returns>A converted vector.</returns>
+        public static SharpDX.Vector2 ToSharpDX(this Vector2 vec) => new(x: vec.X, y: vec.Y);
+
+        /// <summary>
+        /// Converts a System.Numerics vector to SharpDX.
+        /// </summary>
+        /// <param name="vec">Vector to convert.</param>
+        /// <returns>A converted vector.</returns>
+        public static SharpDX.Vector3 ToSharpDX(this Vector3 vec) => new(x: vec.X, y: vec.Y, z: vec.Z);
+
+        /// <summary>
+        /// Converts a System.Numerics vector to SharpDX.
+        /// </summary>
+        /// <param name="vec">Vector to convert.</param>
+        /// <returns>A converted vector.</returns>
+        public static SharpDX.Vector4 ToSharpDX(this Vector4 vec) => new(x: vec.X, y: vec.Y, z: vec.Z, w: vec.W);
+    }
+}


### PR DESCRIPTION
- Moved various extensions to a new utility namespace
- Update plugin installer window to show each dev plugin's filepath
- Don't immediately cleanup outdated GameVersion plugins, allowing for updating. Still enforce not loading.
- Fixes bug with the plugin load/unload button because of duplicate ImGui ID.
- Implement devPlugin load location list. Load your dev plugins from anywhere. Visible in the installer settings window under 3rd party repos.
- Update Assembly.Location and CodeBase hooks due to plugin dependencies breaking.
- More WebClient/HttpClient conversions.