### PR TITLE
Stop dalamud.boot console from hanging

### DIFF
--- a/Dalamud.Boot/dllmain.cpp
+++ b/Dalamud.Boot/dllmain.cpp
@@ -47,6 +47,9 @@ DllExport DWORD WINAPI Initialize(LPVOID lpParam)
     // =========================================================================== //
 
     #ifndef NDEBUG
+    fclose(stdin);
+    fclose(stdout);
+    fclose(stderr);
     FreeConsole();
     #endif
 

--- a/Dalamud.Injector.Boot/main.cpp
+++ b/Dalamud.Injector.Boot/main.cpp
@@ -49,6 +49,9 @@ int wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LP
     // =========================================================================== //
 
     #ifndef NDEBUG
+    fclose(stdin);
+    fclose(stdout);
+    fclose(stderr);
     FreeConsole();
     #endif
 


### PR DESCRIPTION
Found a stackoverflow post, if you free your streams before calling FreeConsole, the dialog closes like its supposed to. This wasn't needed for dalamud.injector.boot because the program exits. 