### PR TITLE
fix: wrong version displaying in the installer

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginChangelogEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginChangelogEntry.cs
@@ -21,10 +21,9 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
             if (plugin.Manifest.Changelog.IsNullOrEmpty())
                 throw new ArgumentException("Manifest has no changelog.");
 
-            var version = plugin.AssemblyName?.Version;
-            version ??= plugin.Manifest.Testing
-                            ? plugin.Manifest.TestingAssemblyVersion
-                            : plugin.Manifest.AssemblyVersion;
+            var version = plugin.Manifest.Testing
+                              ? plugin.Manifest.TestingAssemblyVersion
+                              : plugin.Manifest.AssemblyVersion;
 
             this.Version = version!.ToString();
         }

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -1616,10 +1616,9 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
                     this.DrawUpdateSinglePluginButton(availablePluginUpdate);
 
                 ImGui.SameLine();
-                var version = plugin.AssemblyName?.Version;
-                version ??= plugin.Manifest.Testing
-                                ? plugin.Manifest.TestingAssemblyVersion
-                                : plugin.Manifest.AssemblyVersion;
+                var version = plugin.Manifest.Testing
+                                  ? plugin.Manifest.TestingAssemblyVersion
+                                  : plugin.Manifest.AssemblyVersion;
                 ImGui.TextColored(ImGuiColors.DalamudGrey3, $" v{version}");
 
                 if (plugin.IsDev)
@@ -2308,7 +2307,7 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
             public static string PluginTitleMod_OutdatedError => Loc.Localize("InstallerOutdatedError", " (outdated)");
 
             public static string PluginTitleMod_BannedError => Loc.Localize("InstallerBannedError", " (automatically disabled)");
-            
+
             public static string PluginTitleMod_OrphanedError => Loc.Localize("InstallerOrphanedError", " (unknown repository)");
 
             public static string PluginTitleMod_New => Loc.Localize("InstallerNewPlugin ", " New!");


### PR DESCRIPTION
Assembly version sometimes doesn't reflect the actual plugin version. The manifest should always be correct though, unless I'm mistaken.