### PR TITLE
Add dev state / notice

### DIFF
--- a/Dalamud.sln.DotSettings
+++ b/Dalamud.sln.DotSettings
@@ -55,6 +55,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lumina/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Materia/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=PLUGINM/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=pluginmetadata/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Refilter/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=serveropcode/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Universalis/@EntryIndexedValue">True</s:Boolean>

--- a/Dalamud/Interface/Internal/PluginCategoryManager.cs
+++ b/Dalamud/Interface/Internal/PluginCategoryManager.cs
@@ -24,6 +24,10 @@ namespace Dalamud.Interface.Internal
             new(11, "special.devIconTester", () => Locs.Category_IconTester),
             new(12, "special.dalamud", () => Locs.Category_Dalamud),
             new(13, "special.plugins", () => Locs.Category_Plugins),
+            new(14, "special.outdated", () => Locs.Category_Outdated),
+            new(15, "special.adoptable", () => Locs.Category_Adoptable),
+            new(16, "special.obsolete", () => Locs.Category_Obsolete),
+            new(17, "special.discontinued", () => Locs.Category_Discontinued),
             new(FirstTagBasedCategoryId + 0, "other", () => Locs.Category_Other),
             new(FirstTagBasedCategoryId + 1, "jobs", () => Locs.Category_Jobs),
             new(FirstTagBasedCategoryId + 2, "ui", () => Locs.Category_UI),
@@ -41,6 +45,7 @@ namespace Dalamud.Interface.Internal
             new(GroupKind.DevTools, () => Locs.Group_DevTools, 10, 11),
             new(GroupKind.Installed, () => Locs.Group_Installed, 0),
             new(GroupKind.Available, () => Locs.Group_Available, 0),
+            new(GroupKind.Incompatible, () => Locs.Group_Incompatible, 0, 14, 15, 16, 17),
             new(GroupKind.Changelog, () => Locs.Group_Changelog, 0, 12, 13),
 
             // order important, used for drawing, keep in sync with defaults for currentGroupIdx
@@ -77,6 +82,11 @@ namespace Dalamud.Interface.Internal
             /// UI group: changelog of plugins.
             /// </summary>
             Changelog,
+
+            /// <summary>
+            /// UI group: incompatible plugins.
+            /// </summary>
+            Incompatible,
         }
 
         /// <summary>
@@ -384,6 +394,8 @@ namespace Dalamud.Interface.Internal
 
             public static string Group_Changelog => Loc.Localize("InstallerChangelog", "Changelog");
 
+            public static string Group_Incompatible => Loc.Localize("InstallerIncompatible", "Incompatible Plugins");
+
             #endregion
 
             #region Categories
@@ -413,6 +425,14 @@ namespace Dalamud.Interface.Internal
             public static string Category_Plugins => Loc.Localize("InstallerCategoryPlugins", "Plugins");
 
             public static string Category_Dalamud => Loc.Localize("InstallerCategoryDalamud", "Dalamud");
+
+            public static string Category_Outdated => Loc.Localize("InstallerCategoryOutdated", "Pending Update");
+
+            public static string Category_Adoptable => Loc.Localize("InstallerCategoryAdoptable", "Needs New Developer");
+
+            public static string Category_Obsolete => Loc.Localize("InstallerCategoryObsolete", "Replaced by Game/Plugin");
+
+            public static string Category_Discontinued => Loc.Localize("InstallerCategoryDiscontinued", "Not Coming Back");
 
             #endregion
         }

--- a/Dalamud/Interface/Internal/Types/IncompatibleType.cs
+++ b/Dalamud/Interface/Internal/Types/IncompatibleType.cs
@@ -1,0 +1,32 @@
+﻿namespace Dalamud.Interface.Internal.Types;
+
+/// <summary>
+/// Enum describing incompatible type for the user interface.
+/// </summary>
+public enum IncompatibleType
+{
+    /// <summary>
+    /// Show all incompatible types.
+    /// </summary>
+    All,
+
+    /// <summary>
+    /// Show outdated plugins by api level or game version.
+    /// </summary>
+    Outdated,
+
+    /// <summary>
+    /// Show plugins available for adoption by a new developer.
+    /// </summary>
+    Adoptable,
+
+    /// <summary>
+    /// Show plugins that are no longer needed due to game feature or replacement plugin.
+    /// </summary>
+    Obsolete,
+
+    /// <summary>
+    /// Show plugins removed due to main repo rules or developer's discretion.
+    /// </summary>
+    Discontinued,
+}

