### PR TITLE
More DTR updates

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -262,6 +262,15 @@ namespace Dalamud.Configuration.Internal
         public int DtrSpacing { get; set; } = 10;
 
         /// <summary>
+        /// Gets or sets a value indicating whether to swap the
+        /// direction in which elements are drawn in the DTR.
+        /// False indicates that elements will be drawn from the end of
+        /// the left side of the Server Info bar, and continue leftwards.
+        /// True indicates the opposite.
+        /// </summary>
+        public bool DtrSwapDirection { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets a value indicating whether the title screen menu is shown.
         /// </summary>
         public bool ShowTsm { get; set; } = true;

--- a/Dalamud/Game/Gui/Dtr/DtrBar.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBar.cs
@@ -19,7 +19,6 @@ namespace Dalamud.Game.Gui.Dtr
     [InterfaceVersion("1.0")]
     public sealed unsafe class DtrBar : IDisposable
     {
-        private const uint BaseNodeCount = 17;
         private const uint BaseNodeId = 1000;
 
         private List<DtrBarEntry> entries = new();
@@ -136,9 +135,8 @@ namespace Dalamud.Game.Gui.Dtr
 
             // If we have an unmodified DTR but still have entries, we need to
             // work to reset our state.
-            var nodeCount = dtr->UldManager.NodeListCount;
-            if (nodeCount == BaseNodeCount)
-                this.Reset();
+            if (!this.CheckForDalamudNodes())
+                this.RecreateNodes();
 
             var collisionNode = dtr->UldManager.NodeList[1];
             if (collisionNode == null) return;
@@ -199,7 +197,25 @@ namespace Dalamud.Game.Gui.Dtr
             }
         }
 
