### PR TITLE
Net5 viewport changes

### DIFF
--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -329,6 +329,9 @@ namespace Dalamud.Interface.Internal
 
         private IntPtr PresentDetour(IntPtr swapChain, uint syncInterval, uint presentFlags)
         {
+            if (this.scene != null && swapChain != this.scene.SwapChain.NativePointer)
+                return this.presentHook.Original(swapChain, syncInterval, presentFlags);
+
             if (this.scene == null)
             {
                 this.scene = new RawDX11Scene(swapChain);


### PR DESCRIPTION
- Fix viewport crashing from stack overflow due to present hook collision
  - This is fixed using the same way the ResizeBuffers collision was fixed on initial implementation of viewports
- Updates ImGuiScene viewport code for performance
  - I did not like using unsafe for everything in the initial implementation, but the NET5 PtrToStructure performance regression causes a 20-60% FPS dip when a platform window is being rendered. I didn't find this acceptable, so had to fix it.