### PR TITLE
Plugin feats!

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -93,6 +93,13 @@ namespace Dalamud.Configuration.Internal
         public Dictionary<string, DevPluginSettings> DevPluginSettings { get; set; } = new();
 
         /// <summary>
+        /// Gets or sets a list of additional locations that dev plugins should be loaded from. This can
+        /// be either a DLL or folder, but should be the absolute path, or a path relative to the currently
+        /// injected Dalamud instance.
+        /// </summary>
+        public List<DevPluginLocationSettings> DevPluginLoadLocations { get; set; } = new();
+
+        /// <summary>
         /// Gets or sets the global UI scale.
         /// </summary>
         public float GlobalUiScale { get; set; } = 1.0f;

--- a/Dalamud/Configuration/Internal/DevPluginLocationSettings.cs
+++ b/Dalamud/Configuration/Internal/DevPluginLocationSettings.cs
@@ -1,0 +1,24 @@
+namespace Dalamud.Configuration
+{
+    /// <summary>
+    /// Additional locations to load dev plugins from.
+    /// </summary>
+    internal sealed class DevPluginLocationSettings
+    {
+        /// <summary>
+        /// Gets or sets the dev pluign path.
+        /// </summary>
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the third party repo is enabled.
+        /// </summary>
+        public bool IsEnabled { get; set; }
+
+        /// <summary>
+        /// Clone this object.
+        /// </summary>
+        /// <returns>A shallow copy of this object.</returns>
+        public DevPluginLocationSettings Clone() => this.MemberwiseClone() as DevPluginLocationSettings;
+    }
+}

--- a/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
@@ -614,7 +614,9 @@ namespace Dalamud.Interface.Internal.Windows
                 label += Locs.PluginTitleMod_TestingVersion;
             }
 
-            if (this.DrawPluginCollapsingHeader(label, manifest, false, false, index))
+            ImGui.PushID($"available{index}{manifest.InternalName}");
+
+            if (ImGui.CollapsingHeader($"{label}###Header"))
             {
                 ImGuiHelpers.ScaledDummy(5);
 
@@ -709,6 +711,8 @@ namespace Dalamud.Interface.Internal.Windows
 
                 ImGui.EndPopup();
             }
+
+            ImGui.PopID();
         }
 
         private void DrawInstalledPlugin(LocalPlugin plugin, int index, bool showInstalled = false)
@@ -782,7 +786,9 @@ namespace Dalamud.Interface.Internal.Windows
                 trouble = true;
             }
 
-            if (this.DrawPluginCollapsingHeader(label, plugin.Manifest, trouble, availablePluginUpdate != default, index))
+            ImGui.PushID($"installed{index}{plugin.Manifest.InternalName}");
+
+            if (ImGui.CollapsingHeader($"{label}###Header"))
             {
                 var manifest = plugin.Manifest;
 
@@ -880,6 +886,8 @@ namespace Dalamud.Interface.Internal.Windows
 
                 ImGui.EndPopup();
             }
+
+            ImGui.PopID();
         }
 
         private void DrawPluginControlButton(LocalPlugin plugin)

--- a/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
@@ -798,7 +798,9 @@ namespace Dalamud.Interface.Internal.Windows
                 ImGui.Text(manifest.Name);
 
                 // Download count
-                var downloadText = manifest.DownloadCount > 0
+                var downloadText = plugin.IsDev
+                    ? Locs.PluginBody_AuthorWithoutDownloadCount(manifest.Author)
+                    : manifest.DownloadCount > 0
                     ? Locs.PluginBody_AuthorWithDownloadCount(manifest.Author, manifest.DownloadCount)
                     : Locs.PluginBody_AuthorWithDownloadCountUnavailable(manifest.Author);
 
@@ -806,12 +808,15 @@ namespace Dalamud.Interface.Internal.Windows
                 ImGui.TextColored(ImGuiColors.DalamudGrey3, downloadText);
 
                 // Installed from
