### PR TITLE
Fix beast chakra enum, bump client structs

### DIFF
--- a/Dalamud/Game/ClientState/JobGauge/Enums/BeastChakra.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Enums/BeastChakra.cs
@@ -16,13 +16,13 @@ namespace Dalamud.Game.ClientState.JobGauge.Enums
         COEURL = 1,
 
         /// <summary>
-        /// The Raptor chakra.
-        /// </summary>
-        RAPTOR = 2,
-
-        /// <summary>
         /// The Opo-Opo chakra.
         /// </summary>
-        OPOOPO = 3,
+        OPOOPO = 2,
+
+        /// <summary>
+        /// The Raptor chakra.
+        /// </summary>
+        RAPTOR = 3,
     }
 }

--- a/Dalamud/Game/ClientState/JobGauge/Types/SCHGauge.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Types/SCHGauge.cs
@@ -29,7 +29,7 @@ namespace Dalamud.Game.ClientState.JobGauge.Types
         public byte FairyGauge => this.Struct->FairyGauge;
 
         /// <summary>
-        /// Gets the Seraph time remaiSCHg in milliseconds.
+        /// Gets the remaining time Seraph is active in milliseconds.
         /// </summary>
         public short SeraphTimer => this.Struct->SeraphTimer;
 


### PR DESCRIPTION
Apparently I transposed the enum values at some point. Illion  even told it to me correctly originally.