### PR TITLE
Improvements

### DIFF
--- a/Dalamud.Boot/xivfixes.h
+++ b/Dalamud.Boot/xivfixes.h
@@ -5,6 +5,7 @@ namespace xivfixes {
     void prevent_devicechange_crashes(bool bApply);
     void disable_game_openprocess_access_check(bool bApply);
     void redirect_openprocess(bool bApply);
+    void backup_userdata_save(bool bApply);
 
     void apply_all(bool bApply);
 }

--- a/Dalamud.Injector/EntryPoint.cs
+++ b/Dalamud.Injector/EntryPoint.cs
@@ -315,7 +315,7 @@ namespace Dalamud.Injector
             startInfo.BootShowConsole = args.Contains("--console");
             startInfo.BootEnableEtw = args.Contains("--etw");
             startInfo.BootLogPath = GetLogPath("dalamud.boot");
-            startInfo.BootEnabledGameFixes = new List<string> { "prevent_devicechange_crashes", "disable_game_openprocess_access_check", "redirect_openprocess" };
+            startInfo.BootEnabledGameFixes = new List<string> { "prevent_devicechange_crashes", "disable_game_openprocess_access_check", "redirect_openprocess", "backup_userdata_save" };
             startInfo.BootDotnetOpenProcessHookMode = 0;
             startInfo.BootWaitMessageBox |= args.Contains("--msgbox1") ? 1 : 0;
             startInfo.BootWaitMessageBox |= args.Contains("--msgbox2") ? 2 : 0;

--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -262,6 +262,12 @@ namespace Dalamud.Configuration.Internal
         public bool PluginSafeMode { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating the wait time between plugin unload and plugin assembly unload.
+        /// Uses default value that may change between versions if set to null.
+        /// </summary>
+        public int? PluginWaitBeforeFree { get; set; }
+
+        /// <summary>
         /// Gets or sets a list of saved styles.
         /// </summary>
         [JsonProperty("SavedStyles")]

--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -191,6 +191,11 @@ namespace Dalamud.Configuration.Internal
         public LogEventLevel LogLevel { get; set; } = LogEventLevel.Information;
 
         /// <summary>
+        /// Gets or sets a value indicating whether to write to log files synchronously.
+        /// </summary>
+        public bool LogSynchronously { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets a value indicating whether or not the debug log should scroll automatically.
         /// </summary>
         public bool LogAutoScroll { get; set; } = true;

--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -5,21 +5,11 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.Configuration.Internal;
-using Dalamud.Data;
 using Dalamud.Game;
-using Dalamud.Game.ClientState;
 using Dalamud.Game.Gui.Internal;
-using Dalamud.Game.Internal;
-using Dalamud.Game.Network.Internal;
-using Dalamud.Hooking.Internal;
 using Dalamud.Interface.Internal;
-using Dalamud.Logging.Internal;
 using Dalamud.Plugin.Internal;
-using Dalamud.Support;
-using Dalamud.Utility;
 using Serilog;
-using Serilog.Core;
-using Serilog.Events;
 
 #if DEBUG
 [assembly: InternalsVisibleTo("Dalamud.CorePlugin")]
@@ -46,13 +36,10 @@ namespace Dalamud
         /// Initializes a new instance of the <see cref="Dalamud"/> class.
         /// </summary>
         /// <param name="info">DalamudStartInfo instance.</param>
-        /// <param name="loggingLevelSwitch">LoggingLevelSwitch to control Serilog level.</param>
         /// <param name="configuration">The Dalamud configuration.</param>
         /// <param name="mainThreadContinueEvent">Event used to signal the main thread to continue.</param>
-        public Dalamud(DalamudStartInfo info, LoggingLevelSwitch loggingLevelSwitch, DalamudConfiguration configuration, IntPtr mainThreadContinueEvent)
+        public Dalamud(DalamudStartInfo info, DalamudConfiguration configuration, IntPtr mainThreadContinueEvent)
         {
-            this.LogLevelSwitch = loggingLevelSwitch;
-
             this.unloadSignal = new ManualResetEvent(false);
             this.unloadSignal.Reset();
 
@@ -102,11 +89,6 @@ namespace Dalamud
                 });
             }
         }
-
-        /// <summary>
-        /// Gets LoggingLevelSwitch for Dalamud and Plugin logs.
-        /// </summary>
-        internal LoggingLevelSwitch LogLevelSwitch { get; private set; }
 
         /// <summary>
         /// Gets location of stored assets.

--- a/Dalamud/EntryPoint.cs
+++ b/Dalamud/EntryPoint.cs
@@ -26,6 +26,11 @@ namespace Dalamud
     public sealed class EntryPoint
     {
         /// <summary>
+        /// Log level switch for runtime log level change.
+        /// </summary>
+        public static readonly LoggingLevelSwitch LogLevelSwitch = new(LogEventLevel.Verbose);
+
+        /// <summary>
         /// A delegate used during initialization of the CLR from Dalamud.Boot.
         /// </summary>
         /// <param name="infoPtr">Pointer to a serialized <see cref="DalamudStartInfo"/> data.</param>
@@ -108,6 +113,49 @@ namespace Dalamud
         }
 
         /// <summary>
+        /// Sets up logging.
+        /// </summary>
+        /// <param name="baseDirectory">Base directory.</param>
+        /// <param name="logConsole">Whether to log to console.</param>
+        /// <param name="logSynchronously">Log synchronously.</param>
+        internal static void InitLogging(string baseDirectory, bool logConsole, bool logSynchronously)
+        {
+#if DEBUG
+            var logPath = Path.Combine(baseDirectory, "dalamud.log");
+            var oldPath = Path.Combine(baseDirectory, "dalamud.log.old");
+#else
+            var logPath = Path.Combine(baseDirectory, "..", "..", "..", "dalamud.log");
+            var oldPath = Path.Combine(baseDirectory, "..", "..", "..", "dalamud.log.old");
+#endif
+            Log.CloseAndFlush();
+
+            CullLogFile(logPath, oldPath, 1 * 1024 * 1024);
+            CullLogFile(oldPath, null, 10 * 1024 * 1024);
+
+            var config = new LoggerConfiguration()
+                         .WriteTo.Sink(SerilogEventSink.Instance)
+                         .MinimumLevel.ControlledBy(LogLevelSwitch);
+
+            if (logSynchronously)
+            {
+                config = config.WriteTo.File(logPath, fileSizeLimitBytes: null);
+            }
+            else
+            {
+                config = config.WriteTo.Async(a => a.File(
+                                                  logPath,
+                                                  fileSizeLimitBytes: null,
+                                                  buffered: false,
+                                                  flushToDiskInterval: TimeSpan.FromSeconds(1)));
+            }
+
+            if (logConsole)
+                config = config.WriteTo.Console();
+
+            Log.Logger = config.CreateLogger();
+        }
+
+        /// <summary>
         /// Initialize all Dalamud subsystems and start running on the main thread.
         /// </summary>
         /// <param name="info">The <see cref="DalamudStartInfo"/> containing information needed to initialize Dalamud.</param>
@@ -115,7 +163,7 @@ namespace Dalamud
         private static void RunThread(DalamudStartInfo info, IntPtr mainThreadContinueEvent)
         {
             // Setup logger
-            var levelSwitch = InitLogging(info.WorkingDirectory!, info.BootShowConsole);
+            InitLogging(info.WorkingDirectory!, info.BootShowConsole, true);
             SerilogEventSink.Instance.LogLine += SerilogOnLogLine;
 
             // Load configuration first to get some early persistent state, like log level
@@ -123,7 +171,9 @@ namespace Dalamud
 
             // Set the appropriate logging level from the configuration
 #if !DEBUG
-            levelSwitch.MinimumLevel = configuration.LogLevel;
+            if (!configuration.LogSynchronously)
+                InitLogging(info.WorkingDirectory!, info.BootShowConsole, configuration.LogSynchronously);
+            LogLevelSwitch.MinimumLevel = configuration.LogLevel;
 #endif
 
             // Log any unhandled exception.
@@ -147,7 +197,7 @@ namespace Dalamud
                 if (!Util.IsLinux())
                     InitSymbolHandler(info);
 
-                var dalamud = new Dalamud(info, levelSwitch, configuration, mainThreadContinueEvent);
+                var dalamud = new Dalamud(info, configuration, mainThreadContinueEvent);
                 Log.Information("This is Dalamud - Core: {GitHash}, CS: {CsGitHash}", Util.GetGitHash(), Util.GetGitHashClientStructs());
 
                 dalamud.WaitForUnload();
@@ -197,33 +247,6 @@ namespace Dalamud
             {
                 Log.Error(ex, "SymbolHandler Initialize Failed.");
             }
-        }
-
-        private static LoggingLevelSwitch InitLogging(string baseDirectory, bool logConsole)
-        {
-#if DEBUG
-            var logPath = Path.Combine(baseDirectory, "dalamud.log");
-            var oldPath = Path.Combine(baseDirectory, "dalamud.log.old");
-#else
-            var logPath = Path.Combine(baseDirectory, "..", "..", "..", "dalamud.log");
-            var oldPath = Path.Combine(baseDirectory, "..", "..", "..", "dalamud.log.old");
-#endif
-
-            CullLogFile(logPath, oldPath, 1 * 1024 * 1024);
-            CullLogFile(oldPath, null, 10 * 1024 * 1024);
-
-            var levelSwitch = new LoggingLevelSwitch(LogEventLevel.Verbose);
-            var config = new LoggerConfiguration()
-                         .WriteTo.Async(a => a.File(logPath, fileSizeLimitBytes: null, buffered: false, flushToDiskInterval: TimeSpan.FromSeconds(1)))
-                         .WriteTo.Sink(SerilogEventSink.Instance)
-                         .MinimumLevel.ControlledBy(levelSwitch);
-
-            if (logConsole)
-                config = config.WriteTo.Console();
-
-            Log.Logger = config.CreateLogger();
-
-            return levelSwitch;
         }
 
         private static void CullLogFile(string logPath, string? oldPath, int cullingFileSize)

