### PR TITLE
Bump Reloaded.Hooks and dependencies to 4.0.1

### DIFF
--- a/Dalamud.Injector/Dalamud.Injector.csproj
+++ b/Dalamud.Injector/Dalamud.Injector.csproj
@@ -64,8 +64,8 @@
         <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="PeNet" Version="2.6.4" />
-        <PackageReference Include="Reloaded.Memory" Version="4.1.1" />
-        <PackageReference Include="Reloaded.Memory.Buffers" Version="1.4.4" />
+        <PackageReference Include="Reloaded.Memory" Version="7.0.0" />
+        <PackageReference Include="Reloaded.Memory.Buffers" Version="2.0.0" />
         <PackageReference Include="Serilog" Version="2.11.0" />
         <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />

--- a/Dalamud.Injector/EntryPoint.cs
+++ b/Dalamud.Injector/EntryPoint.cs
@@ -726,7 +726,7 @@ namespace Dalamud.Injector
             using var startInfoBuffer = new MemoryBufferHelper(process).CreatePrivateMemoryBuffer(startInfoBytes.Length + 0x8);
             var startInfoAddress = startInfoBuffer.Add(startInfoBytes);
 
-            if (startInfoAddress == IntPtr.Zero)
+            if (startInfoAddress == UIntPtr.Zero)
                 throw new Exception("Unable to allocate start info JSON");
 
             injector.GetFunctionAddress(bootModule, "Initialize", out var initAddress);

--- a/Dalamud.Injector/NativeFunctions.cs
+++ b/Dalamud.Injector/NativeFunctions.cs
@@ -661,8 +661,8 @@ namespace Dalamud.Injector
             IntPtr hProcess,
             IntPtr lpThreadAttributes,
             UIntPtr dwStackSize,
-            IntPtr lpStartAddress,
-            IntPtr lpParameter,
+            UIntPtr lpStartAddress,
+            UIntPtr lpParameter,
             CreateThreadFlags dwCreationFlags,
             out uint lpThreadId);
 

--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -74,7 +74,7 @@
         <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-        <PackageReference Include="Reloaded.Hooks" Version="3.5.3" />
+        <PackageReference Include="Reloaded.Hooks" Version="4.0.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Also takes care of some minor breaking API changes (mostly `IntPtr` -> `UIntPtr`)

This update adds Large Address Awareness Support (probably irrelevant for Dalamud), but includes some fixes for the memory page cache which should hopefully help with certain edge cases where allocating memory with Penumbra could fail (on wine).