### PR TITLE
Fix crash in flytext

### DIFF
--- a/Dalamud/Game/Gui/FlyText/FlyTextGui.cs
+++ b/Dalamud/Game/Gui/FlyText/FlyTextGui.cs
@@ -213,8 +213,8 @@ namespace Dalamud.Game.Gui.FlyText
                 var tmpKind = kind;
                 var tmpVal1 = val1;
                 var tmpVal2 = val2;
-                var tmpText1 = MemoryHelper.ReadSeStringNullTerminated(text1);
-                var tmpText2 = MemoryHelper.ReadSeStringNullTerminated(text2);
+                var tmpText1 = text1 == IntPtr.Zero ? string.Empty : MemoryHelper.ReadSeStringNullTerminated(text1);
+                var tmpText2 = text2 == IntPtr.Zero ? string.Empty : MemoryHelper.ReadSeStringNullTerminated(text2);
                 var tmpColor = color;
                 var tmpIcon = icon;
                 var tmpYOffset = yOffset;


### PR DESCRIPTION
Testing by Aireil.

```
2021-10-06 22:58:58.655 +02:00 [ERR] Exception occurred in CreateFlyTextDetour!
System.NullReferenceException: Object reference not set to an instance of an object.
   at Dalamud.Memory.MemoryHelper.ReadRawNullTerminated(IntPtr memoryAddress) in C:\goatsoft\companysecrets\dalamud\Memory\MemoryHelper.cs:line 102
   at Dalamud.Game.Gui.FlyText.FlyTextGui.CreateFlyTextDetour(IntPtr addonFlyText, FlyTextKind kind, Int32 val1, Int32 val2, IntPtr text2, UInt32 color, UInt32 icon, IntPtr text1, Single yOffset) in C:\goatsoft\companysecrets\dalamud\Game\Gui\FlyText\FlyTextGui.cs:line 309
```