### PR TITLE
disallow dupes in settings, breakup large method

### DIFF
--- a/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
@@ -167,9 +167,6 @@ namespace Dalamud.Interface.Internal.Windows
         /// <inheritdoc/>
         public override void Draw()
         {
-            var configuration = Service<DalamudConfiguration>.Get();
-            var pluginManager = Service<PluginManager>.Get();
-
             var windowSize = ImGui.GetWindowSize();
             ImGui.BeginChild("scrolling", new Vector2(windowSize.X - 5 - (5 * ImGuiHelpers.GlobalScale), windowSize.Y - 35 - (35 * ImGuiHelpers.GlobalScale)), false, ImGuiWindowFlags.HorizontalScrollbar);
 
@@ -177,373 +174,20 @@ namespace Dalamud.Interface.Internal.Windows
             {
                 if (ImGui.BeginTabItem(Loc.Localize("DalamudSettingsGeneral", "General")))
                 {
-                    ImGui.Text(Loc.Localize("DalamudSettingsLanguage", "Language"));
-                    ImGui.Combo("##XlLangCombo", ref this.langIndex, this.locLanguages, this.locLanguages.Length);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsLanguageHint", "Select the language Dalamud will be displayed in."));
-
-                    ImGuiHelpers.ScaledDummy(5);
-
-                    ImGui.Text(Loc.Localize("DalamudSettingsChannel", "General Chat Channel"));
-                    if (ImGui.BeginCombo("##XlChatTypeCombo", this.dalamudMessagesChatType.ToString()))
-                    {
-                        foreach (var type in Enum.GetValues(typeof(XivChatType)).Cast<XivChatType>())
-                        {
-                            if (ImGui.Selectable(type.ToString(), type == this.dalamudMessagesChatType))
-                            {
-                                this.dalamudMessagesChatType = type;
-                            }
-                        }
-
-                        ImGui.EndCombo();
-                    }
-
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsChannelHint", "Select the chat channel that is to be used for general Dalamud messages."));
-
-                    ImGuiHelpers.ScaledDummy(5);
-
-                    ImGui.Checkbox(Loc.Localize("DalamudSettingsFlash", "Flash FFXIV window on duty pop"), ref this.doCfTaskBarFlash);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsFlashHint", "Flash the FFXIV window in your task bar when a duty is ready."));
-
-                    ImGui.Checkbox(Loc.Localize("DalamudSettingsDutyFinderMessage", "Chatlog message on duty pop"), ref this.doCfChatMessage);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsDutyFinderMessageHint", "Send a message in FFXIV chat when a duty is ready."));
-
-                    ImGui.Checkbox(Loc.Localize("DalamudSettingsPrintPluginsWelcomeMsg", "Display loaded plugins in the welcome message"), ref this.printPluginsWelcomeMsg);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsPrintPluginsWelcomeMsgHint", "Display loaded plugins in FFXIV chat when logging in with a character."));
-
-                    ImGui.Checkbox(Loc.Localize("DalamudSettingsAutoUpdatePlugins", "Auto-update plugins"), ref this.autoUpdatePlugins);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsAutoUpdatePluginsMsgHint", "Automatically update plugins when logging in with a character."));
-
-                    ImGui.Checkbox(Loc.Localize("DalamudSettingsSystemMenu", "Dalamud buttons in system menu"), ref this.doButtonsSystemMenu);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsSystemMenuMsgHint", "Add buttons for Dalamud plugins and settings to the system menu."));
-
+                    this.DrawGeneralTab();
                     ImGui.EndTabItem();
                 }
 
                 if (ImGui.BeginTabItem(Loc.Localize("DalamudSettingsVisual", "Look & Feel")))
                 {
-                    ImGui.SetCursorPosY(ImGui.GetCursorPosY() + 3);
-                    ImGui.Text(Loc.Localize("DalamudSettingsGlobalUiScale", "Global UI Scale"));
-                    ImGui.SameLine();
-                    ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 3);
-                    if (ImGui.Button("Reset"))
-                    {
-                        this.globalUiScale = 1.0f;
-                        ImGui.GetIO().FontGlobalScale = this.globalUiScale;
-                    }
-
-                    if (ImGui.DragFloat("##DalamudSettingsGlobalUiScaleDrag", ref this.globalUiScale, 0.005f, MinScale, MaxScale, "%.2f"))
-                        ImGui.GetIO().FontGlobalScale = this.globalUiScale;
-
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsGlobalUiScaleHint", "Scale all XIVLauncher UI elements - useful for 4K displays."));
-
-                    ImGuiHelpers.ScaledDummy(10, 16);
-
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleUiHideOptOutNote", "Plugins may independently opt out of the settings below."));
-
-                    ImGui.Checkbox(Loc.Localize("DalamudSettingToggleUiHide", "Hide plugin UI when the game UI is toggled off"), ref this.doToggleUiHide);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleUiHideHint", "Hide any open windows by plugins when toggling the game overlay."));
-
-                    ImGui.Checkbox(Loc.Localize("DalamudSettingToggleUiHideDuringCutscenes", "Hide plugin UI during cutscenes"), ref this.doToggleUiHideDuringCutscenes);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleUiHideDuringCutscenesHint", "Hide any open windows by plugins during cutscenes."));
-
-                    ImGui.Checkbox(Loc.Localize("DalamudSettingToggleUiHideDuringGpose", "Hide plugin UI while gpose is active"), ref this.doToggleUiHideDuringGpose);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleUiHideDuringGposeHint", "Hide any open windows by plugins while gpose is active."));
-
-                    ImGuiHelpers.ScaledDummy(10, 16);
-
-                    ImGui.Checkbox(Loc.Localize("DalamudSettingToggleFocusManagement", "Use escape to close Dalamud windows"), ref this.doFocus);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleFocusManagementHint", "This will cause Dalamud windows to behave like in-game windows when pressing escape.\nThey will close one after another until all are closed. May not work for all plugins."));
-
-                    ImGui.Checkbox(Loc.Localize("DalamudSettingToggleViewports", "Enable multi-monitor windows"), ref this.doViewport);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleViewportsHint", "This will allow you move plugin windows onto other monitors.\nWill only work in Borderless Window or Windowed mode."));
-
-                    ImGui.Checkbox(Loc.Localize("DalamudSettingToggleDocking", "Enable window docking"), ref this.doDocking);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleDockingHint", "This will allow you to fuse and tab plugin windows."));
-
-                    ImGui.Checkbox(Loc.Localize("DalamudSettingToggleGamepadNavigation", "Control plugins via gamepad"), ref this.doGamepad);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleGamepadNavigationHint", "This will allow you to toggle between game and plugin navigation via L1+L3.\nToggle the PluginInstaller window via R3 if ImGui navigation is enabled."));
-
+                    this.DrawLookAndFeelTab();
                     ImGui.EndTabItem();
                 }
 
                 if (ImGui.BeginTabItem(Loc.Localize("DalamudSettingsExperimental", "Experimental")))
                 {
-                    #region Plugin testing
-
-                    ImGui.Checkbox(Loc.Localize("DalamudSettingsPluginTest", "Get plugin testing builds"), ref this.doPluginTest);
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsPluginTestHint", "Receive testing prereleases for plugins."));
-                    ImGui.TextColored(this.warnTextColor, Loc.Localize("DalamudSettingsPluginTestWarning", "Testing plugins may not have been vetted before being published. Please only enable this if you are aware of the risks."));
-
-                    #endregion
-
-                    ImGuiHelpers.ScaledDummy(12);
-
-                    #region Hidden plugins
-
-                    if (ImGui.Button(Loc.Localize("DalamudSettingsClearHidden", "Clear hidden plugins")))
-                    {
-                        configuration.HiddenPluginInternalName.Clear();
-                        pluginManager.RefilterPluginMasters();
-                    }
-
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsClearHiddenHint", "Restore plugins you have previously hidden from the plugin installer."));
-
-                    #endregion
-
-                    ImGuiHelpers.ScaledDummy(12);
-
-                    #region Custom repos
-
-                    ImGui.Text(Loc.Localize("DalamudSettingsCustomRepo", "Custom Plugin Repositories"));
-                    if (this.thirdRepoListChanged)
-                    {
-                        ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.HealerGreen);
-                        ImGui.SameLine();
-                        ImGui.Text(Loc.Localize("DalamudSettingsChanged", "(Changed)"));
-                        ImGui.PopStyleColor();
-                    }
-
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingCustomRepoHint", "Add custom plugin repositories."));
-                    ImGui.TextColored(this.warnTextColor, Loc.Localize("DalamudSettingCustomRepoWarning", "We cannot take any responsibility for third-party plugins and repositories.\nTake care when installing third-party plugins from untrusted sources."));
-
-                    ImGuiHelpers.ScaledDummy(5);
-
-                    ImGui.Columns(4);
-                    ImGui.SetColumnWidth(0, 18 + (5 * ImGuiHelpers.GlobalScale));
-                    ImGui.SetColumnWidth(1, ImGui.GetWindowContentRegionWidth() - (18 + 16 + 14) - ((5 + 45 + 26) * ImGuiHelpers.GlobalScale));
-                    ImGui.SetColumnWidth(2, 16 + (45 * ImGuiHelpers.GlobalScale));
-                    ImGui.SetColumnWidth(3, 14 + (26 * ImGuiHelpers.GlobalScale));
-
-                    ImGui.Separator();
-
-                    ImGui.Text("#");
-                    ImGui.NextColumn();
-                    ImGui.Text("URL");
-                    ImGui.NextColumn();
-                    ImGui.Text("Enabled");
-                    ImGui.NextColumn();
-                    ImGui.Text(string.Empty);
-                    ImGui.NextColumn();
-
-                    ImGui.Separator();
-
-                    ImGui.Text("0");
-                    ImGui.NextColumn();
-                    ImGui.Text("XIVLauncher");
-                    ImGui.NextColumn();
-                    ImGui.NextColumn();
-                    ImGui.NextColumn();
-                    ImGui.Separator();
-
-                    ThirdPartyRepoSettings repoToRemove = null;
-
-                    var repoNumber = 1;
-                    foreach (var thirdRepoSetting in this.thirdRepoList)
-                    {
-                        var isEnabled = thirdRepoSetting.IsEnabled;
-
-                        ImGui.PushID($"thirdRepo_{thirdRepoSetting.Url}");
-
-                        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 8 - (ImGui.CalcTextSize(repoNumber.ToString()).X / 2));
-                        ImGui.Text(repoNumber.ToString());
-                        ImGui.NextColumn();
-
-                        ImGui.SetNextItemWidth(-1);
-                        var url = thirdRepoSetting.Url;
-                        if (ImGui.InputText($"##thirdRepoInput", ref url, 65535, ImGuiInputTextFlags.EnterReturnsTrue))
-                        {
-                            thirdRepoSetting.Url = url;
-                            this.thirdRepoListChanged = url != thirdRepoSetting.Url;
-                        }
-
-                        ImGui.NextColumn();
-
-                        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 7 - (12 * ImGuiHelpers.GlobalScale));
-                        ImGui.Checkbox("##thirdRepoCheck", ref isEnabled);
-                        ImGui.NextColumn();
-
-                        if (ImGuiComponents.IconButton(FontAwesomeIcon.Trash))
-                        {
-                            repoToRemove = thirdRepoSetting;
-                        }
-
-                        ImGui.PopID();
-
-                        ImGui.NextColumn();
-                        ImGui.Separator();
-
-                        thirdRepoSetting.IsEnabled = isEnabled;
-
-                        repoNumber++;
-                    }
-
-                    if (repoToRemove != null)
-                    {
-                        this.thirdRepoList.Remove(repoToRemove);
-                        this.thirdRepoListChanged = true;
-                    }
-
-                    ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 8 - (ImGui.CalcTextSize(repoNumber.ToString()).X / 2));
-                    ImGui.Text(repoNumber.ToString());
-                    ImGui.NextColumn();
-                    ImGui.SetNextItemWidth(-1);
-                    ImGui.InputText("##thirdRepoUrlInput", ref this.thirdRepoTempUrl, 300);
-                    ImGui.NextColumn();
-                    // Enabled button
-                    ImGui.NextColumn();
-                    if (!string.IsNullOrEmpty(this.thirdRepoTempUrl) && ImGuiComponents.IconButton(FontAwesomeIcon.Plus))
-                    {
-                        if (this.thirdRepoList.Any(r => string.Equals(r.Url, this.thirdRepoTempUrl, StringComparison.InvariantCultureIgnoreCase)))
-                        {
-                            this.thirdRepoAddError = Loc.Localize("DalamudThirdRepoExists", "Repo already exists.");
-                            Task.Delay(5000).ContinueWith(t => this.thirdRepoAddError = string.Empty);
-                        }
-                        else
-                        {
-                            this.thirdRepoList.Add(new ThirdPartyRepoSettings
-                            {
-                                Url = this.thirdRepoTempUrl,
-                                IsEnabled = true,
-                            });
-                            this.thirdRepoListChanged = true;
-                            this.thirdRepoTempUrl = string.Empty;
-                        }
-                    }
-
-                    ImGui.Columns(1);
-
+                    this.DrawExperimentalTab();
                     ImGui.EndTabItem();
