### PR TITLE
Rework plugin deletion + misc

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -1884,7 +1884,10 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
 
                             unloadTask.Wait();
                             if (!unloadTask.Result)
+                            {
+                                this.enableDisableStatus = OperationStatus.Complete;
                                 return;
+                            }
 
                             var disableTask = Task.Run(() => plugin.Disable())
                                                   .ContinueWith(this.DisplayErrorContinuation, Locs.ErrorModal_DisableFail(plugin.Name));
@@ -1910,7 +1913,10 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
 
                             enableTask.Wait();
                             if (!enableTask.Result)
+                            {
+                                this.enableDisableStatus = OperationStatus.Complete;
                                 return;
+                            }
 
                             var loadTask = Task.Run(() => plugin.LoadAsync(PluginLoadReason.Installer))
                                                .ContinueWith(this.DisplayErrorContinuation, Locs.ErrorModal_LoadFail(plugin.Name));
@@ -2455,7 +2461,7 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
             public static string PluginTitleMod_OutdatedError => Loc.Localize("InstallerOutdatedError", " (outdated)");
 
             public static string PluginTitleMod_BannedError => Loc.Localize("InstallerBannedError", " (automatically disabled)");
-            
+
             public static string PluginTitleMod_OrphanedError => Loc.Localize("InstallerOrphanedError", " (unknown repository)");
 
             public static string PluginTitleMod_New => Loc.Localize("InstallerNewPlugin ", " New!");

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -1614,7 +1614,8 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
             }
 
             // Load error
-            if (plugin.State is PluginState.LoadError or PluginState.DependencyResolutionFailed && plugin.CheckPolicy())
+            if (plugin.State is PluginState.LoadError or PluginState.DependencyResolutionFailed && plugin.CheckPolicy()
+                && !plugin.IsOutdated && !plugin.IsBanned && !plugin.IsOrphaned)
             {
                 label += Locs.PluginTitleMod_LoadError;
                 trouble = true;

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -872,6 +872,21 @@ internal partial class PluginManager : IDisposable, IServiceType
                             {
                                 Log.Information($"Missing manifest: cleaning up {versionDir.FullName}");
                                 versionDir.Delete(true);
+                                continue;
+                            }
+
+                            if (manifestFile.Length == 0)
+                            {
+                                Log.Information($"Manifest empty: cleaning up {versionDir.FullName}");
+                                versionDir.Delete(true);
+                                continue;
+                            }
+
+                            var manifest = LocalPluginManifest.Load(manifestFile);
+                            if (manifest.ScheduledForDeletion)
+                            {
+                                Log.Information($"Scheduled deletion: cleaning up {versionDir.FullName}");
+                                versionDir.Delete(true);
                             }
                         }
                         catch (Exception ex)
@@ -907,6 +922,9 @@ internal partial class PluginManager : IDisposable, IServiceType
                 continue;
 
             if (plugin.InstalledPlugin.Manifest.Disabled && ignoreDisabled)
+                continue;
+
+            if (plugin.InstalledPlugin.Manifest.ScheduledForDeletion)
                 continue;
 
             var result = await this.UpdateSinglePluginAsync(plugin, false, dryRun);

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -848,10 +848,17 @@ internal partial class PluginManager : IDisposable, IServiceType
                 }
                 else
                 {
-                    foreach (var versionDir in versionDirs)
+                    for (var i = 0; i < versionDirs.Length; i++)
                     {
+                        var versionDir = versionDirs[i];
                         try
                         {
+                            if (i != 0)
+                            {
+                                Log.Information($"Old version: cleaning up {versionDir.FullName}");
+                                versionDir.Delete(true);
+                                continue;
+                            }
                             var dllFile = new FileInfo(Path.Combine(versionDir.FullName, $"{pluginDir.Name}.dll"));
                             if (!dllFile.Exists)
                             {

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -560,6 +560,7 @@ internal class LocalPlugin : IDisposable
             throw new InvalidPluginOperationException($"Unable to enable {this.Name}, not disabled");
 
         this.Manifest.Disabled = false;
+        this.Manifest.ScheduledForDeletion = false;
         this.SaveManifest();
     }
 
@@ -611,6 +612,16 @@ internal class LocalPlugin : IDisposable
             throw new InvalidPluginOperationException($"Unable to disable {this.Name}, already disabled");
 
         this.Manifest.Disabled = true;
+        this.SaveManifest();
+    }
+
+    /// <summary>
+    /// Schedule the deletion of this plugin on next cleanup.
+    /// </summary>
+    /// <param name="status">Schedule or cancel the deletion.</param>
+    public void ScheduleDeletion(bool status = true)
+    {
+        this.Manifest.ScheduledForDeletion = status;
         this.SaveManifest();
     }
 

--- a/Dalamud/Plugin/Internal/Types/LocalPluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPluginManifest.cs
@@ -25,6 +25,11 @@ internal record LocalPluginManifest : PluginManifest
     public bool Testing { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the plugin should be deleted during the next cleanup.
+    /// </summary>
+    public bool ScheduledForDeletion { get; set; }
+
+    /// <summary>
     /// Gets or sets the 3rd party repo URL that this plugin was installed from. Used to display where the plugin was
     /// sourced from on the installed plugin view. This should not be included in the plugin master. This value is null
     /// when installed from the main repo.


### PR DESCRIPTION
Allows to always use the trash button as long as the plugin is disabled, but only schedules the deletion (except for dev plugins).
If the plugin has no error, it is simply removed from the plugin list.
If it does have an error, the plugin stays in the plugin list with a (scheduled for deletion) tag in the installer.

I've tried to limit big code changes, so it's easy to read and tested it with multiple scenarios, but if you see anything weird, don't hesitate to ask.