### PR TITLE
Do not allow huge font atlas unless configured

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -141,7 +141,12 @@ namespace Dalamud.Configuration.Internal
         /// * ...TTF fonts loaded with stb or FreeType are in linear space.
         /// * ...the game's prebaked AXIS fonts are in gamma space with gamma value of 1.4.
         /// </summary>
-        public float FontGamma { get; set; } = 1.0f;
+        public float FontGamma { get; set; } = 1.4f;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow big font atlas.
+        /// </summary>
+        public bool AllowBigFontAtlas { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether or not plugin UI should be hidden.

--- a/Dalamud/Interface/GameFonts/GameFontManager.cs
+++ b/Dalamud/Interface/GameFonts/GameFontManager.cs
@@ -292,7 +292,6 @@ namespace Dalamud.Interface.GameFonts
                 fontConfig.PixelSnapH = true;
 
                 var io = ImGui.GetIO();
-                io.Fonts.TexDesiredWidth = 4096;
 
                 this.glyphRectIds.Clear();
                 this.fonts.Clear();

--- a/Dalamud/Interface/GameFonts/GameFontManager.cs
+++ b/Dalamud/Interface/GameFonts/GameFontManager.cs
@@ -117,18 +117,21 @@ namespace Dalamud.Interface.GameFonts
         /// <param name="target">Target font.</param>
         /// <param name="missingOnly">Whether to copy missing glyphs only.</param>
         /// <param name="rebuildLookupTable">Whether to call target.BuildLookupTable().</param>
-        public static void CopyGlyphsAcrossFonts(ImFontPtr? source, ImFontPtr? target, bool missingOnly, bool rebuildLookupTable)
+        /// <param name="rangeLow">Low codepoint range to copy.</param>
+        /// <param name="rangeHigh">High codepoing range to copy.</param>
+        public static void CopyGlyphsAcrossFonts(ImFontPtr? source, ImFontPtr? target, bool missingOnly, bool rebuildLookupTable, int rangeLow = 32, int rangeHigh = 0xFFFE)
         {
             if (!source.HasValue || !target.HasValue)
                 return;
 
+            var scale = target.Value!.FontSize / source.Value!.FontSize;
             unsafe
             {
                 var glyphs = (ImFontGlyphReal*)source.Value!.Glyphs.Data;
                 for (int j = 0, j_ = source.Value!.Glyphs.Size; j < j_; j++)
                 {
                     var glyph = &glyphs[j];
-                    if (glyph->Codepoint < 32 || glyph->Codepoint >= 0xFFFF)
+                    if (glyph->Codepoint < rangeLow || glyph->Codepoint > rangeHigh)
                         continue;
 
                     var prevGlyphPtr = (ImFontGlyphReal*)target.Value!.FindGlyphNoFallback((ushort)glyph->Codepoint).NativePtr;
@@ -137,33 +140,66 @@ namespace Dalamud.Interface.GameFonts
                         target.Value!.AddGlyph(
                             target.Value!.ConfigData,
                             (ushort)glyph->Codepoint,
-                            glyph->X0,
-                            glyph->Y0,
-                            glyph->X0 + ((glyph->X1 - glyph->X0) * target.Value!.FontSize / source.Value!.FontSize),
-                            glyph->Y0 + ((glyph->Y1 - glyph->Y0) * target.Value!.FontSize / source.Value!.FontSize),
+                            glyph->X0 * scale,
+                            glyph->Y0 * scale,
+                            glyph->X1 * scale,
+                            glyph->Y1 * scale,
                             glyph->U0,
                             glyph->V0,
                             glyph->U1,
                             glyph->V1,
-                            glyph->AdvanceX * target.Value!.FontSize / source.Value!.FontSize);
+                            glyph->AdvanceX * scale);
                     }
                     else if (!missingOnly)
                     {
-                        prevGlyphPtr->X0 = glyph->X0;
-                        prevGlyphPtr->Y0 = glyph->Y0;
-                        prevGlyphPtr->X1 = glyph->X0 + ((glyph->X1 - glyph->X0) * target.Value!.FontSize / source.Value!.FontSize);
-                        prevGlyphPtr->Y1 = glyph->Y0 + ((glyph->Y1 - glyph->Y0) * target.Value!.FontSize / source.Value!.FontSize);
+                        prevGlyphPtr->X0 = glyph->X0 * scale;
+                        prevGlyphPtr->Y0 = glyph->Y0 * scale;
+                        prevGlyphPtr->X1 = glyph->X1 * scale;
+                        prevGlyphPtr->Y1 = glyph->Y1 * scale;
                         prevGlyphPtr->U0 = glyph->U0;
                         prevGlyphPtr->V0 = glyph->V0;
                         prevGlyphPtr->U1 = glyph->U1;
                         prevGlyphPtr->V1 = glyph->V1;
-                        prevGlyphPtr->AdvanceX = glyph->AdvanceX * target.Value!.FontSize / source.Value!.FontSize;
+                        prevGlyphPtr->AdvanceX = glyph->AdvanceX * scale;
                     }
                 }
             }
 
             if (rebuildLookupTable)
                 target.Value!.BuildLookupTable();
