### PR TITLE
Use correct codepoint for ArrowLeft

### DIFF
--- a/Dalamud/Interface/FontAwesomeIcon.cs
+++ b/Dalamud/Interface/FontAwesomeIcon.cs
@@ -305,7 +305,7 @@ namespace Dalamud.Interface
         /// <summary>
         /// The Font Awesome "arrow-left" icon unicode character.
         /// </summary>
-        ArrowLeft = 0xF06,
+        ArrowLeft = 0xF060,
 
         /// <summary>
         /// The Font Awesome "arrow-right" icon unicode character.


### PR DESCRIPTION
Someone or some tooling stripped off trailing zeroes maybe? Or maybe someone just typo'd.