### PR TITLE
Change visibility for MarketBoardPurchase and MarketBoardPurchaseHandler Struct

### DIFF
--- a/Dalamud/Game/Network/Structures/MarketBoardPurchase.cs
+++ b/Dalamud/Game/Network/Structures/MarketBoardPurchase.cs
@@ -7,7 +7,7 @@ namespace Dalamud.Game.Network.Structures
     /// Represents market board purchase information. This message is received from the
     /// server when a purchase is made at a market board.
     /// </summary>
-    internal class MarketBoardPurchase
+    public class MarketBoardPurchase
     {
         private MarketBoardPurchase()
         {

--- a/Dalamud/Game/Network/Structures/MarketBoardPurchaseHandler.cs
+++ b/Dalamud/Game/Network/Structures/MarketBoardPurchaseHandler.cs
@@ -7,7 +7,7 @@ namespace Dalamud.Game.Network.Structures
     /// Represents market board purchase information. This message is sent from the
     /// client when a purchase is made at a market board.
     /// </summary>
-    internal class MarketBoardPurchaseHandler
+    public class MarketBoardPurchaseHandler
     {
         private MarketBoardPurchaseHandler()
         {


### PR DESCRIPTION
Makes it easier to check what item an user just purchased from the marketboard, with details like price, without having to refresh the history again, reducing requests to the ff servers