### PR TITLE
chore: always display 2 decimal places when formatting bytes

### DIFF
--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -403,7 +403,7 @@ namespace Dalamud.Utility
                 dblSByte = bytes / 1024.0;
             }
 
-            return $"{dblSByte:0.##} {suffix[i]}";
+            return $"{dblSByte:0.00} {suffix[i]}";
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #969.
Doubt anyone would mind the change, worst case, can add an overload.