### PR TITLE
Make it possible to use AXIS fonts with exactly specified size

### DIFF
--- a/Dalamud/Interface/GameFonts/GameFontManager.cs
+++ b/Dalamud/Interface/GameFonts/GameFontManager.cs
@@ -323,7 +323,7 @@ namespace Dalamud.Interface.GameFonts
                         if (c < 32 || c >= 0xFFFF)
                             continue;
 
-                        var widthAdjustment = style.CalculateWidthAdjustment(fdt, glyph);
+                        var widthAdjustment = style.CalculateBaseWidthAdjustment(fdt, glyph);
                         rectIds[c] = Tuple.Create(
                             io.Fonts.AddCustomRectFontGlyph(
                                 font,
@@ -378,7 +378,7 @@ namespace Dalamud.Interface.GameFonts
                     var rc = ioFonts.GetCustomRectByIndex(rectId);
                     var sourceBuffer = this.texturePixels[glyph.TextureFileIndex];
                     var sourceBufferDelta = glyph.TextureChannelByteIndex;
-                    var widthAdjustment = style.CalculateWidthAdjustment(fdt, glyph);
+                    var widthAdjustment = style.CalculateBaseWidthAdjustment(fdt, glyph);
                     if (widthAdjustment == 0)
                     {
                         for (var y = 0; y < glyph.BoundingHeight; y++)
@@ -404,10 +404,10 @@ namespace Dalamud.Interface.GameFonts
                             for (var y = 0; y < glyph.BoundingHeight; y++)
                             {
                                 float xDelta = xbold;
-                                if (style.SkewStrength > 0)
-                                    xDelta += style.SkewStrength * (fdt.FontHeader.LineHeight - glyph.CurrentOffsetY - y) / fdt.FontHeader.LineHeight;
-                                else if (style.SkewStrength < 0)
-                                    xDelta -= style.SkewStrength * (glyph.CurrentOffsetY + y) / fdt.FontHeader.LineHeight;
+                                if (style.BaseSkewStrength > 0)
+                                    xDelta += style.BaseSkewStrength * (fdt.FontHeader.LineHeight - glyph.CurrentOffsetY - y) / fdt.FontHeader.LineHeight;
+                                else if (style.BaseSkewStrength < 0)
+                                    xDelta -= style.BaseSkewStrength * (glyph.CurrentOffsetY + y) / fdt.FontHeader.LineHeight;
                                 var xDeltaInt = (int)Math.Floor(xDelta);
                                 var xness = xDelta - xDeltaInt;
                                 for (var x = 0; x < glyph.BoundingWidth; x++)

--- a/Dalamud/Interface/GameFonts/GameFontManager.cs
+++ b/Dalamud/Interface/GameFonts/GameFontManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Text;
 
 using Dalamud.Configuration.Internal;
@@ -229,7 +230,10 @@ namespace Dalamud.Interface.GameFonts
             }
 
             if (needRebuild)
+            {
+                Log.Information("[GameFontManager] Calling RebuildFonts because {0} has been requested.", style.ToString());
                 this.interfaceManager.RebuildFonts();
+            }
 
             return new(this, style);
         }
@@ -287,7 +291,8 @@ namespace Dalamud.Interface.GameFonts
         /// <summary>
         /// Build fonts before plugins do something more. To be called from InterfaceManager.
         /// </summary>
-        public void BuildFonts()
+        /// <param name="forceMinSize">Whether to load fonts in minimum sizes.</param>
+        public void BuildFonts(bool forceMinSize)
         {
             unsafe
             {
@@ -305,7 +310,7 @@ namespace Dalamud.Interface.GameFonts
                 {
                     var rectIds = this.glyphRectIds[style] = new();
 
-                    var fdt = this.fdts[(int)style.FamilyAndSize];
+                    var fdt = this.fdts[(int)(forceMinSize ? style.FamilyWithMinimumSize : style.FamilyAndSize)];
                     if (fdt == null)
                         continue;
 
@@ -338,7 +343,8 @@ namespace Dalamud.Interface.GameFonts
         /// <summary>
         /// Post-build fonts before plugins do something more. To be called from InterfaceManager.
         /// </summary>
-        public unsafe void AfterBuildFonts()
+        /// <param name="forceMinSize">Whether to load fonts in minimum sizes.</param>
+        public unsafe void AfterBuildFonts(bool forceMinSize)
         {
             var ioFonts = ImGui.GetIO().Fonts;
             ioFonts.GetTexDataAsRGBA32(out byte* pixels8, out var width, out var height);
@@ -347,7 +353,8 @@ namespace Dalamud.Interface.GameFonts
 
             foreach (var (style, font) in this.fonts)
             {
-                var fdt = this.fdts[(int)style.FamilyAndSize];
+                var fdt = this.fdts[(int)(forceMinSize ? style.FamilyWithMinimumSize : style.FamilyAndSize)];
+                var scale = style.SizePt / fdt.FontHeader.Size;
                 var fontPtr = font.NativePtr;
                 fontPtr->ConfigData->SizePixels = fontPtr->FontSize = fdt.FontHeader.Size * 4 / 3;
                 fontPtr->Ascent = fdt.FontHeader.Ascent;
@@ -363,12 +370,8 @@ namespace Dalamud.Interface.GameFonts
                     }
                 }
 
-                fixed (char* c = FontNames[(int)style.FamilyAndSize])
-                {
-                    for (var j = 0; j < 40; j++)
-                        fontPtr->ConfigData->Name[j] = 0;
-                    Encoding.UTF8.GetBytes(c, FontNames[(int)style.FamilyAndSize].Length, fontPtr->ConfigData->Name, 40);
-                }
+                var nameBytes = Encoding.UTF8.GetBytes(style.ToString() + "\0");
+                Marshal.Copy(nameBytes, 0, (IntPtr)font.ConfigData.Name.Data, Math.Min(nameBytes.Length, font.ConfigData.Name.Count));
 
                 foreach (var (c, (rectId, glyph)) in this.glyphRectIds[style])
                 {
@@ -433,11 +436,9 @@ namespace Dalamud.Interface.GameFonts
                         }
                     }
                 }
-            }
 
-            foreach (var font in this.fonts.Values)
-            {
                 CopyGlyphsAcrossFonts(InterfaceManager.DefaultFont, font, true, false);
+                UnscaleFont(font, 1 / scale, false);
                 font.BuildLookupTable();
             }
         }

--- a/Dalamud/Interface/GameFonts/GameFontStyle.cs
+++ b/Dalamud/Interface/GameFonts/GameFontStyle.cs
@@ -75,6 +75,15 @@ namespace Dalamud.Interface.GameFonts
         }
 
         /// <summary>
