### PR TITLE
Expose PF last patch timestamp

### DIFF
--- a/Dalamud/Game/Gui/PartyFinder/Internal/PartyFinderPacketListing.cs
+++ b/Dalamud/Game/Gui/PartyFinder/Internal/PartyFinderPacketListing.cs
@@ -51,7 +51,7 @@ namespace Dalamud.Game.Gui.PartyFinder.Internal
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
         private readonly byte[] header7; // all zero in every pf I've examined
 
-        private readonly uint lastPatchHotfixTimestamp; // last time the servers were restarted?
+        internal readonly uint LastPatchHotfixTimestamp; // last time the servers were restarted?
         internal readonly ushort SecondsRemaining;
 
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]

--- a/Dalamud/Game/Gui/PartyFinder/Types/PartyFinderListing.cs
+++ b/Dalamud/Game/Gui/PartyFinder/Types/PartyFinderListing.cs
@@ -54,6 +54,7 @@ namespace Dalamud.Game.Gui.PartyFinder.Types
             this.MinimumItemLevel = listing.MinimumItemLevel;
             this.Parties = listing.NumParties;
             this.SlotsAvailable = listing.NumSlots;
+            this.LastPatchHotfixTimestamp = listing.LastPatchHotfixTimestamp;
             this.JobsPresent = listing.JobsPresent
                 .Select(id => new Lazy<ClassJob>(
                     () => id == 0
@@ -142,6 +143,12 @@ namespace Dalamud.Game.Gui.PartyFinder.Types
         /// Gets the number of player slots this listing is recruiting for.
         /// </summary>
         public byte SlotsAvailable { get; }
+
+        /// <summary>
+        /// Gets the time at which the server this listings is on last restarted for a patch/hotfix.
+        /// Probably.
+        /// </summary>
+        public uint LastPatchHotfixTimestamp { get; }
 
         /// <summary>
         /// Gets a list of player slots that the Party Finder is accepting.


### PR DESCRIPTION
This is useful if you're keeping track of PF listing IDs, as they (likely) reset to 0 after a server restart.