### PR TITLE
Add plugin changelogs button

### DIFF
--- a/Dalamud/Game/ChatHandlers.cs
+++ b/Dalamud/Game/ChatHandlers.cs
@@ -305,7 +305,7 @@ namespace Dalamud.Game
                 {
                     if (this.configuration.AutoUpdatePlugins)
                     {
-                        PluginManager.PrintUpdatedPlugins(updatedPlugins, Loc.Localize("DalamudPluginAutoUpdate", "Auto-update:"));
+                        Service<PluginManager>.Get().PrintUpdatedPlugins(updatedPlugins, Loc.Localize("DalamudPluginAutoUpdate", "Auto-update:"));
                         notifications.AddNotification(Loc.Localize("NotificationUpdatedPlugins", "{0} of your plugins were updated.").Format(updatedPlugins.Count), Loc.Localize("NotificationAutoUpdate", "Auto-Update"), NotificationType.Info);
                     }
                     else

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -251,6 +251,11 @@ namespace Dalamud.Interface.Internal
         public void OpenPluginInstaller() => this.pluginWindow.IsOpen = true;
 
         /// <summary>
+        /// Opens the <see cref="PluginInstallerWindow"/> on the plugin changelogs.
+        /// </summary>
+        public void OpenPluginInstallerPluginChangelogs() => this.pluginWindow.OpenPluginChangelogs();
+
+        /// <summary>
         /// Opens the <see cref="SettingsWindow"/>.
         /// </summary>
         public void OpenSettings() => this.settingsWindow.IsOpen = true;

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -217,6 +217,16 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
             this.imageCache.ClearIconCache();
         }
 
+        /// <summary>
+        /// Open the window on the plugin changelogs.
+        /// </summary>
+        public void OpenPluginChangelogs()
+        {
+            this.categoryManager.CurrentGroupIdx = 3;
+            this.categoryManager.CurrentCategoryIdx = 2;
+            this.IsOpen = true;
+        }
+
         private void DrawProgressOverlay()
         {
             var pluginManager = Service<PluginManager>.Get();
@@ -238,7 +248,7 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
 
             ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, Vector2.Zero);
             ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, Vector2.Zero);
-            ImGui.PushStyleVar(ImGuiStyleVar.CellPadding, Vector2.Zero);;
+            ImGui.PushStyleVar(ImGuiStyleVar.CellPadding, Vector2.Zero);
             ImGui.PushStyleVar(ImGuiStyleVar.ChildBorderSize, 0);
             ImGui.PushStyleVar(ImGuiStyleVar.ChildRounding, 0);
 
