### PR TITLE
Show size appropriate fonts

### DIFF
--- a/Dalamud/Interface/GameFonts/GameFontManager.cs
+++ b/Dalamud/Interface/GameFonts/GameFontManager.cs
@@ -292,7 +292,6 @@ namespace Dalamud.Interface.GameFonts
                 fontConfig.PixelSnapH = true;
 
                 var io = ImGui.GetIO();
-                io.Fonts.TexDesiredWidth = 4096;
 
                 this.glyphRectIds.Clear();
                 this.fonts.Clear();

--- a/Dalamud/Interface/GameFonts/GameFontManager.cs
+++ b/Dalamud/Interface/GameFonts/GameFontManager.cs
@@ -117,18 +117,21 @@ namespace Dalamud.Interface.GameFonts
         /// <param name="target">Target font.</param>
         /// <param name="missingOnly">Whether to copy missing glyphs only.</param>
         /// <param name="rebuildLookupTable">Whether to call target.BuildLookupTable().</param>
-        public static void CopyGlyphsAcrossFonts(ImFontPtr? source, ImFontPtr? target, bool missingOnly, bool rebuildLookupTable)
+        /// <param name="rangeLow">Low codepoint range to copy.</param>
+        /// <param name="rangeHigh">High codepoing range to copy.</param>
+        public static void CopyGlyphsAcrossFonts(ImFontPtr? source, ImFontPtr? target, bool missingOnly, bool rebuildLookupTable, int rangeLow = 32, int rangeHigh = 0xFFFE)
         {
             if (!source.HasValue || !target.HasValue)
                 return;
 
+            var scale = target.Value!.FontSize / source.Value!.FontSize;
             unsafe
             {
                 var glyphs = (ImFontGlyphReal*)source.Value!.Glyphs.Data;
                 for (int j = 0, j_ = source.Value!.Glyphs.Size; j < j_; j++)
                 {
                     var glyph = &glyphs[j];
-                    if (glyph->Codepoint < 32 || glyph->Codepoint >= 0xFFFF)
+                    if (glyph->Codepoint < rangeLow || glyph->Codepoint > rangeHigh)
                         continue;
 
                     var prevGlyphPtr = (ImFontGlyphReal*)target.Value!.FindGlyphNoFallback((ushort)glyph->Codepoint).NativePtr;
@@ -137,33 +140,66 @@ namespace Dalamud.Interface.GameFonts
                         target.Value!.AddGlyph(
                             target.Value!.ConfigData,
                             (ushort)glyph->Codepoint,
-                            glyph->X0,
-                            glyph->Y0,
-                            glyph->X0 + ((glyph->X1 - glyph->X0) * target.Value!.FontSize / source.Value!.FontSize),
-                            glyph->Y0 + ((glyph->Y1 - glyph->Y0) * target.Value!.FontSize / source.Value!.FontSize),
+                            glyph->X0 * scale,
+                            glyph->Y0 * scale,
+                            glyph->X1 * scale,
+                            glyph->Y1 * scale,
                             glyph->U0,
                             glyph->V0,
                             glyph->U1,
                             glyph->V1,
-                            glyph->AdvanceX * target.Value!.FontSize / source.Value!.FontSize);
+                            glyph->AdvanceX * scale);
                     }
                     else if (!missingOnly)
                     {
-                        prevGlyphPtr->X0 = glyph->X0;
-                        prevGlyphPtr->Y0 = glyph->Y0;
-                        prevGlyphPtr->X1 = glyph->X0 + ((glyph->X1 - glyph->X0) * target.Value!.FontSize / source.Value!.FontSize);
-                        prevGlyphPtr->Y1 = glyph->Y0 + ((glyph->Y1 - glyph->Y0) * target.Value!.FontSize / source.Value!.FontSize);
+                        prevGlyphPtr->X0 = glyph->X0 * scale;
+                        prevGlyphPtr->Y0 = glyph->Y0 * scale;
+                        prevGlyphPtr->X1 = glyph->X1 * scale;
+                        prevGlyphPtr->Y1 = glyph->Y1 * scale;
                         prevGlyphPtr->U0 = glyph->U0;
                         prevGlyphPtr->V0 = glyph->V0;
                         prevGlyphPtr->U1 = glyph->U1;
                         prevGlyphPtr->V1 = glyph->V1;
-                        prevGlyphPtr->AdvanceX = glyph->AdvanceX * target.Value!.FontSize / source.Value!.FontSize;
+                        prevGlyphPtr->AdvanceX = glyph->AdvanceX * scale;
                     }
                 }
             }
 
             if (rebuildLookupTable)
                 target.Value!.BuildLookupTable();
