### PR TITLE
feat: add dev bar info toggle

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -307,6 +307,11 @@ namespace Dalamud.Configuration.Internal
         public bool IsMbCollect { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not to show info on dev bar.
+        /// </summary>
+        public bool ShowDevBarInfo { get; set; } = true;
+
+        /// <summary>
         /// Load a configuration from the provided path.
         /// </summary>
         /// <param name="path">The path to load the configuration file from.</param>

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -615,6 +615,11 @@ namespace Dalamud.Interface.Internal
                             Log.Information(info);
                         }
 
+                        if (ImGui.MenuItem("Show dev bar info", null, configuration.ShowDevBarInfo))
+                        {
+                            configuration.ShowDevBarInfo = !configuration.ShowDevBarInfo;
+                        }
+
                         ImGui.EndMenu();
                     }
 
@@ -732,14 +737,17 @@ namespace Dalamud.Interface.Internal
                     if (Service<GameGui>.Get().GameUiHidden)
                         ImGui.BeginMenu("UI is hidden...", false);
 
-                    ImGui.PushFont(InterfaceManager.MonoFont);
+                    if (configuration.ShowDevBarInfo)
+                    {
+                        ImGui.PushFont(InterfaceManager.MonoFont);
 
-                    ImGui.BeginMenu(Util.GetGitHash(), false);
-                    ImGui.BeginMenu(this.frameCount.ToString("000000"), false);
-                    ImGui.BeginMenu(ImGui.GetIO().Framerate.ToString("000"), false);
-                    ImGui.BeginMenu($"{Util.FormatBytes(GC.GetTotalMemory(false))}", false);
+                        ImGui.BeginMenu(Util.GetGitHash(), false);
+                        ImGui.BeginMenu(this.frameCount.ToString("000000"), false);
+                        ImGui.BeginMenu(ImGui.GetIO().Framerate.ToString("000"), false);
+                        ImGui.BeginMenu($"{Util.FormatBytes(GC.GetTotalMemory(false))}", false);
 
-                    ImGui.PopFont();
+                        ImGui.PopFont();
+                    }
 
                     ImGui.EndMainMenuBar();
                 }


### PR DESCRIPTION
Add a toggle to hide the informational fields on the right side of the dev bar. It's on by default so no change in existing behavior.

![image](https://user-images.githubusercontent.com/35899782/163913238-5fb28f76-006a-4ed1-859d-3a36b0d2963b.png)


