### PR TITLE
Increase timeout for game window

### DIFF
--- a/Dalamud.Injector/GameStart.cs
+++ b/Dalamud.Injector/GameStart.cs
@@ -127,7 +127,7 @@ namespace Dalamud.Injector
                     try
                     {
                         var tries = 0;
-                        const int maxTries = 120;
+                        const int maxTries = 420;
                         const int timeout = 50;
 
                         do


### PR DESCRIPTION
This raises the timeout to find the game window to effectively 21s since on a cold Wine start the window can take more than 6s to spawn (sometimes drastically longer depending on log level)