### PR TITLE
Add Per-Plugin Log Filtering Support

### DIFF
--- a/Dalamud/EntryPoint.cs
+++ b/Dalamud/EntryPoint.cs
@@ -182,12 +182,17 @@ namespace Dalamud
             }
         }
 
-        private static void SerilogOnLogLine(object? sender, (string Line, LogEventLevel Level, DateTimeOffset TimeStamp, Exception? Exception) e)
+        private static void SerilogOnLogLine(object? sender, (string Line, LogEvent LogEvent) ev)
         {
-            if (e.Exception == null)
+            if (ev.LogEvent.Exception == null)
                 return;
 
-            Troubleshooting.LogException(e.Exception, e.Line);
+            // Don't pass verbose/debug/info exceptions to the troubleshooter, as the developer is probably doing
+            // something intentionally (or this is known).
+            if (ev.LogEvent.Level < LogEventLevel.Warning)
+                return;
+
+            Troubleshooting.LogException(ev.LogEvent.Exception, ev.Line);
         }
 
         private static void InitSymbolHandler(DalamudStartInfo info)

--- a/Dalamud/Logging/Internal/SerilogEventSink.cs
+++ b/Dalamud/Logging/Internal/SerilogEventSink.cs
@@ -25,7 +25,7 @@ namespace Dalamud.Logging.Internal
         /// <summary>
         /// Event on a log line being emitted.
         /// </summary>
-        public event EventHandler<(string Line, LogEventLevel Level, DateTimeOffset TimeStamp, Exception? Exception)>? LogLine;
+        public event EventHandler<(string Line, LogEvent LogEvent)>? LogLine;
 
         /// <summary>
         /// Gets the default instance.
@@ -40,12 +40,18 @@ namespace Dalamud.Logging.Internal
         {
             var message = logEvent.RenderMessage(this.formatProvider);
 
+            if (logEvent.Properties.TryGetValue("SourceContext", out var sourceProp) &&
+                sourceProp is ScalarValue { Value: string source })
+            {
+                message = $"[{source}] {message}";
+            }
+
             if (logEvent.Exception != null)
             {
                 message += "\n" + logEvent.Exception;
             }
 
-            this.LogLine?.Invoke(this, (message, logEvent.Level, logEvent.Timestamp, logEvent.Exception));
+            this.LogLine?.Invoke(this, (message, logEvent));
         }
     }
 }

--- a/Dalamud/Logging/PluginLog.cs
+++ b/Dalamud/Logging/PluginLog.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Reflection;
 