+        }
+
+        /// <summary>
+        /// Unscales fonts after they have been rendered onto atlas.
+        /// </summary>
+        /// <param name="fontPtr">Font to unscale.</param>
+        /// <param name="fontScale">Scale factor.</param>
+        /// <param name="rebuildLookupTable">Whether to call target.BuildLookupTable().</param>
+        public static void UnscaleFont(ImFontPtr fontPtr, float fontScale, bool rebuildLookupTable = true)
+        {
+            unsafe
+            {
+                var font = fontPtr.NativePtr;
+                for (int i = 0, i_ = font->IndexAdvanceX.Size; i < i_; ++i)
+                    ((float*)font->IndexAdvanceX.Data)[i] /= fontScale;
+                font->FallbackAdvanceX /= fontScale;
+                font->FontSize /= fontScale;
+                font->Ascent /= fontScale;
+                font->Descent /= fontScale;
+                var glyphs = (ImFontGlyphReal*)font->Glyphs.Data;
+                for (int i = 0, i_ = font->Glyphs.Size; i < i_; i++)
+                {
+                    var glyph = &glyphs[i];
+                    glyph->X0 /= fontScale;
+                    glyph->X1 /= fontScale;
+                    glyph->Y0 /= fontScale;
+                    glyph->Y1 /= fontScale;
+                    glyph->AdvanceX /= fontScale;
+                }
+            }
+
+            if (rebuildLookupTable)
+                fontPtr.BuildLookupTable();
         }
 
         /// <inheritdoc/>

--- a/Dalamud/Interface/GameFonts/GameFontManager.cs
+++ b/Dalamud/Interface/GameFonts/GameFontManager.cs
@@ -141,9 +141,9 @@ namespace Dalamud.Interface.GameFonts
                             target.Value!.ConfigData,
                             (ushort)glyph->Codepoint,
                             glyph->X0 * scale,
-                            glyph->Y0 * scale,
+                            ((glyph->Y0 - source.Value!.Ascent) * scale) + target.Value!.Ascent,
                             glyph->X1 * scale,
-                            glyph->Y1 * scale,
+                            ((glyph->Y1 - source.Value!.Ascent) * scale) + target.Value!.Ascent,
                             glyph->U0,
                             glyph->V0,
                             glyph->U1,
