### PR TITLE
Expose CopyGlyphsAcrossFonts

### DIFF
--- a/Dalamud/Interface/GameFonts/GameFontManager.cs
+++ b/Dalamud/Interface/GameFonts/GameFontManager.cs
@@ -7,6 +7,7 @@ using System.Text;
 
 using Dalamud.Data;
 using Dalamud.Interface.Internal;
+using Dalamud.Utility;
 using ImGuiNET;
 using Lumina.Data.Files;
 using Serilog;
@@ -111,65 +112,6 @@ namespace Dalamud.Interface.GameFonts
         }
 
         /// <summary>
-        /// Fills missing glyphs in target font from source font, if both are not null.
-        /// </summary>
-        /// <param name="source">Source font.</param>
-        /// <param name="target">Target font.</param>
-        /// <param name="missingOnly">Whether to copy missing glyphs only.</param>
-        /// <param name="rebuildLookupTable">Whether to call target.BuildLookupTable().</param>
-        /// <param name="rangeLow">Low codepoint range to copy.</param>
-        /// <param name="rangeHigh">High codepoing range to copy.</param>
-        public static void CopyGlyphsAcrossFonts(ImFontPtr? source, ImFontPtr? target, bool missingOnly, bool rebuildLookupTable, int rangeLow = 32, int rangeHigh = 0xFFFE)
-        {
-            if (!source.HasValue || !target.HasValue)
-                return;
-
-            var scale = target.Value!.FontSize / source.Value!.FontSize;
-            unsafe
-            {
-                var glyphs = (ImFontGlyphReal*)source.Value!.Glyphs.Data;
-                for (int j = 0, j_ = source.Value!.Glyphs.Size; j < j_; j++)
-                {
-                    var glyph = &glyphs[j];
-                    if (glyph->Codepoint < rangeLow || glyph->Codepoint > rangeHigh)
-                        continue;
-
-                    var prevGlyphPtr = (ImFontGlyphReal*)target.Value!.FindGlyphNoFallback((ushort)glyph->Codepoint).NativePtr;
-                    if ((IntPtr)prevGlyphPtr == IntPtr.Zero)
-                    {
-                        target.Value!.AddGlyph(
-                            target.Value!.ConfigData,
-                            (ushort)glyph->Codepoint,
-                            glyph->X0 * scale,
-                            ((glyph->Y0 - source.Value!.Ascent) * scale) + target.Value!.Ascent,
-                            glyph->X1 * scale,
-                            ((glyph->Y1 - source.Value!.Ascent) * scale) + target.Value!.Ascent,
-                            glyph->U0,
-                            glyph->V0,
-                            glyph->U1,
-                            glyph->V1,
-                            glyph->AdvanceX * scale);
-                    }
-                    else if (!missingOnly)
-                    {
-                        prevGlyphPtr->X0 = glyph->X0 * scale;
-                        prevGlyphPtr->Y0 = ((glyph->Y0 - source.Value!.Ascent) * scale) + target.Value!.Ascent;
-                        prevGlyphPtr->X1 = glyph->X1 * scale;
-                        prevGlyphPtr->Y1 = ((glyph->Y1 - source.Value!.Ascent) * scale) + target.Value!.Ascent;
-                        prevGlyphPtr->U0 = glyph->U0;
-                        prevGlyphPtr->V0 = glyph->V0;
-                        prevGlyphPtr->U1 = glyph->U1;
-                        prevGlyphPtr->V1 = glyph->V1;
-                        prevGlyphPtr->AdvanceX = glyph->AdvanceX * scale;
-                    }
-                }
-            }
-
-            if (rebuildLookupTable)
-                target.Value!.BuildLookupTable();
-        }
-
-        /// <summary>
         /// Unscales fonts after they have been rendered onto atlas.
         /// </summary>
         /// <param name="fontPtr">Font to unscale.</param>
@@ -191,7 +133,7 @@ namespace Dalamud.Interface.GameFonts
                 font->Descent /= fontScale;
                 if (font->ConfigData != null)
                     font->ConfigData->SizePixels /= fontScale;
