### PR TITLE
Update Reloaded.Hooks to 3.5.3

### DIFF
--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -73,7 +73,7 @@
         <PackageReference Include="Serilog" Version="2.10.0" />
         <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-        <PackageReference Include="Reloaded.Hooks" Version="3.5.2" />
+        <PackageReference Include="Reloaded.Hooks" Version="3.5.3" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This makes wine memory allocation more reliable and fixes a bug where the incorrect exception could be thrown when `MemoryBufferHelper.Allocate` fails