### PR TITLE
Persistent plugin feedback contact details

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -333,6 +333,11 @@ namespace Dalamud.Configuration.Internal
         public bool ShowDevBarInfo { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets the last-used contact details for the plugin feedback form.
+        /// </summary>
+        public string LastFeedbackContactDetails { get; set; } = string.Empty;
+
+        /// <summary>
         /// Load a configuration from the provided path.
         /// </summary>
         /// <param name="path">The path to load the configuration file from.</param>

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -666,6 +666,11 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
                             Log.Error("FeedbackPlugin was null.");
                         }
 
+                        if (!string.IsNullOrWhiteSpace(this.feedbackModalContact))
+                        {
+                            Service<DalamudConfiguration>.Get().LastFeedbackContactDetails = this.feedbackModalContact;
+                        }
+
                         ImGui.CloseCurrentPopup();
                     }
                 }
@@ -681,7 +686,7 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
                 if (!this.feedbackModalOnNextFrameDontClear)
                 {
                     this.feedbackModalBody = string.Empty;
-                    this.feedbackModalContact = string.Empty;
+                    this.feedbackModalContact = Service<DalamudConfiguration>.Get().LastFeedbackContactDetails;
                     this.feedbackModalIncludeException = false;
                     this.feedbackIsAnonymous = false;
                 }


### PR DESCRIPTION
Real small change, just making the feedback form remember the last contact details used so the user doesn't have to retype them every time.