-                var glyphs = (ImFontGlyphReal*)font->Glyphs.Data;
+                var glyphs = (Util.ImFontGlyphReal*)font->Glyphs.Data;
                 for (int i = 0, i_ = font->Glyphs.Size; i < i_; i++)
                 {
                     var glyph = &glyphs[i];
@@ -260,7 +202,7 @@ namespace Dalamud.Interface.GameFonts
         /// <param name="rebuildLookupTable">Whether to call target.BuildLookupTable().</param>
         public void CopyGlyphsAcrossFonts(ImFontPtr? source, GameFontStyle target, bool missingOnly, bool rebuildLookupTable)
         {
-            GameFontManager.CopyGlyphsAcrossFonts(source, this.fonts[target], missingOnly, rebuildLookupTable);
+            Util.CopyGlyphsAcrossFonts(source, this.fonts[target], missingOnly, rebuildLookupTable);
         }
 
         /// <summary>
@@ -272,7 +214,7 @@ namespace Dalamud.Interface.GameFonts
         /// <param name="rebuildLookupTable">Whether to call target.BuildLookupTable().</param>
         public void CopyGlyphsAcrossFonts(GameFontStyle source, ImFontPtr? target, bool missingOnly, bool rebuildLookupTable)
         {
-            GameFontManager.CopyGlyphsAcrossFonts(this.fonts[source], target, missingOnly, rebuildLookupTable);
+            Util.CopyGlyphsAcrossFonts(this.fonts[source], target, missingOnly, rebuildLookupTable);
         }
 
         /// <summary>
@@ -284,7 +226,7 @@ namespace Dalamud.Interface.GameFonts
         /// <param name="rebuildLookupTable">Whether to call target.BuildLookupTable().</param>
         public void CopyGlyphsAcrossFonts(GameFontStyle source, GameFontStyle target, bool missingOnly, bool rebuildLookupTable)
         {
-            GameFontManager.CopyGlyphsAcrossFonts(this.fonts[source], this.fonts[target], missingOnly, rebuildLookupTable);
+            Util.CopyGlyphsAcrossFonts(this.fonts[source], this.fonts[target], missingOnly, rebuildLookupTable);
         }
 
         /// <summary>
@@ -449,7 +391,7 @@ namespace Dalamud.Interface.GameFonts
                     }
                 }
 
-                CopyGlyphsAcrossFonts(InterfaceManager.DefaultFont, font, true, false);
+                Util.CopyGlyphsAcrossFonts(InterfaceManager.DefaultFont, font, true, false);
                 UnscaleFont(font, 1 / scale, false);
                 font.BuildLookupTable();
             }
@@ -468,38 +410,6 @@ namespace Dalamud.Interface.GameFonts
 
                 if ((this.fontUseCounter[style] -= 1) == 0)
                     this.fontUseCounter.Remove(style);
-            }
-        }
-
-        private struct ImFontGlyphReal
-        {
-            public uint ColoredVisibleCodepoint;
-            public float AdvanceX;
-            public float X0;
-            public float Y0;
-            public float X1;
-            public float Y1;
-            public float U0;
-            public float V0;
-            public float U1;
-            public float V1;
-
-            public bool Colored
-            {
-                get => ((this.ColoredVisibleCodepoint >> 0) & 1) != 0;
-                set => this.ColoredVisibleCodepoint = (this.ColoredVisibleCodepoint & 0xFFFFFFFEu) | (value ? 1u : 0u);
-            }
-
-            public bool Visible
-            {
-                get => ((this.ColoredVisibleCodepoint >> 1) & 1) != 0;
-                set => this.ColoredVisibleCodepoint = (this.ColoredVisibleCodepoint & 0xFFFFFFFDu) | (value ? 2u : 0u);
-            }
-
-            public int Codepoint
-            {
-                get => (int)(this.ColoredVisibleCodepoint >> 2);
-                set => this.ColoredVisibleCodepoint = (this.ColoredVisibleCodepoint & 3u) | ((uint)this.Codepoint << 2);
             }
         }
     }

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -929,14 +929,14 @@ namespace Dalamud.Interface.Internal
                         font.Descent = mod.SourceAxis.ImFont.Descent;
                         font.FallbackChar = mod.SourceAxis.ImFont.FallbackChar;
                         font.EllipsisChar = mod.SourceAxis.ImFont.EllipsisChar;
