### PR TITLE
Add atlas texture size opportunistic limiter

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -144,9 +144,10 @@ namespace Dalamud.Configuration.Internal
         public float FontGamma { get; set; } = 1.4f;
 
         /// <summary>
-        /// Gets or sets a value indicating whether to allow big font atlas.
+        /// Gets or sets a value indicating the level of font resolution between 1 to 5.
+        /// 0(1024x1024), 1(2048x2048), 2(4096x4096), 3(8192x8192), 4(16384x16384).
         /// </summary>
-        public bool AllowBigFontAtlas { get; set; } = false;
+        public int FontResolutionLevel { get; set; } = 2;
 
         /// <summary>
         /// Gets or sets a value indicating whether or not plugin UI should be hidden.

--- a/Dalamud/Interface/GameFonts/GameFontManager.cs
+++ b/Dalamud/Interface/GameFonts/GameFontManager.cs
@@ -289,7 +289,7 @@ namespace Dalamud.Interface.GameFonts
                 ImFontConfigPtr fontConfig = ImGuiNative.ImFontConfig_ImFontConfig();
                 fontConfig.OversampleH = 1;
                 fontConfig.OversampleV = 1;
-                fontConfig.PixelSnapH = true;
+                fontConfig.PixelSnapH = false;
 
                 var io = ImGui.GetIO();
 
@@ -305,6 +305,7 @@ namespace Dalamud.Interface.GameFonts
                         continue;
 
                     var font = io.Fonts.AddFontDefault(fontConfig);
+
                     this.fonts[style] = font;
                     foreach (var glyph in fdt.Glyphs)
                     {

--- a/Dalamud/Interface/GameFonts/GameFontStyle.cs
+++ b/Dalamud/Interface/GameFonts/GameFontStyle.cs
@@ -87,9 +87,9 @@ namespace Dalamud.Interface.GameFonts
         };
 
         /// <summary>
-        /// Gets the font size.
+        /// Gets the font size in point unit.
         /// </summary>
-        public float Size => this.FamilyAndSize switch
+        public float SizePt => this.FamilyAndSize switch
         {
             GameFontFamilyAndSize.Undefined => 0,
             GameFontFamilyAndSize.Axis96 => 9.6f,
@@ -117,6 +117,11 @@ namespace Dalamud.Interface.GameFonts
             GameFontFamilyAndSize.TrumpGothic68 => 8,
             _ => throw new InvalidOperationException(),
         };
+
+        /// <summary>
+        /// Gets the font size in pixel unit.
+        /// </summary>
+        public float SizePx => this.SizePt * 4 / 3;
 
         /// <summary>
         /// Gets or sets a value indicating whether this font is bold.
@@ -153,59 +158,59 @@ namespace Dalamud.Interface.GameFonts
                     return GameFontFamilyAndSize.Undefined;
 
                 case GameFontFamily.Axis:
-                    if (size <= 9.6)
+                    if (size <= 9.601)
                         return GameFontFamilyAndSize.Axis96;
-                    else if (size <= 12)
+                    else if (size <= 12.001)
                         return GameFontFamilyAndSize.Axis12;
-                    else if (size <= 14)
+                    else if (size <= 14.001)
                         return GameFontFamilyAndSize.Axis14;
-                    else if (size <= 18)
+                    else if (size <= 18.001)
                         return GameFontFamilyAndSize.Axis18;
                     else
                         return GameFontFamilyAndSize.Axis36;
 
                 case GameFontFamily.Jupiter:
-                    if (size <= 16)
+                    if (size <= 16.001)
                         return GameFontFamilyAndSize.Jupiter16;
-                    else if (size <= 20)
+                    else if (size <= 20.001)
                         return GameFontFamilyAndSize.Jupiter20;
-                    else if (size <= 23)
+                    else if (size <= 23.001)
                         return GameFontFamilyAndSize.Jupiter23;
                     else
                         return GameFontFamilyAndSize.Jupiter46;
 
                 case GameFontFamily.JupiterNumeric:
