### PR TITLE
Mark PluginServiceAttribute with MeansImplicitUse

### DIFF
--- a/Dalamud/IoC/PluginServiceAttribute.cs
+++ b/Dalamud/IoC/PluginServiceAttribute.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 
+using JetBrains.Annotations;
+
 namespace Dalamud.IoC
 {
     /// <summary>
     /// This attribute indicates whether an applicable service should be injected into the plugin.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
+    [MeansImplicitUse(ImplicitUseKindFlags.Assign)]
     public class PluginServiceAttribute : Attribute
     {
     }


### PR DESCRIPTION
Fixes IDE warnings about unused setters.