### PR TITLE
null check dpi dispose

### DIFF
--- a/Dalamud/Plugin/Internal/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/LocalPlugin.cs
@@ -183,7 +183,7 @@ namespace Dalamud.Plugin.Internal
             this.instance?.Dispose();
             this.instance = null;
 
-            this.DalamudInterface.Dispose();
+            this.DalamudInterface?.Dispose();
             this.DalamudInterface = null;
 
             this.pluginType = null;


### PR DESCRIPTION
When an out of date plugin is not loaded, it stays in the plugin list so it can be updated. As a result, dpi is never instantiated.  During shutdown, it is expected to be not null. but its null.