### PR TITLE
fix: inconsistencies with plugin installer collapsibles

### DIFF
--- a/Dalamud/Interface/Internal/PluginCategoryManager.cs
+++ b/Dalamud/Interface/Internal/PluginCategoryManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using CheapLoc;
 using Dalamud.Plugin.Internal.Types;
@@ -114,7 +115,8 @@ namespace Dalamud.Interface.Internal
         }
 
         /// <summary>
-        /// Gets a value indicating whether category content needs to be rebuild with BuildCategoryContent() function.
+        /// Gets a value indicating whether current group + category selection changed recently.
+        /// Changes in Available group should be followed with <see cref="GetCurrentCategoryContent"/>, everythine else can use <see cref="ResetContentDirty"/>.
         /// </summary>
         public bool IsContentDirty => this.isContentDirty;
 
@@ -135,6 +137,10 @@ namespace Dalamud.Interface.Internal
         {
             // rebuild map plugin name -> categoryIds
             this.mapPluginCategories.Clear();
+
+            var groupAvail = Array.Find(this.groupList, x => x.GroupKind == GroupKind.Available);
+            var prevCategoryIds = new List<int>();
+            prevCategoryIds.AddRange(groupAvail.Categories);
 
             var categoryList = new List<int>();
             var allCategoryIndices = new List<int>();
@@ -174,7 +180,6 @@ namespace Dalamud.Interface.Internal
             allCategoryIndices.Sort((idxX, idxY) => this.CategoryList[idxX].Name.CompareTo(this.CategoryList[idxY].Name));
 
             // rebuild all categories in group, leaving first entry = All intact and always on top
-            var groupAvail = Array.Find(this.groupList, x => x.GroupKind == GroupKind.Available);
             if (groupAvail.Categories.Count > 1)
             {
                 groupAvail.Categories.RemoveRange(1, groupAvail.Categories.Count - 1);
@@ -185,12 +190,17 @@ namespace Dalamud.Interface.Internal
                 groupAvail.Categories.Add(this.CategoryList[categoryIdx].CategoryId);
             }
 
-            this.isContentDirty = true;
+            // compare with prev state and mark as dirty if needed
+            var noCategoryChanges = Enumerable.SequenceEqual(prevCategoryIds, groupAvail.Categories);
+            if (!noCategoryChanges)
+            {
+                this.isContentDirty = true;
+            }
         }
 
         /// <summary>
         /// Filters list of available plugins based on currently selected category.
-        /// Resets <see cref="isContentDirty"/>.
+        /// Resets <see cref="IsContentDirty"/>.
         /// </summary>
         /// <param name="plugins">List of available plugins to install.</param>
         /// <returns>Filtered list of plugins.</returns>
@@ -225,8 +235,16 @@ namespace Dalamud.Interface.Internal
                 }
             }
 
-            this.isContentDirty = false;
+            this.ResetContentDirty();
             return result;
+        }
+
+        /// <summary>
+        /// Clears <see cref="IsContentDirty"/> flag, indicating that all cached values about currently selected group + category have been updated.
+        /// </summary>
+        public void ResetContentDirty()
+        {
+            this.isContentDirty = false;
         }
 
         /// <summary>

--- a/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
@@ -535,12 +535,7 @@ namespace Dalamud.Interface.Internal.Windows
                 return;
             }
 
-            // reset opened list of collapsibles when switching between categories
-            if (this.categoryManager.IsContentDirty)
-            {
-                this.openPluginCollapsibles.Clear();
-            }
-
+            // get list to show and reset category dirty flag
             var categoryManifestsList = this.categoryManager.GetCurrentCategoryContent(filteredManifests);
 
             var i = 0;
@@ -726,6 +721,18 @@ namespace Dalamud.Interface.Internal.Windows
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, ImGuiHelpers.ScaledVector2(1, 3));
 
             var groupInfo = this.categoryManager.GroupList[this.categoryManager.CurrentGroupIdx];
+            if (this.categoryManager.IsContentDirty)
+            {
+                // reset opened list of collapsibles when switching between categories
+                this.openPluginCollapsibles.Clear();
+
+                // do NOT reset dirty flag when Available group is selected, it will be handled by DrawAvailablePluginList()
+                if (groupInfo.GroupKind != PluginCategoryManager.GroupKind.Available)
+                {
+                    this.categoryManager.ResetContentDirty();
+                }
+            }
+
             if (groupInfo.GroupKind == PluginCategoryManager.GroupKind.DevTools)
             {
                 // this one is never sorted and remains in hardcoded order from group ctor


### PR DESCRIPTION
- no more collapsing after install,
- group/category change will always reset collapsibles