-                    if (size <= 45)
+                    if (size <= 45.001)
                         return GameFontFamilyAndSize.Jupiter45;
                     else
                         return GameFontFamilyAndSize.Jupiter90;
 
                 case GameFontFamily.Meidinger:
-                    if (size <= 16)
+                    if (size <= 16.001)
                         return GameFontFamilyAndSize.Meidinger16;
-                    else if (size <= 20)
+                    else if (size <= 20.001)
                         return GameFontFamilyAndSize.Meidinger20;
                     else
                         return GameFontFamilyAndSize.Meidinger40;
 
                 case GameFontFamily.MiedingerMid:
-                    if (size <= 10)
+                    if (size <= 10.001)
                         return GameFontFamilyAndSize.MiedingerMid10;
-                    else if (size <= 12)
+                    else if (size <= 12.001)
                         return GameFontFamilyAndSize.MiedingerMid12;
-                    else if (size <= 14)
+                    else if (size <= 14.001)
                         return GameFontFamilyAndSize.MiedingerMid14;
-                    else if (size <= 18)
+                    else if (size <= 18.001)
                         return GameFontFamilyAndSize.MiedingerMid18;
                     else
                         return GameFontFamilyAndSize.MiedingerMid36;
 
                 case GameFontFamily.TrumpGothic:
-                    if (size <= 18.4)
+                    if (size <= 18.401)
                         return GameFontFamilyAndSize.TrumpGothic184;
-                    else if (size <= 23)
+                    else if (size <= 23.001)
                         return GameFontFamilyAndSize.TrumpGothic23;
-                    else if (size <= 34)
+                    else if (size <= 34.001)
                         return GameFontFamilyAndSize.TrumpGothic34;
                     else
                         return GameFontFamilyAndSize.TrumpGothic68;

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -216,14 +216,14 @@ namespace Dalamud.Interface.Internal
         public float FontGamma => Math.Max(0.1f, this.FontGammaOverride.GetValueOrDefault(Service<DalamudConfiguration>.Get().FontGamma));
 
         /// <summary>
-        /// Gets or sets a value indicating whether to override configuration for AllowBigFontAtlas.
+        /// Gets or sets a value indicating whether to override configuration for FontResolutionLevel.
         /// </summary>
-        public bool? AllowBigFontAtlasOverride { get; set; } = null;
+        public int? FontResolutionLevelOverride { get; set; } = null;
 
         /// <summary>
-        /// Gets a value indicating whether to allow big font atlas.
+        /// Gets a value indicating the level of font resolution.
         /// </summary>
-        public bool AllowBigFontAtlas => this.AllowBigFontAtlasOverride ?? Service<DalamudConfiguration>.Get().AllowBigFontAtlas;
+        public int FontResolutionLevel => this.FontResolutionLevelOverride ?? Service<DalamudConfiguration>.Get().FontResolutionLevel;
 
         /// <summary>
         /// Enable this module.
@@ -594,21 +594,24 @@ namespace Dalamud.Interface.Internal
             ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.ViewportsEnable;
         }
 
