### PR TITLE
Chat log message sender ID is actually a timestamp.

### DIFF
--- a/Dalamud/Game/ChatHandlers.cs
+++ b/Dalamud/Game/ChatHandlers.cs
@@ -146,7 +146,7 @@ namespace Dalamud.Game
         public static SeString MakeItalics(TextPayload text)
             => new(EmphasisItalicPayload.ItalicsOn, text, EmphasisItalicPayload.ItalicsOff);
 
-        private void OnCheckMessageHandled(XivChatType type, uint senderid, ref SeString sender, ref SeString message, ref bool isHandled)
+        private void OnCheckMessageHandled(XivChatType type, uint timestamp, ref SeString sender, ref SeString message, ref bool isHandled)
         {
             var configuration = Service<DalamudConfiguration>.Get();
 
@@ -174,7 +174,7 @@ namespace Dalamud.Game
             }
         }
 
-        private void OnChatMessage(XivChatType type, uint senderId, ref SeString sender, ref SeString message, ref bool isHandled)
+        private void OnChatMessage(XivChatType type, uint timestamp, ref SeString sender, ref SeString message, ref bool isHandled)
         {
             var startInfo = Service<DalamudStartInfo>.Get();
             var clientState = Service<ClientState.ClientState>.Get();

--- a/Dalamud/Game/Command/CommandManager.cs
+++ b/Dalamud/Game/Command/CommandManager.cs
@@ -149,9 +149,9 @@ namespace Dalamud.Game.Command
             return this.commandMap.Remove(command);
         }
 
-        private void OnCheckMessageHandled(XivChatType type, uint senderId, ref SeString sender, ref SeString message, ref bool isHandled)
+        private void OnCheckMessageHandled(XivChatType type, uint timestamp, ref SeString sender, ref SeString message, ref bool isHandled)
         {
-            if (type == XivChatType.ErrorMessage && senderId == 0)
+            if (type == XivChatType.ErrorMessage && timestamp == 0)
             {
                 var cmdMatch = this.currentLangCommandRegex.Match(message.TextValue).Groups["command"];
                 if (cmdMatch.Success)

--- a/Dalamud/Game/Text/XivChatEntry.cs
+++ b/Dalamud/Game/Text/XivChatEntry.cs
@@ -15,8 +15,11 @@ namespace Dalamud.Game.Text
         public XivChatType Type { get; set; } = XivChatType.Debug;
 
         /// <summary>
-        /// Gets or sets the sender ID.
+        /// Gets or sets the Unix timestamp of the log entry.
+        /// This property was incorrectly named, and is not related to the message sender.
+        /// When printing this chat entry to the log, a value of zero will use the current time.
         /// </summary>
+        [Obsolete("This is actually the Unix timestamp of the log entry, and not the sender's ID.  Use with caution.")]
         public uint SenderId { get; set; }
 
         /// <summary>

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/ChatAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/ChatAgingStep.cs
@@ -62,7 +62,7 @@ namespace Dalamud.Interface.Internal.Windows.SelfTest.AgingSteps
         }
 
         private void ChatOnOnChatMessage(
-            XivChatType type, uint senderid, ref SeString sender, ref SeString message, ref bool ishandled)
+            XivChatType type, uint timestamp, ref SeString sender, ref SeString message, ref bool ishandled)
         {
             if (type == XivChatType.Echo && message.TextValue == "DALAMUD")
             {


### PR DESCRIPTION
What is listed as sender ID in `XivChatEntry` and `ChatGui` appears to actually be a Unix timestamp.  This PR marks the property as obsolete with a warning message to this effect, and changes the XML comments and internal uses.

I'm not sure how this should be fixed in the plugin-visible API; whether new events/delegates should be added with the correct parameter names, or wait for the next plugin API bump, and make it a hard break (rename parameters, make them refs, and rename the property in the struct).

Anyway, I've never seen an ID of any kind in that field, and setting it to a timestamp when printing a message shows the expected time in the chat log.  Given that the chat log stuff is used by a ton of plugins, though, I'd feel better with a second eye on this.  It feels a bit wrong countering RE work that's probably already had a lot of knowlegable people look at it.