### PR TITLE
Add Service<Framework>.RunOnTick()

### DIFF
--- a/Dalamud/Interface/Internal/Windows/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/DataWindow.cs
@@ -1433,6 +1433,14 @@ namespace Dalamud.Interface.Internal.Windows
                 Task.Run(async () => await Service<Framework>.Get().RunOnTick(() => throw new Exception("Test Exception"), cancellationToken: this.taskSchedCancelSource.Token, delay: TimeSpan.FromSeconds(1)));
             }
 
+            ImGui.SameLine();
+
+            if (ImGui.Button("As long as it's in Framework Thread"))
+            {
+                Task.Run(async () => await Service<Framework>.Get().RunOnFrameworkThread(() => { Log.Information("Task dispatched from non-framework.update thread"); }));
+                Service<Framework>.Get().RunOnFrameworkThread(() => { Log.Information("Task dispatched from framework.update thread"); }).Wait();
+            }
+
             if (ImGui.Button("Drown in tasks"))
             {
                 var token = this.taskSchedCancelSource.Token;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3614868/166182597-4e6b0154-0497-4381-9782-2751d9d8a49b.png)

Usage:
```cs
// Runs given function without a return value during next Framework.Update.
framework.RunOnTick(() => { ... });

// Fetches TickCount64 during Framework.Update after 1.5 seconds.
var x = await framework.RunOnTick(() => Environment.TickCount64, delay: TimeSpan.FromSeconds(1.5));

// Generates an exception after 100 ticks (100 frames rendered), but actually cancel right away.
var cts = new CancellationTokenSource();
var task = framework.RunOnTick(() => throw new Exception("A"), delayTicks: 100, cancellationToken: cts.Token);
cts.Cancel();
await task;

// Fetches specified macro's icon ID, by running HotBarSlot.Set/LoadIconFromSlotB in current thread if current thread is the same one with Framework.Update; otherwise, run it on next Framework.Update call.
private static unsafe Task<int> GetMacroIconId(uint macroPage, uint macroId)
{
    return Service<Framework>.Get().RunOnFrameworkThread(() =>
    {
        var pBytes = stackalloc byte[Marshal.SizeOf<HotBarSlot>()];
        var pSlot = (HotBarSlot*)pBytes;
        pSlot->Set(HotbarSlotType.Macro, (macroPage << 8) + macroId);
        pSlot->LoadIconFromSlotB();
        return pSlot->Icon;
    });
}
```