-
-                    if (!string.IsNullOrEmpty(this.thirdRepoAddError))
-                    {
-                        ImGui.TextColored(new Vector4(1, 0, 0, 1), this.thirdRepoAddError);
-                    }
-
-                    #endregion
-
-                    ImGuiHelpers.ScaledDummy(12);
-
-                    #region Custom dev plugin load locations
-
-                    ImGui.Text(Loc.Localize("DalamudSettingsDevPluginLocation", "Dev Plugin Locations"));
-                    if (this.devPluginLocationsChanged)
-                    {
-                        ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.HealerGreen);
-                        ImGui.SameLine();
-                        ImGui.Text(Loc.Localize("DalamudSettingsChanged", "(Changed)"));
-                        ImGui.PopStyleColor();
-                    }
-
-                    ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsDevPluginLocationsHint", "Add additional dev plugin load locations.\nThese can be either the directory or DLL path."));
-
-                    ImGuiHelpers.ScaledDummy(5);
-
-                    ImGui.Columns(4);
-                    ImGui.SetColumnWidth(0, 18 + (5 * ImGuiHelpers.GlobalScale));
-                    ImGui.SetColumnWidth(1, ImGui.GetWindowContentRegionWidth() - (18 + 16 + 14) - ((5 + 45 + 26) * ImGuiHelpers.GlobalScale));
-                    ImGui.SetColumnWidth(2, 16 + (45 * ImGuiHelpers.GlobalScale));
-                    ImGui.SetColumnWidth(3, 14 + (26 * ImGuiHelpers.GlobalScale));
-
-                    ImGui.Separator();
-
-                    ImGui.Text("#");
-                    ImGui.NextColumn();
-                    ImGui.Text("Path");
-                    ImGui.NextColumn();
-                    ImGui.Text("Enabled");
-                    ImGui.NextColumn();
-                    ImGui.Text(string.Empty);
-                    ImGui.NextColumn();
-
-                    ImGui.Separator();
-
-                    DevPluginLocationSettings locationToRemove = null;
-
-                    var locNumber = 1;
-                    foreach (var devPluginLocationSetting in this.devPluginLocations)
-                    {
-                        var isEnabled = devPluginLocationSetting.IsEnabled;
-
-                        ImGui.PushID($"devPluginLocation_{devPluginLocationSetting.Path}");
-
-                        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 8 - (ImGui.CalcTextSize(repoNumber.ToString()).X / 2));
-                        ImGui.Text(locNumber.ToString());
-                        ImGui.NextColumn();
-
-                        ImGui.SetNextItemWidth(-1);
-                        var path = devPluginLocationSetting.Path;
-                        if (ImGui.InputText($"##devPluginLocationInput", ref path, 65535, ImGuiInputTextFlags.EnterReturnsTrue))
-                        {
-                            devPluginLocationSetting.Path = path;
-                            this.devPluginLocationsChanged = path != devPluginLocationSetting.Path;
-                        }
-
-                        ImGui.NextColumn();
-
-                        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 7 - (12 * ImGuiHelpers.GlobalScale));
-                        ImGui.Checkbox("##devPluginLocationCheck", ref isEnabled);
-                        ImGui.NextColumn();
-
-                        if (ImGuiComponents.IconButton(FontAwesomeIcon.Trash))
-                        {
-                            locationToRemove = devPluginLocationSetting;
-                        }
-
-                        ImGui.PopID();
-
-                        ImGui.NextColumn();
-                        ImGui.Separator();
-
-                        devPluginLocationSetting.IsEnabled = isEnabled;
-
-                        locNumber++;
-                    }
-
-                    if (locationToRemove != null)
-                    {
-                        this.devPluginLocations.Remove(locationToRemove);
-                        this.devPluginLocationsChanged = true;
-                    }
-
-                    ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 8 - (ImGui.CalcTextSize(locNumber.ToString()).X / 2));
-                    ImGui.Text(locNumber.ToString());
-                    ImGui.NextColumn();
-                    ImGui.SetNextItemWidth(-1);
-                    ImGui.InputText("##devPluginLocationInput", ref this.devPluginTempLocation, 300);
-                    ImGui.NextColumn();
-                    // Enabled button
-                    ImGui.NextColumn();
-                    if (!string.IsNullOrEmpty(this.devPluginTempLocation) && ImGuiComponents.IconButton(FontAwesomeIcon.Plus))
-                    {
-                        if (this.devPluginLocations.Any(r => string.Equals(r.Path, this.devPluginTempLocation, StringComparison.InvariantCultureIgnoreCase)))
-                        {
-                            this.devPluginLocationAddError = Loc.Localize("DalamudDevPluginLocationExists", "Location already exists.");
-                            Task.Delay(5000).ContinueWith(t => this.devPluginLocationAddError = string.Empty);
-                        }
-                        else
-                        {
-                            this.devPluginLocations.Add(new DevPluginLocationSettings
-                            {
-                                Path = this.devPluginTempLocation,
-                                IsEnabled = true,
-                            });
-                            this.devPluginLocationsChanged = true;
-                            this.devPluginTempLocation = string.Empty;
-                        }
-                    }
-
-                    ImGui.Columns(1);
-
-                    ImGui.EndTabItem();
-
-                    if (!string.IsNullOrEmpty(this.devPluginLocationAddError))
-                    {
-                        ImGui.TextColored(new Vector4(1, 0, 0, 1), this.devPluginLocationAddError);
-                    }
-
-                    #endregion
-
-                    ImGuiHelpers.ScaledDummy(12);
                 }
 
                 ImGui.EndTabBar();