+        }
+
+        /// <summary>
+        /// Unscales fonts after they have been rendered onto atlas.
+        /// </summary>
+        /// <param name="fontPtr">Font to unscale.</param>
+        /// <param name="fontScale">Scale factor.</param>
+        /// <param name="rebuildLookupTable">Whether to call target.BuildLookupTable().</param>
+        public static void UnscaleFont(ImFontPtr fontPtr, float fontScale, bool rebuildLookupTable = true)
+        {
+            unsafe
+            {
+                var font = fontPtr.NativePtr;
+                for (int i = 0, i_ = font->IndexAdvanceX.Size; i < i_; ++i)
+                    ((float*)font->IndexAdvanceX.Data)[i] /= fontScale;
+                font->FallbackAdvanceX /= fontScale;
+                font->FontSize /= fontScale;
+                font->Ascent /= fontScale;
+                font->Descent /= fontScale;
+                var glyphs = (ImFontGlyphReal*)font->Glyphs.Data;
+                for (int i = 0, i_ = font->Glyphs.Size; i < i_; i++)
+                {
+                    var glyph = &glyphs[i];
+                    glyph->X0 /= fontScale;
+                    glyph->X1 /= fontScale;
+                    glyph->Y0 /= fontScale;
+                    glyph->Y1 /= fontScale;
+                    glyph->AdvanceX /= fontScale;
+                }
+            }
+
+            if (rebuildLookupTable)
+                fontPtr.BuildLookupTable();
         }
 
         /// <inheritdoc/>

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -604,6 +604,7 @@ namespace Dalamud.Interface.Internal
 
             this.fontBuildSignal.Reset();
             ioFonts.Clear();
+            ioFonts.TexDesiredWidth = 4096;
 
             ImFontConfigPtr fontConfig = ImGuiNative.ImFontConfig_ImFontConfig();
             fontConfig.OversampleH = 1;
@@ -658,6 +659,10 @@ namespace Dalamud.Interface.Internal
                     List<Tuple<ushort, ushort>> codepointRanges = new();
                     codepointRanges.Add(Tuple.Create(Fallback1Codepoint, Fallback1Codepoint));
                     codepointRanges.Add(Tuple.Create(Fallback2Codepoint, Fallback2Codepoint));
+                    
+                    // ImGui default ellipsis characters
+                    codepointRanges.Add(Tuple.Create<ushort, ushort>(0x2026, 0x2026));
+                    codepointRanges.Add(Tuple.Create<ushort, ushort>(0x0085, 0x0085));
 
                     foreach (var request in requests)
                     {

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -49,6 +49,8 @@ namespace Dalamud.Interface.Internal
     {
         private const float DefaultFontSizePt = 12.0f;
         private const float DefaultFontSizePx = DefaultFontSizePt * 4.0f / 3.0f;
+        private const ushort Fallback1Codepoint = 0x3013; // Geta mark; FFXIV uses this to indicate that a glyph is missing.
+        private const ushort Fallback2Codepoint = '-'; // FFXIV uses dash if Geta mark is unavailable.
 
         private readonly string rtssPath;
 
@@ -603,6 +605,11 @@ namespace Dalamud.Interface.Internal
             this.fontBuildSignal.Reset();
             ioFonts.Clear();
 
+            ImFontConfigPtr fontConfig = ImGuiNative.ImFontConfig_ImFontConfig();
+            fontConfig.OversampleH = 1;
+            fontConfig.OversampleV = 1;
+            fontConfig.PixelSnapH = true;
+
             var fontPathJp = Path.Combine(dalamud.AssetDirectory.FullName, "UIRes", "NotoSansCJKjp-Medium.otf");
             if (!File.Exists(fontPathJp))
                 ShowFontError(fontPathJp);
@@ -610,7 +617,7 @@ namespace Dalamud.Interface.Internal
             // Default font
             {
                 var japaneseRangeHandle = GCHandle.Alloc(GlyphRangesJapanese.GlyphRanges, GCHandleType.Pinned);
-                DefaultFont = ioFonts.AddFontFromFileTTF(fontPathJp, (DefaultFontSizePx + 1) * fontScale, null, japaneseRangeHandle.AddrOfPinnedObject());
+                DefaultFont = ioFonts.AddFontFromFileTTF(fontPathJp, (DefaultFontSizePx + 1) * fontScale, fontConfig, japaneseRangeHandle.AddrOfPinnedObject());
                 japaneseRangeHandle.Free();
                 fontsToUnscale.Add(DefaultFont);
             }
@@ -622,7 +629,7 @@ namespace Dalamud.Interface.Internal
                     ShowFontError(fontPathIcon);
 
                 var iconRangeHandle = GCHandle.Alloc(new ushort[] { 0xE000, 0xF8FF, 0, }, GCHandleType.Pinned);
-                IconFont = ioFonts.AddFontFromFileTTF(fontPathIcon, DefaultFontSizePx * fontScale, null, iconRangeHandle.AddrOfPinnedObject());
+                IconFont = ioFonts.AddFontFromFileTTF(fontPathIcon, DefaultFontSizePx * fontScale, fontConfig, iconRangeHandle.AddrOfPinnedObject());
                 iconRangeHandle.Free();
                 fontsToUnscale.Add(IconFont);
             }
@@ -632,7 +639,7 @@ namespace Dalamud.Interface.Internal
                 var fontPathMono = Path.Combine(dalamud.AssetDirectory.FullName, "UIRes", "Inconsolata-Regular.ttf");
                 if (!File.Exists(fontPathMono))
                     ShowFontError(fontPathMono);
-                MonoFont = ioFonts.AddFontFromFileTTF(fontPathMono, DefaultFontSizePx * fontScale);
+                MonoFont = ioFonts.AddFontFromFileTTF(fontPathMono, DefaultFontSizePx * fontScale, fontConfig);
                 fontsToUnscale.Add(MonoFont);
             }
 
