### PR TITLE
Include the Dalamud assembly as a shared assembly

### DIFF
--- a/Dalamud.CorePlugin/PluginWindow.cs
+++ b/Dalamud.CorePlugin/PluginWindow.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Windowing;

--- a/Dalamud/Plugin/Internal/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/LocalPlugin.cs
@@ -436,6 +436,7 @@ namespace Dalamud.Plugin.Internal
             config.IsUnloadable = true;
             config.LoadInMemory = true;
             config.PreferSharedTypes = false;
+            config.SharedAssemblies.Add(typeof(IDalamudPlugin).Assembly.GetName());
             config.SharedAssemblies.Add(typeof(Lumina.GameData).Assembly.GetName());
             config.SharedAssemblies.Add(typeof(Lumina.Excel.ExcelSheetImpl).Assembly.GetName());
         }


### PR DESCRIPTION
If you don't set dalamud to private=false, so that dalamud.dll is in your dev plugin dist folder, the plugin will fail to load, thinking it should use it's version of Dalamud.dll, so it is now a different IDalamudPlugin