--- a/Dalamud/Game/ClientState/Buddy/BuddyList.cs
+++ b/Dalamud/Game/ClientState/Buddy/BuddyList.cs
@@ -20,12 +20,15 @@ namespace Dalamud.Game.ClientState.Buddy
     {
         private const uint InvalidObjectID = 0xE0000000;
 
+        [ServiceManager.ServiceDependency]
+        private readonly ClientState clientState = Service<ClientState>.Get();
+
         private readonly ClientStateAddressResolver address;
 
         [ServiceManager.ServiceConstructor]
-        private BuddyList(ClientState clientState)
+        private BuddyList()
         {
-            this.address = clientState.AddressResolver;
+            this.address = this.clientState.AddressResolver;
 
             Log.Verbose($"Buddy list address 0x{this.address.BuddyList.ToInt64():X}");
         }
@@ -145,9 +148,7 @@ namespace Dalamud.Game.ClientState.Buddy
         /// <returns><see cref="BuddyMember"/> object containing the requested data.</returns>
         public BuddyMember? CreateBuddyMemberReference(IntPtr address)
         {
-            var clientState = Service<ClientState>.Get();
-
-            if (clientState.LocalContentId == 0)
+            if (this.clientState.LocalContentId == 0)
                 return null;
 
             if (address == IntPtr.Zero)

--- a/Dalamud/Game/ClientState/Buddy/BuddyMember.cs
+++ b/Dalamud/Game/ClientState/Buddy/BuddyMember.cs
@@ -11,6 +11,9 @@ namespace Dalamud.Game.ClientState.Buddy
     /// </summary>
     public unsafe class BuddyMember
     {
+        [ServiceManager.ServiceDependency]
+        private readonly ObjectTable objectTable = Service<ObjectTable>.Get();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="BuddyMember"/> class.
         /// </summary>
@@ -36,7 +39,7 @@ namespace Dalamud.Game.ClientState.Buddy
         /// <remarks>
         /// This iterates the actor table, it should be used with care.
         /// </remarks>
-        public GameObject? GameObject => Service<ObjectTable>.Get().SearchById(this.ObjectId);
+        public GameObject? GameObject => this.objectTable.SearchById(this.ObjectId);
 
         /// <summary>
         /// Gets the current health of this buddy.

--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -52,7 +52,7 @@ namespace Dalamud.Game.ClientState
 
             Log.Verbose($"SetupTerritoryType address 0x{this.address.SetupTerritoryType.ToInt64():X}");
 
-            this.setupTerritoryTypeHook = new Hook<SetupTerritoryTypeDelegate>(this.address.SetupTerritoryType, this.SetupTerritoryTypeDetour);
+            this.setupTerritoryTypeHook = Hook<SetupTerritoryTypeDelegate>.FromAddress(this.address.SetupTerritoryType, this.SetupTerritoryTypeDetour);
 
             this.framework.Update += this.FrameworkOnOnUpdateEvent;
 

--- a/Dalamud/Game/ClientState/Fates/Fate.cs
+++ b/Dalamud/Game/ClientState/Fates/Fate.cs
@@ -46,9 +46,9 @@ namespace Dalamud.Game.ClientState.Fates
         /// <returns>True or false.</returns>
         public static bool IsValid(Fate fate)
         {
-            var clientState = Service<ClientState>.Get();
+            var clientState = Service<ClientState>.GetNullable();
 
-            if (fate == null)
+            if (fate == null || clientState == null)
                 return false;
 
             if (clientState.LocalContentId == 0)

--- a/Dalamud/Game/ClientState/GamePad/GamepadState.cs
+++ b/Dalamud/Game/ClientState/GamePad/GamepadState.cs
@@ -32,7 +32,7 @@ namespace Dalamud.Game.ClientState.GamePad
         {
             var resolver = clientState.AddressResolver;
             Log.Verbose($"GamepadPoll address 0x{resolver.GamepadPoll.ToInt64():X}");
-            this.gamepadPoll = new Hook<ControllerPoll>(resolver.GamepadPoll, this.GamepadPollDetour);
+            this.gamepadPoll = Hook<ControllerPoll>.FromAddress(resolver.GamepadPoll, this.GamepadPollDetour);
         }
 
         private delegate int ControllerPoll(IntPtr controllerInput);

--- a/Dalamud/Game/ClientState/Objects/ObjectTable.cs
+++ b/Dalamud/Game/ClientState/Objects/ObjectTable.cs
@@ -97,9 +97,9 @@ namespace Dalamud.Game.ClientState.Objects
         /// <returns><see cref="GameObject"/> object or inheritor containing the requested data.</returns>
         public unsafe GameObject? CreateObjectReference(IntPtr address)
         {
-            var clientState = Service<ClientState>.Get();
+            var clientState = Service<ClientState>.GetNullable();
 
-            if (clientState.LocalContentId == 0)
+            if (clientState == null || clientState.LocalContentId == 0)
                 return null;
 
             if (address == IntPtr.Zero)

--- a/Dalamud/Game/ClientState/Objects/TargetManager.cs
+++ b/Dalamud/Game/ClientState/Objects/TargetManager.cs
@@ -14,12 +14,18 @@ namespace Dalamud.Game.ClientState.Objects
     [ServiceManager.BlockingEarlyLoadedService]
     public sealed unsafe class TargetManager : IServiceType
     {
+        [ServiceManager.ServiceDependency]
+        private readonly ClientState clientState = Service<ClientState>.Get();
+
+        [ServiceManager.ServiceDependency]
+        private readonly ObjectTable objectTable = Service<ObjectTable>.Get();
+
         private readonly ClientStateAddressResolver address;
 
         [ServiceManager.ServiceConstructor]
-        private TargetManager(ClientState clientState)
+        private TargetManager()
         {
-            this.address = clientState.AddressResolver;
+            this.address = this.clientState.AddressResolver;
         }
 
         /// <summary>
@@ -32,7 +38,7 @@ namespace Dalamud.Game.ClientState.Objects
         /// </summary>
         public GameObject? Target
         {
-            get => Service<ObjectTable>.Get().CreateObjectReference((IntPtr)Struct->Target);
+            get => this.objectTable.CreateObjectReference((IntPtr)Struct->Target);
             set => this.SetTarget(value);
         }
 
@@ -41,7 +47,7 @@ namespace Dalamud.Game.ClientState.Objects
         /// </summary>
         public GameObject? MouseOverTarget
         {
-            get => Service<ObjectTable>.Get().CreateObjectReference((IntPtr)Struct->MouseOverTarget);
+            get => this.objectTable.CreateObjectReference((IntPtr)Struct->MouseOverTarget);
             set => this.SetMouseOverTarget(value);
         }
 
@@ -50,7 +56,7 @@ namespace Dalamud.Game.ClientState.Objects
         /// </summary>
         public GameObject? FocusTarget
         {
-            get => Service<ObjectTable>.Get().CreateObjectReference((IntPtr)Struct->FocusTarget);
+            get => this.objectTable.CreateObjectReference((IntPtr)Struct->FocusTarget);
             set => this.SetFocusTarget(value);
         }
 
@@ -59,7 +65,7 @@ namespace Dalamud.Game.ClientState.Objects
         /// </summary>
         public GameObject? PreviousTarget
         {
-            get => Service<ObjectTable>.Get().CreateObjectReference((IntPtr)Struct->PreviousTarget);
+            get => this.objectTable.CreateObjectReference((IntPtr)Struct->PreviousTarget);
             set => this.SetPreviousTarget(value);
         }
 
@@ -68,7 +74,7 @@ namespace Dalamud.Game.ClientState.Objects
         /// </summary>
         public GameObject? SoftTarget
         {
-            get => Service<ObjectTable>.Get().CreateObjectReference((IntPtr)Struct->SoftTarget);
+            get => this.objectTable.CreateObjectReference((IntPtr)Struct->SoftTarget);
             set => this.SetSoftTarget(value);
         }
 

--- a/Dalamud/Game/ClientState/Objects/Types/GameObject.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/GameObject.cs
@@ -61,9 +61,9 @@ namespace Dalamud.Game.ClientState.Objects.Types
         /// <returns>True or false.</returns>
         public static bool IsValid(GameObject? actor)
         {
-            var clientState = Service<ClientState>.Get();
+            var clientState = Service<ClientState>.GetNullable();
 
-            if (actor is null)
+            if (actor is null || clientState == null)
                 return false;
 
             if (clientState.LocalContentId == 0)

--- a/Dalamud/Game/ClientState/Party/PartyList.cs
+++ b/Dalamud/Game/ClientState/Party/PartyList.cs
@@ -20,12 +20,15 @@ namespace Dalamud.Game.ClientState.Party
         private const int GroupLength = 8;
         private const int AllianceLength = 20;
 
+        [ServiceManager.ServiceDependency]
+        private readonly ClientState clientState = Service<ClientState>.Get();
+
         private readonly ClientStateAddressResolver address;
 
         [ServiceManager.ServiceConstructor]
-        private PartyList(ClientState clientState)
+        private PartyList()
         {
-            this.address = clientState.AddressResolver;
+            this.address = this.clientState.AddressResolver;
 
             Log.Verbose($"Group manager address 0x{this.address.GroupManager.ToInt64():X}");
         }
@@ -115,9 +118,7 @@ namespace Dalamud.Game.ClientState.Party
         /// <returns>The party member object containing the requested data.</returns>
         public PartyMember? CreatePartyMemberReference(IntPtr address)
         {
-            var clientState = Service<ClientState>.Get();
-
-            if (clientState.LocalContentId == 0)
+            if (this.clientState.LocalContentId == 0)
                 return null;
 
             if (address == IntPtr.Zero)
@@ -146,9 +147,7 @@ namespace Dalamud.Game.ClientState.Party
         /// <returns>The party member object containing the requested data.</returns>
         public PartyMember? CreateAllianceMemberReference(IntPtr address)
         {
-            var clientState = Service<ClientState>.Get();
-
-            if (clientState.LocalContentId == 0)
+            if (this.clientState.LocalContentId == 0)
                 return null;
 
             if (address == IntPtr.Zero)

--- a/Dalamud/Game/Command/CommandManager.cs
+++ b/Dalamud/Game/Command/CommandManager.cs
@@ -18,7 +18,7 @@ namespace Dalamud.Game.Command
     [PluginInterface]
     [InterfaceVersion("1.0")]
     [ServiceManager.BlockingEarlyLoadedService]
-    public sealed class CommandManager : IServiceType
+    public sealed class CommandManager : IServiceType, IDisposable
     {
         private readonly Dictionary<string, CommandInfo> commandMap = new();
         private readonly Regex commandRegexEn = new(@"^The command (?<command>.+) does not exist\.$", RegexOptions.Compiled);
@@ -27,6 +27,9 @@ namespace Dalamud.Game.Command
         private readonly Regex commandRegexFr = new(@"^La commande texte “(?<command>.+)” n'existe pas\.$", RegexOptions.Compiled);
         private readonly Regex commandRegexCn = new(@"^^(“|「)(?<command>.+)(”|」)(出现问题：该命令不存在|出現問題：該命令不存在)。$", RegexOptions.Compiled);
         private readonly Regex currentLangCommandRegex;
+
+        [ServiceManager.ServiceDependency]
+        private readonly ChatGui chatGui = Service<ChatGui>.Get();
 
         [ServiceManager.ServiceConstructor]
         private CommandManager(DalamudStartInfo startInfo)
@@ -40,7 +43,7 @@ namespace Dalamud.Game.Command
                 _ => this.currentLangCommandRegex,
             };
 
-            Service<ChatGui>.Get().CheckMessageHandled += this.OnCheckMessageHandled;
+            this.chatGui.CheckMessageHandled += this.OnCheckMessageHandled;
         }
 
         /// <summary>
@@ -169,6 +172,11 @@ namespace Dalamud.Game.Command
                     }
                 }
             }
+        }
+
+        public void Dispose()
+        {
+            this.chatGui.CheckMessageHandled -= this.OnCheckMessageHandled;
         }
     }
 }

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -41,8 +41,8 @@ namespace Dalamud.Game
             this.Address = new FrameworkAddressResolver();
             this.Address.Setup(sigScanner);
 
-            this.updateHook = new Hook<OnUpdateDetour>(this.Address.TickAddress, this.HandleFrameworkUpdate);
-            this.destroyHook = new Hook<OnRealDestroyDelegate>(this.Address.DestroyAddress, this.HandleFrameworkDestroy);
+            this.updateHook = Hook<OnUpdateDetour>.FromAddress(this.Address.TickAddress, this.HandleFrameworkUpdate);
+            this.destroyHook = Hook<OnRealDestroyDelegate>.FromAddress(this.Address.DestroyAddress, this.HandleFrameworkDestroy);
         }
 
         /// <summary>

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -429,6 +429,7 @@ namespace Dalamud.Game
 
             Log.Information("Framework::Destroy!");
             Service<Dalamud>.Get().Unload();
+            this.runOnNextTickTaskList.RemoveAll(x => x.Run());
             ServiceManager.UnloadAllServices();
             Log.Information("Framework::Destroy OK!");
 

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -47,9 +47,9 @@ namespace Dalamud.Game.Gui
             this.address = new ChatGuiAddressResolver();
             this.address.Setup(sigScanner);
 
-            this.printMessageHook = new Hook<PrintMessageDelegate>(this.address.PrintMessage, this.HandlePrintMessageDetour);
-            this.populateItemLinkHook = new Hook<PopulateItemLinkDelegate>(this.address.PopulateItemLinkObject, this.HandlePopulateItemLinkDetour);
-            this.interactableLinkClickedHook = new Hook<InteractableLinkClickedDelegate>(this.address.InteractableLinkClicked, this.InteractableLinkClickedDetour);
+            this.printMessageHook = Hook<PrintMessageDelegate>.FromAddress(this.address.PrintMessage, this.HandlePrintMessageDetour);
+            this.populateItemLinkHook = Hook<PopulateItemLinkDelegate>.FromAddress(this.address.PopulateItemLinkObject, this.HandlePopulateItemLinkDetour);
+            this.interactableLinkClickedHook = Hook<InteractableLinkClickedDelegate>.FromAddress(this.address.InteractableLinkClicked, this.InteractableLinkClickedDetour);
         }
 
         /// <summary>

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -33,6 +33,12 @@ namespace Dalamud.Game.Gui
         private readonly Hook<PopulateItemLinkDelegate> populateItemLinkHook;
         private readonly Hook<InteractableLinkClickedDelegate> interactableLinkClickedHook;
 
+        [ServiceManager.ServiceDependency]
+        private readonly DalamudConfiguration configuration = Service<DalamudConfiguration>.Get();
+
+        [ServiceManager.ServiceDependency]
+        private readonly LibcFunction libcFunction = Service<LibcFunction>.Get();
+
         private IntPtr baseAddress = IntPtr.Zero;
 
         [ServiceManager.ServiceConstructor]
@@ -150,13 +156,11 @@ namespace Dalamud.Game.Gui
         /// <param name="message">A message to send.</param>
         public void Print(string message)
         {
-            var configuration = Service<DalamudConfiguration>.Get();
-
             // Log.Verbose("[CHATGUI PRINT REGULAR]{0}", message);
             this.PrintChat(new XivChatEntry
             {
                 Message = message,
-                Type = configuration.GeneralChatType,
+                Type = this.configuration.GeneralChatType,
             });
         }
 
@@ -167,13 +171,11 @@ namespace Dalamud.Game.Gui
         /// <param name="message">A message to send.</param>
         public void Print(SeString message)
         {
-            var configuration = Service<DalamudConfiguration>.Get();
-
             // Log.Verbose("[CHATGUI PRINT SESTRING]{0}", message.TextValue);
             this.PrintChat(new XivChatEntry
             {
                 Message = message,
-                Type = configuration.GeneralChatType,
+                Type = this.configuration.GeneralChatType,
             });
         }
 
@@ -222,10 +224,10 @@ namespace Dalamud.Game.Gui
                 }
 
                 var senderRaw = (chat.Name ?? string.Empty).Encode();
-                using var senderOwned = Service<LibcFunction>.Get().NewString(senderRaw);
+                using var senderOwned = this.libcFunction.NewString(senderRaw);
 
                 var messageRaw = (chat.Message ?? string.Empty).Encode();
-                using var messageOwned = Service<LibcFunction>.Get().NewString(messageRaw);
+                using var messageOwned = this.libcFunction.NewString(messageRaw);
 
                 this.HandlePrintMessageDetour(this.baseAddress, chat.Type, senderOwned.Address, messageOwned.Address, chat.SenderId, chat.Parameters);
             }
@@ -364,7 +366,7 @@ namespace Dalamud.Game.Gui
 
                 if (!Util.FastByteArrayCompare(originalMessageData, message.RawData))
                 {
-                    allocatedString = Service<LibcFunction>.Get().NewString(message.RawData);
+                    allocatedString = this.libcFunction.NewString(message.RawData);
                     Log.Debug($"HandlePrintMessageDetour String modified: {originalMessageData}({messagePtr}) -> {message}({allocatedString.Address})");
                     messagePtr = allocatedString.Address;
                 }
