### PR TITLE
feat: add option to show dev menu at startup

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -200,6 +200,11 @@ namespace Dalamud.Configuration.Internal
         public bool LogOpenAtStartup { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not the dev bar should open at startup.
+        /// </summary>
+        public bool DevBarOpenAtStartup { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether or not ImGui asserts should be enabled at startup.
         /// </summary>
         public bool AssertsEnabledAtStartup { get; set; }

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -112,6 +112,7 @@ namespace Dalamud.Interface.Internal
             this.WindowSystem.AddWindow(this.fallbackFontNoticeWindow);
 
             ImGuiManagedAsserts.AssertsEnabled = configuration.AssertsEnabledAtStartup;
+            this.isImGuiDrawDevMenu = this.isImGuiDrawDevMenu || configuration.DevBarOpenAtStartup;
 
             interfaceManager.Draw += this.OnDraw;
             var dalamud = Service<Dalamud>.Get();
@@ -433,7 +434,13 @@ namespace Dalamud.Interface.Internal
 
                     if (ImGui.BeginMenu("Dalamud"))
                     {
-                        ImGui.MenuItem("Draw Dalamud dev menu", string.Empty, ref this.isImGuiDrawDevMenu);
+                        ImGui.MenuItem("Draw dev menu", string.Empty, ref this.isImGuiDrawDevMenu);
+                        var devBarAtStartup = configuration.DevBarOpenAtStartup;
+                        if (ImGui.MenuItem("Draw dev menu at startup", string.Empty, ref devBarAtStartup))
+                        {
+                            configuration.DevBarOpenAtStartup ^= true;
+                            configuration.Save();
+                        }
 
                         ImGui.Separator();
 


### PR DESCRIPTION
Add option to show dev bar at startup. If this option is not selected, it'll follow today's behavior and just go based on debug/release.

![image](https://user-images.githubusercontent.com/35899782/164122115-cd3bde2e-23f4-4299-8fe3-f7f6f321c12a.png)
