### PR TITLE
Fixes

### DIFF
--- a/Dalamud/Configuration/Internal/EnvironmentConfiguration.cs
+++ b/Dalamud/Configuration/Internal/EnvironmentConfiguration.cs
@@ -23,9 +23,14 @@ namespace Dalamud.Configuration.Internal
         public static bool DalamudNoPlugins { get; } = GetEnvironmentVariable("DALAMUD_NOT_HAVE_PLUGINS");
 
         /// <summary>
+        /// Gets a value indicating whether the DalamudForceReloaded setting has been enabled.
+        /// </summary>
+        public static bool DalamudForceReloaded { get; } = GetEnvironmentVariable("DALAMUD_FORCE_RELOADED");
+
+        /// <summary>
         /// Gets a value indicating whether the DalamudForceCoreHook setting has been enabled.
         /// </summary>
-        public static bool DalamudForceMinHook { get; } = GetEnvironmentVariable("DALAMUD_FORCE_COREHOOK");
+        public static bool DalamudForceMinHook { get; } = GetEnvironmentVariable("DALAMUD_FORCE_MINHOOK");
 
         private static bool GetEnvironmentVariable(string name)
             => bool.Parse(Environment.GetEnvironmentVariable(name) ?? "false");

--- a/Dalamud/Configuration/Internal/EnvironmentConfiguration.cs
+++ b/Dalamud/Configuration/Internal/EnvironmentConfiguration.cs
@@ -28,7 +28,7 @@ namespace Dalamud.Configuration.Internal
         public static bool DalamudForceReloaded { get; } = GetEnvironmentVariable("DALAMUD_FORCE_RELOADED");
 
         /// <summary>
-        /// Gets a value indicating whether the DalamudForceCoreHook setting has been enabled.
+        /// Gets a value indicating whether the DalamudForceMinHook setting has been enabled.
         /// </summary>
         public static bool DalamudForceMinHook { get; } = GetEnvironmentVariable("DALAMUD_FORCE_MINHOOK");
 

