### PR TITLE
feat: add support state and notice

### DIFF
--- a/Dalamud.sln.DotSettings
+++ b/Dalamud.sln.DotSettings
@@ -58,6 +58,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Materia/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=PLUGINM/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pluginmaster/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=pluginmetadata/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=PLUGINR/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Refilter/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=serveropcode/@EntryIndexedValue">True</s:Boolean>

--- a/Dalamud/Plugin/Internal/Types/DevSupportState.cs
+++ b/Dalamud/Plugin/Internal/Types/DevSupportState.cs
@@ -1,0 +1,48 @@
+﻿namespace Dalamud.Plugin.Internal.Types;
+
+/// <summary>
+/// Current supported level of the plugin.
+/// </summary>
+internal enum DevSupportState
+{
+    /// <summary>
+    /// New features and support for issues (default).
+    /// </summary>
+    Active,
+
+    /// <summary>
+    /// Stable and only fix issues or update for patches.
+    /// </summary>
+    MaintenanceOnly,
+
+    /// <summary>
+    /// Waiting for a new dev to take over (adopt-a-plugin).
+    /// </summary>
+    Adoptable,
+
+    /// <summary>
+    /// Replaced by another plugin or vanilla feature.
+    /// </summary>
+    Obsolete,
+
+    /// <summary>
+    /// Removed due to plugin rules or other reasons by the dev.
+    /// </summary>
+    Discontinued,
+}
+
+/// <summary>
+/// Extension methods for DevSupportState.
+/// </summary>
+internal static class DevSupportStateExtensions
+{
+    /// <summary>
+    /// Checks if plugin is supported.
+    /// </summary>
+    /// <param name="value">The enum value to be checked.</param>
+    /// <returns>indicator if plugin is supported.</returns>
+    internal static bool IsSupported(this DevSupportState value)
+    {
+        return value is DevSupportState.Active or DevSupportState.MaintenanceOnly;
+    }
+}

--- a/Dalamud/Plugin/Internal/Types/PluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginManifest.cs
@@ -159,4 +159,19 @@ internal record PluginManifest
     /// Gets a message that is shown to users when sending feedback.
     /// </summary>
     public string? FeedbackMessage { get; init; }
+
+    /// <summary>
+    /// Gets notice/warning to display for plugin (can be used where there is an issue but not ban worthy).
+    /// </summary>
+    public string Notice { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets developer support state.
+    /// </summary>
+    public DevSupportState DevSupportState { get; set; } = DevSupportState.Active;
+
+    /// <summary>
+    /// Gets or sets reason / comment for the current developer state.
+    /// </summary>
+    public string DevSupportStateReason { get; set; } = string.Empty;
 }

--- a/Dalamud/Plugin/Internal/Types/PluginMetaData.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginMetaData.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+
+namespace Dalamud.Plugin.Internal.Types;
+
+/// <summary>
+/// Plugin meta data supplements and overrides to take precedence over plugin manifest.
+/// </summary>
+internal struct PluginMetaData
+{
+    /// <summary>
+    /// Gets plugin name.
+    /// </summary>
+    [JsonProperty]
+    public string Name { get; private set; }
+
+    /// <summary>
+    /// Gets or sets notice/warning to display for plugin (can be used where there is an issue but not ban worthy).
+    /// </summary>
+    [JsonProperty]
+    public string Notice { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets developer support state.
+    /// </summary>
+    [JsonProperty]
+    public DevSupportState DevSupportState { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets reason / comment for the current developer state.
+    /// </summary>
+    [JsonProperty]
+    public string DevSupportStateReason { get; internal set; }
+}


### PR DESCRIPTION
This is a refactored version of https://github.com/goatcorp/Dalamud/pull/835 that excludes the new installer view.
---

This adds the feature to let users see warnings about plugins and also if a given plugin is waiting for an update or has been deprecated.

**New Fields**
- DevSupportState
- DevSupportStateReason
- Notice

**Field Logic**
The fields can be loaded from either dalamud assets or the plugin manifest. If both are set, the dalamud assets version will take precedence. In dalamud assets, these are defined in a new pluginmetadata file which can be extended to add more fields that would benefit from central control.

**DevSupportState**
DevSupportState is an enum that defines the level of support that is currently provided for a plugin. There were discussions in discord/issue#814 with a few more options but I've started with a smaller subset for now.
- Active - new updates/features (default)
- MaintenanceOnly - only bug fixes, stable
- Adoptable - waiting for new dev to give it a home
- Obsolete - replaced by vanilla feature, other plugin
- Discontinued - against current rules or dev reasons

**DevSupportStateReason**
DevSupportStateReason is a string to use to provide more detail for the state. For example, you can reference the replacing plugin or describe why a plugin was discontinued.

**Notice**
Notice can be used to show extra warnings for a plugin. This can be used for cases where we don't want to ban a version but help to try to avoid some common support issue.

**Screenshots**
![notice](https://user-images.githubusercontent.com/35899782/169173626-b0e5401c-b9e3-40db-ac97-a557766f9704.PNG)
![notice2](https://user-images.githubusercontent.com/35899782/169173633-27dffdeb-ea3a-42c1-936a-26e131482577.PNG)
![notice3](https://user-images.githubusercontent.com/35899782/169173641-cdc82457-b7a5-4c45-9927-23581d358adc.PNG)

**Related PRs**
https://github.com/goatcorp/DalamudAssets/pull/50
https://github.com/goatcorp/DalamudPackager/pull/6