### PR TITLE
File selector

### DIFF
--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.Files.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.Files.cs
@@ -298,70 +298,25 @@ namespace Dalamud.Interface.ImGuiFileDialog
 
         private void SetupSideBar()
         {
-            var drives = DriveInfo.GetDrives();
-            foreach (var drive in drives)
+            foreach (var drive in DriveInfo.GetDrives())
             {
-                this.drives.Add(new SideBarItem
-                {
-                    Icon = FontAwesomeIcon.Server,
-                    Location = drive.Name,
-                    Text = drive.Name,
-                });
+                this.drives.Add(new SideBarItem(drive.Name, drive.Name, FontAwesomeIcon.Server));
             }
 
             var personal = Path.GetDirectoryName(Environment.GetFolderPath(Environment.SpecialFolder.Personal));
 
-            this.quickAccess.Add(new SideBarItem
-            {
-                Icon = FontAwesomeIcon.Desktop,
-                Location = Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
-                Text = "Desktop",
-            });
-
-            this.quickAccess.Add(new SideBarItem
-            {
-                Icon = FontAwesomeIcon.File,
-                Location = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                Text = "Documents",
-            });
+            this.quickAccess.Add(new SideBarItem("Desktop", Environment.GetFolderPath(Environment.SpecialFolder.Desktop), FontAwesomeIcon.Desktop));
+            this.quickAccess.Add(new SideBarItem("Documents", Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), FontAwesomeIcon.File));
 
             if (!string.IsNullOrEmpty(personal))
             {
-                this.quickAccess.Add(new SideBarItem
-                {
-                    Icon = FontAwesomeIcon.Download,
-                    Location = Path.Combine(personal, "Downloads"),
-                    Text = "Downloads",
-                });
+                this.quickAccess.Add(new SideBarItem("Downloads", Path.Combine(personal, "Downloads"), FontAwesomeIcon.Download));
             }
 
-            this.quickAccess.Add(new SideBarItem
-            {
-                Icon = FontAwesomeIcon.Star,
-                Location = Environment.GetFolderPath(Environment.SpecialFolder.Favorites),
-                Text = "Favorites",
-            });
-
-            this.quickAccess.Add(new SideBarItem
-            {
-                Icon = FontAwesomeIcon.Music,
-                Location = Environment.GetFolderPath(Environment.SpecialFolder.MyMusic),
-                Text = "Music",
-            });
-
-            this.quickAccess.Add(new SideBarItem
-            {
-                Icon = FontAwesomeIcon.Image,
-                Location = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures),
-                Text = "Pictures",
-            });
-
-            this.quickAccess.Add(new SideBarItem
-            {
-                Icon = FontAwesomeIcon.Video,
-                Location = Environment.GetFolderPath(Environment.SpecialFolder.MyVideos),
-                Text = "Videos",
-            });
+            this.quickAccess.Add(new SideBarItem("Favorites", Environment.GetFolderPath(Environment.SpecialFolder.Favorites), FontAwesomeIcon.Star));
+            this.quickAccess.Add(new SideBarItem("Music", Environment.GetFolderPath(Environment.SpecialFolder.MyMusic), FontAwesomeIcon.Music));
+            this.quickAccess.Add(new SideBarItem("Pictures", Environment.GetFolderPath(Environment.SpecialFolder.MyPictures), FontAwesomeIcon.Image));
+            this.quickAccess.Add(new SideBarItem("Videos", Environment.GetFolderPath(Environment.SpecialFolder.MyVideos), FontAwesomeIcon.Video));
         }
 
         private void SortFields(SortingField sortingField, bool canChangeOrder = false)

--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.Structs.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.Structs.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Numerics;
+using Dalamud.Utility;
 
 namespace Dalamud.Interface.ImGuiFileDialog
 {
@@ -19,7 +21,27 @@ namespace Dalamud.Interface.ImGuiFileDialog
             public string FileModifiedDate;
         }
 
-        private record struct SideBarItem(string Text, string Location, FontAwesomeIcon Icon);
+        private readonly struct SideBarItem
+        {
+            public SideBarItem(string text, string location, FontAwesomeIcon icon)
+            {
+                this.Text = text;
+                this.Location = location;
+                this.Icon = icon;
+                this.Exists = !this.Location.IsNullOrEmpty() && Directory.Exists(this.Location);
+            }
+
+            public string Text { get; init; }
+
+            public string Location { get; init; }
+
+            public FontAwesomeIcon Icon { get; init; }
+
+            public bool Exists { get; init; }
+
+            public bool CheckExistence()
+                => !this.Location.IsNullOrEmpty() && Directory.Exists(this.Location);
+        }
 
         private struct FilterStruct
         {

--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.cs
@@ -229,7 +229,7 @@ namespace Dalamud.Interface.ImGuiFileDialog
             var result = this.fileNameBuffer;
 
             // a collection like {.cpp, .h}, so can't decide on an extension
-            if (this.selectedFilter.CollectionFilters != null && this.selectedFilter.CollectionFilters.Count > 0)
+            if (this.selectedFilter.CollectionFilters is { Count: > 0 })
             {
                 return result;
             }
@@ -240,7 +240,7 @@ namespace Dalamud.Interface.ImGuiFileDialog
                 var lastPoint = result.LastIndexOf('.');
                 if (lastPoint != -1)
                 {
-                    result = result.Substring(0, lastPoint);
+                    result = result[..lastPoint];
                 }
 
                 result += this.selectedFilter.Filter;
@@ -275,7 +275,7 @@ namespace Dalamud.Interface.ImGuiFileDialog
             this.currentPath = dir.FullName;
             if (this.currentPath[^1] == Path.DirectorySeparatorChar)
             { // handle selecting a drive, like C: -> C:\
-                this.currentPath = this.currentPath[0..^1];
+                this.currentPath = this.currentPath[..^1];
             }
 
             this.pathInputBuffer = this.currentPath;


### PR DESCRIPTION
Bit of ImGui cleanup, stop the list clipper from leaking memory, and store the directory existence for quick access folders on setup instead of checking it per frame.