### PR TITLE
Expose Dalamud's StartInfo in DalamudPluginInterface

### DIFF
--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -87,6 +87,11 @@ namespace Dalamud.Plugin
         public PluginLoadReason Reason { get; }
 
         /// <summary>
+        /// Gets the Dalamud Start Info.
+        /// </summary>
+        public DalamudStartInfo StartInfo => this.dalamud.StartInfo;
+
+        /// <summary>
         /// Gets the directory Dalamud assets are stored in.
         /// </summary>
         public DirectoryInfo DalamudAssetDirectory => this.dalamud.AssetDirectory;


### PR DESCRIPTION
Expose the Dalamud's StartInfo structure which contains the following information such as Game Version, Working Directory among other things.

May need more work to make sure the StartInfo fields are exposed securely, preferably converting them to properties

 