@@ -551,8 +195,409 @@ namespace Dalamud.Interface.Internal.Windows
 
             ImGui.EndChild();
 
+            this.DrawSaveCloseButtons();
+        }
+
+        private void DrawGeneralTab()
+        {
+            ImGui.Text(Loc.Localize("DalamudSettingsLanguage", "Language"));
+            ImGui.Combo("##XlLangCombo", ref this.langIndex, this.locLanguages, this.locLanguages.Length);
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsLanguageHint", "Select the language Dalamud will be displayed in."));
+
+            ImGuiHelpers.ScaledDummy(5);
+
+            ImGui.Text(Loc.Localize("DalamudSettingsChannel", "General Chat Channel"));
+            if (ImGui.BeginCombo("##XlChatTypeCombo", this.dalamudMessagesChatType.ToString()))
+            {
+                foreach (var type in Enum.GetValues(typeof(XivChatType)).Cast<XivChatType>())
+                {
+                    if (ImGui.Selectable(type.ToString(), type == this.dalamudMessagesChatType))
+                    {
+                        this.dalamudMessagesChatType = type;
+                    }
+                }
+
+                ImGui.EndCombo();
+            }
+
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsChannelHint", "Select the chat channel that is to be used for general Dalamud messages."));
+
+            ImGuiHelpers.ScaledDummy(5);
+
+            ImGui.Checkbox(Loc.Localize("DalamudSettingsFlash", "Flash FFXIV window on duty pop"), ref this.doCfTaskBarFlash);
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsFlashHint", "Flash the FFXIV window in your task bar when a duty is ready."));
+
+            ImGui.Checkbox(Loc.Localize("DalamudSettingsDutyFinderMessage", "Chatlog message on duty pop"), ref this.doCfChatMessage);
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsDutyFinderMessageHint", "Send a message in FFXIV chat when a duty is ready."));
+
+            ImGui.Checkbox(Loc.Localize("DalamudSettingsPrintPluginsWelcomeMsg", "Display loaded plugins in the welcome message"), ref this.printPluginsWelcomeMsg);
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsPrintPluginsWelcomeMsgHint", "Display loaded plugins in FFXIV chat when logging in with a character."));
+
+            ImGui.Checkbox(Loc.Localize("DalamudSettingsAutoUpdatePlugins", "Auto-update plugins"), ref this.autoUpdatePlugins);
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsAutoUpdatePluginsMsgHint", "Automatically update plugins when logging in with a character."));
+
+            ImGui.Checkbox(Loc.Localize("DalamudSettingsSystemMenu", "Dalamud buttons in system menu"), ref this.doButtonsSystemMenu);
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsSystemMenuMsgHint", "Add buttons for Dalamud plugins and settings to the system menu."));
+        }
+
+        private void DrawLookAndFeelTab()
+        {
+            ImGui.SetCursorPosY(ImGui.GetCursorPosY() + 3);
+            ImGui.Text(Loc.Localize("DalamudSettingsGlobalUiScale", "Global UI Scale"));
+            ImGui.SameLine();
+            ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 3);
+            if (ImGui.Button("Reset"))
+            {
+                this.globalUiScale = 1.0f;
+                ImGui.GetIO().FontGlobalScale = this.globalUiScale;
+            }
+
+            if (ImGui.DragFloat("##DalamudSettingsGlobalUiScaleDrag", ref this.globalUiScale, 0.005f, MinScale, MaxScale, "%.2f"))
+                ImGui.GetIO().FontGlobalScale = this.globalUiScale;
+
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsGlobalUiScaleHint", "Scale all XIVLauncher UI elements - useful for 4K displays."));
+
+            ImGuiHelpers.ScaledDummy(10, 16);
+
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleUiHideOptOutNote", "Plugins may independently opt out of the settings below."));
+
+            ImGui.Checkbox(Loc.Localize("DalamudSettingToggleUiHide", "Hide plugin UI when the game UI is toggled off"), ref this.doToggleUiHide);
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleUiHideHint", "Hide any open windows by plugins when toggling the game overlay."));
+
+            ImGui.Checkbox(Loc.Localize("DalamudSettingToggleUiHideDuringCutscenes", "Hide plugin UI during cutscenes"), ref this.doToggleUiHideDuringCutscenes);
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleUiHideDuringCutscenesHint", "Hide any open windows by plugins during cutscenes."));
+
+            ImGui.Checkbox(Loc.Localize("DalamudSettingToggleUiHideDuringGpose", "Hide plugin UI while gpose is active"), ref this.doToggleUiHideDuringGpose);
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleUiHideDuringGposeHint", "Hide any open windows by plugins while gpose is active."));
+
+            ImGuiHelpers.ScaledDummy(10, 16);
+
+            ImGui.Checkbox(Loc.Localize("DalamudSettingToggleFocusManagement", "Use escape to close Dalamud windows"), ref this.doFocus);
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleFocusManagementHint", "This will cause Dalamud windows to behave like in-game windows when pressing escape.\nThey will close one after another until all are closed. May not work for all plugins."));
+
+            ImGui.Checkbox(Loc.Localize("DalamudSettingToggleViewports", "Enable multi-monitor windows"), ref this.doViewport);
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleViewportsHint", "This will allow you move plugin windows onto other monitors.\nWill only work in Borderless Window or Windowed mode."));
+
+            ImGui.Checkbox(Loc.Localize("DalamudSettingToggleDocking", "Enable window docking"), ref this.doDocking);
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleDockingHint", "This will allow you to fuse and tab plugin windows."));
+
+            ImGui.Checkbox(Loc.Localize("DalamudSettingToggleGamepadNavigation", "Control plugins via gamepad"), ref this.doGamepad);
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingToggleGamepadNavigationHint", "This will allow you to toggle between game and plugin navigation via L1+L3.\nToggle the PluginInstaller window via R3 if ImGui navigation is enabled."));
+        }
+
+        private void DrawExperimentalTab()
+        {
+            var configuration = Service<DalamudConfiguration>.Get();
+            var pluginManager = Service<PluginManager>.Get();
+
+            #region Plugin testing
+
+            ImGui.Checkbox(Loc.Localize("DalamudSettingsPluginTest", "Get plugin testing builds"), ref this.doPluginTest);
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsPluginTestHint", "Receive testing prereleases for plugins."));
+            ImGui.TextColored(this.warnTextColor, Loc.Localize("DalamudSettingsPluginTestWarning", "Testing plugins may not have been vetted before being published. Please only enable this if you are aware of the risks."));
+
+            #endregion
+
+            ImGuiHelpers.ScaledDummy(12);
+
+            #region Hidden plugins
+
+            if (ImGui.Button(Loc.Localize("DalamudSettingsClearHidden", "Clear hidden plugins")))
+            {
+                configuration.HiddenPluginInternalName.Clear();
+                pluginManager.RefilterPluginMasters();
+            }
+
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsClearHiddenHint", "Restore plugins you have previously hidden from the plugin installer."));
+
+            #endregion
+
+            ImGuiHelpers.ScaledDummy(12);
+
+            this.DrawCustomReposSection();
+
+            ImGuiHelpers.ScaledDummy(12);
+
+            this.DrawDevPluginLocationsSection();
+
+            ImGuiHelpers.ScaledDummy(12);
+        }
+
+        private void DrawCustomReposSection()
+        {
+            ImGui.Text(Loc.Localize("DalamudSettingsCustomRepo", "Custom Plugin Repositories"));
+            if (this.thirdRepoListChanged)
+            {
+                ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.HealerGreen);
+                ImGui.SameLine();
+                ImGui.Text(Loc.Localize("DalamudSettingsChanged", "(Changed)"));
+                ImGui.PopStyleColor();
+            }
+
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingCustomRepoHint", "Add custom plugin repositories."));
+            ImGui.TextColored(this.warnTextColor, Loc.Localize("DalamudSettingCustomRepoWarning", "We cannot take any responsibility for third-party plugins and repositories.\nTake care when installing third-party plugins from untrusted sources."));
+
+            ImGuiHelpers.ScaledDummy(5);
+
+            ImGui.Columns(4);
+            ImGui.SetColumnWidth(0, 18 + (5 * ImGuiHelpers.GlobalScale));
+            ImGui.SetColumnWidth(1, ImGui.GetWindowContentRegionWidth() - (18 + 16 + 14) - ((5 + 45 + 26) * ImGuiHelpers.GlobalScale));
+            ImGui.SetColumnWidth(2, 16 + (45 * ImGuiHelpers.GlobalScale));
+            ImGui.SetColumnWidth(3, 14 + (26 * ImGuiHelpers.GlobalScale));
+
+            ImGui.Separator();
+
+            ImGui.Text("#");
+            ImGui.NextColumn();
+            ImGui.Text("URL");
+            ImGui.NextColumn();
+            ImGui.Text("Enabled");
+            ImGui.NextColumn();
+            ImGui.Text(string.Empty);
+            ImGui.NextColumn();
+
+            ImGui.Separator();
+
+            ImGui.Text("0");
+            ImGui.NextColumn();
+            ImGui.Text("XIVLauncher");
+            ImGui.NextColumn();
+            ImGui.NextColumn();
+            ImGui.NextColumn();
+            ImGui.Separator();
+
+            ThirdPartyRepoSettings repoToRemove = null;
+
+            var repoNumber = 1;
+            foreach (var thirdRepoSetting in this.thirdRepoList)
+            {
+                var isEnabled = thirdRepoSetting.IsEnabled;
+
+                ImGui.PushID($"thirdRepo_{thirdRepoSetting.Url}");
+
+                ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 8 - (ImGui.CalcTextSize(repoNumber.ToString()).X / 2));
+                ImGui.Text(repoNumber.ToString());
+                ImGui.NextColumn();
+
+                ImGui.SetNextItemWidth(-1);
+                var url = thirdRepoSetting.Url;
+                if (ImGui.InputText($"##thirdRepoInput", ref url, 65535, ImGuiInputTextFlags.EnterReturnsTrue))
+                {
+                    var contains = this.thirdRepoList.Select(repo => repo.Url).Contains(url);
+                    if (thirdRepoSetting.Url == url)
+                    {
+                        // no change.
+                    }
+                    else if (contains && thirdRepoSetting.Url != url)
+                    {
+                        this.thirdRepoAddError = Loc.Localize("DalamudThirdRepoExists", "Repo already exists.");
+                        Task.Delay(5000).ContinueWith(t => this.thirdRepoAddError = string.Empty);
+                    }
+                    else
+                    {
+                        thirdRepoSetting.Url = url;
+                        this.thirdRepoListChanged = url != thirdRepoSetting.Url;
+                    }
+                }
+
+                ImGui.NextColumn();
+
+                ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 7 - (12 * ImGuiHelpers.GlobalScale));
+                ImGui.Checkbox("##thirdRepoCheck", ref isEnabled);
+                ImGui.NextColumn();
+
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.Trash))
+                {
+                    repoToRemove = thirdRepoSetting;
+                }
+
+                ImGui.PopID();
+
+                ImGui.NextColumn();
+                ImGui.Separator();
+
+                thirdRepoSetting.IsEnabled = isEnabled;
+
+                repoNumber++;
+            }
+
+            if (repoToRemove != null)
+            {
+                this.thirdRepoList.Remove(repoToRemove);
+                this.thirdRepoListChanged = true;
+            }
+
+            ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 8 - (ImGui.CalcTextSize(repoNumber.ToString()).X / 2));
+            ImGui.Text(repoNumber.ToString());
+            ImGui.NextColumn();
+            ImGui.SetNextItemWidth(-1);
+            ImGui.InputText("##thirdRepoUrlInput", ref this.thirdRepoTempUrl, 300);
+            ImGui.NextColumn();
+            // Enabled button
+            ImGui.NextColumn();
+            if (!string.IsNullOrEmpty(this.thirdRepoTempUrl) && ImGuiComponents.IconButton(FontAwesomeIcon.Plus))
+            {
+                if (this.thirdRepoList.Any(r => string.Equals(r.Url, this.thirdRepoTempUrl, StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    this.thirdRepoAddError = Loc.Localize("DalamudThirdRepoExists", "Repo already exists.");
+                    Task.Delay(5000).ContinueWith(t => this.thirdRepoAddError = string.Empty);
+                }
+                else
+                {
+                    this.thirdRepoList.Add(new ThirdPartyRepoSettings
+                    {
+                        Url = this.thirdRepoTempUrl,
+                        IsEnabled = true,
+                    });
+                    this.thirdRepoListChanged = true;
+                    this.thirdRepoTempUrl = string.Empty;
+                }
+            }
+
+            ImGui.Columns(1);
+
+            if (!string.IsNullOrEmpty(this.thirdRepoAddError))
+            {
+                ImGui.TextColored(new Vector4(1, 0, 0, 1), this.thirdRepoAddError);
+            }
+        }
+
+        private void DrawDevPluginLocationsSection()
+        {
+            ImGui.Text(Loc.Localize("DalamudSettingsDevPluginLocation", "Dev Plugin Locations"));
+            if (this.devPluginLocationsChanged)
+            {
+                ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.HealerGreen);
+                ImGui.SameLine();
+                ImGui.Text(Loc.Localize("DalamudSettingsChanged", "(Changed)"));
+                ImGui.PopStyleColor();
+            }
+
+            ImGui.TextColored(this.hintTextColor, Loc.Localize("DalamudSettingsDevPluginLocationsHint", "Add additional dev plugin load locations.\nThese can be either the directory or DLL path."));
+
+            ImGuiHelpers.ScaledDummy(5);
+
+            ImGui.Columns(4);
+            ImGui.SetColumnWidth(0, 18 + (5 * ImGuiHelpers.GlobalScale));
+            ImGui.SetColumnWidth(1, ImGui.GetWindowContentRegionWidth() - (18 + 16 + 14) - ((5 + 45 + 26) * ImGuiHelpers.GlobalScale));
+            ImGui.SetColumnWidth(2, 16 + (45 * ImGuiHelpers.GlobalScale));
+            ImGui.SetColumnWidth(3, 14 + (26 * ImGuiHelpers.GlobalScale));
+
+            ImGui.Separator();
+
+            ImGui.Text("#");
+            ImGui.NextColumn();
+            ImGui.Text("Path");
+            ImGui.NextColumn();
+            ImGui.Text("Enabled");
+            ImGui.NextColumn();
+            ImGui.Text(string.Empty);
+            ImGui.NextColumn();
+
+            ImGui.Separator();
+
+            DevPluginLocationSettings locationToRemove = null;
+
+            var locNumber = 1;
+            foreach (var devPluginLocationSetting in this.devPluginLocations)
+            {
+                var isEnabled = devPluginLocationSetting.IsEnabled;
+
+                ImGui.PushID($"devPluginLocation_{devPluginLocationSetting.Path}");
+
+                ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 8 - (ImGui.CalcTextSize(locNumber.ToString()).X / 2));
+                ImGui.Text(locNumber.ToString());
+                ImGui.NextColumn();
+
+                ImGui.SetNextItemWidth(-1);
+                var path = devPluginLocationSetting.Path;
+                if (ImGui.InputText($"##devPluginLocationInput", ref path, 65535, ImGuiInputTextFlags.EnterReturnsTrue))
+                {
+                    var contains = this.devPluginLocations.Select(loc => loc.Path).Contains(path);
+                    if (devPluginLocationSetting.Path == path)
+                    {
+                        // no change.
+                    }
+                    else if (contains && devPluginLocationSetting.Path != path)
+                    {
+                        this.devPluginLocationAddError = Loc.Localize("DalamudDevPluginLocationExists", "Location already exists.");
+                        Task.Delay(5000).ContinueWith(t => this.devPluginLocationAddError = string.Empty);
+                    }
+                    else
+                    {
+                        devPluginLocationSetting.Path = path;
+                        this.devPluginLocationsChanged = path != devPluginLocationSetting.Path;
+                    }
+                }
+
+                ImGui.NextColumn();
+
+                ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 7 - (12 * ImGuiHelpers.GlobalScale));
+                ImGui.Checkbox("##devPluginLocationCheck", ref isEnabled);
+                ImGui.NextColumn();
+
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.Trash))
+                {
+                    locationToRemove = devPluginLocationSetting;
+                }
+
+                ImGui.PopID();
+
+                ImGui.NextColumn();
+                ImGui.Separator();
+
+                devPluginLocationSetting.IsEnabled = isEnabled;
+
+                locNumber++;
+            }
+
+            if (locationToRemove != null)
+            {
+                this.devPluginLocations.Remove(locationToRemove);
+                this.devPluginLocationsChanged = true;
+            }
+
+            ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 8 - (ImGui.CalcTextSize(locNumber.ToString()).X / 2));
+            ImGui.Text(locNumber.ToString());
+            ImGui.NextColumn();
+            ImGui.SetNextItemWidth(-1);
+            ImGui.InputText("##devPluginLocationInput", ref this.devPluginTempLocation, 300);
+            ImGui.NextColumn();
+            // Enabled button
+            ImGui.NextColumn();
+            if (!string.IsNullOrEmpty(this.devPluginTempLocation) && ImGuiComponents.IconButton(FontAwesomeIcon.Plus))
+            {
+                if (this.devPluginLocations.Any(r => string.Equals(r.Path, this.devPluginTempLocation, StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    this.devPluginLocationAddError = Loc.Localize("DalamudDevPluginLocationExists", "Location already exists.");
+                    Task.Delay(5000).ContinueWith(t => this.devPluginLocationAddError = string.Empty);
+                }
+                else
+                {
+                    this.devPluginLocations.Add(new DevPluginLocationSettings
+                    {
+                        Path = this.devPluginTempLocation,
+                        IsEnabled = true,
+                    });
+                    this.devPluginLocationsChanged = true;
+                    this.devPluginTempLocation = string.Empty;
+                }
+            }
+
+            ImGui.Columns(1);
+
+            if (!string.IsNullOrEmpty(this.devPluginLocationAddError))
+            {
+                ImGui.TextColored(new Vector4(1, 0, 0, 1), this.devPluginLocationAddError);
+            }
+        }
+
+        private void DrawSaveCloseButtons()
+        {
             var buttonSave = false;
             var buttonClose = false;
+
+            var pluginManager = Service<PluginManager>.Get();
 
             if (ImGui.Button(Loc.Localize("Save", "Save")))
                 buttonSave = true;


### PR DESCRIPTION
The SettingsWindow draw method was huuuuuge. So I split it up a little bit.

This also adds dedup/error displaying if the input fields are changed to a duplicate value.