+        /// Gets or sets the base skew strength.
+        /// </summary>
+        public float BaseSkewStrength
+        {
+            get => this.SkewStrength * this.BaseSizePx / this.SizePx;
+            set => this.SkewStrength = value * this.SizePx / this.BaseSizePx;
+        }
+
+        /// <summary>
         /// Gets the font family.
         /// </summary>
         public GameFontFamily Family => this.FamilyAndSize switch
@@ -172,9 +181,7 @@ namespace Dalamud.Interface.GameFonts
         public bool Italic
         {
             get => this.SkewStrength != 0;
-            set => this.SkewStrength = value ? this.SizePx / 8 : 0;
-
-            // Goat said that skewing by 4 pixels on 30px font looks the best, so 7.5 it is, but rounded.
+            set => this.SkewStrength = value ? this.SizePx / 7 : 0;
         }
 
         /// <summary>
@@ -262,13 +269,13 @@ namespace Dalamud.Interface.GameFonts
         /// <param name="reader">Font information.</param>
         /// <param name="glyph">Glyph.</param>
         /// <returns>Width adjustment in pixel unit.</returns>
-        public int CalculateWidthAdjustment(FdtReader reader, FdtReader.FontTableEntry glyph)
+        public int CalculateBaseWidthAdjustment(FdtReader reader, FdtReader.FontTableEntry glyph)
         {
             var widthDelta = this.Weight;
-            if (this.SkewStrength > 0)
-                widthDelta += 1f * this.SkewStrength * (reader.FontHeader.LineHeight - glyph.CurrentOffsetY) / reader.FontHeader.LineHeight;
-            else if (this.SkewStrength < 0)
-                widthDelta -= 1f * this.SkewStrength * (glyph.CurrentOffsetY + glyph.BoundingHeight) / reader.FontHeader.LineHeight;
+            if (this.BaseSkewStrength > 0)
+                widthDelta += 1f * this.BaseSkewStrength * (reader.FontHeader.LineHeight - glyph.CurrentOffsetY) / reader.FontHeader.LineHeight;
+            else if (this.BaseSkewStrength < 0)
+                widthDelta -= 1f * this.BaseSkewStrength * (glyph.CurrentOffsetY + glyph.BoundingHeight) / reader.FontHeader.LineHeight;
 
             return (int)Math.Ceiling(widthDelta);
         }

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -625,7 +625,7 @@ namespace Dalamud.Interface.Internal
                 this.Axis = axis;
                 this.TargetSizePx = sizePx;
                 this.Scale = scale;
