### PR TITLE
fix: unable to delete unloaded plugin config

### DIFF
--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1086,7 +1086,7 @@ internal partial class PluginManager : IDisposable, IServiceType
     /// <returns>The task.</returns>
     public async Task DeleteConfigurationAsync(LocalPlugin plugin)
     {
-        if (plugin.State == PluginState.Loading || plugin.State == PluginState.Unloaded)
+        if (plugin.State == PluginState.Loading || plugin.State == PluginState.Unloading)
             throw new Exception("Cannot delete configuration for a loading/unloading plugin");
 
         if (plugin.IsLoaded)


### PR DESCRIPTION
Not tested at all, what could go wrong?