### PR TITLE
Check punchlines while searching for plugins

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -2013,6 +2013,7 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
             return hasSearchString && !(
                 manifest.Name.ToLowerInvariant().Contains(searchString) ||
                 (!manifest.Author.IsNullOrEmpty() && manifest.Author.Equals(this.searchText, StringComparison.InvariantCultureIgnoreCase)) ||
+                (!manifest.Punchline.IsNullOrEmpty() && manifest.Punchline.ToLowerInvariant().Contains(searchString)) ||
                 (manifest.Tags != null && manifest.Tags.Contains(searchString, StringComparer.InvariantCultureIgnoreCase)));
         }
 


### PR DESCRIPTION
Small change, but this fixes #684 and also a minor gripe of mine. For example, now searching for "chat" shows the Teleporter plugin which the issue mentioned:

![image](https://user-images.githubusercontent.com/54911369/165879563-447e15f4-cfdb-429e-a7a4-49682c98e749.png)

And this also fixes another issue where some plugins might look like they're missing because they can't be searched easily:

![image](https://user-images.githubusercontent.com/54911369/165879924-2f5e0c55-5b7a-4d1f-a7a1-8b0143850b63.png)
![image](https://user-images.githubusercontent.com/54911369/165879631-da19cf88-92bc-423e-bb2a-b670901c1b1e.png)

The issue mentions searching descriptions, but they probably really only meant the punchline since that's whats visible by default in the list anyway.