@@ -379,7 +381,7 @@ namespace Dalamud.Game.Gui
 
                 if (!Util.FastByteArrayCompare(originalSenderData, sender.RawData))
                 {
-                    allocatedStringSender = Service<LibcFunction>.Get().NewString(sender.RawData);
+                    allocatedStringSender = this.libcFunction.NewString(sender.RawData);
                     Log.Debug(
                         $"HandlePrintMessageDetour Sender modified: {originalSenderData}({senderPtr}) -> {sender}({allocatedStringSender.Address})");
                     senderPtr = allocatedStringSender.Address;

--- a/Dalamud/Game/Gui/ContextMenus/ContextMenu.cs
+++ b/Dalamud/Game/Gui/ContextMenus/ContextMenu.cs
@@ -58,11 +58,11 @@ namespace Dalamud.Game.Gui.ContextMenus
             {
                 this.openSubContextMenu = Marshal.GetDelegateForFunctionPointer<OpenSubContextMenuDelegate>(this.Address.OpenSubContextMenuPtr);
 
-                this.contextMenuOpeningHook = new Hook<ContextMenuOpeningDelegate>(this.Address.ContextMenuOpeningPtr, this.ContextMenuOpeningDetour);
-                this.contextMenuOpenedHook = new Hook<ContextMenuOpenedDelegate>(this.Address.ContextMenuOpenedPtr, this.ContextMenuOpenedDetour);
-                this.contextMenuItemSelectedHook = new Hook<ContextMenuItemSelectedDelegate>(this.Address.ContextMenuItemSelectedPtr, this.ContextMenuItemSelectedDetour);
-                this.subContextMenuOpeningHook = new Hook<SubContextMenuOpeningDelegate>(this.Address.SubContextMenuOpeningPtr, this.SubContextMenuOpeningDetour);
-                this.subContextMenuOpenedHook = new Hook<ContextMenuOpenedDelegate>(this.Address.SubContextMenuOpenedPtr, this.SubContextMenuOpenedDetour);
+                this.contextMenuOpeningHook = Hook<ContextMenuOpeningDelegate>.FromAddress(this.Address.ContextMenuOpeningPtr, this.ContextMenuOpeningDetour);
+                this.contextMenuOpenedHook = Hook<ContextMenuOpenedDelegate>.FromAddress(this.Address.ContextMenuOpenedPtr, this.ContextMenuOpenedDetour);
+                this.contextMenuItemSelectedHook = Hook<ContextMenuItemSelectedDelegate>.FromAddress(this.Address.ContextMenuItemSelectedPtr, this.ContextMenuItemSelectedDetour);
+                this.subContextMenuOpeningHook = Hook<SubContextMenuOpeningDelegate>.FromAddress(this.Address.SubContextMenuOpeningPtr, this.SubContextMenuOpeningDetour);
+                this.subContextMenuOpenedHook = Hook<ContextMenuOpenedDelegate>.FromAddress(this.Address.SubContextMenuOpenedPtr, this.SubContextMenuOpenedDetour);
             }
         }
 

--- a/Dalamud/Game/Gui/Dtr/DtrBar.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBar.cs
@@ -22,17 +22,26 @@ namespace Dalamud.Game.Gui.Dtr
     {
         private const uint BaseNodeId = 1000;
 
+        [ServiceManager.ServiceDependency]
+        private readonly Framework framework = Service<Framework>.Get();
+
+        [ServiceManager.ServiceDependency]
+        private readonly GameGui gameGui = Service<GameGui>.Get();
+
+        [ServiceManager.ServiceDependency]
+        private readonly DalamudConfiguration configuration = Service<DalamudConfiguration>.Get();
+
         private List<DtrBarEntry> entries = new();
         private uint runningNodeIds = BaseNodeId;
 
         [ServiceManager.ServiceConstructor]
-        private DtrBar(DalamudConfiguration configuration, Framework framework)
+        private DtrBar()
         {
-            framework.Update += this.Update;
+            this.framework.Update += this.Update;
 
-            configuration.DtrOrder ??= new List<string>();
-            configuration.DtrIgnore ??= new List<string>();
-            configuration.Save();
+            this.configuration.DtrOrder ??= new List<string>();
+            this.configuration.DtrIgnore ??= new List<string>();
+            this.configuration.Save();
         }
 
         /// <summary>
@@ -48,14 +57,13 @@ namespace Dalamud.Game.Gui.Dtr
             if (this.entries.Any(x => x.Title == title))
                 throw new ArgumentException("An entry with the same title already exists.");
 
-            var configuration = Service<DalamudConfiguration>.Get();
             var node = this.MakeNode(++this.runningNodeIds);
             var entry = new DtrBarEntry(title, node);
             entry.Text = text;
 
             // Add the entry to the end of the order list, if it's not there already.
-            if (!configuration.DtrOrder!.Contains(title))
-                configuration.DtrOrder!.Add(title);
+            if (!this.configuration.DtrOrder!.Contains(title))
+                this.configuration.DtrOrder!.Add(title);
             this.entries.Add(entry);
             this.ApplySort();
 
@@ -69,7 +77,7 @@ namespace Dalamud.Game.Gui.Dtr
                 this.RemoveNode(entry.TextNode);
 
             this.entries.Clear();
-            Service<Framework>.Get().Update -= this.Update;
+            this.framework.Update -= this.Update;
         }
 
         /// <summary>
@@ -112,12 +120,11 @@ namespace Dalamud.Game.Gui.Dtr
         /// </summary>
         internal void ApplySort()
         {
-            var configuration = Service<DalamudConfiguration>.Get();
-
             // Sort the current entry list, based on the order in the configuration.
-            var positions = configuration.DtrOrder!
-                                         .Select(entry => (entry, index: configuration.DtrOrder!.IndexOf(entry)))
-                                         .ToDictionary(x => x.entry, x => x.index);
+            var positions = this.configuration
+                                .DtrOrder!
+                                .Select(entry => (entry, index: this.configuration.DtrOrder!.IndexOf(entry)))
+                                .ToDictionary(x => x.entry, x => x.index);
 
             this.entries.Sort((x, y) =>
             {
@@ -127,13 +134,13 @@ namespace Dalamud.Game.Gui.Dtr
             });
         }
 
