### PR TITLE
feat: coloring and row/page numbering for IME

### DIFF
--- a/Dalamud/Interface/Internal/Windows/IMEWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/IMEWindow.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 
 using Dalamud.Game.Gui.Internal;
+using Dalamud.Interface.Colors;
 using Dalamud.Interface.Windowing;
 using ImGuiNET;
 
@@ -11,11 +12,13 @@ namespace Dalamud.Interface.Internal.Windows
     /// </summary>
     internal class IMEWindow : Window
     {
+        private const int ImePageSize = 9;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="IMEWindow"/> class.
         /// </summary>
         public IMEWindow()
-            : base("Dalamud IME", ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoFocusOnAppearing)
+            : base("Dalamud IME", ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoFocusOnAppearing | ImGuiWindowFlags.AlwaysAutoResize)
         {
             this.Size = new Vector2(100, 200);
             this.SizeCondition = ImGuiCond.FirstUseEver;
@@ -37,10 +40,30 @@ namespace Dalamud.Interface.Internal.Windows
             ImGui.Text(ime.ImmComp);
 
             ImGui.Separator();
+
+            var native = ime.ImmCandNative;
             for (var i = 0; i < ime.ImmCand.Count; i++)
             {
+                var selected = i == (native.Selection % ImePageSize);
+
+                if (selected)
+                    ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.HealerGreen);
+
                 ImGui.Text($"{i + 1}. {ime.ImmCand[i]}");
+
+                if (selected)
+                    ImGui.PopStyleColor();
             }
+
+            var totalIndex = native.Selection + 1;
+            var totalSize = native.Count;
+
+            var pageStart = native.PageStart;
+            var pageIndex = (pageStart / ImePageSize) + 1;
+            var pageCount = (totalSize / ImePageSize) + 1;
+
+            ImGui.Separator();
+            ImGui.Text($"{totalIndex}/{totalSize} ({pageIndex}/{pageCount})");
         }
     }
 }


### PR DESCRIPTION
Similar to the ffxiv IME window, adds `i/total (page#/total)` to the bottom of the window, and highlights in HealerGreen the current line.