### PR TITLE
Fix plugin entries staying open across tabs

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
@@ -440,6 +440,7 @@ namespace Dalamud.Interface.Internal.Windows
 
         private void DrawPluginTab(string title, Action drawPluginList)
         {
+            ImGui.PushID(title);
             if (ImGui.BeginTabItem(title))
             {
                 ImGui.BeginChild($"Scrolling{title}", ImGuiHelpers.ScaledVector2(0, -30), true, ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.NoBackground);
@@ -457,6 +458,8 @@ namespace Dalamud.Interface.Internal.Windows
 
                 ImGui.EndTabItem();
             }
+
+            ImGui.PopID();
         }
 
         private void DrawAvailablePluginList()


### PR DESCRIPTION
Current behavior: Plugin listing at index i will be open on all tabs if opened on any tabs.
Fix: Push ID of current tab before drawing.