-                        GameFontManager.CopyGlyphsAcrossFonts(mod.SourceAxis.ImFont, font, false, false);
+                        Util.CopyGlyphsAcrossFonts(mod.SourceAxis.ImFont, font, false, false);
                     }
                     else if (mod.Axis == TargetFontModification.AxisMode.GameGlyphsOnly)
                     {
                         Log.Verbose("[FONT] {0}: Overwrite game specific glyphs from AXIS of size {1}px", mod.Name, mod.SourceAxis.ImFont.FontSize, font.FontSize);
                         if (!this.UseAxis && font.NativePtr == DefaultFont.NativePtr)
                             mod.SourceAxis.ImFont.FontSize -= 1;
-                        GameFontManager.CopyGlyphsAcrossFonts(mod.SourceAxis.ImFont, font, true, false, 0xE020, 0xE0DB);
+                        Util.CopyGlyphsAcrossFonts(mod.SourceAxis.ImFont, font, true, false, 0xE020, 0xE0DB);
                         if (!this.UseAxis && font.NativePtr == DefaultFont.NativePtr)
                             mod.SourceAxis.ImFont.FontSize += 1;
                     }
@@ -946,7 +946,7 @@ namespace Dalamud.Interface.Internal
                 }
 
                 // Fill missing glyphs in MonoFont from DefaultFont
-                GameFontManager.CopyGlyphsAcrossFonts(DefaultFont, MonoFont, true, false);
+                Util.CopyGlyphsAcrossFonts(DefaultFont, MonoFont, true, false);
 
                 for (int i = 0, i_ = ioFonts.Fonts.Size; i < i_; i++)
                 {

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -249,6 +249,11 @@ namespace Dalamud.Interface.Internal
         public int FontResolutionLevel => this.FontResolutionLevelOverride ?? Service<DalamudConfiguration>.Get().FontResolutionLevel;
 
         /// <summary>
+        /// Gets a value indicating whether we're building fonts but haven't generated atlas yet.
+        /// </summary>
+        public bool IsBuildingFontsBeforeAtlasBuild => this.isRebuildingFonts && !this.fontBuildSignal.WaitOne(0);
+
+        /// <summary>
         /// Enable this module.
         /// </summary>
         public void Enable()
@@ -900,7 +905,7 @@ namespace Dalamud.Interface.Internal
                         texPixels[i] = (byte)(Math.Pow(texPixels[i] / 255.0f, 1.0f / fontGamma) * 255.0f);
                 }
 
