### PR TITLE
Remove "Reload All Plugins" Command

### DIFF
--- a/Dalamud/Interface/Internal/DalamudCommands.cs
+++ b/Dalamud/Interface/Internal/DalamudCommands.cs
@@ -30,12 +30,6 @@ namespace Dalamud.Interface.Internal
                 ShowInHelp = false,
             });
 
-            commandManager.AddHandler("/xldreloadplugins", new CommandInfo(this.OnPluginReloadCommand)
-            {
-                HelpMessage = Loc.Localize("DalamudPluginReloadHelp", "Reloads all plugins."),
-                ShowInHelp = false,
-            });
-
             commandManager.AddHandler("/xlhelp", new CommandInfo(this.OnHelpCommand)
             {
                 HelpMessage = Loc.Localize("DalamudCmdInfoHelp", "Shows list of commands available."),
@@ -167,24 +161,6 @@ namespace Dalamud.Interface.Internal
                     continue;
 
                 chatGui.Print($"{cmd.Key}: {cmd.Value.HelpMessage}");
-            }
-        }
-
-        private void OnPluginReloadCommand(string command, string arguments)
-        {
-            var chatGui = Service<ChatGui>.Get();
-
-            chatGui.Print("Reloading...");
-
-            try
-            {
-                Service<PluginManager>.Get().ReloadAllPluginsAsync().Wait();
-                chatGui.Print("OK");
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Plugin reload failed.");
-                chatGui.PrintError("Reload failed.");
             }
         }
 

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -780,19 +780,6 @@ namespace Dalamud.Interface.Internal
                             }
                         }
 
-                        if (ImGui.MenuItem("Reload plugins"))
-                        {
-                            try
-                            {
-                                pluginManager.ReloadAllPluginsAsync().Wait();
-                            }
-                            catch (Exception ex)
-                            {
-                                Service<ChatGui>.Get().PrintError("Reload failed.");
-                                PluginLog.Error(ex, "Plugin reload failed.");
-                            }
-                        }
-
                         if (ImGui.MenuItem("Scan dev plugins"))
                         {
                             pluginManager.ScanDevPlugins();

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -535,6 +535,7 @@ internal partial class PluginManager : IDisposable, IServiceType
     /// Reload all loaded plugins.
     /// </summary>
     /// <returns>A task.</returns>
+    [Obsolete("This method should no longer be used and will be removed in a future release.")]
     public Task ReloadAllPluginsAsync()
     {
         lock (this.pluginListLock)


### PR DESCRIPTION
RIP AND TEAR.

- Remove the "Reload All Plugins" MenuItem from `/xldev`
- Remove the `/xldreloadplugins` Command
- Mark `PluginManager#ReloadAllPluginsAsync()` as obsolete for removal in the future