### PR TITLE
Make plugins load asynchronously

### DIFF
--- a/Dalamud.CorePlugin/Dalamud.CorePlugin.csproj
+++ b/Dalamud.CorePlugin/Dalamud.CorePlugin.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Lumina" Version="3.7.0" />
+        <PackageReference Include="Lumina" Version="3.8.0" />
         <PackageReference Include="Lumina.Excel" Version="6.1.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333">

--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -65,7 +65,7 @@
     <ItemGroup>
         <PackageReference Include="CheapLoc" Version="1.1.6" />
         <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
-        <PackageReference Include="Lumina" Version="3.7.0" />
+        <PackageReference Include="Lumina" Version="3.8.0" />
         <PackageReference Include="Lumina.Excel" Version="6.1.1" />
         <PackageReference Include="MinSharp" Version="1.0.4" />
         <PackageReference Include="MonoMod.RuntimeDetour" Version="21.10.10.01" />

--- a/Dalamud/Game/BaseAddressResolver.cs
+++ b/Dalamud/Game/BaseAddressResolver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using JetBrains.Annotations;
 
 namespace Dalamud.Game
 {
@@ -21,7 +22,16 @@ namespace Dalamud.Game
         protected bool IsResolved { get; set; }
 
         /// <summary>
-        /// Setup the resolver, calling the appopriate method based on the process architecture.
+        /// Setup the resolver, calling the appropriate method based on the process architecture,
+        /// using the default SigScanner.
+        ///
+        /// For plugins. Not intended to be called from Dalamud Service{T} constructors.
+        /// </summary>
+        [UsedImplicitly]
+        public void Setup() => this.Setup(Service<SigScanner>.Get());
+
+        /// <summary>
+        /// Setup the resolver, calling the appropriate method based on the process architecture.
         /// </summary>
         /// <param name="scanner">The SigScanner instance.</param>
         public void Setup(SigScanner scanner)

--- a/Dalamud/Game/SigScanner.cs
+++ b/Dalamud/Game/SigScanner.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
+using System.Windows.Forms;
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
 using Dalamud.Utility.Timing;
@@ -340,9 +340,15 @@ namespace Dalamud.Game
         /// <returns>The real offset of the found signature.</returns>
         public IntPtr ScanText(string signature)
         {
-            if (this.textCache != null && this.textCache.TryGetValue(signature, out var address))
+            if (this.textCache != null)
             {
-                return new IntPtr(address + this.Module.BaseAddress.ToInt64());
+                lock (this.textCache)
+                {
+                    if (this.textCache.TryGetValue(signature, out var address))
+                    {
+                        return new IntPtr(address + this.Module.BaseAddress.ToInt64());
+                    }
+                }
             }
 
             var mBase = this.IsCopy ? this.moduleCopyPtr : this.TextSectionBase;
@@ -356,7 +362,13 @@ namespace Dalamud.Game
             if (insnByte == 0xE8 || insnByte == 0xE9)
                 scanRet = ReadJmpCallSig(scanRet);
 
-            this.textCache?.Add(signature, scanRet.ToInt64() - this.Module.BaseAddress.ToInt64());
+            if (this.textCache != null)
+            {
+                lock (this.textCache)
+                {
+                    this.textCache[signature] = scanRet.ToInt64() - this.Module.BaseAddress.ToInt64();
+                }
+            }
 
             return scanRet;
         }

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -121,11 +121,6 @@ namespace Dalamud.Interface.Internal
         private delegate void InstallRTSSHook();
 
         /// <summary>
-        /// Gets a task that gets completed when scene gets initialized.
-        /// </summary>
-        public Task SceneInitializeTask => this.sceneInitializeTaskCompletionSource.Task;
-
-        /// <summary>
         /// This event gets called each frame to facilitate ImGui drawing.
         /// </summary>
         public event RawDX11Scene.BuildUIDelegate Draw;
@@ -164,6 +159,11 @@ namespace Dalamud.Interface.Internal
         /// Gets an included monospaced font.
         /// </summary>
         public static ImFontPtr MonoFont { get; private set; }
+
+        /// <summary>
+        /// Gets a task that gets completed when scene gets initialized.
+        /// </summary>
+        public Task SceneInitializeTask => this.sceneInitializeTaskCompletionSource.Task;
 
         /// <summary>
         /// Gets or sets the pointer to ImGui.IO(), when it was last used.
@@ -448,7 +448,6 @@ namespace Dalamud.Interface.Internal
                     try
                     {
                         this.scene = new RawDX11Scene(swapChain);
-                        this.sceneInitializeTaskCompletionSource.SetResult();
                     }
                     catch (DllNotFoundException ex)
                     {
@@ -568,10 +567,16 @@ namespace Dalamud.Interface.Internal
 
                 this.RenderImGui();
 
+                if (!this.SceneInitializeTask.IsCompleted)
+                    this.sceneInitializeTaskCompletionSource.SetResult();
+
                 return pRes;
             }
 
             this.RenderImGui();
+
+            if (!this.SceneInitializeTask.IsCompleted)
+                this.sceneInitializeTaskCompletionSource.SetResult();
 
             return this.presentHook.Original(swapChain, syncInterval, presentFlags);
         }

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -103,19 +103,22 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
                 MaximumSize = new Vector2(5000, 5000),
             };
 
