### PR TITLE
feat(plugins): skip plugins that share InternalNames with official plugins

### DIFF
--- a/Dalamud/Plugin/Internal/Types/PluginRepository.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginRepository.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -106,6 +108,36 @@ internal class PluginRepository
             foreach (var manifest in pluginMaster)
             {
                 manifest.SourceRepo = this;
+            }
+
+            var pm = Service<PluginManager>.Get();
+            var official = pm.Repos.First();
+            Debug.Assert(!official.IsThirdParty, "First repository should be official repository");
+
+            if (official.State == PluginRepositoryState.Success && this.IsThirdParty)
+            {
+                pluginMaster = pluginMaster.Where(thisRepoEntry =>
+                {
+                    if (official.PluginMaster!.Any(officialRepoEntry =>
+                                                       string.Equals(thisRepoEntry.InternalName, officialRepoEntry.InternalName, StringComparison.InvariantCultureIgnoreCase) ||
+                                                       thisRepoEntry.Name.Contains(officialRepoEntry.Name)))
+                    {
+                        Log.Warning(
+                            "The repository {RepoName} tried to replace the plugin {PluginName}, which is already installed through the official repo - this is no longer allowed for security reasons. " +
+                            "Please reach out if you have an use case for this.",
+                            this.PluginMasterUrl,
+                            thisRepoEntry.InternalName);
+                        return false;
+                    }
+
+                    return true;
+                }).ToList();
+            }
+            else if (this.IsThirdParty)
+            {
+                Log.Warning("Official repository not loaded - couldn't check for overrides!");
+                this.State = PluginRepositoryState.Fail;
+                return;
             }
 
             this.PluginMaster = pluginMaster.AsReadOnly();


### PR DESCRIPTION
I was talking with a few folks and realised our current plugin loading solution will allow for third-party plugins with the same `InternalName` to take precedence over the official repo. This means that users could unintentionally load out-of-date or malicious versions of plugins.

This PR fixes that by ensuring that the official repo gets loaded first, and then filtering out any plugins in successive repo loads that have already been loaded by the official repo.

This solution has `O(NM)` complexity, where `N` is the number of plugins in the repo-to-load and `M` is the number of plugins in the official repo. We might want to revisit this at some point if it shows up on the graphs (a `HashSet` should suffice?)