### PR TITLE
Show DLL description and version into xivfixes dll load list

### DIFF
--- a/Dalamud.Boot/utils.h
+++ b/Dalamud.Boot/utils.h
@@ -58,9 +58,15 @@ namespace utils {
         void* get_imported_function_pointer(const char* pcszDllName, const char* pcszFunctionName, uint32_t hintOrOrdinal) const;
         template<typename TFn> TFn** get_imported_function_pointer(const char* pcszDllName, const char* pcszFunctionName, uint32_t hintOrOrdinal) { return reinterpret_cast<TFn**>(get_imported_function_pointer(pcszDllName, pcszFunctionName, hintOrOrdinal)); }
 
+        [[nodiscard]] std::unique_ptr<std::remove_pointer_t<HGLOBAL>, decltype(&FreeResource)> get_resource(LPCWSTR lpName, LPCWSTR lpType) const;
+        [[nodiscard]] std::wstring get_description() const;
+        [[nodiscard]] VS_FIXEDFILEINFO get_file_version() const;
+
         static loaded_module current_process();
         static std::vector<loaded_module> all_modules();
     };
+
+    std::wstring format_file_version(const VS_FIXEDFILEINFO& v);
 
     class signature_finder {
         std::vector<std::span<const char>> m_ranges;

--- a/Dalamud.Boot/xivfixes.cpp
+++ b/Dalamud.Boot/xivfixes.cpp
@@ -26,7 +26,20 @@ void xivfixes::unhook_dll(bool bApply) {
         std::filesystem::path path;
         try {
             path = mod.path();
-            logging::I("{} [{}/{}] Module 0x{:X} ~ 0x{:X} (0x{:X}): \"{}\"", LogTagW, i + 1, mods.size(), mod.address_int(), mod.address_int() + mod.image_size(), mod.image_size(), path.wstring());
+            std::wstring version, description;
+            try {
+                version = utils::format_file_version(mod.get_file_version());
+            } catch (...) {
+                version = L"<unknown>";
+            }
+            
+            try {
+                description = mod.get_description();
+            } catch (...) {
+                description = L"<unknown>";
+            }
+            
+            logging::I(R"({} [{}/{}] Module 0x{:X} ~ 0x{:X} (0x{:X}): "{}" ("{}" ver {}))", LogTagW, i + 1, mods.size(), mod.address_int(), mod.address_int() + mod.image_size(), mod.image_size(), path.wstring(), description, version);
         } catch (const std::exception& e) {
             logging::W("{} [{}/{}] Module 0x{:X}: Failed to resolve path: {}", LogTag, i + 1, mods.size(), mod.address_int(), e.what());
             return;


### PR DESCRIPTION
```
[16:13:43 CPP/INF] [xivfixes:unhook_dll] [3/45] Module 0x7FF9D5B80000 ~ 0x7FF9D5C3D000 (0xBD000): "C:\Windows\System32\KERNEL32.DLL" ("Windows NT BASE API Client DLL" ver 10.0.22000.708)

[16:13:46 CPP/INF] [global_import_hook] "C:\Windows\System32\MMDevApi.dll" ("MMDevice API" ver 10.0.22000.708) has been loaded at 0x7FF9CBC80000 ~ 0x7FF9CBD1C000 (0x9C000); finding import table items to hook.
```

DLL load information will now contain DLL descriptions and version strings if provided.