### PR TITLE
Log RTSS hook installation

### DIFF
--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -198,7 +198,9 @@ namespace Dalamud.Interface.Internal
                     var rtssModule = NativeFunctions.GetModuleHandleW("RTSSHooks64.dll");
                     var installAddr = NativeFunctions.GetProcAddress(rtssModule, "InstallRTSSHook");
 
+                    Log.Debug("Installing RTSS hook");
                     Marshal.GetDelegateForFunctionPointer<InstallRTSSHook>(installAddr).Invoke();
+                    Log.Debug("RTSS hook OK!");
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Due to a recent troubleshooting expedition, RTSS was determined to be the cause. This will (hopefully) prevent such needed troubleshooting by logging the hook installation invocation.