### PR TITLE
Update FileDialog.UI.cs

### DIFF
--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.UI.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.UI.cs
@@ -163,7 +163,6 @@ namespace Dalamud.Interface.ImGuiFileDialog
                 {
                     ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
                     ImGui.InputText("##pathedit", ref this.pathInputBuffer, 255);
-                    ImGui.PopItemWidth();
                 }
                 else
                 {


### PR DESCRIPTION
Fix a crash I included by forgetting to remove a PopItemWidth after changing PushItemWidth to SetNextItemWidth.