### PR TITLE
PartyFinderGui is exploding  on dispose occasionally

### DIFF
--- a/Dalamud/Game/Gui/PartyFinder/PartyFinderGui.cs
+++ b/Dalamud/Game/Gui/PartyFinder/PartyFinderGui.cs
@@ -66,7 +66,15 @@ namespace Dalamud.Game.Gui.PartyFinder
         public void Dispose()
         {
             this.receiveListingHook.Dispose();
-            Marshal.FreeHGlobal(this.memory);
+
+            try
+            {
+                Marshal.FreeHGlobal(this.memory);
+            }
+            catch (BadImageFormatException)
+            {
+                Log.Warning("Could not free PartyFinderGui memory.");
+            }
         }
 
         private void HandleReceiveListingDetour(IntPtr managerPtr, IntPtr data)


### PR DESCRIPTION
I'm not sure why this happens. I can only assume the game is disposing the m emory during normal shutdown.