--- a/Dalamud/Plugin/Internal/Types/DevSupportState.cs
+++ b/Dalamud/Plugin/Internal/Types/DevSupportState.cs
@@ -1,0 +1,48 @@
+﻿namespace Dalamud.Plugin.Internal.Types;
+
+/// <summary>
+/// Current supported level of the plugin.
+/// </summary>
+internal enum DevSupportState
+{
+    /// <summary>
+    /// New features and support for issues (default).
+    /// </summary>
+    Active,
+
+    /// <summary>
+    /// Stable and only fix issues or update for patches.
+    /// </summary>
+    MaintenanceOnly,
+
+    /// <summary>
+    /// Waiting for a new dev to take over (adopt-a-plugin).
+    /// </summary>
+    Adoptable,
+
+    /// <summary>
+    /// Replaced by another plugin or vanilla feature.
+    /// </summary>
+    Obsolete,
+
+    /// <summary>
+    /// Removed due to plugin rules or other reasons by the dev.
+    /// </summary>
+    Discontinued,
+}
+
+/// <summary>
+/// Extension methods for DevSupportState.
+/// </summary>
+internal static class DevSupportStateExtensions
+{
+    /// <summary>
+    /// Checks if plugin is supported.
+    /// </summary>
+    /// <param name="value">The enum value to be checked.</param>
+    /// <returns>indicator if plugin is supported.</returns>
+    internal static bool IsSupported(this DevSupportState value)
+    {
+        return value is DevSupportState.Active or DevSupportState.MaintenanceOnly;
+    }
+}

--- a/Dalamud/Plugin/Internal/Types/PluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginManifest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 
 using Dalamud.Game;
+using Dalamud.Interface.Internal.Types;
 using Newtonsoft.Json;
 
 namespace Dalamud.Plugin.Internal.Types
@@ -176,5 +177,26 @@ namespace Dalamud.Plugin.Internal.Types
         /// Gets a value indicating the webhook URL feedback is sent to.
         /// </summary>
         public string? FeedbackWebhook { get; init; }
+
+        /// <summary>
+        /// Gets notice/warning to display for plugin (can be used where there is an issue but not ban worthy).
+        /// </summary>
+        public string Notice { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets developer support state.
+        /// </summary>
+        public DevSupportState DevSupportState { get; set; } = DevSupportState.Active;
+
+        /// <summary>
+        /// Gets or sets reason / comment for the current developer state.
+        /// </summary>
+        public string DevSupportStateReason { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets incompatible type for display (outdated or unsupported).
+        /// </summary>
+        [JsonIgnore]
+        public IncompatibleType? IncompatibleType { get; internal set; }
     }
 }

--- a/Dalamud/Plugin/Internal/Types/PluginMetaData.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginMetaData.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+
+namespace Dalamud.Plugin.Internal.Types;
+
+/// <summary>
+/// Plugin meta data supplements and overrides to take precedence over plugin manifest.
+/// </summary>
+internal struct PluginMetaData
+{
+    /// <summary>
+    /// Gets plugin name.
+    /// </summary>
+    [JsonProperty]
+    public string Name { get; private set; }
+
+    /// <summary>
+    /// Gets or sets notice/warning to display for plugin (can be used where there is an issue but not ban worthy).
+    /// </summary>
+    [JsonProperty]
+    public string Notice { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets developer support state.
+    /// </summary>
+    [JsonProperty]
+    public DevSupportState DevSupportState { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets reason / comment for the current developer state.
+    /// </summary>
+    [JsonProperty]
+    public string DevSupportStateReason { get; internal set; }
+}


### PR DESCRIPTION
This adds the feature to let users see warnings about plugins and also if a given plugin is waiting for an update or has been deprecated.

This introduces the following plugin fields:
- DevSupportState
- DevSupportStateReason
- Notice

The fields can be loaded from either dalamud assets or the plugin manifest. If both are set, the dalamud assets version will take precedence. In dalamud assets, these are defined in a new pluginmetadata file which can be extended to add more fields that would benefit from central control.

DevSupportState is an enum that defines the level of support that is currently provided for a plugin. There were discussions in discord/issue#814 with a few more options but I've started with a smaller subset for now.
- Active - new updates/features (default)
- MaintenanceOnly - only bug fixes, stable
- Adoptable - waiting for new dev to give it a home
- Obsolete - replaced by vanilla feature, other plugin
- Discontinued - against current rules or dev reasons

DevSupportStateReason is a string to use to provide more detail for the state. For example, you can reference the replacing plugin or describe why a plugin was discontinued.

Notice can be used to show extra warnings for a plugin. This can be used for cases where we don't want to ban a version but help to try to avoid some commmon support issue.

**Incompatible Plugins**
![image](https://user-images.githubusercontent.com/35899782/167239134-9f00df78-61db-4096-a884-20a86a42681b.png)

**Notice**
![image](https://user-images.githubusercontent.com/35899782/167239158-93df3cda-3094-4d4e-81d3-ac121cebb532.png)

**Related PRs**
https://github.com/goatcorp/DalamudAssets/pull/50
https://github.com/goatcorp/DalamudPackager/pull/6
