### PR TITLE
Added a method for retrieving a Window object by name.

### DIFF
--- a/Dalamud/Interface/Windowing/WindowSystem.cs
+++ b/Dalamud/Interface/Windowing/WindowSystem.cs
@@ -85,6 +85,13 @@ namespace Dalamud.Interface.Windowing
         public void RemoveAllWindows() => this.windows.Clear();
 
         /// <summary>
+        /// Get a window by name.
+        /// </summary>
+        /// <param name="windowName">The name of the <see cref="Window"/></param>
+        /// <returns>The <see cref="Window"/> object with matching name or null.</returns>
+        public Window? GetWindow(string windowName) => this.windows.FirstOrDefault(w => w.WindowName == windowName);
+
+        /// <summary>
         /// Draw all registered windows using ImGui.
         /// </summary>
         public void Draw()


### PR DESCRIPTION
I added a method to get a Window object from the WindowSystem by name. This allows users to simply use WindowSystem.GetName("name") to retrieve a Window from the list without directly interacting with the list itself, maintaining encapsulation while offering more freedom.