-        private unsafe void SetupFonts()
+        private unsafe void SetupFonts(int scaler = 0)
         {
             var gameFontManager = Service<GameFontManager>.Get();
             var dalamud = Service<Dalamud>.Get();
             var io = ImGui.GetIO();
             var ioFonts = io.Fonts;
-            var fontLoadScale = this.AllowBigFontAtlas ? io.FontGlobalScale : 1;
-            var fontGamma = this.FontGamma;
             List<ImFontPtr> fontsToUnscale = new();
             List<bool> fontsToOverwriteFromAxis = new();
             List<float?> fontsToReassignSizes = new();
 
+            var maxTexDimension = 1 << (10 + Math.Max(0, Math.Min(4, this.FontResolutionLevel)));
+            var disableBigFonts = scaler != 0;
+            var fontLoadScale = disableBigFonts ? Math.Min(io.FontGlobalScale, 1.0f / scaler) : io.FontGlobalScale;
+            var fontGamma = this.FontGamma;
+
             this.fontBuildSignal.Reset();
             ioFonts.Clear();
-            ioFonts.TexDesiredWidth = this.AllowBigFontAtlas ? 4096 : 2048;
+            ioFonts.TexDesiredWidth = maxTexDimension;
 
             Log.Verbose("[FONT] SetupFonts - 1");
 
@@ -633,7 +636,6 @@ namespace Dalamud.Interface.Internal
                 fontConfig = ImGuiNative.ImFontConfig_ImFontConfig();
                 fontConfig.OversampleH = 1;
                 fontConfig.OversampleV = 1;
-                fontConfig.PixelSnapH = true;
 
                 var fontPathJp = Path.Combine(dalamud.AssetDirectory.FullName, "UIRes", "NotoSansCJKjp-Medium.otf");
                 if (!File.Exists(fontPathJp))
@@ -641,15 +643,17 @@ namespace Dalamud.Interface.Internal
 
                 // Default font
                 Log.Verbose("[FONT] SetupFonts - Default font");
-                this.axisFontHandles.Add(gameFontManager.NewFontRef(this.AllowBigFontAtlas ? new(GameFontFamily.Axis, DefaultFontSizePt * fontLoadScale) : new(GameFontFamilyAndSize.Axis12)));
+                this.axisFontHandles.Add(gameFontManager.NewFontRef(new(GameFontFamily.Axis, DefaultFontSizePt * fontLoadScale)));
+                Log.Verbose("[FONT] SetupFonts - Default corresponding AXIS size: {0}pt ({1}px)", this.axisFontHandles.Last().Style.SizePt, this.axisFontHandles.Last().Style.SizePx);
                 if (this.UseAxis)
                 {
                     fontConfig.GlyphRanges = dummyRangeHandle.AddrOfPinnedObject();
                     fontConfig.SizePixels = DefaultFontSizePx * fontLoadScale;
+                    fontConfig.PixelSnapH = false;
                     DefaultFont = ioFonts.AddFontDefault(fontConfig);
                     fontsToUnscale.Add(DefaultFont);
                     fontsToOverwriteFromAxis.Add(true);
-                    fontsToReassignSizes.Add(null);
+                    fontsToReassignSizes.Add(disableBigFonts ? DefaultFontSizePx * fontLoadScale : null);
                 }
                 else
                 {
@@ -657,6 +661,7 @@ namespace Dalamud.Interface.Internal
                     garbageList.Add(japaneseRangeHandle);
 
                     fontConfig.GlyphRanges = japaneseRangeHandle.AddrOfPinnedObject();
+                    fontConfig.PixelSnapH = true;
                     DefaultFont = ioFonts.AddFontFromFileTTF(fontPathJp, (DefaultFontSizePx + 1) * fontLoadScale, fontConfig);
                     fontsToUnscale.Add(DefaultFont);
                     fontsToOverwriteFromAxis.Add(false);
@@ -674,6 +679,7 @@ namespace Dalamud.Interface.Internal
                     garbageList.Add(iconRangeHandle);
 
                     fontConfig.GlyphRanges = iconRangeHandle.AddrOfPinnedObject();
+                    fontConfig.PixelSnapH = true;
                     IconFont = ioFonts.AddFontFromFileTTF(fontPathIcon, DefaultFontSizePx * fontLoadScale, fontConfig);
                     fontsToUnscale.Add(IconFont);
                     this.axisFontHandles.Add(null);
@@ -689,6 +695,7 @@ namespace Dalamud.Interface.Internal
                         ShowFontError(fontPathMono);
 
                     fontConfig.GlyphRanges = IntPtr.Zero;
+                    fontConfig.PixelSnapH = true;
                     MonoFont = ioFonts.AddFontFromFileTTF(fontPathMono, DefaultFontSizePx * fontLoadScale, fontConfig);
                     fontsToUnscale.Add(MonoFont);
                     this.axisFontHandles.Add(null);
@@ -742,24 +749,26 @@ namespace Dalamud.Interface.Internal
                         flattenedRanges.Add(0);
 
                         ImFontPtr sizedFont;
-                        this.axisFontHandles.Add(gameFontManager.NewFontRef(this.AllowBigFontAtlas ? new(GameFontFamily.Axis, fontSize * 3 / 4 * fontLoadScale) : new(GameFontFamilyAndSize.Axis12)));
+                        this.axisFontHandles.Add(gameFontManager.NewFontRef(new(GameFontFamily.Axis, (disableBigFonts ? DefaultFontSizePt : fontSize * 3 / 4) * fontLoadScale)));
                         if (this.UseAxis)
                         {
                             fontConfig.GlyphRanges = dummyRangeHandle.AddrOfPinnedObject();
-                            fontConfig.SizePixels = (this.AllowBigFontAtlas ? fontSize : DefaultFontSizePx) * fontLoadScale;
+                            fontConfig.SizePixels = this.axisFontHandles.Last().Style.SizePx;
+                            fontConfig.PixelSnapH = false;
                             sizedFont = ioFonts.AddFontDefault(fontConfig);
                             fontsToUnscale.Add(sizedFont);
                             fontsToOverwriteFromAxis.Add(true);
-                            fontsToReassignSizes.Add(this.AllowBigFontAtlas ? null : fontSize);
+                            fontsToReassignSizes.Add(disableBigFonts ? fontLoadScale * fontSize : null);
                         }
                         else
                         {
                             var rangeHandle = GCHandle.Alloc(flattenedRanges.ToArray(), GCHandleType.Pinned);
                             garbageList.Add(rangeHandle);
-                            sizedFont = ioFonts.AddFontFromFileTTF(fontPathJp, (this.AllowBigFontAtlas ? fontSize : DefaultFontSizePx + 1) * fontLoadScale, fontConfig, rangeHandle.AddrOfPinnedObject());
+                            fontConfig.PixelSnapH = true;
+                            sizedFont = ioFonts.AddFontFromFileTTF(fontPathJp, (disableBigFonts ? fontSize : DefaultFontSizePx + 1) * fontLoadScale, fontConfig, rangeHandle.AddrOfPinnedObject());
                             fontsToUnscale.Add(sizedFont);
                             fontsToOverwriteFromAxis.Add(false);
-                            fontsToReassignSizes.Add(this.AllowBigFontAtlas ? null : fontSize);
+                            fontsToReassignSizes.Add(disableBigFonts ? fontSize : null);
                         }
 
                         foreach (var request in requests)
@@ -769,16 +778,36 @@ namespace Dalamud.Interface.Internal
 
                 gameFontManager.BuildFonts();
 
+                var customFontFirstConfigIndex = ioFonts.ConfigData.Size;
+
                 Log.Verbose("[FONT] Invoke OnBuildFonts");
                 this.BuildFonts?.Invoke();
                 Log.Verbose("[FONT] OnBuildFonts OK!");
 
-                for (var i = 0; i < ImGui.GetIO().Fonts.Fonts.Size; i++)
+                for (int i = customFontFirstConfigIndex, i_ = ioFonts.ConfigData.Size; i < i_; i++)
                 {
-                    Log.Verbose("{0} - {1}", i, ImGui.GetIO().Fonts.Fonts[i].GetDebugName());
+                    var configPtr = ioFonts.ConfigData[i].NativePtr;
+                    configPtr->OversampleH = 1;
+                    configPtr->OversampleV = 1;
+                    if (disableBigFonts)
+                        configPtr->SizePixels = DefaultFontSizePx * fontLoadScale;
                 }
 
                 ioFonts.Build();
+
+                if (ioFonts.TexHeight > maxTexDimension)
+                {
+                    if (scaler < 4)
+                    {
+                        Log.Information("[FONT] Atlas size is {0}x{1} which is bigger than allowed {2}x{3}. Retrying with scale {4}.", ioFonts.TexWidth, ioFonts.TexHeight, maxTexDimension, maxTexDimension, scaler + 1);
+                        this.SetupFonts(scaler + 1);
+                        return;
+                    }
+                    else
+                    {
+                        Log.Warning("[FONT] Atlas size is {0}x{1} which is bigger than allowed {2}x{3}, but giving up trying to scale smaller.", ioFonts.TexWidth, ioFonts.TexHeight, maxTexDimension, maxTexDimension);
+                    }
+                }
 
                 if (Math.Abs(fontGamma - 1.0f) >= 0.001)
                 {

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -653,7 +653,7 @@ namespace Dalamud.Interface.Internal
                     DefaultFont = ioFonts.AddFontDefault(fontConfig);
                     fontsToUnscale.Add(DefaultFont);
                     fontsToOverwriteFromAxis.Add(true);
-                    fontsToReassignSizes.Add(disableBigFonts ? DefaultFontSizePx * fontLoadScale : null);
+                    fontsToReassignSizes.Add(disableBigFonts ? DefaultFontSizePx : null);
                 }
                 else
                 {
@@ -758,14 +758,14 @@ namespace Dalamud.Interface.Internal
                             sizedFont = ioFonts.AddFontDefault(fontConfig);
                             fontsToUnscale.Add(sizedFont);
                             fontsToOverwriteFromAxis.Add(true);
-                            fontsToReassignSizes.Add(disableBigFonts ? fontLoadScale * fontSize : null);
+                            fontsToReassignSizes.Add(disableBigFonts ? fontSize : null);
                         }
                         else
                         {
                             var rangeHandle = GCHandle.Alloc(flattenedRanges.ToArray(), GCHandleType.Pinned);
                             garbageList.Add(rangeHandle);
                             fontConfig.PixelSnapH = true;
-                            sizedFont = ioFonts.AddFontFromFileTTF(fontPathJp, (disableBigFonts ? fontSize : DefaultFontSizePx + 1) * fontLoadScale, fontConfig, rangeHandle.AddrOfPinnedObject());
+                            sizedFont = ioFonts.AddFontFromFileTTF(fontPathJp, (disableBigFonts ? DefaultFontSizePx + 1 : fontSize) * fontLoadScale, fontConfig, rangeHandle.AddrOfPinnedObject());
                             fontsToUnscale.Add(sizedFont);
                             fontsToOverwriteFromAxis.Add(false);
                             fontsToReassignSizes.Add(disableBigFonts ? fontSize : null);
@@ -849,7 +849,7 @@ namespace Dalamud.Interface.Internal
                     }
 
                     if (overwriteSize != null)
-                        scale *= overwriteSize.Value / fontPtr->ConfigData->SizePixels;
+                        scale *= fontLoadScale * overwriteSize.Value / fontPtr->ConfigData->SizePixels;
 
                     if (scale != 1f)
                         GameFontManager.UnscaleFont(font, 1 / scale, false);

--- a/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
@@ -38,9 +38,11 @@ namespace Dalamud.Interface.Internal.Windows
         private bool doCfChatMessage;
         private bool doMbCollect;
 
+        private readonly string[] fontResolutionLevelStrings;
+        private int fontResolutionLevel;
+
         private float globalUiScale;
         private bool doUseAxisFontsFromGame;
-        private bool doAllowBigFontAtlas;
         private float fontGamma;
         private bool doToggleUiHide;
         private bool doToggleUiHideDuringCutscenes;
@@ -97,7 +99,7 @@ namespace Dalamud.Interface.Internal.Windows
             this.globalUiScale = configuration.GlobalUiScale;
             this.fontGamma = configuration.FontGamma;
             this.doUseAxisFontsFromGame = configuration.UseAxisFontsFromGame;
-            this.doAllowBigFontAtlas = configuration.AllowBigFontAtlas;
+            this.fontResolutionLevel = configuration.FontResolutionLevel;
             this.doToggleUiHide = configuration.ToggleUiHide;
             this.doToggleUiHideDuringCutscenes = configuration.ToggleUiHideDuringCutscenes;
             this.doToggleUiHideDuringGpose = configuration.ToggleUiHideDuringGpose;
@@ -119,6 +121,15 @@ namespace Dalamud.Interface.Internal.Windows
             this.autoUpdatePlugins = configuration.AutoUpdatePlugins;
             this.doButtonsSystemMenu = configuration.DoButtonsSystemMenu;
             this.disableRmtFiltering = configuration.DisableRmtFiltering;
+
+            this.fontResolutionLevelStrings = new string[]
+            {
+                Loc.Localize("DalamudSettingsFontResolutionLevel0", "Least (1k x 1k texture)"),
+                Loc.Localize("DalamudSettingsFontResolutionLevel1", "Lesser (2k x 2k texture)"),
+                Loc.Localize("DalamudSettingsFontResolutionLevel2", "Normal (4k x 4k texture)"),
+                Loc.Localize("DalamudSettingsFontResolutionLevel3", "Better (8k x 8k texture)"),
+                Loc.Localize("DalamudSettingsFontResolutionLevel4", "Best (16k x 16k texture)"),
+            };
 
             this.languages = Localization.ApplicableLangCodes.Prepend("en").ToArray();
             try
@@ -188,7 +199,7 @@ namespace Dalamud.Interface.Internal.Windows
 
             ImGui.GetIO().FontGlobalScale = configuration.GlobalUiScale;
             interfaceManager.FontGammaOverride = null;
-            interfaceManager.AllowBigFontAtlasOverride = null;
+            interfaceManager.FontResolutionLevelOverride = null;
             interfaceManager.UseAxisOverride = null;
             this.thirdRepoList = configuration.ThirdRepoList.Select(x => x.Clone()).ToList();
             this.devPluginLocations = configuration.DevPluginLoadLocations.Select(x => x.Clone()).ToList();
@@ -296,9 +307,41 @@ namespace Dalamud.Interface.Internal.Windows
             ImGui.Text(Loc.Localize("DalamudSettingsGlobalUiScale", "Global UI Scale"));
             ImGui.SameLine();
             ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 3);
-            if (ImGui.Button(Loc.Localize("DalamudSettingsIndividualConfigResetToDefaultValue", "Reset") + "##DalamudSettingsGlobalUiScaleReset"))
+            if (ImGui.Button(Loc.Localize("DalamudSettingsIndividualConfigResetToDefaultValue", "9.6pt") + "##DalamudSettingsGlobalUiScaleReset96"))
+            {
+                this.globalUiScale = 9.6f / 12.0f;
+                ImGui.GetIO().FontGlobalScale = this.globalUiScale;
+                interfaceManager.RebuildFonts();
+            }
+
+            ImGui.SameLine();
+            if (ImGui.Button(Loc.Localize("DalamudSettingsIndividualConfigResetToDefaultValue", "Reset (12pt)") + "##DalamudSettingsGlobalUiScaleReset12"))
             {
                 this.globalUiScale = 1.0f;
+                ImGui.GetIO().FontGlobalScale = this.globalUiScale;
+                interfaceManager.RebuildFonts();
+            }
+
+            ImGui.SameLine();
+            if (ImGui.Button(Loc.Localize("DalamudSettingsIndividualConfigResetToDefaultValue", "14pt") + "##DalamudSettingsGlobalUiScaleReset14"))
+            {
+                this.globalUiScale = 14.0f / 12.0f;
+                ImGui.GetIO().FontGlobalScale = this.globalUiScale;
+                interfaceManager.RebuildFonts();
+            }
+
+            ImGui.SameLine();
+            if (ImGui.Button(Loc.Localize("DalamudSettingsIndividualConfigResetToDefaultValue", "18pt") + "##DalamudSettingsGlobalUiScaleReset18"))
+            {
+                this.globalUiScale = 18.0f / 12.0f;
+                ImGui.GetIO().FontGlobalScale = this.globalUiScale;
+                interfaceManager.RebuildFonts();
+            }
+
+            ImGui.SameLine();
+            if (ImGui.Button(Loc.Localize("DalamudSettingsIndividualConfigResetToDefaultValue", "36pt") + "##DalamudSettingsGlobalUiScaleReset36"))
+            {
+                this.globalUiScale = 36.0f / 12.0f;
                 ImGui.GetIO().FontGlobalScale = this.globalUiScale;
                 interfaceManager.RebuildFonts();
             }
@@ -332,13 +375,17 @@ namespace Dalamud.Interface.Internal.Windows
 
             ImGui.TextColored(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingToggleUiAxisFontsHint", "Use AXIS fonts (the game's main UI fonts) as default Dalamud font."));
 
-            if (ImGui.Checkbox(Loc.Localize("DalamudSettingAllowBigFontAtlas", "Allow big font atlas"), ref this.doAllowBigFontAtlas))
+            ImGui.Text(Loc.Localize("DalamudSettingsFontResolutionLevel", "Font resolution level"));
+            if (ImGui.Combo("##DalamudSettingsFontResolutionLevelCombo", ref this.fontResolutionLevel, this.fontResolutionLevelStrings, this.fontResolutionLevelStrings.Length))
             {
-                interfaceManager.AllowBigFontAtlasOverride = this.doAllowBigFontAtlas;
+                interfaceManager.FontResolutionLevelOverride = this.fontResolutionLevel;
                 interfaceManager.RebuildFonts();
             }
 
-            ImGui.TextColored(ImGuiColors.DalamudGrey, string.Format(Loc.Localize("DalamudSettingAllowBigFontAtlas", "Displays text crisply, but may crash if your GPU does not support it.\nCurrent size: {0}px * {1}px"), ImGui.GetIO().Fonts.TexWidth, ImGui.GetIO().Fonts.TexHeight));
+            ImGui.TextColored(ImGuiColors.DalamudGrey, string.Format(
+                Loc.Localize("DalamudSettingsFontResolutionLevel", "Your PC may not support loading all font into memory at maximum sizes, and it may crash. Adjust this option to try to show more crisp text.\nCurrent font atlas size is {0}px * {1}px."),
+                ImGui.GetIO().Fonts.TexWidth,
+                ImGui.GetIO().Fonts.TexHeight));
 
             ImGui.Checkbox(Loc.Localize("DalamudSettingToggleUiHide", "Hide plugin UI when the game UI is toggled off"), ref this.doToggleUiHide);
             ImGui.TextColored(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingToggleUiHideHint", "Hide any open windows by plugins when toggling the game overlay."));
@@ -867,7 +914,7 @@ namespace Dalamud.Interface.Internal.Windows
             configuration.ShowTsm = this.doTsm;
 
             configuration.UseAxisFontsFromGame = this.doUseAxisFontsFromGame;
-            configuration.AllowBigFontAtlas = this.doAllowBigFontAtlas;
+            configuration.FontResolutionLevel = this.fontResolutionLevel;
             configuration.FontGamma = this.fontGamma;
 
             // This is applied every frame in InterfaceManager::CheckViewportState()

--- a/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
@@ -127,8 +127,8 @@ namespace Dalamud.Interface.Internal.Windows
                 Loc.Localize("DalamudSettingsFontResolutionLevel0", "Least (1k x 1k texture)"),
                 Loc.Localize("DalamudSettingsFontResolutionLevel1", "Lesser (2k x 2k texture)"),
                 Loc.Localize("DalamudSettingsFontResolutionLevel2", "Normal (4k x 4k texture)"),
-                Loc.Localize("DalamudSettingsFontResolutionLevel3", "Better (8k x 8k texture)"),
-                Loc.Localize("DalamudSettingsFontResolutionLevel4", "Best (16k x 16k texture)"),
+                Loc.Localize("DalamudSettingsFontResolutionLevel3", "Better (8k x 8k texture, may crash your game)"),
+                Loc.Localize("DalamudSettingsFontResolutionLevel4", "Best (16k x 16k texture, may crash your game)"),
             };
 
             this.languages = Localization.ApplicableLangCodes.Prepend("en").ToArray();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3614868/161693291-391e9881-1160-4f06-90ad-dda90bff509b.png)

![image](https://user-images.githubusercontent.com/3614868/161693308-84477903-5dd7-4aa7-8553-0062702c7259.png)

When a plugin or something is requesting a font to be loaded resulting in a font atlas texture too big, it will scale all fonts to make all glyphs fit into the given restrictions in texture resolutions.