--- a/Dalamud/Hooking/Hook.cs
+++ b/Dalamud/Hooking/Hook.cs
@@ -61,7 +61,7 @@ namespace Dalamud.Hooking
             {
                 var indexList = hasOtherHooks
                     ? HookManager.MultiHookTracker[address]
-                    : HookManager.MultiHookTracker[address] = new();
+                    : (HookManager.MultiHookTracker[address] = new());
                 var index = (ulong)indexList.Count;
 
                 this.minHookImpl = new MinSharp.Hook<T>(address, detour, index);

--- a/Dalamud/Hooking/Hook.cs
+++ b/Dalamud/Hooking/Hook.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 using Dalamud.Configuration.Internal;
@@ -59,9 +60,9 @@ namespace Dalamud.Hooking
             this.address = address;
             if (this.isMinHook)
             {
-                var indexList = hasOtherHooks
-                    ? HookManager.MultiHookTracker[address]
-                    : (HookManager.MultiHookTracker[address] = new());
+                if (!HookManager.MultiHookTracker.TryGetValue(address, out var indexList))
+                    indexList = HookManager.MultiHookTracker[address] = new();
+
                 var index = (ulong)indexList.Count;
 
                 this.minHookImpl = new MinSharp.Hook<T>(address, detour, index);
@@ -191,7 +192,9 @@ namespace Dalamud.Hooking
             if (this.isMinHook)
             {
                 this.minHookImpl.Dispose();
-                HookManager.MultiHookTracker[this.address] = null;
+
+                var index = HookManager.MultiHookTracker[this.address].IndexOf(this);
+                HookManager.MultiHookTracker[this.address][index] = null;
             }
             else
             {

--- a/Dalamud/Hooking/Hook.cs
+++ b/Dalamud/Hooking/Hook.cs
@@ -47,7 +47,7 @@ namespace Dalamud.Hooking
         private Hook(IntPtr address, T detour, bool useMinHook, Assembly callingAssembly)
         {
             address = HookManager.FollowJmp(address);
-            this.isMinHook = EnvironmentConfiguration.DalamudForceMinHook || useMinHook;
+            this.isMinHook = !EnvironmentConfiguration.DalamudForceReloaded && (EnvironmentConfiguration.DalamudForceMinHook || useMinHook);
 
             var hasOtherHooks = HookManager.Originals.ContainsKey(address);
             if (!hasOtherHooks)

--- a/Dalamud/Hooking/Hook.cs
+++ b/Dalamud/Hooking/Hook.cs
@@ -27,7 +27,7 @@ namespace Dalamud.Hooking
         /// <param name="address">A memory address to install a hook.</param>
         /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
         public Hook(IntPtr address, T detour)
-            : this(address, detour, false)
+            : this(address, detour, false, Assembly.GetCallingAssembly())
         {
         }
 
@@ -40,6 +40,11 @@ namespace Dalamud.Hooking
         /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
         /// <param name="useMinHook">Use the MinHook hooking library instead of Reloaded.</param>
         public Hook(IntPtr address, T detour, bool useMinHook)
+            : this(address, detour, useMinHook, Assembly.GetCallingAssembly())
+        {
+        }
+
+        private Hook(IntPtr address, T detour, bool useMinHook, Assembly callingAssembly)
         {
             address = HookManager.FollowJmp(address);
             this.isMinHook = EnvironmentConfiguration.DalamudForceMinHook || useMinHook;
@@ -69,7 +74,7 @@ namespace Dalamud.Hooking
                 this.hookImpl = ReloadedHooks.Instance.CreateHook<T>(detour, address.ToInt64());
             }
 
-            HookManager.TrackedHooks.Add(new HookInfo(this, detour, Assembly.GetCallingAssembly()));
+            HookManager.TrackedHooks.Add(new HookInfo(this, detour, callingAssembly));
         }
 
         /// <summary>

--- a/Dalamud/Hooking/Hook.cs
+++ b/Dalamud/Hooking/Hook.cs
@@ -1,12 +1,10 @@
 using System;
-using System.Diagnostics;
 using System.Reflection;
 
 using Dalamud.Configuration.Internal;
 using Dalamud.Hooking.Internal;
 using Dalamud.Memory;
 using Reloaded.Hooks;
-using Serilog;
 
 namespace Dalamud.Hooking
 {

--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -196,7 +196,7 @@ namespace Dalamud.Interface.Internal.Windows
             if (ImGui.IsItemHovered())
                 ImGui.SetTooltip("Kill game");
 
-            ImGui.BeginChild("scrolling", new Vector2(0, ImGui.GetFrameHeightWithSpacing() - 55), false, ImGuiWindowFlags.HorizontalScrollbar);
+            ImGui.BeginChild("scrolling", new Vector2(0, ImGui.GetFrameHeightWithSpacing() - 55), false, ImGuiWindowFlags.AlwaysHorizontalScrollbar | ImGuiWindowFlags.AlwaysVerticalScrollbar);
 
             if (clear)
             {

--- a/Dalamud/Interface/Internal/Windows/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/DataWindow.cs
@@ -1564,6 +1564,8 @@ namespace Dalamud.Interface.Internal.Windows
 
                 if (ImGui.CollapsingHeader($"#{task.Id} - {task.Status} {(subTime - task.StartTime).TotalMilliseconds}ms###task{i}"))
                 {
+                    task.IsBeingViewed = true;
+
                     if (ImGui.Button("CANCEL (May not work)"))
                     {
                         try
@@ -1588,6 +1590,10 @@ namespace Dalamud.Interface.Internal.Windows
                         ImGui.TextColored(ImGuiColors.DalamudRed, "EXCEPTION:");
                         ImGui.TextUnformatted(task.Exception.ToString());
                     }
+                }
+                else
+                {
+                    task.IsBeingViewed = false;
                 }
 
                 ImGui.PopStyleColor(1);

--- a/Dalamud/Logging/Internal/TaskTracker.cs
+++ b/Dalamud/Logging/Internal/TaskTracker.cs
@@ -123,10 +123,16 @@ namespace Dalamud.Logging.Internal
             var patchMethod = typeof(TaskTracker).GetMethod(nameof(AddToActiveTasksHook), BindingFlags.NonPublic | BindingFlags.Static);
 
             if (targetMethod == null)
-                Log.Error("TargetMethod null!");
+            {
+                Log.Error("AddToActiveTasks TargetMethod null!");
+                return;
+            }
 
             if (patchMethod == null)
-                Log.Error("PatchMethod null!");
+            {
+                Log.Error("AddToActiveTasks PatchMethod null!");
+                return;
+            }
 
             this.scheduleAndStartHook = new MonoMod.RuntimeDetour.Hook(targetMethod, patchMethod);
 

--- a/Dalamud/NativeFunctions.cs
+++ b/Dalamud/NativeFunctions.cs
@@ -478,8 +478,8 @@ namespace Dalamud
             WM_INPUT_DEVICE_CHANGE = 0x00FE,
             WM_INPUT = 0x00FF,
 
-            WM_KEYFIRST = WM_KEYDOWN,
-            WM_KEYDOWN = 0x0100,
+            WM_KEYFIRST = 0x0100,
+            WM_KEYDOWN = WM_KEYFIRST,
             WM_KEYUP = 0x0101,
             WM_CHAR = 0x0102,
             WM_DEADCHAR = 0x0103,
@@ -525,8 +525,8 @@ namespace Dalamud
             WM_CTLCOLORSTATIC = 0x0138,
             MN_GETHMENU = 0x01E1,
 
-            WM_MOUSEFIRST = WM_MOUSEMOVE,
-            WM_MOUSEMOVE = 0x0200,
+            WM_MOUSEFIRST = 0x0200,
+            WM_MOUSEMOVE = WM_MOUSEFIRST,
             WM_LBUTTONDOWN = 0x0201,
             WM_LBUTTONUP = 0x0202,
             WM_LBUTTONDBLCLK = 0x0203,


### PR DESCRIPTION
Couple things I've found.

- [FIX] MinHook currently crashes on plugin reload. This is because the Hook.Dispose() method nulls the list itself in the multi-hook tracker, rather than the hook index in the list.
- [EDIT] Change DALAMUD_FORCE_COREHOOK to DALAMUD_FORCE_MINHOOK
- [FEAT] Add DALAMUD_FORCE_RELOADED
- [FEAT/FIX] TaskTracker is currently a "memory leak" in that it grows forever, quickly, with certain plugins (Sonar) and you can never clear it once it goes over the "crash imgui" size. This limits the size to 1000, and adds a variable so that viewed/expanded tasks are not cleared. 
- [FIX] TaskTracker monohook does not bail when the hook fails. It will now.
- [FIX] A previous change of mine to add isMinHook broke Assembly.CallingAssembly semantics. This is a fix.