### PR TITLE
Fix WindowSystem loop issues

### DIFF
--- a/Dalamud/Interface/Windowing/WindowSystem.cs
+++ b/Dalamud/Interface/Windowing/WindowSystem.cs
@@ -106,7 +106,8 @@ namespace Dalamud.Interface.Windowing
             if (hasNamespace)
                 ImGui.PushID(this.Namespace);
 
-            foreach (var window in this.windows)
+            // Shallow clone the list of windows so that we can edit it without modifying it while the loop is iterating
+            foreach (var window in this.windows.ToArray())
             {
 #if DEBUG
                 // Log.Verbose($"[WS{(hasNamespace ? "/" + this.Namespace : string.Empty)}] Drawing {window.WindowName}");


### PR DESCRIPTION
Currently, WindowSystem only allows a Window to be added/removed from the windows list at very specific times; namely when the `Draw()` loop is currently not iterating. This causes problematic behavior and exceptions when attempting to modify the Window list in certain contexts (e.g. disposing of a window while a Draw is happening, or registering/removing windows from a different thread).

This pull request seeks to fix this bug by instead creating a shallow copy of the list prior to iteration, such that the original list can be edited through the existing API without fear of tampering with any existing running loop.

This solution was chosen primarily for its simplicity; rather than creating an add/remove queue (which can break in unexpected cases and has order dependencies) or locking, this simply snapshots the list at any given moment in time. This does create a downside of any changes to the window list not taking effect until the next `WindowSystem#Draw()` call, but this is negligible and would have been a consideration with any other solution.

This change does not change APIs, should not (noticeably) change behavior, and appears to cause little to no performance impact.