-        private void Reset()
+        /// <summary>
+        /// Checks if there are any Dalamud nodes in the DTR.
+        /// </summary>
+        /// <returns>True if there are nodes with an ID > 1000.</returns>
+        private bool CheckForDalamudNodes()
+        {
+            var dtr = GetDtr();
+            if (dtr == null || dtr->RootNode == null) return false;
+
+            for (int i = 0; i < dtr->UldManager.NodeListCount; i++)
+            {
+                if (dtr->UldManager.NodeList[i]->NodeID > 1000)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private void RecreateNodes()
         {
             this.runningNodeIds = BaseNodeId;
             foreach (var entry in this.entries)

--- a/Dalamud/Game/Gui/Dtr/DtrBar.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBar.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -142,9 +142,12 @@ namespace Dalamud.Game.Gui.Dtr
 
             var collisionNode = dtr->UldManager.NodeList[1];
             if (collisionNode == null) return;
-            var runningXPos = collisionNode->X;
 
             var configuration = Service<DalamudConfiguration>.Get();
+
+            // If we are drawing backwards, we should start from the right side of the collision node. That is,
+            // collisionNode->X + collisionNode->Width.
+            var runningXPos = configuration.DtrSwapDirection ? collisionNode->X + collisionNode->Width : collisionNode->X;
 
             for (var i = 0; i < this.entries.Count; i++)
             {
@@ -178,8 +181,18 @@ namespace Dalamud.Game.Gui.Dtr
 
                 if (!isHide)
                 {
-                    runningXPos -= data.TextNode->AtkResNode.Width + configuration.DtrSpacing;
-                    data.TextNode->AtkResNode.SetPositionFloat(runningXPos, 2);
+                    var elementWidth = data.TextNode->AtkResNode.Width + configuration.DtrSpacing;
+
+                    if (configuration.DtrSwapDirection)
+                    {
+                        data.TextNode->AtkResNode.SetPositionFloat(runningXPos, 2);
+                        runningXPos += elementWidth;
+                    }
+                    else
+                    {
+                        runningXPos -= elementWidth;
+                        data.TextNode->AtkResNode.SetPositionFloat(runningXPos, 2);
+                    }
                 }
 
                 this.entries[i] = data;

--- a/Dalamud/Game/Gui/Dtr/DtrBar.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBar.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -19,8 +19,11 @@ namespace Dalamud.Game.Gui.Dtr
     [InterfaceVersion("1.0")]
     public sealed unsafe class DtrBar : IDisposable
     {
+        private const uint BaseNodeCount = 17;
+        private const uint BaseNodeId = 1000;
+
         private List<DtrBarEntry> entries = new();
-        private uint runningNodeIds = 1000;
+        private uint runningNodeIds = BaseNodeId;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DtrBar"/> class.
@@ -130,6 +133,13 @@ namespace Dalamud.Game.Gui.Dtr
 
             // The collision node on the DTR element is always the width of its content
             if (dtr->UldManager.NodeList == null) return;
+
+            // If we have an unmodified DTR but still have entries, we need to
+            // work to reset our state.
+            var nodeCount = dtr->UldManager.NodeListCount;
+            if (nodeCount == BaseNodeCount)
+                this.Reset();
+
             var collisionNode = dtr->UldManager.NodeList[1];
             if (collisionNode == null) return;
             var runningXPos = collisionNode->X;
@@ -173,6 +183,16 @@ namespace Dalamud.Game.Gui.Dtr
                 }
 
                 this.entries[i] = data;
+            }
+        }
+
+        private void Reset()
+        {
+            this.runningNodeIds = BaseNodeId;
+            foreach (var entry in this.entries)
+            {
+                entry.TextNode = this.MakeNode(++this.runningNodeIds);
+                entry.Added = false;
             }
         }
 

--- a/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
@@ -49,6 +49,7 @@ namespace Dalamud.Interface.Internal.Windows
         private List<string>? dtrOrder;
         private List<string>? dtrIgnore;
         private int dtrSpacing;
+        private bool dtrSwapDirection;
 
         private List<ThirdPartyRepoSettings> thirdRepoList;
         private bool thirdRepoListChanged;
@@ -99,6 +100,7 @@ namespace Dalamud.Interface.Internal.Windows
             this.doTsm = configuration.ShowTsm;
 
             this.dtrSpacing = configuration.DtrSpacing;
+            this.dtrSwapDirection = configuration.DtrSwapDirection;
 
             this.doPluginTest = configuration.DoPluginTest;
             this.thirdRepoList = configuration.ThirdRepoList.Select(x => x.Clone()).ToList();
@@ -416,6 +418,10 @@ namespace Dalamud.Interface.Internal.Windows
             ImGui.Text(Loc.Localize("DalamudSettingServerInfoBarSpacing", "Server Info Bar spacing"));
             ImGui.TextColored(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingServerInfoBarSpacingHint", "Configure the amount of space between entries in the server info bar here."));
             ImGui.SliderInt("Spacing", ref this.dtrSpacing, 0, 40);
+
+            ImGui.Text(Loc.Localize("DalamudSettingServerInfoBarDirection", "Server Info Bar direction"));
+            ImGui.TextColored(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingServerInfoBarDirectionHint", "If checked, the Server Info Bar elements will expand to the right instead of the left."));
+            ImGui.Checkbox("Swap Direction", ref this.dtrSwapDirection);
         }
 
         private void DrawExperimentalTab()
@@ -823,6 +829,7 @@ namespace Dalamud.Interface.Internal.Windows
             this.dtrIgnore = configuration.DtrIgnore;
 
             configuration.DtrSpacing = this.dtrSpacing;
+            configuration.DtrSwapDirection = this.dtrSwapDirection;
 
             configuration.DoPluginTest = this.doPluginTest;
             configuration.ThirdRepoList = this.thirdRepoList.Select(x => x.Clone()).ToList();


### PR DESCRIPTION
Relogging after DTR elements are drawn should no longer cause DTR elements to vanish.
- The previous code would hang on to the text node pointer and assume it was always valid. If the DTR addon was destroyed, no new nodes would be created as is necessary. The new code checks if there are Dalamud-specific nodes in the DTR to determine if the DTR addon has reset itself.

The DTR elements can now expand to the right.
- The appropriate settings option in the UI, and accompanying config fields have been added.