@@ -153,9 +153,9 @@ namespace Dalamud.Interface.GameFonts
                     else if (!missingOnly)
                     {
                         prevGlyphPtr->X0 = glyph->X0 * scale;
-                        prevGlyphPtr->Y0 = glyph->Y0 * scale;
+                        prevGlyphPtr->Y0 = ((glyph->Y0 - source.Value!.Ascent) * scale) + target.Value!.Ascent;
                         prevGlyphPtr->X1 = glyph->X1 * scale;
-                        prevGlyphPtr->Y1 = glyph->Y1 * scale;
+                        prevGlyphPtr->Y1 = ((glyph->Y1 - source.Value!.Ascent) * scale) + target.Value!.Ascent;
                         prevGlyphPtr->U0 = glyph->U0;
                         prevGlyphPtr->V0 = glyph->V0;
                         prevGlyphPtr->U1 = glyph->U1;
@@ -343,7 +343,7 @@ namespace Dalamud.Interface.GameFonts
             {
                 var fdt = this.fdts[(int)style.FamilyAndSize];
                 var fontPtr = font.NativePtr;
-                fontPtr->ConfigData->SizePixels = fontPtr->FontSize = fdt.FontHeader.LineHeight;
+                fontPtr->ConfigData->SizePixels = fontPtr->FontSize = fdt.FontHeader.Size * 4 / 3;
                 fontPtr->Ascent = fdt.FontHeader.Ascent;
                 fontPtr->Descent = fdt.FontHeader.Descent;
                 fontPtr->EllipsisChar = '…';
@@ -444,6 +444,9 @@ namespace Dalamud.Interface.GameFonts
         {
             lock (this.syncRoot)
             {
+                if (!this.fontUseCounter.ContainsKey(style))
+                    return;
+
                 if ((this.fontUseCounter[style] -= 1) == 0)
                     this.fontUseCounter.Remove(style);
             }

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -604,6 +604,7 @@ namespace Dalamud.Interface.Internal
 
             this.fontBuildSignal.Reset();
             ioFonts.Clear();
+            ioFonts.TexDesiredWidth = 4096;
 
             ImFontConfigPtr fontConfig = ImGuiNative.ImFontConfig_ImFontConfig();
             fontConfig.OversampleH = 1;
@@ -658,6 +659,10 @@ namespace Dalamud.Interface.Internal
                     List<Tuple<ushort, ushort>> codepointRanges = new();
                     codepointRanges.Add(Tuple.Create(Fallback1Codepoint, Fallback1Codepoint));
                     codepointRanges.Add(Tuple.Create(Fallback2Codepoint, Fallback2Codepoint));
+                    
+                    // ImGui default ellipsis characters
+                    codepointRanges.Add(Tuple.Create<ushort, ushort>(0x2026, 0x2026));
+                    codepointRanges.Add(Tuple.Create<ushort, ushort>(0x0085, 0x0085));
 
                     foreach (var request in requests)
                     {

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -49,6 +49,8 @@ namespace Dalamud.Interface.Internal
     {
         private const float DefaultFontSizePt = 12.0f;
         private const float DefaultFontSizePx = DefaultFontSizePt * 4.0f / 3.0f;
+        private const ushort Fallback1Codepoint = 0x3013; // Geta mark; FFXIV uses this to indicate that a glyph is missing.
+        private const ushort Fallback2Codepoint = '-'; // FFXIV uses dash if Geta mark is unavailable.
 
         private readonly string rtssPath;
 
@@ -603,6 +605,11 @@ namespace Dalamud.Interface.Internal
             this.fontBuildSignal.Reset();
             ioFonts.Clear();
 
+            ImFontConfigPtr fontConfig = ImGuiNative.ImFontConfig_ImFontConfig();
+            fontConfig.OversampleH = 1;
+            fontConfig.OversampleV = 1;
+            fontConfig.PixelSnapH = true;
+
             var fontPathJp = Path.Combine(dalamud.AssetDirectory.FullName, "UIRes", "NotoSansCJKjp-Medium.otf");
             if (!File.Exists(fontPathJp))
                 ShowFontError(fontPathJp);
@@ -610,7 +617,7 @@ namespace Dalamud.Interface.Internal
             // Default font
             {
                 var japaneseRangeHandle = GCHandle.Alloc(GlyphRangesJapanese.GlyphRanges, GCHandleType.Pinned);
-                DefaultFont = ioFonts.AddFontFromFileTTF(fontPathJp, (DefaultFontSizePx + 1) * fontScale, null, japaneseRangeHandle.AddrOfPinnedObject());
+                DefaultFont = ioFonts.AddFontFromFileTTF(fontPathJp, (DefaultFontSizePx + 1) * fontScale, fontConfig, japaneseRangeHandle.AddrOfPinnedObject());
                 japaneseRangeHandle.Free();
                 fontsToUnscale.Add(DefaultFont);
             }
@@ -622,7 +629,7 @@ namespace Dalamud.Interface.Internal
                     ShowFontError(fontPathIcon);
 
                 var iconRangeHandle = GCHandle.Alloc(new ushort[] { 0xE000, 0xF8FF, 0, }, GCHandleType.Pinned);
-                IconFont = ioFonts.AddFontFromFileTTF(fontPathIcon, DefaultFontSizePx * fontScale, null, iconRangeHandle.AddrOfPinnedObject());
+                IconFont = ioFonts.AddFontFromFileTTF(fontPathIcon, DefaultFontSizePx * fontScale, fontConfig, iconRangeHandle.AddrOfPinnedObject());
                 iconRangeHandle.Free();
                 fontsToUnscale.Add(IconFont);
             }
@@ -632,7 +639,7 @@ namespace Dalamud.Interface.Internal
                 var fontPathMono = Path.Combine(dalamud.AssetDirectory.FullName, "UIRes", "Inconsolata-Regular.ttf");
                 if (!File.Exists(fontPathMono))
                     ShowFontError(fontPathMono);
-                MonoFont = ioFonts.AddFontFromFileTTF(fontPathMono, DefaultFontSizePx * fontScale);
+                MonoFont = ioFonts.AddFontFromFileTTF(fontPathMono, DefaultFontSizePx * fontScale, fontConfig);
                 fontsToUnscale.Add(MonoFont);
             }
 
@@ -649,6 +656,9 @@ namespace Dalamud.Interface.Internal
                 foreach (var (fontSize, requests) in extraFontRequests)
                 {
                     List<Tuple<ushort, ushort>> codepointRanges = new();
+                    codepointRanges.Add(Tuple.Create(Fallback1Codepoint, Fallback1Codepoint));
+                    codepointRanges.Add(Tuple.Create(Fallback2Codepoint, Fallback2Codepoint));
+
                     foreach (var request in requests)
                     {
                         foreach (var range in request.CodepointRanges)
@@ -674,7 +684,7 @@ namespace Dalamud.Interface.Internal
                     flattenedRanges.Add(0);
 
                     var rangeHandle = GCHandle.Alloc(flattenedRanges.ToArray(), GCHandleType.Pinned);
-                    var sizedFont = ioFonts.AddFontFromFileTTF(fontPathJp, fontSize * fontScale, null, rangeHandle.AddrOfPinnedObject());
+                    var sizedFont = ioFonts.AddFontFromFileTTF(fontPathJp, fontSize * fontScale, fontConfig, rangeHandle.AddrOfPinnedObject());
                     rangeHandle.Free();
 
                     fontsToUnscale.Add(sizedFont);
@@ -713,7 +723,12 @@ namespace Dalamud.Interface.Internal
 
             foreach (var font in fontsToUnscale)
             {
-                if (font.NativePtr == MonoFont.NativePtr || font.NativePtr == IconFont.NativePtr)
+                // Leave IconFont alone.
+                if (font.NativePtr == IconFont.NativePtr)
+                    continue;
+
+                // MonoFont will be filled later from DefaultFont.
+                if (font.NativePtr == MonoFont.NativePtr)
                     continue;
 
                 if (this.overwriteAllNotoGlyphsWithAxis)
@@ -722,11 +737,17 @@ namespace Dalamud.Interface.Internal
                     GameFontManager.CopyGlyphsAcrossFonts(this.axisFontHandle?.ImFont, font, false, false, 0xE020, 0xE0DB);
             }
 
+            // Fill missing glyphs in DefaultFont from Axis
+            GameFontManager.CopyGlyphsAcrossFonts(this.axisFontHandle?.ImFont, DefaultFont, true, false);
+
             // Fill missing glyphs in MonoFont from DefaultFont
             GameFontManager.CopyGlyphsAcrossFonts(DefaultFont, MonoFont, true, false);
 
             foreach (var font in fontsToUnscale)
+            {
+                font.FallbackChar = Fallback1Codepoint;
                 font.BuildLookupTable();
+            }
 
             Log.Verbose("[FONT] Invoke OnAfterBuildFonts");
             this.AfterBuildFonts?.Invoke();
@@ -734,6 +755,7 @@ namespace Dalamud.Interface.Internal
 
             Log.Verbose("[FONT] Fonts built!");
 
+            fontConfig.Destroy();
             this.fontBuildSignal.Set();
 
             this.FontsReady = true;

--- a/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
@@ -26,7 +26,7 @@ namespace Dalamud.Interface.Internal.Windows
     internal class SettingsWindow : Window
     {
         private const float MinScale = 0.3f;
-        private const float MaxScale = 2.0f;
+        private const float MaxScale = 3.0f;
 
         private readonly string[] languages;
         private readonly string[] locLanguages;

--- a/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
@@ -39,6 +39,7 @@ namespace Dalamud.Interface.Internal.Windows
 
         private float globalUiScale;
         private bool doUseAxisFontsFromGame;
+        private bool doAllowBigFontAtlas;
         private float fontGamma;
         private bool doToggleUiHide;
         private bool doToggleUiHideDuringCutscenes;
@@ -96,6 +97,7 @@ namespace Dalamud.Interface.Internal.Windows
             this.globalUiScale = configuration.GlobalUiScale;
             this.fontGamma = configuration.FontGamma;
             this.doUseAxisFontsFromGame = configuration.UseAxisFontsFromGame;
+            this.doAllowBigFontAtlas = configuration.AllowBigFontAtlas;
             this.doToggleUiHide = configuration.ToggleUiHide;
             this.doToggleUiHideDuringCutscenes = configuration.ToggleUiHideDuringCutscenes;
             this.doToggleUiHideDuringGpose = configuration.ToggleUiHideDuringGpose;
@@ -188,6 +190,8 @@ namespace Dalamud.Interface.Internal.Windows
 
             ImGui.GetIO().FontGlobalScale = configuration.GlobalUiScale;
             interfaceManager.FontGammaOverride = null;
+            interfaceManager.AllowBigFontAtlasOverride = null;
+            interfaceManager.UseAxisOverride = null;
             this.thirdRepoList = configuration.ThirdRepoList.Select(x => x.Clone()).ToList();
             this.devPluginLocations = configuration.DevPluginLoadLocations.Select(x => x.Clone()).ToList();
 
@@ -325,8 +329,21 @@ namespace Dalamud.Interface.Internal.Windows
 
             ImGui.TextColored(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingToggleUiHideOptOutNote", "Plugins may independently opt out of the settings below."));
 
-            ImGui.Checkbox(Loc.Localize("DalamudSettingToggleAxisFonts", "Use AXIS fonts as default Dalamud font"), ref this.doUseAxisFontsFromGame);
+            if (ImGui.Checkbox(Loc.Localize("DalamudSettingToggleAxisFonts", "Use AXIS fonts as default Dalamud font"), ref this.doUseAxisFontsFromGame))
+            {
+                interfaceManager.UseAxisOverride = this.doUseAxisFontsFromGame;
+                interfaceManager.RebuildFonts();
+            }
+
             ImGui.TextColored(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingToggleUiAxisFontsHint", "Use AXIS fonts (the game's main UI fonts) as default Dalamud font."));
+
+            if (ImGui.Checkbox(Loc.Localize("DalamudSettingAllowBigFontAtlas", "Allow big font atlas"), ref this.doAllowBigFontAtlas))
+            {
+                interfaceManager.AllowBigFontAtlasOverride = this.doAllowBigFontAtlas;
+                interfaceManager.RebuildFonts();
+            }
+
+            ImGui.TextColored(ImGuiColors.DalamudGrey, string.Format(Loc.Localize("DalamudSettingAllowBigFontAtlas", "Displays text crisply, but may crash if your GPU does not support it.\nCurrent size: {0}px * {1}px"), ImGui.GetIO().Fonts.TexWidth, ImGui.GetIO().Fonts.TexHeight));
 
             ImGui.Checkbox(Loc.Localize("DalamudSettingToggleUiHide", "Hide plugin UI when the game UI is toggled off"), ref this.doToggleUiHide);
             ImGui.TextColored(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingToggleUiHideHint", "Hide any open windows by plugins when toggling the game overlay."));
@@ -856,6 +873,7 @@ namespace Dalamud.Interface.Internal.Windows
             configuration.Fools22 = this.doFools22;
 
             configuration.UseAxisFontsFromGame = this.doUseAxisFontsFromGame;
+            configuration.AllowBigFontAtlas = this.doAllowBigFontAtlas;
             configuration.FontGamma = this.fontGamma;
 
             // This is applied every frame in InterfaceManager::CheckViewportState()

--- a/Dalamud/Interface/Internal/Windows/TitleScreenMenuWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/TitleScreenMenuWindow.cs
@@ -245,6 +245,7 @@ namespace Dalamud.Interface.Internal.Windows
                 this.specialGlyphRequests[entry.Name] = fontHandle = Service<InterfaceManager>.Get().NewFontSizeRef(TargetFontSizePx, entry.Name);
 
             ImGui.PushFont(fontHandle.Font);
+            ImGui.SetWindowFontScale(TargetFontSizePx / fontHandle.Size);
 
             var scale = ImGui.GetIO().FontGlobalScale;
 

--- a/lib/CoreCLR/CoreCLR.cpp
+++ b/lib/CoreCLR/CoreCLR.cpp
@@ -37,12 +37,12 @@ int CoreCLR::load_hostfxr(const struct get_hostfxr_parameters* parameters)
         && m_hostfxr_close_fptr ? 0 : -1;
 }
 
-bool CoreCLR::load_runtime(const std::wstring& runtime_config_path)
+int CoreCLR::load_runtime(const std::wstring& runtime_config_path)
 {
     return CoreCLR::load_runtime(runtime_config_path, nullptr);
 }
 
-bool CoreCLR::load_runtime(const std::wstring& runtime_config_path, const struct hostfxr_initialize_parameters* parameters)
+int CoreCLR::load_runtime(const std::wstring& runtime_config_path, const struct hostfxr_initialize_parameters* parameters)
 {
     int result;
 

--- a/lib/CoreCLR/CoreCLR.h
+++ b/lib/CoreCLR/CoreCLR.h
@@ -12,8 +12,8 @@ class CoreCLR {
     int load_hostfxr();
     int load_hostfxr(const get_hostfxr_parameters* parameters);
 
-    bool load_runtime(const std::wstring& runtime_config_path);
-    bool load_runtime(
+    int load_runtime(const std::wstring& runtime_config_path);
+    int load_runtime(
         const std::wstring& runtime_config_path,
         const struct hostfxr_initialize_parameters* parameters);
 

--- a/lib/CoreCLR/boot.cpp
+++ b/lib/CoreCLR/boot.cpp
@@ -90,7 +90,7 @@ int InitializeClrAndGetEntryPoint(
     printf("Loading hostfxr... ");
     if ((result = g_clr->load_hostfxr(&init_parameters)) != 0)
     {
-        printf("\nError: Failed to load the `hostfxr` library (err=%d)\n", result);
+        printf("\nError: Failed to load the `hostfxr` library (err=0x%08x)\n", result);
         return result;
     }
     printf("Done!\n");


### PR DESCRIPTION
By default, only axis12pt or noto17px will be loaded. The option needs to be checked to allow that.

![image](https://user-images.githubusercontent.com/3614868/161108730-6b9a5417-d900-45cf-88fe-1e8d5d780239.png)
![image](https://user-images.githubusercontent.com/3614868/161108739-6f933855-d98f-4403-8141-1347a230856a.png)
![image](https://user-images.githubusercontent.com/3614868/161108756-4db592fb-9aa3-4002-9760-df212b2a064b.png)
![image](https://user-images.githubusercontent.com/3614868/161108770-9f57bd9b-3541-4466-8647-202b2a28a80b.png)
![image](https://user-images.githubusercontent.com/3614868/161108779-ba34cbe8-a7c7-4072-8e5e-c3fd4550d6e9.png)
![image](https://user-images.githubusercontent.com/3614868/161108787-bb5b5ac0-d635-4d88-b61e-ebc0aa94a33c.png)
