### PR TITLE
Add support for font gamma

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -135,6 +135,15 @@ namespace Dalamud.Configuration.Internal
         public bool UseAxisFontsFromGame { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets the gamma value to apply for Dalamud fonts. Effects text thickness.
+        ///
+        /// Before gamma is applied...
+        /// * ...TTF fonts loaded with stb or FreeType are in linear space.
+        /// * ...the game's prebaked AXIS fonts are in gamma space with gamma value of 1.4.
+        /// </summary>
+        public float FontGamma { get; set; } = 1.0f;
+
+        /// <summary>
         /// Gets or sets a value indicating whether or not plugin UI should be hidden.
         /// </summary>
         public bool ToggleUiHide { get; set; } = true;

--- a/Dalamud/Interface/GameFonts/GameFontHandle.cs
+++ b/Dalamud/Interface/GameFonts/GameFontHandle.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Numerics;
+
 using ImGuiNET;
 
 namespace Dalamud.Interface.GameFonts
@@ -31,7 +32,16 @@ namespace Dalamud.Interface.GameFonts
         /// <summary>
         /// Gets a value indicating whether this font is ready for use.
         /// </summary>
-        public bool Available => this.manager.GetFont(this.fontStyle) != null;
+        public bool Available
+        {
+            get
+            {
+                unsafe
+                {
+                    return this.manager.GetFont(this.fontStyle).GetValueOrDefault(null).NativePtr != null;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets the font.
@@ -68,9 +78,13 @@ namespace Dalamud.Interface.GameFonts
             }
             else
             {
-                this.LayoutBuilder(text)
-                    .Build()
-                    .Draw(ImGui.GetWindowDrawList(), ImGui.GetWindowPos() + ImGui.GetCursorPos(), ImGui.GetColorU32(ImGuiCol.Text));
+                var pos = ImGui.GetWindowPos() + ImGui.GetCursorPos();
+                pos.X -= ImGui.GetScrollX();
+                pos.Y -= ImGui.GetScrollY();
+
+                var layout = this.LayoutBuilder(text).Build();
+                layout.Draw(ImGui.GetWindowDrawList(), pos, ImGui.GetColorU32(ImGuiCol.Text));
+                ImGui.Dummy(new Vector2(layout.Width, layout.Height));
             }
         }
 

--- a/Dalamud/Interface/GameFonts/GameFontLayoutPlan.cs
+++ b/Dalamud/Interface/GameFonts/GameFontLayoutPlan.cs
@@ -73,7 +73,6 @@ namespace Dalamud.Interface.GameFonts
         /// <param name="col">Color.</param>
         public void Draw(ImDrawListPtr drawListPtr, Vector2 pos, uint col)
         {
-            ImGui.Dummy(new Vector2(this.Width, this.Height));
             foreach (var element in this.Elements)
             {
                 if (element.IsControl)


### PR DESCRIPTION
Dalamud should be using Noto Sans **Regular** instead of Medium after this PR is merged.

## Examples
### Noto Sans Medium with gamma value of 1.0 (linear space)
![image](https://user-images.githubusercontent.com/3614868/156485984-0d99d805-0ec0-4079-9298-103e21558c46.png)

This is how it is without this PR.

### Noto Sans Medium with gamma value of 1.4 (Windows default)
![image](https://user-images.githubusercontent.com/3614868/156486059-9f931f0b-ac85-41a3-be26-727a6a85b62a.png)

The game's prebaked font files are also based on gamma value of 1.4.

### AXIS Regular with gamma value of 0.8
![image](https://user-images.githubusercontent.com/3614868/156486119-4c881f6d-d49a-409a-bfba-1cc750ec2c73.png)

## Misc
* Screenshot compare: http://www.framecompare.com/screenshotcomparison/WDPG7NNX
* Also, fixed GameFontHandle.Text functions not counting in window scrolls.