### PR TITLE
Only allow updates from the same repo or main repo

### DIFF
--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1234,7 +1234,7 @@ internal partial class PluginManager : IDisposable, IServiceType
 
             var updates = this.AvailablePlugins
                               .Where(remoteManifest => plugin.Manifest.InternalName == remoteManifest.InternalName)
-                              .Where(remoteManifest => plugin.Manifest.RepoUrl == remoteManifest.RepoUrl || !remoteManifest.SourceRepo.IsThirdParty)
+                              .Where(remoteManifest => plugin.Manifest.InstalledFromUrl == remoteManifest.SourceRepo.PluginMasterUrl || !remoteManifest.SourceRepo.IsThirdParty)
                               .Select(remoteManifest =>
                               {
                                   var useTesting = UseTesting(remoteManifest);

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1234,6 +1234,7 @@ internal partial class PluginManager : IDisposable, IServiceType
 
             var updates = this.AvailablePlugins
                               .Where(remoteManifest => plugin.Manifest.InternalName == remoteManifest.InternalName)
+                              .Where(remoteManifest => plugin.Manifest.RepoUrl == remoteManifest.RepoUrl || !remoteManifest.SourceRepo.IsThirdParty)
                               .Select(remoteManifest =>
                               {
                                   var useTesting = UseTesting(remoteManifest);


### PR DESCRIPTION
Will prevent unexpected behaviour wherein a repo may update another repo's plugins