-                this.SourceAxis = Service<GameFontManager>.Get().NewFontRef(new(GameFontFamily.Axis, sizePx * scale * 3 / 4));
+                this.SourceAxis = Service<GameFontManager>.Get().NewFontRef(new(GameFontFamily.Axis, sizePx * scale));
             }
 
             internal enum AxisMode
@@ -705,7 +705,7 @@ namespace Dalamud.Interface.Internal
                     this.UseAxis ? TargetFontModification.AxisMode.Overwrite : TargetFontModification.AxisMode.GameGlyphsOnly,
                     this.UseAxis ? DefaultFontSizePx : DefaultFontSizePx + 1,
                     fontLoadScale);
-                Log.Verbose("[FONT] SetupFonts - Default corresponding AXIS size: {0}pt ({1}px)", fontInfo.SourceAxis.Style.SizePt, fontInfo.SourceAxis.Style.SizePx);
+                Log.Verbose("[FONT] SetupFonts - Default corresponding AXIS size: {0}pt ({1}px)", fontInfo.SourceAxis.Style.BaseSizePt, fontInfo.SourceAxis.Style.BaseSizePx);
                 if (this.UseAxis)
                 {
                     fontConfig.GlyphRanges = dummyRangeHandle.AddrOfPinnedObject();
@@ -807,7 +807,7 @@ namespace Dalamud.Interface.Internal
                         if (this.UseAxis)
                         {
                             fontConfig.GlyphRanges = dummyRangeHandle.AddrOfPinnedObject();
-                            fontConfig.SizePixels = fontInfo.SourceAxis.Style.SizePx;
+                            fontConfig.SizePixels = fontInfo.SourceAxis.Style.BaseSizePx;
                             fontConfig.PixelSnapH = false;
 
                             var sizedFont = ioFonts.AddFontDefault(fontConfig);
@@ -829,7 +829,7 @@ namespace Dalamud.Interface.Internal
                     }
                 }
 
-                gameFontManager.BuildFonts();
+                gameFontManager.BuildFonts(disableBigFonts);
 
                 var customFontFirstConfigIndex = ioFonts.ConfigData.Size;
 
@@ -903,7 +903,7 @@ namespace Dalamud.Interface.Internal
                         texPixels[i] = (byte)(Math.Pow(texPixels[i] / 255.0f, 1.0f / fontGamma) * 255.0f);
                 }
 
-                gameFontManager.AfterBuildFonts();
+                gameFontManager.AfterBuildFonts(disableBigFonts);
 
                 foreach (var (font, mod) in this.loadedFontInfo)
                 {


### PR DESCRIPTION
From plugin:

```cs
var font1 = pluginInterface.UiBuilder.GetGameFontHandle(new(GameFontFamily.Axis, 24f * 4 / 3) {
    Italic = false,
});
var font2 = pluginInterface.UiBuilder.GetGameFontHandle(new(GameFontFamily.MiedingerMid, 24f * 4 / 3) {
    Italic = true,
});

...

ImGui.PushFont(font1);
...
ImGui.PopFont();

...

font2.Dispose();
font1.Dispose();
```