-        private static AtkUnitBase* GetDtr() => (AtkUnitBase*)Service<GameGui>.Get().GetAddonByName("_DTR", 1).ToPointer();
+        private AtkUnitBase* GetDtr() => (AtkUnitBase*)this.gameGui.GetAddonByName("_DTR", 1).ToPointer();
 
         private void Update(Framework unused)
         {
             this.HandleRemovedNodes();
 
-            var dtr = GetDtr();
+            var dtr = this.GetDtr();
             if (dtr == null) return;
 
             // The collision node on the DTR element is always the width of its content
@@ -147,16 +154,16 @@ namespace Dalamud.Game.Gui.Dtr
             var collisionNode = dtr->UldManager.NodeList[1];
             if (collisionNode == null) return;
 
-            var configuration = Service<DalamudConfiguration>.Get();
-
             // If we are drawing backwards, we should start from the right side of the collision node. That is,
             // collisionNode->X + collisionNode->Width.
-            var runningXPos = configuration.DtrSwapDirection ? collisionNode->X + collisionNode->Width : collisionNode->X;
+            var runningXPos = this.configuration.DtrSwapDirection
+                                  ? collisionNode->X + collisionNode->Width
+                                  : collisionNode->X;
 
             for (var i = 0; i < this.entries.Count; i++)
             {
                 var data = this.entries[i];
-                var isHide = configuration.DtrIgnore!.Any(x => x == data.Title) || !data.Shown;
+                var isHide = this.configuration.DtrIgnore!.Any(x => x == data.Title) || !data.Shown;
 
                 if (data.Dirty && data.Added && data.Text != null && data.TextNode != null)
                 {
@@ -185,9 +192,9 @@ namespace Dalamud.Game.Gui.Dtr
 
                 if (!isHide)
                 {
-                    var elementWidth = data.TextNode->AtkResNode.Width + configuration.DtrSpacing;
+                    var elementWidth = data.TextNode->AtkResNode.Width + this.configuration.DtrSpacing;
 
-                    if (configuration.DtrSwapDirection)
+                    if (this.configuration.DtrSwapDirection)
                     {
                         data.TextNode->AtkResNode.SetPositionFloat(runningXPos, 2);
                         runningXPos += elementWidth;
@@ -209,7 +216,7 @@ namespace Dalamud.Game.Gui.Dtr
         /// <returns>True if there are nodes with an ID > 1000.</returns>
         private bool CheckForDalamudNodes()
         {
-            var dtr = GetDtr();
+            var dtr = this.GetDtr();
             if (dtr == null || dtr->RootNode == null) return false;
 
             for (var i = 0; i < dtr->UldManager.NodeListCount; i++)
@@ -233,7 +240,7 @@ namespace Dalamud.Game.Gui.Dtr
 
         private bool AddNode(AtkTextNode* node)
         {
-            var dtr = GetDtr();
+            var dtr = this.GetDtr();
             if (dtr == null || dtr->RootNode == null || dtr->UldManager.NodeList == null || node == null) return false;
 
             var lastChild = dtr->RootNode->ChildNode;
@@ -253,7 +260,7 @@ namespace Dalamud.Game.Gui.Dtr
 
         private bool RemoveNode(AtkTextNode* node)
         {
-            var dtr = GetDtr();
+            var dtr = this.GetDtr();
             if (dtr == null || dtr->RootNode == null || dtr->UldManager.NodeList == null || node == null) return false;
 
             var tmpPrevNode = node->AtkResNode.PrevSiblingNode;

--- a/Dalamud/Game/Gui/FlyText/FlyTextGui.cs
+++ b/Dalamud/Game/Gui/FlyText/FlyTextGui.cs
@@ -36,7 +36,7 @@ namespace Dalamud.Game.Gui.FlyText
             this.Address.Setup(sigScanner);
 
             this.addFlyTextNative = Marshal.GetDelegateForFunctionPointer<AddFlyTextDelegate>(this.Address.AddFlyText);
-            this.createFlyTextHook = new Hook<CreateFlyTextDelegate>(this.Address.CreateFlyText, this.CreateFlyTextDetour);
+            this.createFlyTextHook = Hook<CreateFlyTextDelegate>.FromAddress(this.Address.CreateFlyText, this.CreateFlyTextDetour);
         }
 
         /// <summary>

--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -60,23 +60,23 @@ namespace Dalamud.Game.Gui
             Log.Verbose($"HandleItemOut address 0x{this.address.HandleItemOut.ToInt64():X}");
             Log.Verbose($"HandleImm address 0x{this.address.HandleImm.ToInt64():X}");
 
-            this.setGlobalBgmHook = new Hook<SetGlobalBgmDelegate>(this.address.SetGlobalBgm, this.HandleSetGlobalBgmDetour);
+            this.setGlobalBgmHook = Hook<SetGlobalBgmDelegate>.FromAddress(this.address.SetGlobalBgm, this.HandleSetGlobalBgmDetour);
 
-            this.handleItemHoverHook = new Hook<HandleItemHoverDelegate>(this.address.HandleItemHover, this.HandleItemHoverDetour);
-            this.handleItemOutHook = new Hook<HandleItemOutDelegate>(this.address.HandleItemOut, this.HandleItemOutDetour);
+            this.handleItemHoverHook = Hook<HandleItemHoverDelegate>.FromAddress(this.address.HandleItemHover, this.HandleItemHoverDetour);
+            this.handleItemOutHook = Hook<HandleItemOutDelegate>.FromAddress(this.address.HandleItemOut, this.HandleItemOutDetour);
 
-            this.handleActionHoverHook = new Hook<HandleActionHoverDelegate>(this.address.HandleActionHover, this.HandleActionHoverDetour);
-            this.handleActionOutHook = new Hook<HandleActionOutDelegate>(this.address.HandleActionOut, this.HandleActionOutDetour);
+            this.handleActionHoverHook = Hook<HandleActionHoverDelegate>.FromAddress(this.address.HandleActionHover, this.HandleActionHoverDetour);
+            this.handleActionOutHook = Hook<HandleActionOutDelegate>.FromAddress(this.address.HandleActionOut, this.HandleActionOutDetour);
 
-            this.handleImmHook = new Hook<HandleImmDelegate>(this.address.HandleImm, this.HandleImmDetour);
+            this.handleImmHook = Hook<HandleImmDelegate>.FromAddress(this.address.HandleImm, this.HandleImmDetour);
 
             this.getMatrixSingleton = Marshal.GetDelegateForFunctionPointer<GetMatrixSingletonDelegate>(this.address.GetMatrixSingleton);
 
             this.screenToWorldNative = Marshal.GetDelegateForFunctionPointer<ScreenToWorldNativeDelegate>(this.address.ScreenToWorld);
 
-            this.toggleUiHideHook = new Hook<ToggleUiHideDelegate>(this.address.ToggleUiHide, this.ToggleUiHideDetour);
+            this.toggleUiHideHook = Hook<ToggleUiHideDelegate>.FromAddress(this.address.ToggleUiHide, this.ToggleUiHideDetour);
 
-            this.utf8StringFromSequenceHook = new Hook<Utf8StringFromSequenceDelegate>(this.address.Utf8StringFromSequence, this.Utf8StringFromSequenceDetour);
+            this.utf8StringFromSequenceHook = Hook<Utf8StringFromSequenceDelegate>.FromAddress(this.address.Utf8StringFromSequence, this.Utf8StringFromSequenceDetour);
         }
 
         // Marshaled delegates

--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -436,12 +436,6 @@ namespace Dalamud.Game.Gui
         /// </summary>
         void IDisposable.Dispose()
         {
-            Service<ChatGui>.Get().ExplicitDispose();
-            Service<ToastGui>.Get().ExplicitDispose();
-            Service<FlyTextGui>.Get().ExplicitDispose();
-            Service<PartyFinderGui>.Get().ExplicitDispose();
-            Service<ContextMenu>.Get().ExplicitDispose();
-            Service<DtrBar>.Get().ExplicitDispose();
             this.setGlobalBgmHook.Dispose();
             this.handleItemHoverHook.Dispose();
             this.handleItemOutHook.Dispose();

--- a/Dalamud/Game/Gui/Internal/DalamudIME.cs
+++ b/Dalamud/Game/Gui/Internal/DalamudIME.cs
@@ -266,9 +266,9 @@ namespace Dalamud.Game.Gui.Internal
         private void ToggleWindow(bool visible)
         {
             if (visible)
-                Service<DalamudInterface>.Get().OpenImeWindow();
+                Service<DalamudInterface>.GetNullable()?.OpenImeWindow();
             else
-                Service<DalamudInterface>.Get().CloseImeWindow();
+                Service<DalamudInterface>.GetNullable()?.CloseImeWindow();
         }
     }
 }

--- a/Dalamud/Game/Gui/PartyFinder/PartyFinderGui.cs
+++ b/Dalamud/Game/Gui/PartyFinder/PartyFinderGui.cs
@@ -35,7 +35,7 @@ namespace Dalamud.Game.Gui.PartyFinder
 
             this.memory = Marshal.AllocHGlobal(PartyFinderPacket.PacketSize);
 
-            this.receiveListingHook = new Hook<ReceiveListingDelegate>(this.address.ReceiveListing, new ReceiveListingDelegate(this.HandleReceiveListingDetour));
+            this.receiveListingHook = Hook<ReceiveListingDelegate>.FromAddress(this.address.ReceiveListing, new ReceiveListingDelegate(this.HandleReceiveListingDetour));
         }
 
         /// <summary>

--- a/Dalamud/Game/Gui/Toast/ToastGui.cs
+++ b/Dalamud/Game/Gui/Toast/ToastGui.cs
@@ -39,9 +39,9 @@ namespace Dalamud.Game.Gui.Toast
             this.address = new ToastGuiAddressResolver();
             this.address.Setup(sigScanner);
 
-            this.showNormalToastHook = new Hook<ShowNormalToastDelegate>(this.address.ShowNormalToast, new ShowNormalToastDelegate(this.HandleNormalToastDetour));
-            this.showQuestToastHook = new Hook<ShowQuestToastDelegate>(this.address.ShowQuestToast, new ShowQuestToastDelegate(this.HandleQuestToastDetour));
-            this.showErrorToastHook = new Hook<ShowErrorToastDelegate>(this.address.ShowErrorToast, new ShowErrorToastDelegate(this.HandleErrorToastDetour));
+            this.showNormalToastHook = Hook<ShowNormalToastDelegate>.FromAddress(this.address.ShowNormalToast, new ShowNormalToastDelegate(this.HandleNormalToastDetour));
+            this.showQuestToastHook = Hook<ShowQuestToastDelegate>.FromAddress(this.address.ShowQuestToast, new ShowQuestToastDelegate(this.HandleQuestToastDetour));
+            this.showErrorToastHook = Hook<ShowErrorToastDelegate>.FromAddress(this.address.ShowErrorToast, new ShowErrorToastDelegate(this.HandleErrorToastDetour));
         }
 
         #region Event delegates

--- a/Dalamud/Game/Internal/DalamudAtkTweaks.cs
+++ b/Dalamud/Game/Internal/DalamudAtkTweaks.cs
@@ -48,7 +48,7 @@ namespace Dalamud.Game.Internal
         {
             var openSystemMenuAddress = sigScanner.ScanText("E8 ?? ?? ?? ?? 32 C0 4C 8B AC 24 ?? ?? ?? ?? 48 8B 8D ?? ?? ?? ??");
 
-            this.hookAgentHudOpenSystemMenu = new Hook<AgentHudOpenSystemMenuPrototype>(openSystemMenuAddress, this.AgentHudOpenSystemMenuDetour);
+            this.hookAgentHudOpenSystemMenu = Hook<AgentHudOpenSystemMenuPrototype>.FromAddress(openSystemMenuAddress, this.AgentHudOpenSystemMenuDetour);
 
             var atkValueChangeTypeAddress = sigScanner.ScanText("E8 ?? ?? ?? ?? 45 84 F6 48 8D 4C 24 ??");
             this.atkValueChangeType = Marshal.GetDelegateForFunctionPointer<AtkValueChangeType>(atkValueChangeTypeAddress);
@@ -57,10 +57,10 @@ namespace Dalamud.Game.Internal
             this.atkValueSetString = Marshal.GetDelegateForFunctionPointer<AtkValueSetString>(atkValueSetStringAddress);
 
             var uiModuleRequestMainCommandAddress = sigScanner.ScanText("40 53 56 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 8B 01 8B DA 48 8B F1 FF 90 ?? ?? ?? ??");
-            this.hookUiModuleRequestMainCommand = new Hook<UiModuleRequestMainCommand>(uiModuleRequestMainCommandAddress, this.UiModuleRequestMainCommandDetour);
+            this.hookUiModuleRequestMainCommand = Hook<UiModuleRequestMainCommand>.FromAddress(uiModuleRequestMainCommandAddress, this.UiModuleRequestMainCommandDetour);
 
             var atkUnitBaseReceiveGlobalEventAddress = sigScanner.ScanText("48 89 5C 24 ?? 48 89 7C 24 ?? 55 41 56 41 57 48 8B EC 48 83 EC 50 44 0F B7 F2 ");
-            this.hookAtkUnitBaseReceiveGlobalEvent = new Hook<AtkUnitBaseReceiveGlobalEvent>(atkUnitBaseReceiveGlobalEventAddress, this.AtkUnitBaseReceiveGlobalEventDetour);
+            this.hookAtkUnitBaseReceiveGlobalEvent = Hook<AtkUnitBaseReceiveGlobalEvent>.FromAddress(atkUnitBaseReceiveGlobalEventAddress, this.AtkUnitBaseReceiveGlobalEventDetour);
 
             this.locDalamudPlugins = Loc.Localize("SystemMenuPlugins", "Dalamud Plugins");
             this.locDalamudSettings = Loc.Localize("SystemMenuSettings", "Dalamud Settings");

--- a/Dalamud/Game/Internal/DalamudAtkTweaks.cs
+++ b/Dalamud/Game/Internal/DalamudAtkTweaks.cs
@@ -9,7 +9,6 @@ using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Hooking;
-using Dalamud.Interface;
 using Dalamud.Interface.Internal;
 using Dalamud.Interface.Windowing;
 using FFXIVClientStructs.FFXIV.Component.GUI;
@@ -35,11 +34,17 @@ namespace Dalamud.Game.Internal
 
         private readonly Hook<AtkUnitBaseReceiveGlobalEvent> hookAtkUnitBaseReceiveGlobalEvent;
 
+        [ServiceManager.ServiceDependency]
+        private readonly DalamudConfiguration configuration = Service<DalamudConfiguration>.Get();
+
+        [ServiceManager.ServiceDependency]
+        private readonly ContextMenu contextMenu = Service<ContextMenu>.Get();
+
         private readonly string locDalamudPlugins;
         private readonly string locDalamudSettings;
 
         [ServiceManager.ServiceConstructor]
-        private DalamudAtkTweaks(SigScanner sigScanner, ContextMenu contextMenu)
+        private DalamudAtkTweaks(SigScanner sigScanner)
         {
             var openSystemMenuAddress = sigScanner.ScanText("E8 ?? ?? ?? ?? 32 C0 4C 8B AC 24 ?? ?? ?? ?? 48 8B 8D ?? ?? ?? ??");
 
@@ -60,7 +65,7 @@ namespace Dalamud.Game.Internal
             this.locDalamudPlugins = Loc.Localize("SystemMenuPlugins", "Dalamud Plugins");
             this.locDalamudSettings = Loc.Localize("SystemMenuSettings", "Dalamud Settings");
 
-            contextMenu.ContextMenuOpened += this.ContextMenuOnContextMenuOpened;
+            this.contextMenu.ContextMenuOpened += this.ContextMenuOnContextMenuOpened;
         }
 
         private delegate void AgentHudOpenSystemMenuPrototype(void* thisPtr, AtkValue* atkValueArgs, uint menuSize);
@@ -83,11 +88,13 @@ namespace Dalamud.Game.Internal
 
         private void ContextMenuOnContextMenuOpened(ContextMenuOpenedArgs args)
         {
-            var systemText = Service<DataManager>.Get().GetExcelSheet<Addon>()!.GetRow(1059)!.Text.RawString; // "System"
-            var configuration = Service<DalamudConfiguration>.Get();
-            var interfaceManager = Service<InterfaceManager>.Get();
+            var systemText = Service<DataManager>.GetNullable()?.GetExcelSheet<Addon>()?.GetRow(1059)?.Text?.RawString; // "System"
+            var interfaceManager = Service<InterfaceManager>.GetNullable();
 
-            if (args.Title == systemText && configuration.DoButtonsSystemMenu && interfaceManager.IsDispatchingEvents)
+            if (systemText == null || interfaceManager == null)
+                return;
+
+            if (args.Title == systemText && this.configuration.DoButtonsSystemMenu && interfaceManager.IsDispatchingEvents)
             {
                 var dalamudInterface = Service<DalamudInterface>.Get();
 
@@ -109,7 +116,7 @@ namespace Dalamud.Game.Internal
 
             // "SendHotkey"
             // 3 == Close
-            if (cmd == 12 && WindowSystem.HasAnyWindowSystemFocus && *arg == 3 && Service<DalamudConfiguration>.Get().IsFocusManagementEnabled)
+            if (cmd == 12 && WindowSystem.HasAnyWindowSystemFocus && *arg == 3 && this.configuration.IsFocusManagementEnabled)
             {
                 Log.Verbose($"Cancelling global event SendHotkey command due to WindowSystem {WindowSystem.FocusedWindowSystemNamespace}");
                 return IntPtr.Zero;
@@ -120,14 +127,18 @@ namespace Dalamud.Game.Internal
 
         private void AgentHudOpenSystemMenuDetour(void* thisPtr, AtkValue* atkValueArgs, uint menuSize)
         {
-            if (WindowSystem.HasAnyWindowSystemFocus && Service<DalamudConfiguration>.Get().IsFocusManagementEnabled)
+            if (WindowSystem.HasAnyWindowSystemFocus && this.configuration.IsFocusManagementEnabled)
             {
                 Log.Verbose($"Cancelling OpenSystemMenu due to WindowSystem {WindowSystem.FocusedWindowSystemNamespace}");
                 return;
             }
 
-            var configuration = Service<DalamudConfiguration>.Get();
-            var interfaceManager = Service<InterfaceManager>.Get();
+            var interfaceManager = Service<InterfaceManager>.GetNullable();
+            if (interfaceManager == null)
+            {
+                this.hookAgentHudOpenSystemMenu.Original(thisPtr, atkValueArgs, menuSize);
+                return;
+            }
 
             if (!configuration.DoButtonsSystemMenu || !interfaceManager.IsDispatchingEvents)
             {
@@ -207,15 +218,15 @@ namespace Dalamud.Game.Internal
 
         private void UiModuleRequestMainCommandDetour(void* thisPtr, int commandId)
         {
-            var dalamudInterface = Service<DalamudInterface>.Get();
+            var dalamudInterface = Service<DalamudInterface>.GetNullable();
 
             switch (commandId)
             {
                 case 69420:
-                    dalamudInterface.TogglePluginInstallerWindow();
+                    dalamudInterface?.TogglePluginInstallerWindow();
                     break;
                 case 69421:
-                    dalamudInterface.ToggleSettingsWindow();
+                    dalamudInterface?.ToggleSettingsWindow();
                     break;
                 default:
                     this.hookUiModuleRequestMainCommand.Original(thisPtr, commandId);
@@ -259,7 +270,7 @@ namespace Dalamud.Game.Internal
                 this.hookUiModuleRequestMainCommand.Dispose();
                 this.hookAtkUnitBaseReceiveGlobalEvent.Dispose();
 
-                Service<ContextMenu>.Get().ContextMenuOpened -= this.ContextMenuOnContextMenuOpened;
+                this.contextMenu.ContextMenuOpened -= this.ContextMenuOnContextMenuOpened;
             }
 
             this.disposed = true;

--- a/Dalamud/Game/Network/GameNetwork.cs
+++ b/Dalamud/Game/Network/GameNetwork.cs
@@ -34,8 +34,8 @@ namespace Dalamud.Game.Network
             Log.Verbose($"ProcessZonePacketDown address 0x{this.address.ProcessZonePacketDown.ToInt64():X}");
             Log.Verbose($"ProcessZonePacketUp address 0x{this.address.ProcessZonePacketUp.ToInt64():X}");
 
-            this.processZonePacketDownHook = new Hook<ProcessZonePacketDownDelegate>(this.address.ProcessZonePacketDown, this.ProcessZonePacketDownDetour);
-            this.processZonePacketUpHook = new Hook<ProcessZonePacketUpDelegate>(this.address.ProcessZonePacketUp, this.ProcessZonePacketUpDetour);
+            this.processZonePacketDownHook = Hook<ProcessZonePacketDownDelegate>.FromAddress(this.address.ProcessZonePacketDown, this.ProcessZonePacketDownDetour);
+            this.processZonePacketUpHook = Hook<ProcessZonePacketUpDelegate>.FromAddress(this.address.ProcessZonePacketUp, this.ProcessZonePacketUpDetour);
         }
 
         /// <summary>

--- a/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
+++ b/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
@@ -32,7 +32,9 @@ namespace Dalamud.Game.Network.Internal.MarketBoardUploaders.Universalis
         /// <inheritdoc/>
         public async Task Upload(MarketBoardItemRequest request)
         {
-            var clientState = Service<ClientState.ClientState>.Get();
+            var clientState = Service<ClientState.ClientState>.GetNullable();
+            if (clientState == null)
+                return;
 
             Log.Verbose("Starting Universalis upload.");
             var uploader = clientState.LocalContentId;
@@ -118,7 +120,9 @@ namespace Dalamud.Game.Network.Internal.MarketBoardUploaders.Universalis
         /// <inheritdoc/>
         public async Task UploadTax(MarketTaxRates taxRates)
         {
-            var clientState = Service<ClientState.ClientState>.Get();
+            var clientState = Service<ClientState.ClientState>.GetNullable();
+            if (clientState == null)
+                return;
 
             // ====================================================================================
 
@@ -157,7 +161,9 @@ namespace Dalamud.Game.Network.Internal.MarketBoardUploaders.Universalis
         /// </remarks>
         public async Task UploadPurchase(MarketBoardPurchaseHandler purchaseHandler)
         {
-            var clientState = Service<ClientState.ClientState>.Get();
+            var clientState = Service<ClientState.ClientState>.GetNullable();
+            if (clientState == null)
+                return;
 
             var itemId = purchaseHandler.CatalogId;
             var worldId = clientState.LocalPlayer?.CurrentWorld.Id ?? 0;

--- a/Dalamud/Game/Network/Internal/NetworkHandlers.cs
+++ b/Dalamud/Game/Network/Internal/NetworkHandlers.cs
@@ -28,6 +28,9 @@ namespace Dalamud.Game.Network.Internal
 
         private readonly IMarketBoardUploader uploader;
 
+        [ServiceManager.ServiceDependency]
+        private readonly DalamudConfiguration configuration = Service<DalamudConfiguration>.Get();
+
         private MarketBoardPurchaseHandler marketBoardPurchaseHandler;
 
         [ServiceManager.ServiceConstructor]
@@ -47,14 +50,12 @@ namespace Dalamud.Game.Network.Internal
         {
             var dataManager = Service<DataManager>.GetNullable();
 
-            if (dataManager?.IsDataReady == false)
+            if (dataManager?.IsDataReady != true)
                 return;
-
-            var configuration = Service<DalamudConfiguration>.Get();
 
             if (direction == NetworkMessageDirection.ZoneUp)
             {
-                if (configuration.IsMbCollect)
+                if (this.configuration.IsMbCollect)
                 {
                     if (opCode == dataManager.ClientOpCodes["MarketBoardPurchaseHandler"])
                     {
@@ -72,7 +73,7 @@ namespace Dalamud.Game.Network.Internal
                 return;
             }
 
-            if (configuration.IsMbCollect)
+            if (this.configuration.IsMbCollect)
             {
                 if (opCode == dataManager.ServerOpCodes["MarketBoardItemRequestStart"])
                 {
@@ -236,8 +237,9 @@ namespace Dalamud.Game.Network.Internal
 
         private unsafe void HandleCfPop(IntPtr dataPtr)
         {
-            var dataManager = Service<DataManager>.Get();
-            var configuration = Service<DalamudConfiguration>.Get();
+            var dataManager = Service<DataManager>.GetNullable();
+            if (dataManager == null)
+                return;
 
             using var stream = new UnmanagedMemoryStream((byte*)dataPtr.ToPointer(), 64);
             using var reader = new BinaryReader(stream);
@@ -266,7 +268,7 @@ namespace Dalamud.Game.Network.Internal
             }
 
             // Flash window
-            if (configuration.DutyFinderTaskbarFlash && !NativeFunctions.ApplicationIsActivated())
+            if (this.configuration.DutyFinderTaskbarFlash && !NativeFunctions.ApplicationIsActivated())
             {
                 var flashInfo = new NativeFunctions.FlashWindowInfo
                 {
@@ -281,9 +283,9 @@ namespace Dalamud.Game.Network.Internal
 
             Task.Run(() =>
             {
-                if (configuration.DutyFinderChatMessage)
+                if (this.configuration.DutyFinderChatMessage)
                 {
-                    Service<ChatGui>.Get().Print($"Duty pop: {cfcName}");
+                    Service<ChatGui>.GetNullable()?.Print($"Duty pop: {cfcName}");
                 }
 
                 this.CfPop?.Invoke(this, cfCondition);

--- a/Dalamud/Game/Network/Internal/WinSockHandlers.cs
+++ b/Dalamud/Game/Network/Internal/WinSockHandlers.cs
@@ -18,7 +18,7 @@ namespace Dalamud.Game.Network.Internal
         [ServiceManager.ServiceConstructor]
         private WinSockHandlers()
         {
-            this.ws2SocketHook = Hook<SocketDelegate>.FromImport(Process.GetCurrentProcess().MainModule, "ws2_32.dll", "socket", 23, this.OnSocket);
+            this.ws2SocketHook = Hook<SocketDelegate>.FromImport(null, "ws2_32.dll", "socket", 23, this.OnSocket);
             this.ws2SocketHook?.Enable();
         }
 

--- a/Dalamud/Game/SigScanner.cs
+++ b/Dalamud/Game/SigScanner.cs
@@ -359,6 +359,7 @@ namespace Dalamud.Game
         /// </summary>
         public void Dispose()
         {
+            this.Save();
             Marshal.FreeHGlobal(this.moduleCopyPtr);
         }
 
@@ -370,7 +371,14 @@ namespace Dalamud.Game
             if (this.cacheFile == null)
                 return;
 
-            File.WriteAllText(this.cacheFile.FullName, JsonConvert.SerializeObject(this.textCache));
+            try
+            {
+                File.WriteAllText(this.cacheFile.FullName, JsonConvert.SerializeObject(this.textCache));
+            }
+            catch (Exception e)
+            {
+                Log.Warning(e, "Failed to save cache to {0}", this.cacheFile);
+            }
         }
 
         /// <summary>

--- a/Dalamud/Hooking/Internal/HookManager.cs
+++ b/Dalamud/Hooking/Internal/HookManager.cs
@@ -24,6 +24,11 @@ namespace Dalamud.Hooking.Internal
         }
 
         /// <summary>
+        /// Gets sync root object for hook enabling/disabling.
+        /// </summary>
+        internal static object HookEnableSyncRoot { get; } = new();
+
+        /// <summary>
         /// Gets a static list of tracked and registered hooks.
         /// </summary>
         internal static ConcurrentDictionary<Guid, HookInfo> TrackedHooks { get; } = new();

--- a/Dalamud/Interface/GameFonts/GameFontManager.cs
+++ b/Dalamud/Interface/GameFonts/GameFontManager.cs
@@ -18,7 +18,7 @@ namespace Dalamud.Interface.GameFonts
     /// Loads game font for use in ImGui.
     /// </summary>
     [ServiceManager.EarlyLoadedService]
-    internal class GameFontManager : IDisposable, IServiceType
+    internal class GameFontManager : IServiceType
     {
         private static readonly string?[] FontNames =
         {
@@ -156,11 +156,6 @@ namespace Dalamud.Interface.GameFonts
 
             if (rebuildLookupTable)
                 fontPtr.BuildLookupTable();
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
         }
 
         /// <summary>

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -60,8 +60,6 @@ namespace Dalamud.Interface.Internal
         private readonly TextureWrap logoTexture;
         private readonly TextureWrap tsmLogoTexture;
 
-        private ulong frameCount = 0;
-
 #if DEBUG
         private bool isImGuiDrawDevMenu = true;
 #else
@@ -80,7 +78,8 @@ namespace Dalamud.Interface.Internal
         private DalamudInterface(
             Dalamud dalamud,
             DalamudConfiguration configuration,
-            InterfaceManager.InterfaceManagerWithScene interfaceManagerWithScene)
+            InterfaceManager.InterfaceManagerWithScene interfaceManagerWithScene,
+            PluginImageCache pluginImageCache)
         {
             var interfaceManager = interfaceManagerWithScene.Manager;
             this.WindowSystem = new WindowSystem("DalamudCore");
@@ -94,7 +93,7 @@ namespace Dalamud.Interface.Internal
             this.imeWindow = new IMEWindow() { IsOpen = false };
             this.consoleWindow = new ConsoleWindow() { IsOpen = configuration.LogOpenAtStartup };
             this.pluginStatWindow = new PluginStatWindow() { IsOpen = false };
-            this.pluginWindow = new PluginInstallerWindow() { IsOpen = false };
+            this.pluginWindow = new PluginInstallerWindow(pluginImageCache) { IsOpen = false };
             this.settingsWindow = new SettingsWindow() { IsOpen = false };
             this.selfTestWindow = new SelfTestWindow() { IsOpen = false };
             this.styleEditorWindow = new StyleEditorWindow() { IsOpen = false };
@@ -146,6 +145,11 @@ namespace Dalamud.Interface.Internal
                 tsm.AddEntry(Loc.Localize("TSMDalamudDevMenu", "Developer Menu"), this.tsmLogoTexture, () => this.isImGuiDrawDevMenu = true);
             }
         }
+
+        /// <summary>
+        /// Gets the number of frames since Dalamud has loaded.
+        /// </summary>
+        public ulong FrameCount { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="WindowSystem"/> controlling all Dalamud-internal windows.
@@ -373,7 +377,7 @@ namespace Dalamud.Interface.Internal
 
         private void OnDraw()
         {
-            this.frameCount++;
+            this.FrameCount++;
 
 #if BOOT_AGING
             if (this.frameCount > 500 && !this.signaledBoot)
@@ -795,7 +799,7 @@ namespace Dalamud.Interface.Internal
                         ImGui.PushFont(InterfaceManager.MonoFont);
 
                         ImGui.BeginMenu(Util.GetGitHash(), false);
-                        ImGui.BeginMenu(this.frameCount.ToString("000000"), false);
+                        ImGui.BeginMenu(this.FrameCount.ToString("000000"), false);
                         ImGui.BeginMenu(ImGui.GetIO().Framerate.ToString("000"), false);
                         ImGui.BeginMenu($"{Util.FormatBytes(GC.GetTotalMemory(false))}", false);
 

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -137,12 +137,12 @@ namespace Dalamud.Interface.Internal
             this.tsmLogoTexture = tsmLogoTex;
 
             var tsm = Service<TitleScreenMenu>.Get();
-            tsm.AddEntry(Loc.Localize("TSMDalamudPlugins", "Plugin Installer"), this.tsmLogoTexture, () => this.pluginWindow.IsOpen = true);
-            tsm.AddEntry(Loc.Localize("TSMDalamudSettings", "Dalamud Settings"), this.tsmLogoTexture, () => this.settingsWindow.IsOpen = true);
+            tsm.AddEntryCore(Loc.Localize("TSMDalamudPlugins", "Plugin Installer"), this.tsmLogoTexture, () => this.pluginWindow.IsOpen = true);
+            tsm.AddEntryCore(Loc.Localize("TSMDalamudSettings", "Dalamud Settings"), this.tsmLogoTexture, () => this.settingsWindow.IsOpen = true);
 
             if (configuration.IsConventionalStaging)
             {
-                tsm.AddEntry(Loc.Localize("TSMDalamudDevMenu", "Developer Menu"), this.tsmLogoTexture, () => this.isImGuiDrawDevMenu = true);
+                tsm.AddEntryCore(Loc.Localize("TSMDalamudDevMenu", "Developer Menu"), this.tsmLogoTexture, () => this.isImGuiDrawDevMenu = true);
             }
         }
 

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -498,15 +498,28 @@ namespace Dalamud.Interface.Internal
                         {
                             foreach (var logLevel in Enum.GetValues(typeof(LogEventLevel)).Cast<LogEventLevel>())
                             {
-                                if (ImGui.MenuItem(logLevel + "##logLevelSwitch", string.Empty, dalamud.LogLevelSwitch.MinimumLevel == logLevel))
+                                if (ImGui.MenuItem(logLevel + "##logLevelSwitch", string.Empty, EntryPoint.LogLevelSwitch.MinimumLevel == logLevel))
                                 {
-                                    dalamud.LogLevelSwitch.MinimumLevel = logLevel;
+                                    EntryPoint.LogLevelSwitch.MinimumLevel = logLevel;
                                     configuration.LogLevel = logLevel;
                                     configuration.Save();
                                 }
                             }
 
                             ImGui.EndMenu();
+                        }
+
+                        var logSynchronously = configuration.LogSynchronously;
+                        if (ImGui.MenuItem("Log Synchronously", null, ref logSynchronously))
+                        {
+                            configuration.LogSynchronously = logSynchronously;
+                            configuration.Save();
+
+                            var startupInfo = Service<DalamudStartInfo>.Get();
+                            EntryPoint.InitLogging(
+                                startupInfo.WorkingDirectory!,
+                                startupInfo.BootShowConsole,
+                                configuration.LogSynchronously);
                         }
 
                         var antiDebug = Service<AntiDebug>.Get();
@@ -588,12 +601,21 @@ namespace Dalamud.Interface.Internal
                             Marshal.ReadByte(IntPtr.Zero);
                         }
 
-                        if (ImGui.MenuItem("Crash game"))
+                        if (ImGui.MenuItem("Crash game (nullptr)"))
                         {
                             unsafe
                             {
                                 var framework = Framework.Instance();
                                 framework->UIModule = (UIModule*)0;
+                            }
+                        }
+
+                        if (ImGui.MenuItem("Crash game (non-nullptr)"))
+                        {
+                            unsafe
+                            {
+                                var framework = Framework.Instance();
+                                framework->UIModule = (UIModule*)0x12345678;
                             }
                         }
 

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -57,6 +57,9 @@ namespace Dalamud.Interface.Internal
         private readonly HashSet<SpecialGlyphRequest> glyphRequests = new();
         private readonly Dictionary<ImFontPtr, TargetFontModification> loadedFontInfo = new();
 
+        [ServiceManager.ServiceDependency]
+        private readonly Framework framework = Service<Framework>.Get();
+
         private readonly ManualResetEvent fontBuildSignal;
         private readonly SwapChainVtableResolver address;
         private readonly Hook<DispatchMessageWDelegate> dispatchMessageWHook;
@@ -73,12 +76,12 @@ namespace Dalamud.Interface.Internal
         private bool isOverrideGameCursor = true;
 
         [ServiceManager.ServiceConstructor]
-        private InterfaceManager(SigScanner sigScanner)
+        private InterfaceManager()
         {
             this.dispatchMessageWHook = Hook<DispatchMessageWDelegate>.FromImport(
-                Process.GetCurrentProcess().MainModule, "user32.dll", "DispatchMessageW", 0, this.DispatchMessageWDetour);
+                null, "user32.dll", "DispatchMessageW", 0, this.DispatchMessageWDetour);
             this.setCursorHook = Hook<SetCursorDelegate>.FromImport(
-                Process.GetCurrentProcess().MainModule, "user32.dll", "SetCursor", 0, this.SetCursorDetour);
+                null, "user32.dll", "SetCursor", 0, this.SetCursorDetour);
 
             this.fontBuildSignal = new ManualResetEvent(false);
 
@@ -90,12 +93,6 @@ namespace Dalamud.Interface.Internal
 
         [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         private delegate IntPtr ResizeBuffersDelegate(IntPtr swapChain, uint bufferCount, uint width, uint height, uint newFormat, uint swapChainFlags);
-
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int CreateDXGIFactoryDelegate(Guid riid, out IntPtr ppFactory);
-
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int IDXGIFactory_CreateSwapChainDelegate(IntPtr pFactory, IntPtr pDevice, IntPtr pDesc, out IntPtr ppSwapChain);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate IntPtr SetCursorDelegate(IntPtr hCursor);
@@ -248,14 +245,7 @@ namespace Dalamud.Interface.Internal
         /// </summary>
         public void Dispose()
         {
-            // HACK: this is usually called on a separate thread from PresentDetour (likely on a dedicated render thread)
-            // and if we aren't already disabled, disposing of the scene and hook can frequently crash due to the hook
-            // being disposed of in this thread while it is actively in use in the render thread.
-            // This is a terrible way to prevent issues, but should basically always work to ensure that all outstanding
-            // calls to PresentDetour have finished (and Disable means no new ones will start), before we try to cleanup
-            // So... not great, but much better than constantly crashing on unload
-            this.Disable();
-            Thread.Sleep(500);
+            this.framework.RunOnFrameworkThread(this.Disable).Wait();
 
             this.scene?.Dispose();
             this.setCursorHook.Dispose();
@@ -1104,7 +1094,7 @@ namespace Dalamud.Interface.Internal
             if (this.lastWantCapture == true && (!this.scene?.IsImGuiCursor(hCursor) ?? false) && this.OverrideGameCursor)
                 return IntPtr.Zero;
 
-            return this.setCursorHook!.Original(hCursor);
+            return this.setCursorHook.IsDisposed ? User32.SetCursor(new User32.SafeCursorHandle(hCursor, false)).DangerousGetHandle() : this.setCursorHook.Original(hCursor);
         }
 
         private void OnNewInputFrame()

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -980,8 +980,8 @@ namespace Dalamud.Interface.Internal
                         break;
                 }
 
-                this.presentHook = new Hook<PresentDelegate>(this.address.Present, this.PresentDetour);
-                this.resizeBuffersHook = new Hook<ResizeBuffersDelegate>(this.address.ResizeBuffers, this.ResizeBuffersDetour);
+                this.presentHook = Hook<PresentDelegate>.FromAddress(this.address.Present, this.PresentDetour);
+                this.resizeBuffersHook = Hook<ResizeBuffersDelegate>.FromAddress(this.address.ResizeBuffers, this.ResizeBuffersDetour);
 
                 Log.Verbose("===== S W A P C H A I N =====");
                 Log.Verbose($"Present address 0x{this.presentHook!.Address.ToInt64():X}");

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -245,13 +245,15 @@ namespace Dalamud.Interface.Internal
         /// </summary>
         public void Dispose()
         {
-            this.framework.RunOnFrameworkThread(this.Disable).Wait();
+            this.framework.RunOnFrameworkThread(() =>
+            {
+                this.setCursorHook.Dispose();
+                this.presentHook?.Dispose();
+                this.resizeBuffersHook?.Dispose();
+                this.dispatchMessageWHook.Dispose();
+            }).Wait();
 
             this.scene?.Dispose();
-            this.setCursorHook.Dispose();
-            this.presentHook?.Dispose();
-            this.resizeBuffersHook?.Dispose();
-            this.dispatchMessageWHook.Dispose();
         }
 
 #nullable enable
@@ -992,14 +994,6 @@ namespace Dalamud.Interface.Internal
                 this.resizeBuffersHook.Enable();
                 this.dispatchMessageWHook.Enable();
             });
-        }
-
-        private void Disable()
-        {
-            this.setCursorHook.Disable();
-            this.presentHook?.Disable();
-            this.resizeBuffersHook?.Disable();
-            this.dispatchMessageWHook.Disable();
         }
 
         // This is intended to only be called as a handler attached to scene.OnNewRenderFrame

--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -123,7 +123,6 @@ namespace Dalamud.Interface.Internal.Windows
             // Options menu
             if (ImGui.BeginPopup("Options"))
             {
-                var dalamud = Service<Dalamud>.Get();
                 var configuration = Service<DalamudConfiguration>.Get();
 
                 if (ImGui.Checkbox("Auto-scroll", ref this.autoScroll))
@@ -138,10 +137,10 @@ namespace Dalamud.Interface.Internal.Windows
                     configuration.Save();
                 }
 
-                var prevLevel = (int)dalamud.LogLevelSwitch.MinimumLevel;
+                var prevLevel = (int)EntryPoint.LogLevelSwitch.MinimumLevel;
                 if (ImGui.Combo("Log Level", ref prevLevel, Enum.GetValues(typeof(LogEventLevel)).Cast<LogEventLevel>().Select(x => x.ToString()).ToArray(), 6))
                 {
-                    dalamud.LogLevelSwitch.MinimumLevel = (LogEventLevel)prevLevel;
+                    EntryPoint.LogLevelSwitch.MinimumLevel = (LogEventLevel)prevLevel;
                     configuration.LogLevel = (LogEventLevel)prevLevel;
                     configuration.Save();
                 }

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -37,8 +37,8 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
         private readonly Vector4 changelogBgColor = new(0.114f, 0.584f, 0.192f, 0.678f);
         private readonly Vector4 changelogTextColor = new(0.812f, 1.000f, 0.816f, 1.000f);
 
+        private readonly PluginImageCache imageCache;
         private readonly PluginCategoryManager categoryManager = new();
-        private readonly PluginImageCache imageCache = new();
         private readonly DalamudChangelogManager dalamudChangelogManager = new();
 
         private readonly List<int> openPluginCollapsibles = new();
@@ -87,12 +87,14 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
         /// <summary>
         /// Initializes a new instance of the <see cref="PluginInstallerWindow"/> class.
         /// </summary>
-        public PluginInstallerWindow()
+        /// <param name="imageCache">An instance of <see cref="PluginImageCache"/> class.</param>
+        public PluginInstallerWindow(PluginImageCache imageCache)
             : base(
                 Locs.WindowTitle + (Service<DalamudConfiguration>.Get().DoPluginTest ? Locs.WindowTitleMod_Testing : string.Empty) + "###XlPluginInstaller",
                 ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoScrollbar)
         {
             this.IsOpen = true;
+            this.imageCache = imageCache;
 
             this.Size = new Vector2(830, 570);
             this.SizeCondition = ImGuiCond.FirstUseEver;
@@ -200,6 +202,7 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
             ImGui.SetCursorPosY(ImGui.GetCursorPosY() - (5 * ImGuiHelpers.GlobalScale));
 
             var searchInputWidth = 240 * ImGuiHelpers.GlobalScale;
+            var searchClearButtonWidth = 40 * ImGuiHelpers.GlobalScale;
 
             var sortByText = Locs.SortBy_Label;
             var sortByTextWidth = ImGui.CalcTextSize(sortByText).X;
@@ -224,12 +227,27 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
             // Shift down a little to align with the middle of the header text
             ImGui.SetCursorPosY(ImGui.GetCursorPosY() + (headerTextSize.Y / 4) - 2);
 
-            ImGui.SetCursorPosX(windowSize.X - sortSelectWidth - style.ItemSpacing.X - searchInputWidth);
+            ImGui.SetCursorPosX(windowSize.X - sortSelectWidth - style.ItemSpacing.X - searchInputWidth - searchClearButtonWidth);
+
+            var searchTextChanged = false;
             ImGui.SetNextItemWidth(searchInputWidth);
-            if (ImGui.InputTextWithHint("###XlPluginInstaller_Search", Locs.Header_SearchPlaceholder, ref this.searchText, 100))
+            searchTextChanged |= ImGui.InputTextWithHint(
+                "###XlPluginInstaller_Search",
+                Locs.Header_SearchPlaceholder,
+                ref this.searchText,
+                100);
+
+            ImGui.SameLine();
+
+            ImGui.SetNextItemWidth(searchClearButtonWidth);
+            if (ImGuiComponents.IconButton(FontAwesomeIcon.Times))
             {
-                this.UpdateCategoriesOnSearchChange();
+                this.searchText = string.Empty;
+                searchTextChanged = true;
             }
+
+            if (searchTextChanged)
+                this.UpdateCategoriesOnSearchChange();
 
             ImGui.SameLine();
             ImGui.SetCursorPosX(windowSize.X - sortSelectWidth);
@@ -552,7 +570,8 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
             var i = 0;
             foreach (var manifest in categoryManifestsList)
             {
-                var remoteManifest = manifest as RemotePluginManifest;
+                if (manifest is not RemotePluginManifest remoteManifest)
+                    continue;
                 var (isInstalled, plugin) = this.IsManifestInstalled(remoteManifest);
 
                 ImGui.PushID($"{manifest.InternalName}{manifest.AssemblyVersion}");
@@ -1087,51 +1106,38 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
 
             ImGui.SetCursorPos(startCursor);
 
-            var iconTex = this.imageCache.DefaultIcon;
-            var hasIcon = this.imageCache.TryGetIcon(plugin, manifest, isThirdParty, out var cachedIconTex);
-            if (hasIcon && cachedIconTex != null)
-            {
-                iconTex = cachedIconTex;
-            }
-
             var iconSize = ImGuiHelpers.ScaledVector2(64, 64);
-
             var cursorBeforeImage = ImGui.GetCursorPos();
-            ImGui.Image(iconTex.ImGuiHandle, iconSize);
-            ImGui.SameLine();
+            var rectOffset = ImGui.GetWindowContentRegionMin() + ImGui.GetWindowPos();
+            if (ImGui.IsRectVisible(rectOffset + cursorBeforeImage, rectOffset + cursorBeforeImage + iconSize))
+            {
+                var iconTex = this.imageCache.DefaultIcon;
+                var hasIcon = this.imageCache.TryGetIcon(plugin, manifest, isThirdParty, out var cachedIconTex);
+                if (hasIcon && cachedIconTex != null)
+                {
+                    iconTex = cachedIconTex;
+                }
+
+                ImGui.Image(iconTex.ImGuiHandle, iconSize);
+                ImGui.SameLine();
+                ImGui.SetCursorPos(cursorBeforeImage);
+            }
 
             var isLoaded = plugin is { IsLoaded: true };
 
             if (updateAvailable)
-            {
-                ImGui.SetCursorPos(cursorBeforeImage);
                 ImGui.Image(this.imageCache.UpdateIcon.ImGuiHandle, iconSize);
-                ImGui.SameLine();
-            }
             else if (trouble)
-            {
-                ImGui.SetCursorPos(cursorBeforeImage);
                 ImGui.Image(this.imageCache.TroubleIcon.ImGuiHandle, iconSize);
-                ImGui.SameLine();
-            }
             else if (isLoaded && isThirdParty)
-            {
-                ImGui.SetCursorPos(cursorBeforeImage);
                 ImGui.Image(this.imageCache.ThirdInstalledIcon.ImGuiHandle, iconSize);
-                ImGui.SameLine();
-            }
             else if (isThirdParty)
-            {
-                ImGui.SetCursorPos(cursorBeforeImage);
                 ImGui.Image(this.imageCache.ThirdIcon.ImGuiHandle, iconSize);
-                ImGui.SameLine();
-            }
             else if (isLoaded)
-            {
-                ImGui.SetCursorPos(cursorBeforeImage);
                 ImGui.Image(this.imageCache.InstalledIcon.ImGuiHandle, iconSize);
-                ImGui.SameLine();
-            }
+            else
+                ImGui.Dummy(iconSize);
+            ImGui.SameLine();
 
             ImGuiHelpers.ScaledDummy(5);
             ImGui.SameLine();
@@ -1208,23 +1214,32 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
             var startCursor = ImGui.GetCursorPos();
 
             var iconSize = ImGuiHelpers.ScaledVector2(64, 64);
-
-            TextureWrap icon;
-            if (log is PluginChangelogEntry pluginLog)
+            var cursorBeforeImage = ImGui.GetCursorPos();
+            var rectOffset = ImGui.GetWindowContentRegionMin() + ImGui.GetWindowPos();
+            if (ImGui.IsRectVisible(rectOffset + cursorBeforeImage, rectOffset + cursorBeforeImage + iconSize))
             {
-                icon = this.imageCache.DefaultIcon;
-                var hasIcon = this.imageCache.TryGetIcon(pluginLog.Plugin, pluginLog.Plugin.Manifest, pluginLog.Plugin.Manifest.IsThirdParty, out var cachedIconTex);
-                if (hasIcon && cachedIconTex != null)
+                TextureWrap icon;
+                if (log is PluginChangelogEntry pluginLog)
                 {
-                    icon = cachedIconTex;
+                    icon = this.imageCache.DefaultIcon;
+                    var hasIcon = this.imageCache.TryGetIcon(pluginLog.Plugin, pluginLog.Plugin.Manifest, pluginLog.Plugin.Manifest.IsThirdParty, out var cachedIconTex);
+                    if (hasIcon && cachedIconTex != null)
+                    {
+                        icon = cachedIconTex;
+                    }
                 }
+                else
+                {
+                    icon = this.imageCache.CorePluginIcon;
+                }
+
+                ImGui.Image(icon.ImGuiHandle, iconSize);
             }
             else
             {
-                icon = this.imageCache.CorePluginIcon;
+                ImGui.Dummy(iconSize);
             }
 
-            ImGui.Image(icon.ImGuiHandle, iconSize);
             ImGui.SameLine();
 
             ImGuiHelpers.ScaledDummy(5);

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -1644,7 +1644,7 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
 
                     this.installStatus = OperationStatus.InProgress;
 
-                    Task.Run(() => pluginManager.DeleteConfiguration(plugin))
+                    Task.Run(() => pluginManager.DeleteConfigurationAsync(plugin))
                         .ContinueWith(task =>
                         {
                             this.installStatus = OperationStatus.Idle;
@@ -1670,7 +1670,7 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
             // Disable everything if the plugin is outdated
             disabled = disabled || (plugin.IsOutdated && !configuration.LoadAllApiLevels) || plugin.IsBanned;
 
-            if (plugin.State == PluginState.InProgress)
+            if (plugin.State == PluginState.Loading || plugin.State == PluginState.Unloading)
             {
                 ImGuiComponents.DisabledButton(Locs.PluginButton_Working);
             }
@@ -1686,7 +1686,7 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
                     {
                         Task.Run(() =>
                         {
-                            var unloadTask = Task.Run(() => plugin.Unload())
+                            var unloadTask = Task.Run(() => plugin.UnloadAsync())
                                 .ContinueWith(this.DisplayErrorContinuation, Locs.ErrorModal_UnloadFail(plugin.Name));
 
                             unloadTask.Wait();

--- a/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
@@ -57,6 +57,8 @@ namespace Dalamud.Interface.Internal.Windows
         private int dtrSpacing;
         private bool dtrSwapDirection;
 
+        private int? pluginWaitBeforeFree;
+
         private List<ThirdPartyRepoSettings> thirdRepoList;
         private bool thirdRepoListChanged;
         private string thirdRepoTempUrl = string.Empty;
@@ -112,6 +114,8 @@ namespace Dalamud.Interface.Internal.Windows
 
             this.dtrSpacing = configuration.DtrSpacing;
             this.dtrSwapDirection = configuration.DtrSwapDirection;
+
+            this.pluginWaitBeforeFree = configuration.PluginWaitBeforeFree;
 
             this.doPluginTest = configuration.DoPluginTest;
             this.thirdRepoList = configuration.ThirdRepoList.Select(x => x.Clone()).ToList();
@@ -561,6 +565,32 @@ namespace Dalamud.Interface.Internal.Windows
             var configuration = Service<DalamudConfiguration>.Get();
             var pluginManager = Service<PluginManager>.Get();
 
+            var useCustomPluginWaitBeforeFree = this.pluginWaitBeforeFree.HasValue;
+            if (ImGui.Checkbox(
+                    Loc.Localize("DalamudSettingsPluginCustomizeWaitTime", "Customize wait time for plugin unload"),
+                    ref useCustomPluginWaitBeforeFree))
+            {
+                if (!useCustomPluginWaitBeforeFree)
+                    this.pluginWaitBeforeFree = null;
+                else
+                    this.pluginWaitBeforeFree = PluginManager.PluginWaitBeforeFreeDefault;
+            }
+
+            if (useCustomPluginWaitBeforeFree)
+            {
+                var waitTime = this.pluginWaitBeforeFree ?? PluginManager.PluginWaitBeforeFreeDefault;
+                if (ImGui.SliderInt(
+                        "Wait time###DalamudSettingsPluginCuistomizeWaitTimeSlider",
+                        ref waitTime,
+                        0,
+                        5000))
+                {
+                    this.pluginWaitBeforeFree = waitTime;
+                }
+            }
+
+            ImGuiHelpers.ScaledDummy(12);
+
             #region Plugin testing
 
             ImGui.Checkbox(Loc.Localize("DalamudSettingsPluginTest", "Get plugin testing builds"), ref this.doPluginTest);
@@ -973,6 +1003,8 @@ namespace Dalamud.Interface.Internal.Windows
 
             configuration.DtrSpacing = this.dtrSpacing;
             configuration.DtrSwapDirection = this.dtrSwapDirection;
+
+            configuration.PluginWaitBeforeFree = this.pluginWaitBeforeFree;
 
             configuration.DoPluginTest = this.doPluginTest;
             configuration.ThirdRepoList = this.thirdRepoList.Select(x => x.Clone()).ToList();

--- a/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SettingsWindow.cs
@@ -580,7 +580,7 @@ namespace Dalamud.Interface.Internal.Windows
             {
                 var waitTime = this.pluginWaitBeforeFree ?? PluginManager.PluginWaitBeforeFreeDefault;
                 if (ImGui.SliderInt(
-                        "Wait time###DalamudSettingsPluginCuistomizeWaitTimeSlider",
+                        "Wait time###DalamudSettingsPluginCustomizeWaitTimeSlider",
                         ref waitTime,
                         0,
                         5000))
@@ -588,6 +588,8 @@ namespace Dalamud.Interface.Internal.Windows
                     this.pluginWaitBeforeFree = waitTime;
                 }
             }
+
+            ImGui.TextColored(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsPluginCustomizeWaitTimeHint", "Configure the wait time between stopping plugin and completely unloading plugin. If you are experiencing crashes when exiting the game, try increasing this value."));
 
             ImGuiHelpers.ScaledDummy(12);
 

--- a/Dalamud/Interface/TitleScreenMenu.cs
+++ b/Dalamud/Interface/TitleScreenMenu.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using System.Linq;
+using System.Reflection;
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
 using ImGuiScene;
@@ -47,36 +48,139 @@ namespace Dalamud.Interface
                 throw new ArgumentException("Texture must be 64x64");
             }
 
-            var entry = new TitleScreenMenuEntry(text, texture, onTriggered);
-            this.entries.Add(entry);
-            return entry;
+            lock (this.entries)
+            {
+                var entriesOfAssembly = this.entries.Where(x => x.CallingAssembly == Assembly.GetCallingAssembly()).ToList();
+                var priority = entriesOfAssembly.Any()
+                                   ? unchecked(entriesOfAssembly.Select(x => x.Priority).Max() + 1)
+                                   : 0;
+                var entry = new TitleScreenMenuEntry(Assembly.GetCallingAssembly(), priority, text, texture, onTriggered);
+                var i = this.entries.BinarySearch(entry);
+                if (i < 0)
+                    i = ~i;
+                this.entries.Insert(i, entry);
+                return entry;
+            }
+        }
+
+        /// <summary>
+        /// Adds a new entry to the title screen menu.
+        /// </summary>
+        /// <param name="priority">Priority of the entry.</param>
+        /// <param name="text">The text to show.</param>
+        /// <param name="texture">The texture to show.</param>
+        /// <param name="onTriggered">The action to execute when the option is selected.</param>
+        /// <returns>A <see cref="TitleScreenMenu"/> object that can be used to manage the entry.</returns>
+        /// <exception cref="ArgumentException">Thrown when the texture provided does not match the required resolution(64x64).</exception>
+        public TitleScreenMenuEntry AddEntry(ulong priority, string text, TextureWrap texture, Action onTriggered)
+        {
+            if (texture.Height != TextureSize || texture.Width != TextureSize)
+            {
+                throw new ArgumentException("Texture must be 64x64");
+            }
+
+            lock (this.entries)
+            {
+                var entry = new TitleScreenMenuEntry(Assembly.GetCallingAssembly(), priority, text, texture, onTriggered);
+                var i = this.entries.BinarySearch(entry);
+                if (i < 0)
+                    i = ~i;
+                this.entries.Insert(i, entry);
+                return entry;
+            }
         }
 
         /// <summary>
         /// Remove an entry from the title screen menu.
         /// </summary>
         /// <param name="entry">The entry to remove.</param>
-        public void RemoveEntry(TitleScreenMenuEntry entry) => this.entries.Remove(entry);
+        public void RemoveEntry(TitleScreenMenuEntry entry)
+        {
+            lock (this.entries)
+            {
+                this.entries.Remove(entry);
+            }
+        }
+
+        /// <summary>
+        /// Adds a new entry to the title screen menu.
+        /// </summary>
+        /// <param name="priority">Priority of the entry.</param>
+        /// <param name="text">The text to show.</param>
+        /// <param name="texture">The texture to show.</param>
+        /// <param name="onTriggered">The action to execute when the option is selected.</param>
+        /// <returns>A <see cref="TitleScreenMenu"/> object that can be used to manage the entry.</returns>
+        /// <exception cref="ArgumentException">Thrown when the texture provided does not match the required resolution(64x64).</exception>
+        internal TitleScreenMenuEntry AddEntryCore(ulong priority, string text, TextureWrap texture, Action onTriggered)
+        {
+            if (texture.Height != TextureSize || texture.Width != TextureSize)
+            {
+                throw new ArgumentException("Texture must be 64x64");
+            }
+
+            lock (this.entries)
+            {
+                var entry = new TitleScreenMenuEntry(null, priority, text, texture, onTriggered);
+                this.entries.Add(entry);
+                return entry;
+            }
+        }
+
+        /// <summary>
+        /// Adds a new entry to the title screen menu.
+        /// </summary>
+        /// <param name="text">The text to show.</param>
+        /// <param name="texture">The texture to show.</param>
+        /// <param name="onTriggered">The action to execute when the option is selected.</param>
+        /// <returns>A <see cref="TitleScreenMenu"/> object that can be used to manage the entry.</returns>
+        /// <exception cref="ArgumentException">Thrown when the texture provided does not match the required resolution(64x64).</exception>
+        internal TitleScreenMenuEntry AddEntryCore(string text, TextureWrap texture, Action onTriggered)
+        {
+            if (texture.Height != TextureSize || texture.Width != TextureSize)
+            {
+                throw new ArgumentException("Texture must be 64x64");
+            }
+
+            lock (this.entries)
+            {
+                var entriesOfAssembly = this.entries.Where(x => x.CallingAssembly == null).ToList();
+                var priority = entriesOfAssembly.Any()
+                                   ? unchecked(entriesOfAssembly.Select(x => x.Priority).Max() + 1)
+                                   : 0;
+                var entry = new TitleScreenMenuEntry(null, priority, text, texture, onTriggered);
+                this.entries.Add(entry);
+                return entry;
+            }
+        }
 
         /// <summary>
         /// Class representing an entry in the title screen menu.
         /// </summary>
-        public class TitleScreenMenuEntry
+        public class TitleScreenMenuEntry : IComparable<TitleScreenMenuEntry>
         {
             private readonly Action onTriggered;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="TitleScreenMenuEntry"/> class.
             /// </summary>
+            /// <param name="callingAssembly">The calling assembly.</param>
+            /// <param name="priority">The priority of this entry.</param>
             /// <param name="text">The text to show.</param>
             /// <param name="texture">The texture to show.</param>
             /// <param name="onTriggered">The action to execute when the option is selected.</param>
-            internal TitleScreenMenuEntry(string text, TextureWrap texture, Action onTriggered)
+            internal TitleScreenMenuEntry(Assembly? callingAssembly, ulong priority, string text, TextureWrap texture, Action onTriggered)
             {
+                this.CallingAssembly = callingAssembly;
+                this.Priority = priority;
                 this.Name = text;
                 this.Texture = texture;
                 this.onTriggered = onTriggered;
             }
+
+            /// <summary>
+            /// Gets the priority of this entry.
+            /// </summary>
+            public ulong Priority { get; init; }
 
             /// <summary>
             /// Gets or sets the name of this entry.
@@ -89,6 +193,11 @@ namespace Dalamud.Interface
             public TextureWrap Texture { get; set; }
 
             /// <summary>
+            /// Gets the calling assembly of this entry.
+            /// </summary>
+            internal Assembly? CallingAssembly { get; init; }
+
+            /// <summary>
             /// Gets the internal ID of this entry.
             /// </summary>
             internal Guid Id { get; init; } = Guid.NewGuid();
@@ -99,6 +208,32 @@ namespace Dalamud.Interface
             internal void Trigger()
             {
                 this.onTriggered();
+            }
+
+            /// <inheritdoc/>
+            public int CompareTo(TitleScreenMenuEntry? other)
+            {
+                if (other == null)
+                    return 1;
+                if (this.CallingAssembly != other.CallingAssembly)
+                {
+                    if (this.CallingAssembly == null && other.CallingAssembly == null)
+                        return 0;
+                    if (this.CallingAssembly == null && other.CallingAssembly != null)
+                        return -1;
+                    if (this.CallingAssembly != null && other.CallingAssembly == null)
+                        return 1;
+                    return string.Compare(
+                        this.CallingAssembly!.FullName!,
+                        other.CallingAssembly!.FullName!,
+                        StringComparison.CurrentCultureIgnoreCase);
+                }
+
+                if (this.Priority != other.Priority)
+                    return this.Priority.CompareTo(other.Priority);
+                if (this.Name != other.Name)
+                    return string.Compare(this.Name, other.Name, StringComparison.InvariantCultureIgnoreCase);
+                return string.Compare(this.Name, other.Name, StringComparison.InvariantCulture);
             }
         }
     }

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -24,6 +24,8 @@ namespace Dalamud.Interface
     {
         private readonly Stopwatch stopwatch;
         private readonly string namespaceName;
+        private readonly InterfaceManager interfaceManager = Service<InterfaceManager>.Get();
+        private readonly GameFontManager gameFontManager = Service<GameFontManager>.Get();
 
         private bool hasErrorWindow = false;
         private bool lastFrameUiHideState = false;
@@ -38,11 +40,10 @@ namespace Dalamud.Interface
             this.stopwatch = new Stopwatch();
             this.namespaceName = namespaceName;
 
-            var interfaceManager = Service<InterfaceManager>.Get();
-            interfaceManager.Draw += this.OnDraw;
-            interfaceManager.BuildFonts += this.OnBuildFonts;
-            interfaceManager.AfterBuildFonts += this.OnAfterBuildFonts;
-            interfaceManager.ResizeBuffers += this.OnResizeBuffers;
+            this.interfaceManager.Draw += this.OnDraw;
+            this.interfaceManager.BuildFonts += this.OnBuildFonts;
+            this.interfaceManager.AfterBuildFonts += this.OnAfterBuildFonts;
+            this.interfaceManager.ResizeBuffers += this.OnResizeBuffers;
         }
 
         /// <summary>
@@ -109,12 +110,12 @@ namespace Dalamud.Interface
         /// <summary>
         /// Gets the game's active Direct3D device.
         /// </summary>
-        public Device Device => Service<InterfaceManager.InterfaceManagerWithScene>.Get().Manager.Device!;
+        public Device Device => this.InterfaceManagerWithScene.Device!;
 
         /// <summary>
         /// Gets the game's main window handle.
         /// </summary>
-        public IntPtr WindowHandlePtr => Service<InterfaceManager.InterfaceManagerWithScene>.Get().Manager.WindowHandlePtr;
+        public IntPtr WindowHandlePtr => this.InterfaceManagerWithScene.WindowHandlePtr;
 
         /// <summary>
         /// Gets or sets a value indicating whether this plugin should hide its UI automatically when the game's UI is hidden.
@@ -141,8 +142,8 @@ namespace Dalamud.Interface
         /// </summary>
         public bool OverrideGameCursor
         {
-            get => Service<InterfaceManager>.Get().OverrideGameCursor;
-            set => Service<InterfaceManager>.Get().OverrideGameCursor = value;
+            get => this.interfaceManager.OverrideGameCursor;
+            set => this.interfaceManager.OverrideGameCursor = value;
         }
 
         /// <summary>
@@ -157,7 +158,9 @@ namespace Dalamud.Interface
         {
             get
             {
-                var condition = Service<Condition>.Get();
+                var condition = Service<Condition>.GetNullable();
+                if (condition == null)
+                    return false;
                 return condition[ConditionFlag.OccupiedInCutSceneEvent]
                        || condition[ConditionFlag.WatchingCutscene78];
             }
@@ -170,7 +173,9 @@ namespace Dalamud.Interface
         {
             get
             {
-                var condition = Service<Condition>.Get();
+                var condition = Service<Condition>.GetNullable();
+                if (condition == null)
+                    return false;
                 return condition[ConditionFlag.WatchingCutscene];
             }
         }
@@ -178,7 +183,7 @@ namespace Dalamud.Interface
         /// <summary>
         /// Gets a value indicating whether this plugin should modify the game's interface at this time.
         /// </summary>
-        public bool ShouldModifyUi => Service<InterfaceManager>.GetNullable()?.IsDispatchingEvents ?? true;
+        public bool ShouldModifyUi => this.interfaceManager.IsDispatchingEvents;
 
         /// <summary>
         /// Gets or sets a value indicating whether statistics about UI draw time should be collected.
@@ -209,21 +214,22 @@ namespace Dalamud.Interface
         /// </summary>
         internal List<long> DrawTimeHistory { get; set; } = new List<long>();
 
+        private InterfaceManager InterfaceManagerWithScene =>
+            Service<InterfaceManager.InterfaceManagerWithScene>.Get().Manager;
+
         /// <summary>
         /// Loads an image from the specified file.
         /// </summary>
         /// <param name="filePath">The full filepath to the image.</param>
         /// <returns>A <see cref="TextureWrap"/> object wrapping the created image.  Use <see cref="TextureWrap.ImGuiHandle"/> inside ImGui.Image().</returns>
-        public TextureWrap LoadImage(string filePath)
-            => Service<InterfaceManager.InterfaceManagerWithScene>.Get().Manager.LoadImage(filePath);
+        public TextureWrap LoadImage(string filePath) => this.InterfaceManagerWithScene.LoadImage(filePath);
 
         /// <summary>
         /// Loads an image from a byte stream, such as a png downloaded into memory.
         /// </summary>
         /// <param name="imageData">A byte array containing the raw image data.</param>
         /// <returns>A <see cref="TextureWrap"/> object wrapping the created image.  Use <see cref="TextureWrap.ImGuiHandle"/> inside ImGui.Image().</returns>
-        public TextureWrap LoadImage(byte[] imageData)
-            => Service<InterfaceManager.InterfaceManagerWithScene>.Get().Manager.LoadImage(imageData);
+        public TextureWrap LoadImage(byte[] imageData) => this.InterfaceManagerWithScene.LoadImage(imageData);
 
         /// <summary>
         /// Loads an image from raw unformatted pixel data, with no type or header information.  To load formatted data, use <see cref="LoadImage(byte[])"/>.
@@ -234,14 +240,14 @@ namespace Dalamud.Interface
         /// <param name="numChannels">The number of channels (bytes per pixel) of the image contained in <paramref name="imageData"/>.  This should usually be 4.</param>
         /// <returns>A <see cref="TextureWrap"/> object wrapping the created image.  Use <see cref="TextureWrap.ImGuiHandle"/> inside ImGui.Image().</returns>
         public TextureWrap LoadImageRaw(byte[] imageData, int width, int height, int numChannels)
-            => Service<InterfaceManager.InterfaceManagerWithScene>.Get().Manager.LoadImageRaw(imageData, width, height, numChannels);
+            => this.InterfaceManagerWithScene.LoadImageRaw(imageData, width, height, numChannels);
 
         /// <summary>
         /// Gets a game font.
         /// </summary>
         /// <param name="style">Font to get.</param>
         /// <returns>Handle to the game font which may or may not be available for use yet.</returns>
-        public GameFontHandle GetGameFontHandle(GameFontStyle style) => Service<GameFontManager>.Get().NewFontRef(style);
+        public GameFontHandle GetGameFontHandle(GameFontStyle style) => this.gameFontManager.NewFontRef(style);
 
         /// <summary>
         /// Call this to queue a rebuild of the font atlas.<br/>
@@ -251,7 +257,7 @@ namespace Dalamud.Interface
         public void RebuildFonts()
         {
             Log.Verbose("[FONT] {0} plugin is initiating FONT REBUILD", this.namespaceName);
-            Service<InterfaceManager>.Get().RebuildFonts();
+            this.interfaceManager.RebuildFonts();
         }
 
         /// <summary>
@@ -262,19 +268,25 @@ namespace Dalamud.Interface
         /// <param name="type">The type of the notification.</param>
         /// <param name="msDelay">The time the notification should be displayed for.</param>
         public void AddNotification(
-            string content, string? title = null, NotificationType type = NotificationType.None, uint msDelay = 3000) =>
-            Service<NotificationManager>.Get().AddNotification(content, title, type, msDelay);
+            string content, string? title = null, NotificationType type = NotificationType.None, uint msDelay = 3000)
+        {
+            Service<NotificationManager>
+                .GetAsync()
+                .ContinueWith(task =>
+                {
+                    if (task.IsCompletedSuccessfully)
+                        task.Result.AddNotification(content, title, type, msDelay);
+                });
+        }
 
         /// <summary>
         /// Unregister the UiBuilder. Do not call this in plugin code.
         /// </summary>
         void IDisposable.Dispose()
         {
-            var interfaceManager = Service<InterfaceManager>.Get();
-
-            interfaceManager.Draw -= this.OnDraw;
-            interfaceManager.BuildFonts -= this.OnBuildFonts;
-            interfaceManager.ResizeBuffers -= this.OnResizeBuffers;
+            this.interfaceManager.Draw -= this.OnDraw;
+            this.interfaceManager.BuildFonts -= this.OnBuildFonts;
+            this.interfaceManager.ResizeBuffers -= this.OnResizeBuffers;
         }
 
         /// <summary>
@@ -304,8 +316,9 @@ namespace Dalamud.Interface
         private void OnDraw()
         {
             var configuration = Service<DalamudConfiguration>.Get();
-            var gameGui = Service<GameGui>.Get();
-            var interfaceManager = Service<InterfaceManager>.Get();
+            var gameGui = Service<GameGui>.GetNullable();
+            if (gameGui == null)
+                return;
 
             if ((gameGui.GameUiHidden && configuration.ToggleUiHide &&
                  !(this.DisableUserUiHide || this.DisableAutomaticUiHide)) ||
@@ -329,7 +342,7 @@ namespace Dalamud.Interface
                 this.ShowUi?.Invoke();
             }
 
-            if (!interfaceManager.FontsReady)
+            if (!this.interfaceManager.FontsReady)
                 return;
 
             ImGui.PushID(this.namespaceName);

--- a/Dalamud/Logging/Internal/TaskTracker.cs
+++ b/Dalamud/Logging/Internal/TaskTracker.cs
@@ -20,6 +20,9 @@ namespace Dalamud.Logging.Internal
         private static readonly ConcurrentQueue<TaskInfo> NewlyCreatedTasks = new();
         private static bool clearRequested = false;
 
+        [ServiceManager.ServiceDependency]
+        private readonly Framework framework = Service<Framework>.Get();
+
         private MonoMod.RuntimeDetour.Hook? scheduleAndStartHook;
         private bool enabled = false;
 
@@ -111,8 +114,7 @@ namespace Dalamud.Logging.Internal
 
             this.ApplyPatch();
 
-            var framework = Service<Framework>.Get();
-            framework.Update += this.FrameworkOnUpdate;
+            this.framework.Update += this.FrameworkOnUpdate;
             this.enabled = true;
         }
 
@@ -121,8 +123,7 @@ namespace Dalamud.Logging.Internal
         {
             this.scheduleAndStartHook?.Dispose();
 
-            var framework = Service<Framework>.Get();
-            framework.Update -= this.FrameworkOnUpdate;
+            this.framework.Update -= this.FrameworkOnUpdate;
         }
 
         private static bool AddToActiveTasksHook(Func<Task, bool> orig, Task self)

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -15,6 +15,7 @@ using Dalamud.Game.Text.Sanitizer;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Interface;
+using Dalamud.Interface.GameFonts;
 using Dalamud.Interface.Internal;
 using Dalamud.Plugin.Internal;
 using Dalamud.Plugin.Ipc;

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -207,7 +207,7 @@ internal partial class PluginManager : IDisposable, IServiceType
     /// <inheritdoc/>
     public void Dispose()
     {
-        foreach (var plugin in this.InstalledPlugins)
+        Task.WaitAll(this.InstalledPlugins.Select(plugin => Task.Run(() =>
         {
             try
             {
@@ -217,7 +217,7 @@ internal partial class PluginManager : IDisposable, IServiceType
             {
                 Log.Error(ex, $"Error disposing {plugin.Name}");
             }
-        }
+        })).ToArray());
 
         this.assemblyLocationMonoHook?.Dispose();
         this.assemblyCodeBaseMonoHook?.Dispose();

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -38,6 +38,11 @@ internal partial class PluginManager : IDisposable, IServiceType
     /// </summary>
     public const int DalamudApiLevel = 6;
 
+    /// <summary>
+    /// Default time to wait between plugin unload and plugin assembly unload.
+    /// </summary>
+    public const int PluginWaitBeforeFreeDefault = 500;
+
     private static readonly ModuleLog Log = new("PLUGINM");
 
     private readonly object pluginListLock = new();
@@ -219,7 +224,7 @@ internal partial class PluginManager : IDisposable, IServiceType
         {
             try
             {
-                plugin.UnloadAsync(true).Wait();
+                plugin.UnloadAsync(true, false).Wait();
             }
             catch (Exception ex)
             {
@@ -233,7 +238,7 @@ internal partial class PluginManager : IDisposable, IServiceType
                          {
                              try
                              {
-                                 await plugin.UnloadAsync(true);
+                                 await plugin.UnloadAsync(true, false);
                              }
                              catch (Exception ex)
                              {
@@ -243,7 +248,7 @@ internal partial class PluginManager : IDisposable, IServiceType
 
         // Just in case plugins still have tasks running that they didn't cancel when they should have,
         // give them some time to complete it.
-        Thread.Sleep(500);
+        Thread.Sleep(this.configuration.PluginWaitBeforeFree ?? PluginWaitBeforeFreeDefault);
 
         // Now that we've waited enough, dispose the whole plugin.
         // Since plugins should have been unloaded above, this should be done quickly. 

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -207,6 +207,13 @@ internal partial class PluginManager : IDisposable, IServiceType
     /// <inheritdoc/>
     public void Dispose()
     {
+        if (!this.InstalledPlugins.Any())
+        {
+            this.assemblyLocationMonoHook?.Dispose();
+            this.assemblyCodeBaseMonoHook?.Dispose();
+            return;
+        }
+
         // Unload them first, just in case some of plugin codes are still running via callbacks initiated externally.
         foreach (var plugin in this.InstalledPlugins.Where(plugin => !plugin.Manifest.CanUnloadAsync))
         {

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -213,8 +213,17 @@ internal class LocalPlugin : IDisposable
     /// <inheritdoc/>
     public void Dispose()
     {
-        this.instance?.Dispose();
-        this.instance = null;
+        var framework = Service<Framework>.GetNullable();
+
+        if (this.instance != null)
+        {
+            if (this.Manifest.CanUnloadAsync || framework == null)
+                this.instance.Dispose();
+            else
+                framework.RunOnFrameworkThread(() => this.instance.Dispose()).Wait();
+
+            this.instance = null;
+        }
 
         this.DalamudInterface?.ExplicitDispose();
         this.DalamudInterface = null;

--- a/Dalamud/Plugin/Internal/Types/PluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginManifest.cs
@@ -157,6 +157,12 @@ internal record PluginManifest
     public int LoadPriority { get; init; }
 
     /// <summary>
+    /// Gets a value indicating whether the plugin can be unloaded asynchronously. 
+    /// </summary>
+    [JsonProperty]
+    public bool CanUnloadAsync { get; init; }
+
+    /// <summary>
     /// Gets a list of screenshot image URLs to show in the plugin installer.
     /// </summary>
     public List<string>? ImageUrls { get; init; }

--- a/Dalamud/Plugin/Internal/Types/PluginState.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginState.cs
@@ -16,9 +16,9 @@ internal enum PluginState
     UnloadError,
 
     /// <summary>
-    /// Currently loading.
+    /// Currently unloading.
     /// </summary>
-    InProgress,
+    Unloading,
 
     /// <summary>
     /// Load is successful.
@@ -29,4 +29,9 @@ internal enum PluginState
     /// Plugin has thrown an error during loading.
     /// </summary>
     LoadError,
+
+    /// <summary>
+    /// Currently loading.
+    /// </summary>
+    Loading,
 }

--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -15,6 +15,7 @@ using Dalamud.Game;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
+using Dalamud.Logging.Internal;
 using ImGuiNET;
 using Microsoft.Win32;
 using Serilog;
@@ -534,6 +535,31 @@ namespace Dalamud.Utility
         internal static void ExplicitDispose<T>(this T obj) where T : IDisposable
         {
             obj.Dispose();
+        }
+
+        /// <summary>
+        /// Dispose this object.
+        /// </summary>
+        /// <param name="obj">The object to dispose.</param>
+        /// <param name="logMessage">Log message to print, if specified and an error occurs.</param>
+        /// <param name="moduleLog">Module logger, if any.</param>
+        /// <typeparam name="T">The type of object to dispose.</typeparam>
+        internal static void ExplicitDisposeIgnoreExceptions<T>(this T obj, string? logMessage = null, ModuleLog? moduleLog = null) where T : IDisposable
+        {
+            try
+            {
+                obj.Dispose();
+            }
+            catch (Exception e)
+            {
+                if (logMessage == null)
+                    return;
+
+                if (moduleLog != null)
+                    moduleLog.Error(e, logMessage);
+                else
+                    Log.Error(e, logMessage);
+            }
         }
 
         private static unsafe void ShowValue(ulong addr, IEnumerable<string> path, Type type, object value)


### PR DESCRIPTION
* Added Clear button next to search input text box in Plugin Installer.
* Added an option to make Serilog log synchronously without any additional buffering else than operating system level buffers.
* Added an xivfix that will prevent the game from ending up corrupting configuration data when it crashes while saving.
    * This will make xiv write to .new files when it's trying to write to .cfg or .dat files, and then rename those .new files into original filenames after the game is done writing.
* Made Plugin Installer download up to 8 images concurrently, but only for visible images. Images for the items that aren't visible won't be downloaded until scrolled.
* Made TitleScreenMenu order stable.
* Made Dalamud Unload reliably work, and made it quicker, by forcing all Service{T}.Dispose to run in Framework.Tick if invoked manually, or during Framework.Destroy if invoked by game quit.
* Made hook create/dispose/enable/disable run in synchronized blocks.
* Made Dalamud wait 0.5 seconds by default for plugins after Plugin.Dispose before Loader.Dispose. Wait time is configurable via Experimental tab.
    * If a plugin results in a crash when this value is set to zero, that plugin needs to be fixed to properly cancel and wait for all Tasks that plugin has fired.
* Ensured plugin to load in the context of Framework.Tick if synchronous load is requested, except when plugin's load mode is 2 (anytime).