### PR TITLE
Lenient GameVersion cleanup

### DIFF
--- a/Dalamud/Game/GameVersion.cs
+++ b/Dalamud/Game/GameVersion.cs
@@ -209,6 +209,32 @@ namespace Dalamud.Game
             return v2 <= v1;
         }
 
+        public static GameVersion operator +(GameVersion v1, TimeSpan v2)
+        {
+            if (v1 == null)
+                throw new ArgumentNullException(nameof(v1));
+
+            if (v1.Year == -1 || v1.Month == -1 || v1.Day == -1)
+                return v1;
+
+            var date = new DateTime(v1.Year, v1.Month, v1.Day) + v2;
+
+            return new GameVersion(date.Year, date.Month, date.Day, v1.Major, v1.Minor);
+        }
+
+        public static GameVersion operator -(GameVersion v1, TimeSpan v2)
+        {
+            if (v1 == null)
+                throw new ArgumentNullException(nameof(v1));
+
+            if (v1.Year == -1 || v1.Month == -1 || v1.Day == -1)
+                return v1;
+
+            var date = new DateTime(v1.Year, v1.Month, v1.Day) - v2;
+
+            return new GameVersion(date.Year, date.Month, date.Day, v1.Major, v1.Minor);
+        }
+
         /// <summary>
         /// Parse a version string. YYYY.MM.DD.majr.minr or "any".
         /// </summary>

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -595,7 +595,7 @@ namespace Dalamud.Plugin.Internal
                                     continue;
                                 }
 
-                                if (manifest.ApplicableVersion < this.dalamud.StartInfo.GameVersion)
+                                if (manifest.ApplicableVersion < this.dalamud.StartInfo.GameVersion - TimeSpan.FromDays(90))
                                 {
                                     Log.Information($"Inapplicable version: cleaning up {versionDir.FullName}");
                                     versionDir.Delete(true);


### PR DESCRIPTION
This makes it so the cleanup method doesnt immediately nuke out of date via GameVersion for 3 months. They still won't be loaded, but will remain in the list so that theyre eligible for upgrading.