+using Serilog;
+using Serilog.Events;
+
 namespace Dalamud.Logging
 {
     /// <summary>
@@ -16,7 +19,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void Log(string messageTemplate, params object[] values)
-            => Serilog.Log.Information($"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Information, messageTemplate, null, values);
 
         /// <summary>
         /// Log a templated message to the in-game debug log.
@@ -25,7 +28,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void Log(Exception exception, string messageTemplate, params object[] values)
-            => Serilog.Log.Information(exception, $"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Information, messageTemplate, exception, values);
 
         /// <summary>
         /// Log a templated verbose message to the in-game debug log.
@@ -33,7 +36,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void LogVerbose(string messageTemplate, params object[] values)
-            => Serilog.Log.Verbose($"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Verbose, messageTemplate, null, values);
 
         /// <summary>
         /// Log a templated verbose message to the in-game debug log.
@@ -42,7 +45,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void LogVerbose(Exception exception, string messageTemplate, params object[] values)
-            => Serilog.Log.Verbose(exception, $"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Verbose, messageTemplate, exception, values);
 
         /// <summary>
         /// Log a templated debug message to the in-game debug log.
@@ -50,7 +53,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void LogDebug(string messageTemplate, params object[] values)
-            => Serilog.Log.Debug($"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Debug, messageTemplate, null, values);
 
         /// <summary>
         /// Log a templated debug message to the in-game debug log.
@@ -59,7 +62,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void LogDebug(Exception exception, string messageTemplate, params object[] values)
-            => Serilog.Log.Debug(exception, $"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Debug, messageTemplate, exception, values);
 
         /// <summary>
         /// Log a templated information message to the in-game debug log.
@@ -67,7 +70,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void LogInformation(string messageTemplate, params object[] values)
-            => Serilog.Log.Information($"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Information, messageTemplate, null, values);
 
         /// <summary>
         /// Log a templated information message to the in-game debug log.
@@ -76,7 +79,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void LogInformation(Exception exception, string messageTemplate, params object[] values)
-            => Serilog.Log.Information(exception, $"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Information, messageTemplate, exception, values);
 
         /// <summary>
         /// Log a templated warning message to the in-game debug log.
@@ -84,7 +87,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void LogWarning(string messageTemplate, params object[] values)
-            => Serilog.Log.Warning($"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Warning, messageTemplate, null, values);
 
         /// <summary>
         /// Log a templated warning message to the in-game debug log.
@@ -93,7 +96,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void LogWarning(Exception exception, string messageTemplate, params object[] values)
-            => Serilog.Log.Warning(exception, $"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Warning, messageTemplate, exception, values);
 
         /// <summary>
         /// Log a templated error message to the in-game debug log.
@@ -101,7 +104,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void LogError(string messageTemplate, params object[] values)
-            => Serilog.Log.Error($"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Error, messageTemplate, null, values);
 
         /// <summary>
         /// Log a templated error message to the in-game debug log.
@@ -110,7 +113,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void LogError(Exception exception, string messageTemplate, params object[] values)
-            => Serilog.Log.Error(exception, $"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Error, messageTemplate, exception, values);
 
         /// <summary>
         /// Log a templated fatal message to the in-game debug log.
@@ -118,7 +121,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void LogFatal(string messageTemplate, params object[] values)
-            => Serilog.Log.Fatal($"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Fatal, messageTemplate, null, values);
 
         /// <summary>
         /// Log a templated fatal message to the in-game debug log.
@@ -127,7 +130,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void LogFatal(Exception exception, string messageTemplate, params object[] values)
-            => Serilog.Log.Fatal(exception, $"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Fatal, messageTemplate, exception, values);
 
         #endregion
 
@@ -139,7 +142,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void Verbose(string messageTemplate, params object[] values)
-            => Serilog.Log.Verbose($"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Verbose, messageTemplate, null, values);
 
         /// <summary>
         /// Log a templated verbose message to the in-game debug log.
@@ -148,7 +151,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void Verbose(Exception exception, string messageTemplate, params object[] values)
-            => Serilog.Log.Verbose(exception, $"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Verbose, messageTemplate, exception, values);
 
         /// <summary>
         /// Log a templated debug message to the in-game debug log.
@@ -156,7 +159,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void Debug(string messageTemplate, params object[] values)
-            => Serilog.Log.Debug($"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Debug, messageTemplate, null, values);
 
         /// <summary>
         /// Log a templated debug message to the in-game debug log.
@@ -165,7 +168,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void Debug(Exception exception, string messageTemplate, params object[] values)
-            => Serilog.Log.Debug(exception, $"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Debug, messageTemplate, exception, values);
 
         /// <summary>
         /// Log a templated information message to the in-game debug log.
@@ -173,7 +176,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void Information(string messageTemplate, params object[] values)
-            => Serilog.Log.Information($"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Information, messageTemplate, null, values);
 
         /// <summary>
         /// Log a templated information message to the in-game debug log.
@@ -182,7 +185,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void Information(Exception exception, string messageTemplate, params object[] values)
-            => Serilog.Log.Information(exception, $"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Information, messageTemplate, exception, values);
 
         /// <summary>
         /// Log a templated warning message to the in-game debug log.
@@ -190,7 +193,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void Warning(string messageTemplate, params object[] values)
-            => Serilog.Log.Warning($"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Warning, messageTemplate, null, values);
 
         /// <summary>
         /// Log a templated warning message to the in-game debug log.
@@ -199,7 +202,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void Warning(Exception exception, string messageTemplate, params object[] values)
-            => Serilog.Log.Warning(exception, $"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Warning, messageTemplate, exception, values);
 
         /// <summary>
         /// Log a templated error message to the in-game debug log.
@@ -207,7 +210,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void Error(string messageTemplate, params object[] values)
-            => Serilog.Log.Error($"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Error, messageTemplate, null, values);
 
         /// <summary>
         /// Log a templated error message to the in-game debug log.
@@ -216,7 +219,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void Error(Exception exception, string messageTemplate, params object[] values)
-            => Serilog.Log.Error(exception, $"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Error, messageTemplate, exception, values);
 
         /// <summary>
         /// Log a templated fatal message to the in-game debug log.
@@ -224,7 +227,7 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void Fatal(string messageTemplate, params object[] values)
-            => Serilog.Log.Fatal($"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Fatal, messageTemplate, null, values);
 
         /// <summary>
         /// Log a templated fatal message to the in-game debug log.
@@ -233,8 +236,19 @@ namespace Dalamud.Logging
         /// <param name="messageTemplate">The message template.</param>
         /// <param name="values">Values to log.</param>
         public static void Fatal(Exception exception, string messageTemplate, params object[] values)
-            => Serilog.Log.Fatal(exception, $"[{Assembly.GetCallingAssembly().GetName().Name}] {messageTemplate}", values);
+            => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Fatal, messageTemplate, exception, values);
 
         #endregion
+
+        private static ILogger GetPluginLogger(string? pluginName)
+        {
+            return Serilog.Log.ForContext("SourceContext", pluginName ?? string.Empty);
+        }
+
+        private static void WriteLog(string? pluginName, LogEventLevel level, string messageTemplate, Exception? exception = null, params object[] values)
+        {
+            var pluginLogger = GetPluginLogger(pluginName);
+            pluginLogger.Write(level, exception: exception, messageTemplate: messageTemplate, values);
+        }
     }
 }


### PR DESCRIPTION
This commit adds first-pass support for more robust plugin log filtering. No changes were made that affect PluginLog's APIs nor log format. This change works by making use of Serilog's `SourceContext` property to attach plugin information to all log messages. The in-game log UI can then be used to filter based on this property.

Future expansions for this system include the ability to set different plugins to different log levels (something that already can technically be done, but requires those plugins be hard-coded through `MinimumLevel.Override`), creating new root loggers for each plugin (thereby giving plugin devs more control over their logging should they want to use it), plus other potential improvements in the way of adding context or rich information.

- Update `PluginLog` to attach a `SourceContext` property to all log messages.
- Tweak the `SerilogEventSink` to pass the original log event around.
- Suppress Info/Debug/Verbose exceptions from Troubleshooting reports.
- Fix the `ConsoleWindow` log filter to use _all_ filters, rather than just one.
- Add `ConsoleWindow` dropdown to select plugins to filter logs by
- Add support for multiple log levels to `ConsoleWindow` filtering