-            var pluginManager = Service<PluginManager>.Get();
-
-            // For debugging
-            if (pluginManager.PluginsReady)
-                this.OnInstalledPluginsChanged();
-
-            pluginManager.OnAvailablePluginsChanged += this.OnAvailablePluginsChanged;
-            pluginManager.OnInstalledPluginsChanged += this.OnInstalledPluginsChanged;
-
-            for (var i = 0; i < this.testerImagePaths.Length; i++)
+            Service<PluginManager>.GetAsync().ContinueWith(pluginManagerTask =>
             {
-                this.testerImagePaths[i] = string.Empty;
-            }
+                var pluginManager = pluginManagerTask.Result;
+
+                // For debugging
+                if (pluginManager.PluginsReady)
+                    this.OnInstalledPluginsChanged();
+
+                pluginManager.OnAvailablePluginsChanged += this.OnAvailablePluginsChanged;
+                pluginManager.OnInstalledPluginsChanged += this.OnInstalledPluginsChanged;
+
+                for (var i = 0; i < this.testerImagePaths.Length; i++)
+                {
+                    this.testerImagePaths[i] = string.Empty;
+                }
+            });
         }
 
         private enum OperationStatus

--- a/Dalamud/Plugin/Internal/Types/PluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginManifest.cs
@@ -135,6 +135,22 @@ internal record PluginManifest
     public string DownloadLinkTesting { get; init; } = null!;
 
     /// <summary>
+    /// Gets the required Dalamud load step for this plugin to load. Takes precedence over LoadPriority.
+    /// Valid values are:
+    /// 0. During Framework.Tick, when drawing facilities are available
+    /// 1. During Framework.Tick
+    /// 2. No requirement
+    /// </summary>
+    [JsonProperty]
+    public int LoadRequiredState { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether Dalamud must load this plugin not at the same time with other plugins and the game.
+    /// </summary>
+    [JsonProperty]
+    public bool LoadSync { get; init; }
+
+    /// <summary>
     /// Gets the load priority for this plugin. Higher values means higher priority. 0 is default priority.
     /// </summary>
     [JsonProperty]


### PR DESCRIPTION
Tested with all plugins installed at the same time.

`PluginManifest` got two new fields.
* `LoadSync`: Whether to block other plugins from loading and game from initializing, when game is starting up. Default is false.
    * Along with this, setting `LoadPriority` will no longer affect whether it blocks.
* `LoadRequiredState`: Specifies when this plugin can get loaded, when being loaded via startup(boot).
    * 0: During first `Framework.Tick` after first `PresentDetour` call (default.)
    * 1: During first `Framework.Tick`.
    * 2: Before any of the game code runs.
    * If `LoadSync` is false, the code runs in a worker thread, and `Framework.Tick` will not wait for them for 0 and 1, nor it will block game code from execution for 2.