### PR TITLE
fix: handling installed plugins in category view, adjusted tags

### DIFF
--- a/Dalamud/Interface/Internal/PluginCategoryManager.cs
+++ b/Dalamud/Interface/Internal/PluginCategoryManager.cs
@@ -24,7 +24,7 @@ namespace Dalamud.Interface.Internal
             new(FirstTagBasedCategoryId + 0, "other", () => Locs.Category_Other),
             new(FirstTagBasedCategoryId + 1, "jobs", () => Locs.Category_Jobs),
             new(FirstTagBasedCategoryId + 2, "ui", () => Locs.Category_UI),
-            new(FirstTagBasedCategoryId + 3, "minigame", () => Locs.Category_MiniGames),
+            new(FirstTagBasedCategoryId + 3, "minigames", () => Locs.Category_MiniGames),
             new(FirstTagBasedCategoryId + 4, "inventory", () => Locs.Category_Inventory),
             new(FirstTagBasedCategoryId + 5, "sound", () => Locs.Category_Sound),
             new(FirstTagBasedCategoryId + 6, "social", () => Locs.Category_Social),

--- a/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
@@ -741,7 +741,7 @@ namespace Dalamud.Interface.Internal.Windows
                         this.openPluginCollapsibles.Clear();
                     }
 
-                    var filteredManifests = pluginList.Where(rm => !this.IsManifestFiltered(rm));
+                    var filteredManifests = pluginList.Where(rm => !this.IsManifestFiltered(rm) && !this.IsManifestInstalled(rm).IsInstalled);
                     var categoryManifestsList = this.categoryManager.GetCurrentCategoryContent(filteredManifests);
 
                     if (categoryManifestsList.Count > 0)


### PR DESCRIPTION
Tags are now matching fallbacks used by plugin master generator.