### PR TITLE
Language handling

### DIFF
--- a/Dalamud.Injector/EntryPoint.cs
+++ b/Dalamud.Injector/EntryPoint.cs
@@ -334,12 +334,17 @@ namespace Dalamud.Injector
                 Console.WriteLine("{0}        [--handle-owner=inherited-handle-value]", exeSpaces);
                 Console.WriteLine("{0}        [--without-dalamud]", exeSpaces);
                 Console.WriteLine("{0}        [-- game_arg1=value1 game_arg2=value2 ...]", exeSpaces);
+                Console.WriteLine(" * All arguments for injector MUST come before --.");
+                Console.WriteLine(" * Otherwise, they will all be passed to the game.");
+                Console.WriteLine();
             }
 
             Console.WriteLine("Specifying dalamud start info: [--dalamud-working-directory=path] [--dalamud-configuration-path=path]");
             Console.WriteLine("                               [--dalamud-plugin-directory=path] [--dalamud-dev-plugin-directory=path]");
-            Console.WriteLine("                               [--dalamud-asset-directory=path] [--dalamud-delay-initialize=0(ms)]");
+            Console.WriteLine("                               [--dalamud-asset-directory=path] [--dalamud-delay-initialize=0]");
             Console.WriteLine("                               [--dalamud-client-language=0-3|j(apanese)|e(nglish)|d|g(erman)|f(rench)]");
+            Console.WriteLine(" * --dalamud-delay-initialize takes integer parameter, which will be interpreted as in milliseconds unit.");
+            Console.WriteLine();
 
             return 0;
         }

--- a/Dalamud/DalamudStartInfo.cs
+++ b/Dalamud/DalamudStartInfo.cs
@@ -51,5 +51,30 @@ namespace Dalamud
         /// Gets a value that specifies how much to wait before a new Dalamud session.
         /// </summary>
         public int DelayInitializeMs { get; init; } = 0;
+
+        /// <summary>
+        /// Returns a new copy of <see cref="DalamudStartInfo"/>, with altered fields.
+        /// </summary>
+        /// <param name="workingDirectory">New working directory.</param>
+        /// <param name="configurationPath">New configuration path.</param>
+        /// <param name="pluginDirectory">New plugin directory.</param>
+        /// <param name="defaultPluginDirectory">New default plugin directory.</param>
+        /// <param name="assetDirectory">New asset directory.</param>
+        /// <param name="language">New language.</param>
+        /// <param name="gameVersion">New game version.</param>
+        /// <returns>New copy of <see cref="DalamudStartInfo"/>.</returns>
+        public DalamudStartInfo Alter(string? workingDirectory = null, string? configurationPath = null, string? pluginDirectory = null, string? defaultPluginDirectory = null, string? assetDirectory = null, ClientLanguage? language = null, GameVersion? gameVersion = null)
+        {
+            return new()
+            {
+                WorkingDirectory = workingDirectory ?? this.WorkingDirectory,
+                ConfigurationPath = configurationPath ?? this.ConfigurationPath,
+                PluginDirectory = pluginDirectory ?? this.PluginDirectory,
+                DefaultPluginDirectory = defaultPluginDirectory ?? this.DefaultPluginDirectory,
+                AssetDirectory = assetDirectory ?? this.AssetDirectory,
+                Language = language ?? this.Language,
+                GameVersion = workingDirectory ?? this.GameVersion,
+            };
+        }
     }
 }


### PR DESCRIPTION
* Overwrite DalamudStartInfo.Language from the game's language byte stored in Framework, if signatures are resolvable.
* To account for the cases where they have a different LogMessage from what we usually expect, generate corresponding regular expression from LogMessage[725], and use it to detect Command not found messages.
* Explain a little bit better on injector help message.