### PR TITLE
Status list fixes

### DIFF
--- a/Dalamud/Game/ClientState/Fates/FateTable.cs
+++ b/Dalamud/Game/ClientState/Fates/FateTable.cs
@@ -111,7 +111,7 @@ namespace Dalamud.Game.ClientState.Fates
         /// </summary>
         /// <param name="offset">The offset of the actor in memory.</param>
         /// <returns><see cref="Fate"/> object containing requested data.</returns>
-        internal Fate? CreateFateReference(IntPtr offset)
+        public Fate? CreateFateReference(IntPtr offset)
         {
             var clientState = Service<ClientState>.Get();
 

--- a/Dalamud/Game/ClientState/Fates/FateTable.cs
+++ b/Dalamud/Game/ClientState/Fates/FateTable.cs
@@ -29,6 +29,11 @@ namespace Dalamud.Game.ClientState.Fates
         }
 
         /// <summary>
+        /// Gets the address of the Fate table.
+        /// </summary>
+        public IntPtr Address => this.address.FateTablePtr;
+
+        /// <summary>
         /// Gets the amount of currently active Fates.
         /// </summary>
         public unsafe int Length

--- a/Dalamud/Game/ClientState/Statuses/StatusList.cs
+++ b/Dalamud/Game/ClientState/Statuses/StatusList.cs
@@ -36,23 +36,9 @@ namespace Dalamud.Game.ClientState.Statuses
         public IntPtr Address { get; }
 
         /// <summary>
-        /// Gets the amount of status effects the actor has.
+        /// Gets the amount of status effect slots the actor has.
         /// </summary>
-        public int Length
-        {
-            get
-            {
-                var i = 0;
-                for (; i < StatusListLength; i++)
-                {
-                    var status = this[i];
-                    if (status == null || status.StatusId == 0)
-                        break;
-                }
-
-                return i;
-            }
-        }
+        public int Length => StatusListLength;
 
         private static int StatusSize { get; } = Marshal.SizeOf<FFXIVClientStructs.FFXIV.Client.Game.Status>();
 

--- a/Dalamud/Game/ClientState/Statuses/StatusList.cs
+++ b/Dalamud/Game/ClientState/Statuses/StatusList.cs
@@ -57,8 +57,47 @@ namespace Dalamud.Game.ClientState.Statuses
                     return null;
 
                 var addr = this.GetStatusAddress(index);
-                return this.CreateStatusReference(addr);
+                return CreateStatusReference(addr);
             }
+        }
+
+        /// <summary>
+        /// Create a reference to an FFXIV actor status list.
+        /// </summary>
+        /// <param name="address">The address of the status list in memory.</param>
+        /// <returns>The status object containing the requested data.</returns>
+        public static StatusList? CreateStatusListReference(IntPtr address)
+        {
+            // The use case for CreateStatusListReference and CreateStatusReference to be static is so
+            // fake status lists can be generated. Since they aren't exposed as services, it's either
+            // here or somewhere else.
+            var clientState = Service<ClientState>.Get();
+
+            if (clientState.LocalContentId == 0)
+                return null;
+
+            if (address == IntPtr.Zero)
+                return null;
+
+            return new StatusList(address);
+        }
+
+        /// <summary>
+        /// Create a reference to an FFXIV actor status.
+        /// </summary>
+        /// <param name="address">The address of the status effect in memory.</param>
+        /// <returns>The status object containing the requested data.</returns>
+        public static Status? CreateStatusReference(IntPtr address)
+        {
+            var clientState = Service<ClientState>.Get();
+
+            if (clientState.LocalContentId == 0)
+                return null;
+
+            if (address == IntPtr.Zero)
+                return null;
+
+            return new Status(address);
         }
 
         /// <summary>
@@ -72,24 +111,6 @@ namespace Dalamud.Game.ClientState.Statuses
                 return IntPtr.Zero;
 
             return (IntPtr)(this.Struct->Status + (index * StatusSize));
-        }
-
-        /// <summary>
-        /// Create a reference to an FFXIV actor status.
-        /// </summary>
-        /// <param name="address">The address of the status effect in memory.</param>
-        /// <returns>The status object containing the requested data.</returns>
-        public Status? CreateStatusReference(IntPtr address)
-        {
-            var clientState = Service<ClientState>.Get();
-
-            if (clientState.LocalContentId == 0)
-                return null;
-
-            if (address == IntPtr.Zero)
-                return null;
-
-            return new Status(address);
         }
     }
 


### PR DESCRIPTION
StatusList.Length is an easy one, since we dont control the contents of the list, apparently nulls can be interspersed throughout. So the length will not be the count of statuses, but the length of the total list.

Exposing CreateStatusRef and CreateStatusListRef as static sort of breaks the pattern we had on the objectTable, but since StatusList isn't exposed as service, it either needs to be static, or available somewhere else. maybe clientstate?