### PR TITLE
Show ban/api warnings without expanding header

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
@@ -635,7 +635,7 @@ namespace Dalamud.Interface.Internal.Windows
                     this.DrawPluginCategorySelectors();
 
                     ImGui.TableNextColumn();
-                    if (ImGui.BeginChild("ScrollingPlugins", new Vector2(-1, 0), false, ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.NoBackground))
+                    if (ImGui.BeginChild("ScrollingPlugins", new Vector2(-1, 0), false, ImGuiWindowFlags.NoBackground))
                     {
                         this.DrawPluginCategoryContent();
                     }


### PR DESCRIPTION
Replaces the punchline when a plugin is banned or old, avoids having to expand the header to see it.

![demo](https://i.imgur.com/FyUwk2Z.png)

Removes the horizontal scrollbar for plugins child. When resizing, it just created a scrollbar, meaning text was unreadable without scrolling instead of wrapping.

The diff is a bit weird, but it's basically 2 copy-pastes with patterns as conditions.