-                gameFontManager.AfterBuildFonts(disableBigFonts);
+                gameFontManager.AfterBuildFonts();
 
                 foreach (var (font, mod) in this.loadedFontInfo)
                 {

--- a/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
@@ -179,7 +179,8 @@ namespace Dalamud.Interface.Internal.Windows
             var configuration = Service<DalamudConfiguration>.Get();
             var interfaceManager = Service<InterfaceManager>.Get();
 
-            var rebuildFont = interfaceManager.FontGamma != configuration.FontGammaLevel
+            var rebuildFont = ImGui.GetIO().FontGlobalScale != configuration.GlobalUiScale
+                || interfaceManager.FontGamma != configuration.FontGammaLevel
                 || interfaceManager.FontResolutionLevel != configuration.FontResolutionLevel
                 || interfaceManager.UseAxis != configuration.UseAxisFontsFromGame;
 


### PR DESCRIPTION
Example usage:

![image](https://user-images.githubusercontent.com/3614868/165796125-ccc391a4-ef5b-45d7-b15b-bed5b0b911ac.png)

```cs
using Dalamud.Interface.GameFonts;
using Dalamud.IoC;
using Dalamud.Plugin;
using Dalamud.Utility;
using ImGuiNET;
using System;
using System.Collections.Generic;

namespace TestPlugin {
    public class Plugin : IDalamudPlugin {
        public string Name => "TestPlugin";
        private readonly DalamudPluginInterface _pluginInterface;
        private readonly List<Tuple<GameFontHandle, ImFontPtr, GameFontHandle, ImFontPtr>> _fonts = new();
        private readonly List<Tuple<GameFontHandle, ImFontPtr>> _italicFonts = new();
        private readonly List<string> _lines = new() {
            "E020 ",
            "E040 ",
            "E060 ",
            "E080 ",
            "E0A0 ",
            "E0C0 ",
        };

        public Plugin([RequiredVersion("1.0")] DalamudPluginInterface pluginInterface) {
            _pluginInterface = pluginInterface;
            _pluginInterface.UiBuilder.Draw += DrawUI;
            _pluginInterface.UiBuilder.BuildFonts += MyBuildFonts;
            _pluginInterface.UiBuilder.AfterBuildFonts += MyAfterBuildFonts;
            _pluginInterface.UiBuilder.RebuildFonts();
        }

        private void MyBuildFonts() {
            foreach (var (f1, _, f2, _) in _fonts) {
                f1.Dispose();
                f2.Dispose();
            }
            _fonts.Clear();
            foreach (var size in new float[] { 18, 19, 20, 21, 22 }) {
                _fonts.Add(Tuple.Create(
                    _pluginInterface.UiBuilder.GetGameFontHandle(new(GameFontFamily.Axis, size)),
                    ImGui.GetIO().Fonts.AddFontFromFileTTF("C:/Windows/Fonts/comic.ttf", size),
                    _pluginInterface.UiBuilder.GetGameFontHandle(new(GameFontFamily.Axis, size) { SkewStrength = size / 6 }),
                    ImGui.GetIO().Fonts.AddFontFromFileTTF("C:/Windows/Fonts/comici.ttf", size)
                ));
            }
        }

        private void MyAfterBuildFonts() {
            foreach (var (gameFont, imFont, gameFontItalic, imFontItalic) in _fonts) {
                Util.CopyGlyphsAcrossFonts(
                    source: gameFont!.ImFont,
                    target: imFont,
                    missingOnly: false,
                    rebuildLookupTable: true,
                    rangeLow: 0xE020,
                    rangeHigh: 0xE0DB);
                Util.CopyGlyphsAcrossFonts(
                    source: gameFontItalic!.ImFont,
                    target: imFontItalic,
                    missingOnly: false,
                    rebuildLookupTable: true,
                    rangeLow: 0xE020,
                    rangeHigh: 0xE0DB);
            }
        }

        public void Dispose() {
            _pluginInterface.UiBuilder.AfterBuildFonts -= MyAfterBuildFonts;
            _pluginInterface.UiBuilder.BuildFonts -= MyBuildFonts;
            _pluginInterface.UiBuilder.Draw -= DrawUI;
            foreach (var (f1, _, f2, _) in _fonts) {
                f1.Dispose();
                f2.Dispose();
            }
            _fonts.Clear();
        }

        private void DrawUI() {
            if (ImGui.Begin("TestPlugin")) {
                foreach (var line in _lines) {
                    foreach (var (_, font, _, fontItalic) in _fonts) {
                        ImGui.PushFont(font);
                        ImGui.TextUnformatted($"{font.FontSize}px: {line}");
                        ImGui.PopFont();
                        ImGui.SameLine();
                        ImGui.SetCursorPosX(720);
                        ImGui.PushFont(fontItalic);
                        ImGui.TextUnformatted($"{font.FontSize}px: {line}");
                        ImGui.PopFont();
                    }
                }
                ImGui.End();
            }
        }
    }
}
```