### PR TITLE
Add fallible methods to SigScanner

### DIFF
--- a/Dalamud/Game/SigScanner.cs
+++ b/Dalamud/Game/SigScanner.cs
@@ -135,6 +135,28 @@ namespace Dalamud.Game
         }
 
         /// <summary>
+        /// Try scanning memory for a signature.
+        /// </summary>
+        /// <param name="baseAddress">The base address to scan from.</param>
+        /// <param name="size">The amount of bytes to scan.</param>
+        /// <param name="signature">The signature to search for.</param>
+        /// <param name="result">The offset, if found.</param>
+        /// <returns>true if the signature was found.</returns>
+        public static bool TryScan(IntPtr baseAddress, int size, string signature, out IntPtr result)
+        {
+            result = IntPtr.Zero;
+            try
+            {
+                result = Scan(baseAddress, size, signature);
+                return true;
+            }
+            catch (KeyNotFoundException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Scan for a .data address using a .text function.
         /// This is intended to be used with IDA sigs.
         /// Place your cursor on the line calling a static address, and create and IDA sig.
@@ -161,6 +183,29 @@ namespace Dalamud.Game
         }
 
         /// <summary>
+        /// Try scanning for a .data address using a .text function.
+        /// This is intended to be used with IDA sigs.
+        /// Place your cursor on the line calling a static address, and create and IDA sig.
+        /// </summary>
+        /// <param name="signature">The signature of the function using the data.</param>
+        /// <param name="result">An IntPtr to the static memory location, if found.</param>
+        /// <param name="offset">The offset from function start of the instruction using the data.</param>
+        /// <returns>true if the signature was found.</returns>
+        public bool TryGetStaticAddressFromSig(string signature, out IntPtr result, int offset = 0)
+        {
+            result = IntPtr.Zero;
+            try
+            {
+                result = this.GetStaticAddressFromSig(signature, offset);
+                return true;
+            }
+            catch (KeyNotFoundException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Scan for a byte signature in the .data section.
         /// </summary>
         /// <param name="signature">The signature.</param>
@@ -176,6 +221,26 @@ namespace Dalamud.Game
         }
 
         /// <summary>
+        /// Try scanning for a byte signature in the .data section.
+        /// </summary>
+        /// <param name="signature">The signature.</param>
+        /// <param name="result">The real offset of the signature, if found.</param>
+        /// <returns>true if the signature was found.</returns>
+        public bool TryScanData(string signature, out IntPtr result)
+        {
+            result = IntPtr.Zero;
+            try
+            {
+                result = this.ScanData(signature);
+                return true;
+            }
+            catch (KeyNotFoundException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Scan for a byte signature in the whole module search area.
         /// </summary>
         /// <param name="signature">The signature.</param>
@@ -188,6 +253,26 @@ namespace Dalamud.Game
                 scanRet = new IntPtr(scanRet.ToInt64() - this.moduleCopyOffset);
 
             return scanRet;
+        }
+
+        /// <summary>
+        /// Try scanning for a byte signature in the whole module search area.
+        /// </summary>
+        /// <param name="signature">The signature.</param>
+        /// <param name="result">The real offset of the signature, if found.</param>
+        /// <returns>true if the signature was found.</returns>
+        public bool TryScanModule(string signature, out IntPtr result)
+        {
+            result = IntPtr.Zero;
+            try
+            {
+                result = this.ScanModule(signature);
+                return true;
+            }
+            catch (KeyNotFoundException)
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -222,6 +307,26 @@ namespace Dalamud.Game
                 return ReadJmpCallSig(scanRet);
 
             return scanRet;
+        }
+
+        /// <summary>
+        /// Try scanning for a byte signature in the .text section.
+        /// </summary>
+        /// <param name="signature">The signature.</param>
+        /// <param name="result">The real offset of the signature, if found.</param>
+        /// <returns>true if the signature was found.</returns>
+        public bool TryScanText(string signature, out IntPtr result)
+        {
+            result = IntPtr.Zero;
+            try
+            {
+                result = this.ScanText(signature);
+                return true;
+            }
+            catch (KeyNotFoundException)
+            {
+                return false;
+            }
         }
 
         /// <summary>

--- a/Dalamud/Game/SigScanner.cs
+++ b/Dalamud/Game/SigScanner.cs
@@ -144,7 +144,6 @@ namespace Dalamud.Game
         /// <returns>true if the signature was found.</returns>
         public static bool TryScan(IntPtr baseAddress, int size, string signature, out IntPtr result)
         {
-            result = IntPtr.Zero;
             try
             {
                 result = Scan(baseAddress, size, signature);
@@ -152,6 +151,7 @@ namespace Dalamud.Game
             }
             catch (KeyNotFoundException)
             {
+                result = IntPtr.Zero;
                 return false;
             }
         }
@@ -193,7 +193,6 @@ namespace Dalamud.Game
         /// <returns>true if the signature was found.</returns>
         public bool TryGetStaticAddressFromSig(string signature, out IntPtr result, int offset = 0)
         {
-            result = IntPtr.Zero;
             try
             {
                 result = this.GetStaticAddressFromSig(signature, offset);
@@ -201,6 +200,7 @@ namespace Dalamud.Game
             }
             catch (KeyNotFoundException)
             {
+                result = IntPtr.Zero;
                 return false;
             }
         }
@@ -228,7 +228,6 @@ namespace Dalamud.Game
         /// <returns>true if the signature was found.</returns>
         public bool TryScanData(string signature, out IntPtr result)
         {
-            result = IntPtr.Zero;
             try
             {
                 result = this.ScanData(signature);
@@ -236,6 +235,7 @@ namespace Dalamud.Game
             }
             catch (KeyNotFoundException)
             {
+                result = IntPtr.Zero;
                 return false;
             }
         }
@@ -263,7 +263,6 @@ namespace Dalamud.Game
         /// <returns>true if the signature was found.</returns>
         public bool TryScanModule(string signature, out IntPtr result)
         {
-            result = IntPtr.Zero;
             try
             {
                 result = this.ScanModule(signature);
@@ -271,6 +270,7 @@ namespace Dalamud.Game
             }
             catch (KeyNotFoundException)
             {
+                result = IntPtr.Zero;
                 return false;
             }
         }
@@ -317,7 +317,6 @@ namespace Dalamud.Game
         /// <returns>true if the signature was found.</returns>
         public bool TryScanText(string signature, out IntPtr result)
         {
-            result = IntPtr.Zero;
             try
             {
                 result = this.ScanText(signature);
@@ -325,6 +324,7 @@ namespace Dalamud.Game
             }
             catch (KeyNotFoundException)
             {
+                result = IntPtr.Zero;
                 return false;
             }
         }


### PR DESCRIPTION
I make a static class with `TryScanText` in every plugin. I figure other devs might find this useful.