-                if (!string.IsNullOrEmpty(manifest.InstalledFromUrl))
+                if (plugin.IsDev)
+                {
+                    var fileText = Locs.PluginBody_DevPluginPath(plugin.DllFile.FullName);
+                    ImGui.TextColored(ImGuiColors.DalamudGrey3, fileText);
+                }
+                else if (!string.IsNullOrEmpty(manifest.InstalledFromUrl))
                 {
                     var repoText = Locs.PluginBody_Plugin3rdPartyRepo(manifest.InstalledFromUrl);
                     ImGui.TextColored(ImGuiColors.DalamudGrey3, repoText);
-
-                    ImGuiHelpers.ScaledDummy(2);
                 }
 
                 // Description
@@ -1502,9 +1507,13 @@ namespace Dalamud.Interface.Internal.Windows
 
             #region Plugin body
 
+            public static string PluginBody_AuthorWithoutDownloadCount(string author) => Loc.Localize("InstallerAuthorWithoutDownloadCount", " by {0}").Format(author);
+
             public static string PluginBody_AuthorWithDownloadCount(string author, long count) => Loc.Localize("InstallerAuthorWithDownloadCount", " by {0}, {1} downloads").Format(author, count);
 
             public static string PluginBody_AuthorWithDownloadCountUnavailable(string author) => Loc.Localize("InstallerAuthorWithDownloadCountUnavailable", " by {0}, download count unavailable").Format(author);
+
+            public static string PluginBody_DevPluginPath(string path) => Loc.Localize("InstallerDevPluginPath", "From {0}").Format(path);
 
             public static string PluginBody_Plugin3rdPartyRepo(string url) => Loc.Localize("InstallerPlugin3rdPartyRepo", "From custom plugin repository {0}").Format(url);
 

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -186,7 +186,22 @@ namespace Dalamud.Plugin.Internal
             }
 
             // devPlugins are more freeform. Look for any dll and hope to get lucky.
-            var devDllFiles = this.devPluginDirectory.GetFiles("*.dll", SearchOption.AllDirectories);
+            var devDllFiles = this.devPluginDirectory.GetFiles("*.dll", SearchOption.AllDirectories).ToList();
+
+            foreach (var setting in this.dalamud.Configuration.DevPluginLoadLocations)
+            {
+                if (!setting.IsEnabled)
+                    continue;
+
+                if (Directory.Exists(setting.Path))
+                {
+                    devDllFiles.AddRange(new DirectoryInfo(setting.Path).GetFiles("*.dll", SearchOption.AllDirectories));
+                }
+                else if (File.Exists(setting.Path))
+                {
+                    devDllFiles.Add(new FileInfo(setting.Path));
+                }
+            }
 
             foreach (var dllFile in devDllFiles)
             {
@@ -299,7 +314,22 @@ namespace Dalamud.Plugin.Internal
                 this.devPluginDirectory.Create();
 
             // devPlugins are more freeform. Look for any dll and hope to get lucky.
-            var devDllFiles = this.devPluginDirectory.GetFiles("*.dll", SearchOption.AllDirectories);
+            var devDllFiles = this.devPluginDirectory.GetFiles("*.dll", SearchOption.AllDirectories).ToList();
+
+            foreach (var setting in this.dalamud.Configuration.DevPluginLoadLocations)
+            {
+                if (!setting.IsEnabled)
+                    continue;
+
+                if (Directory.Exists(setting.Path))
+                {
+                    devDllFiles.AddRange(new DirectoryInfo(setting.Path).GetFiles("*.dll", SearchOption.AllDirectories));
+                }
+                else if (File.Exists(setting.Path))
+                {
+                    devDllFiles.Add(new FileInfo(setting.Path));
+                }
+            }
 
             var listChanged = false;
 


### PR DESCRIPTION
-  This adds a new config section to the /xlplugins settings window for additional arbitrary paths that the devPlugin scanner can look in.
- Does a Push/PopID to solve a duplicate ImGui ID issue preventing the plugin control button from working.
- Modifies the individual plugin display to show the filepath a devPlugin is installed from as necessary.