### PR TITLE
Fix dev plugin dependency loading when not auto-load

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstallerWindow.cs
@@ -1606,7 +1606,7 @@ namespace Dalamud.Interface.Internal.Windows
                             if (!enableTask.Result)
                                 return;
 
-                            var loadTask = Task.Run(() => plugin.Load(PluginLoadReason.Installer, plugin is LocalDevPlugin))
+                            var loadTask = Task.Run(() => plugin.Load(PluginLoadReason.Installer))
                                 .ContinueWith(this.DisplayErrorContinuation, Locs.ErrorModal_LoadFail(plugin.Name));
 
                             loadTask.Wait();


### PR DESCRIPTION
Give it a test drive, appears to work.

I used a basic non-merged plugin with XivCommon as a dependency.