### PR TITLE
HookManager hook revert fix

### DIFF
--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -388,7 +388,7 @@ namespace Dalamud
                 __result = (IntPtr)0xFFFFFFFF;
             }
 
-            //Log.Verbose($"Process.Handle // {__instance.ProcessName} // {__result:X}");
+            // Log.Verbose($"Process.Handle // {__instance.ProcessName} // {__result:X}");
         }
 
         private void ApplyProcessPatch()

--- a/Dalamud/Hooking/Internal/HookManager.cs
+++ b/Dalamud/Hooking/Internal/HookManager.cs
@@ -169,15 +169,14 @@ namespace Dalamud.Hooking.Internal
                         break;
                 }
 
+                var snippet = originalBytes[0..i];
+
                 if (i > 0)
                 {
-                    Log.Verbose($"Reverting hook at 0x{address.ToInt64():X}");
-                    fixed (byte* original = originalBytes)
-                    {
-                        MemoryHelper.ChangePermission(address, i, MemoryProtection.ExecuteReadWrite, out var oldPermissions);
-                        MemoryHelper.WriteRaw(address, originalBytes);
-                        MemoryHelper.ChangePermission(address, i, oldPermissions);
-                    }
+                    Log.Verbose($"Reverting hook at 0x{address.ToInt64():X} ({snippet.Length} bytes)");
+                    MemoryHelper.ChangePermission(address, i, MemoryProtection.ExecuteReadWrite, out var oldPermissions);
+                    MemoryHelper.WriteRaw(address, snippet);
+                    MemoryHelper.ChangePermission(address, i, oldPermissions);
                 }
             }
         }


### PR DESCRIPTION
HookManager reverts the full 50 bytes every time, regardless of required length. Anna found a hook that causes an access violation due to this. 

Fix: only revert the identified number of bytes.