### PR TITLE
feat: Add AtkArrayData browser to the data inspector window

### DIFF
--- a/Dalamud/Interface/Internal/Windows/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/DataWindow.cs
@@ -132,6 +132,7 @@ namespace Dalamud.Interface.Internal.Windows
             Command,
             Addon,
             Addon_Inspector,
+            AtkArrayData_Browser,
             StartInfo,
             Target,
             Toast,
@@ -272,6 +273,10 @@ namespace Dalamud.Interface.Internal.Windows
 
                         case DataKind.Addon_Inspector:
                             this.DrawAddonInspector();
+                            break;
+
+                        case DataKind.AtkArrayData_Browser:
+                            this.DrawAtkArrayDataBrowser();
                             break;
 
                         case DataKind.StartInfo:
@@ -944,6 +949,153 @@ namespace Dalamud.Interface.Internal.Windows
         {
             this.addonInspector ??= new UIDebug();
             this.addonInspector.Draw();
+        }
+
+        private unsafe void DrawAtkArrayDataBrowser()
+        {
+            var fontWidth = ImGui.CalcTextSize("A").X;
+            var fontHeight = ImGui.GetTextLineHeightWithSpacing();
+            var uiModule = FFXIVClientStructs.FFXIV.Client.System.Framework.Framework.Instance()->GetUiModule();
+
+            if (uiModule == null)
+            {
+                ImGui.Text("UIModule unavailable.");
+                return;
+            }
+
+            var atkArrayDataHolder = &uiModule->GetRaptureAtkModule()->AtkModule.AtkArrayDataHolder;
+
+            if (ImGui.BeginTabBar("AtkArrayDataBrowserTabBar"))
+            {
+                if (ImGui.BeginTabItem($"NumberArrayData [{atkArrayDataHolder->NumberArrayCount}]"))
+                {
+                    if (ImGui.BeginTable("NumberArrayDataTable", 3, ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY))
+                    {
+                        ImGui.TableSetupColumn("Index", ImGuiTableColumnFlags.WidthFixed, fontWidth * 10);
+                        ImGui.TableSetupColumn("Size", ImGuiTableColumnFlags.WidthFixed, fontWidth * 10);
+                        ImGui.TableSetupColumn("Pointer", ImGuiTableColumnFlags.WidthStretch);
+                        ImGui.TableHeadersRow();
+                        for (int numberArrayIndex = 0; numberArrayIndex < atkArrayDataHolder->NumberArrayCount; numberArrayIndex++)
+                        {
+                            ImGui.TableNextRow();
+                            ImGui.TableNextColumn();
+                            ImGui.Text($"{numberArrayIndex} [{numberArrayIndex * 8:X}]");
+                            ImGui.TableNextColumn();
+                            var numberArrayData = atkArrayDataHolder->NumberArrays[numberArrayIndex];
+                            if (numberArrayData != null)
+                            {
+                                ImGui.Text($"{numberArrayData->AtkArrayData.Size}");
+                                ImGui.TableNextColumn();
+                                if (ImGui.TreeNodeEx($"{(long)numberArrayData:X}###{numberArrayIndex}", ImGuiTreeNodeFlags.SpanFullWidth))
+                                {
+                                    ImGui.NewLine();
+                                    int tableHeight = Math.Min(40, numberArrayData->AtkArrayData.Size + 4);
+                                    if (ImGui.BeginTable($"NumberArrayDataTable", 4, ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY, new Vector2(0.0F, fontHeight * tableHeight)))
+                                    {
+                                        ImGui.TableSetupColumn("Index", ImGuiTableColumnFlags.WidthFixed, fontWidth * 6);
+                                        ImGui.TableSetupColumn("Hex", ImGuiTableColumnFlags.WidthFixed, fontWidth * 9);
+                                        ImGui.TableSetupColumn("Integer", ImGuiTableColumnFlags.WidthFixed, fontWidth * 12);
+                                        ImGui.TableSetupColumn("Float", ImGuiTableColumnFlags.WidthFixed, fontWidth * 20);
+                                        ImGui.TableHeadersRow();
+                                        for (int numberIndex = 0; numberIndex < numberArrayData->AtkArrayData.Size; numberIndex++)
+                                        {
+                                            ImGui.TableNextRow();
+                                            ImGui.TableNextColumn();
+                                            ImGui.Text($"{numberIndex}");
+                                            ImGui.TableNextColumn();
+                                            ImGui.Text($"{numberArrayData->IntArray[numberIndex]:X}");
+                                            ImGui.TableNextColumn();
+                                            ImGui.Text($"{numberArrayData->IntArray[numberIndex]}");
+                                            ImGui.TableNextColumn();
+                                            ImGui.Text($"{*(float*)&numberArrayData->IntArray[numberIndex]}");
+                                        }
+
+                                        ImGui.EndTable();
+                                    }
+
+                                    ImGui.TreePop();
+                                }
+                            }
+                            else
+                            {
+                                ImGui.TextDisabled("--");
+                                ImGui.TableNextColumn();
+                                ImGui.TextDisabled("--");
+                            }
+                        }
+
+                        ImGui.EndTable();
+                    }
+
+                    ImGui.EndTabItem();
+                }
+
+                if (ImGui.BeginTabItem($"StringArrayData [{atkArrayDataHolder->StringArrayCount}]"))
+                {
+                    if (ImGui.BeginTable("StringArrayDataTable", 3, ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY))
+                    {
+                        ImGui.TableSetupColumn("Index", ImGuiTableColumnFlags.WidthFixed, fontWidth * 10);
+                        ImGui.TableSetupColumn("Size", ImGuiTableColumnFlags.WidthFixed, fontWidth * 10);
+                        ImGui.TableSetupColumn("Pointer", ImGuiTableColumnFlags.WidthStretch);
+                        ImGui.TableHeadersRow();
+                        for (int stringArrayIndex = 0; stringArrayIndex < atkArrayDataHolder->StringArrayCount; stringArrayIndex++)
+                        {
+                            ImGui.TableNextRow();
+                            ImGui.TableNextColumn();
+                            ImGui.Text($"{stringArrayIndex} [{stringArrayIndex * 8:X}]");
+                            ImGui.TableNextColumn();
+                            var stringArrayData = atkArrayDataHolder->StringArrays[stringArrayIndex];
+                            if (stringArrayData != null)
+                            {
+                                ImGui.Text($"{stringArrayData->AtkArrayData.Size}");
+                                ImGui.TableNextColumn();
+                                if (ImGui.TreeNodeEx($"{(long)stringArrayData:X}###{stringArrayIndex}", ImGuiTreeNodeFlags.SpanFullWidth))
+                                {
+                                    ImGui.NewLine();
+                                    int tableHeight = Math.Min(40, stringArrayData->AtkArrayData.Size + 4);
+                                    if (ImGui.BeginTable($"StringArrayDataTable", 2, ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY, new Vector2(0.0F, fontHeight * tableHeight)))
+                                    {
+                                        ImGui.TableSetupColumn("Index", ImGuiTableColumnFlags.WidthFixed, fontWidth * 6);
+                                        ImGui.TableSetupColumn("String", ImGuiTableColumnFlags.WidthStretch);
+                                        ImGui.TableHeadersRow();
+                                        for (int stringIndex = 0; stringIndex < stringArrayData->AtkArrayData.Size; stringIndex++)
+                                        {
+                                            ImGui.TableNextRow();
+                                            ImGui.TableNextColumn();
+                                            ImGui.Text($"{stringIndex}");
+                                            ImGui.TableNextColumn();
+                                            if (stringArrayData->StringArray[stringIndex] != null)
+                                            {
+                                                ImGui.Text($"{MemoryHelper.ReadSeStringNullTerminated(new IntPtr(stringArrayData->StringArray[stringIndex]))}");
+                                            }
+                                            else
+                                            {
+                                                ImGui.TextDisabled("--");
+                                            }
+                                        }
+
+                                        ImGui.EndTable();
+                                    }
+
+                                    ImGui.TreePop();
+                                }
+                            }
+                            else
+                            {
+                                ImGui.TextDisabled("--");
+                                ImGui.TableNextColumn();
+                                ImGui.TextDisabled("--");
+                            }
+                        }
+
+                        ImGui.EndTable();
+                    }
+
+                    ImGui.EndTabItem();
+                }
+
+                ImGui.EndTabBar();
+            }
         }
 
         private void DrawStartInfo()


### PR DESCRIPTION
AtkArrayData is a bunch of number and string arrays used to pass data to UI Addons from the agents and modules. All dynamic data displayed in the UI by Addon classes is read from the array data rather than pulled directly from their source.

There's some duplicated code here but shrug.

![StringWindow](https://user-images.githubusercontent.com/1631648/138612384-887fda8b-14c2-4576-992d-2794e5ce94e9.png)