@@ -649,6 +656,9 @@ namespace Dalamud.Interface.Internal
                 foreach (var (fontSize, requests) in extraFontRequests)
                 {
                     List<Tuple<ushort, ushort>> codepointRanges = new();
+                    codepointRanges.Add(Tuple.Create(Fallback1Codepoint, Fallback1Codepoint));
+                    codepointRanges.Add(Tuple.Create(Fallback2Codepoint, Fallback2Codepoint));
+
                     foreach (var request in requests)
                     {
                         foreach (var range in request.CodepointRanges)
@@ -674,7 +684,7 @@ namespace Dalamud.Interface.Internal
                     flattenedRanges.Add(0);
 
                     var rangeHandle = GCHandle.Alloc(flattenedRanges.ToArray(), GCHandleType.Pinned);
-                    var sizedFont = ioFonts.AddFontFromFileTTF(fontPathJp, fontSize * fontScale, null, rangeHandle.AddrOfPinnedObject());
+                    var sizedFont = ioFonts.AddFontFromFileTTF(fontPathJp, fontSize * fontScale, fontConfig, rangeHandle.AddrOfPinnedObject());
                     rangeHandle.Free();
 
                     fontsToUnscale.Add(sizedFont);
@@ -713,7 +723,12 @@ namespace Dalamud.Interface.Internal
 
             foreach (var font in fontsToUnscale)
             {
-                if (font.NativePtr == MonoFont.NativePtr || font.NativePtr == IconFont.NativePtr)
+                // Leave IconFont alone.
+                if (font.NativePtr == IconFont.NativePtr)
+                    continue;
+
+                // MonoFont will be filled later from DefaultFont.
+                if (font.NativePtr == MonoFont.NativePtr)
                     continue;
 
                 if (this.overwriteAllNotoGlyphsWithAxis)
@@ -722,11 +737,17 @@ namespace Dalamud.Interface.Internal
                     GameFontManager.CopyGlyphsAcrossFonts(this.axisFontHandle?.ImFont, font, false, false, 0xE020, 0xE0DB);
             }
 
+            // Fill missing glyphs in DefaultFont from Axis
+            GameFontManager.CopyGlyphsAcrossFonts(this.axisFontHandle?.ImFont, DefaultFont, true, false);
+
             // Fill missing glyphs in MonoFont from DefaultFont
             GameFontManager.CopyGlyphsAcrossFonts(DefaultFont, MonoFont, true, false);
 
             foreach (var font in fontsToUnscale)
+            {
+                font.FallbackChar = Fallback1Codepoint;
                 font.BuildLookupTable();
+            }
 
             Log.Verbose("[FONT] Invoke OnAfterBuildFonts");
             this.AfterBuildFonts?.Invoke();
@@ -734,6 +755,7 @@ namespace Dalamud.Interface.Internal
 
             Log.Verbose("[FONT] Fonts built!");
 
+            fontConfig.Destroy();
             this.fontBuildSignal.Set();
 
             this.FontsReady = true;

--- a/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
@@ -26,7 +26,7 @@ namespace Dalamud.Interface.Internal.Windows
     internal class SettingsWindow : Window
     {
         private const float MinScale = 0.3f;
-        private const float MaxScale = 2.0f;
+        private const float MaxScale = 3.0f;
 
         private readonly string[] languages;
         private readonly string[] locLanguages;

--- a/Dalamud/Interface/Internal/Windows/TitleScreenMenuWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/TitleScreenMenuWindow.cs
@@ -245,6 +245,7 @@ namespace Dalamud.Interface.Internal.Windows
                 this.specialGlyphRequests[entry.Name] = fontHandle = Service<InterfaceManager>.Get().NewFontSizeRef(TargetFontSizePx, entry.Name);
 
             ImGui.PushFont(fontHandle.Font);
+            ImGui.SetWindowFontScale(TargetFontSizePx / fontHandle.Size);
 
             var scale = ImGui.GetIO().FontGlobalScale;
 


### PR DESCRIPTION
* Load size-appropriate Noto fonts when global scale is not 1.
* Load select glyph of specified size for some strings when requested.
* Add drop shadow to title menu text, and scale each item's height according to global scale.
* Always use special characters from the game even when AXIS font isn't the default font.

![image](https://user-images.githubusercontent.com/3614868/156969848-9f74b076-4638-4e96-b00f-38e5a6d81003.png)
![image](https://user-images.githubusercontent.com/3614868/156969858-4decdc87-64f4-46db-8745-b4f54ec43a31.png)
![image](https://user-images.githubusercontent.com/3614868/156970044-ef99d893-766c-4339-b05c-7655d3136cc1.png)
![image](https://user-images.githubusercontent.com/3614868/156971290-2946eccd-63ad-45f3-b677-eb21d7ee0ec8.png)