@@ -497,7 +507,7 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
 
                                 if (this.updatePluginCount > 0)
                                 {
-                                    PluginManager.PrintUpdatedPlugins(this.updatedPlugins, Locs.PluginUpdateHeader_Chatbox);
+                                    Service<PluginManager>.Get().PrintUpdatedPlugins(this.updatedPlugins, Locs.PluginUpdateHeader_Chatbox);
                                     notifications.AddNotification(Locs.Notifications_UpdatesInstalled(this.updatePluginCount), Locs.Notifications_UpdatesInstalledTitle, NotificationType.Success);
 
                                     var installedGroupIdx = this.categoryManager.GroupList.TakeWhile(

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -17,6 +17,8 @@ using Dalamud.Game;
 using Dalamud.Game.Gui;
 using Dalamud.Game.Gui.Dtr;
 using Dalamud.Game.Text;
+using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Interface.Internal;
 using Dalamud.Logging.Internal;
 using Dalamud.Plugin.Internal.Exceptions;
@@ -49,6 +51,8 @@ internal partial class PluginManager : IDisposable, IServiceType
     private readonly DirectoryInfo pluginDirectory;
     private readonly DirectoryInfo devPluginDirectory;
     private readonly BannedPlugin[]? bannedPlugins;
+
+    private readonly DalamudLinkPayload openInstallerWindowPluginChangelogsLink;
 
     [ServiceManager.ServiceDependency]
     private readonly DalamudConfiguration configuration = Service<DalamudConfiguration>.Get();
@@ -100,6 +104,11 @@ internal partial class PluginManager : IDisposable, IServiceType
         {
             throw new InvalidDataException("Couldn't deserialize banned plugins manifest.");
         }
+
+        this.openInstallerWindowPluginChangelogsLink = Service<ChatGui>.Get().AddChatLinkHandler("Dalamud", 1003, (i, m) =>
+        {
+            Service<DalamudInterface>.GetNullable()?.OpenPluginInstallerPluginChangelogs();
+        });
 
         this.ApplyPatches();
     }
@@ -169,25 +178,38 @@ internal partial class PluginManager : IDisposable, IServiceType
     /// </summary>
     /// <param name="updateMetadata">The list of updated plugin metadata.</param>
     /// <param name="header">The header text to send to chat prior to any update info.</param>
-    public static void PrintUpdatedPlugins(List<PluginUpdateStatus>? updateMetadata, string header)
+    public void PrintUpdatedPlugins(List<PluginUpdateStatus>? updateMetadata, string header)
     {
         var chatGui = Service<ChatGui>.Get();
 
         if (updateMetadata is { Count: > 0 })
         {
-            chatGui.Print(header);
+            chatGui.PrintChat(new XivChatEntry
+            {
+                Message = new SeString(new List<Payload>()
+                {
+                    new TextPayload(header),
+                    new TextPayload("  ["),
+                    new UIForegroundPayload(500),
+                    this.openInstallerWindowPluginChangelogsLink,
+                    new TextPayload(Loc.Localize("DalamudInstallerPluginChangelogHelp", "Open plugin changelogs") + " "),
+                    RawPayload.LinkTerminator,
+                    new UIForegroundPayload(0),
+                    new TextPayload("]"),
+                }),
+            });
 
             foreach (var metadata in updateMetadata)
             {
                 if (metadata.WasUpdated)
                 {
-                    chatGui.Print(Locs.DalamudPluginUpdateSuccessful(metadata.Name, metadata.Version));
+                    chatGui.Print(Locs.DalamudPluginUpdateSuccessful(metadata.Name, metadata.Version) + (metadata.HasChangelog ? " " : string.Empty));
                 }
                 else
                 {
                     chatGui.PrintChat(new XivChatEntry
                     {
-                        Message = Locs.DalamudPluginUpdateFailed(metadata.Name, metadata.Version),
+                        Message = Locs.DalamudPluginUpdateFailed(metadata.Name, metadata.Version) + (metadata.HasChangelog ? " " : string.Empty),
                         Type = XivChatType.Urgent,
                     });
                 }
@@ -975,6 +997,7 @@ internal partial class PluginManager : IDisposable, IServiceType
                            ? metadata.UpdateManifest.TestingAssemblyVersion
                            : metadata.UpdateManifest.AssemblyVersion)!,
             WasUpdated = true,
+            HasChangelog = !metadata.UpdateManifest.Changelog.IsNullOrWhitespace(),
         };
 
         if (!dryRun)

--- a/Dalamud/Plugin/Internal/Types/PluginUpdateStatus.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginUpdateStatus.cs
@@ -26,4 +26,9 @@ internal class PluginUpdateStatus
     /// Gets or sets a value indicating whether the plugin was updated.
     /// </summary>
     public bool WasUpdated { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the plugin has a changelog if it was updated.
+    /// </summary>
+    public bool HasChangelog { get; init; }
 }


### PR DESCRIPTION
The button opens the installer in plugin changelogs. It is always displayed, even if there is no changelog for the updated plugins, the star icon shows which plugins have a changelog.
![demo](https://user-images.githubusercontent.com/33433913/182395472-ed0ba86e-04dc-4266-9ad0-248552663d0e.png)

Edit: Not sure if the star is really necessary, as most plugins have changelogs, thoughts? 🤔 