### PR TITLE
DalamudCrashHandler: log dll descr/version on crash too

### DIFF
--- a/DalamudCrashHandler/DalamudCrashHandler.vcxproj
+++ b/DalamudCrashHandler/DalamudCrashHandler.vcxproj
@@ -50,7 +50,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>Winhttp.lib;Dbghelp.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Version.lib;Winhttp.lib;Dbghelp.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
This will help identifying whether unwanted stuff for the purpose of giving support is installed just from the crash log file itself, skipping the step of asking for dalamud logs.

For example:

```Modules
{
  00400000	C:\Windows\SYSTEM32\XInput1_3.dll	Microsoft Common Controller API v9.18.944.0
....
  7FF6CA380000	C:\Program Files (x86)\SquareEnix\FINAL FANTASY XIV - A Realm Reborn\game\ffxiv_dx11.exe	FINAL FANTASY XIV v1.0.0.0
...
  7FFAACA10000	C:\Windows\System32\clbcatq.dll	COM+ Configuration Catalog file=v2001.12.10941.16384 prod=v10.0.22000.1
  7FFAACAC0000	C:\Windows\System32\ADVAPI32.dll	Advanced Windows 32 Base API file=v6.2.22000.653 prod=v10.0.22000.653
  7FFAACCD0000	C:\Windows\System32\IMM32.dll	Multi-User Windows IMM32 API Client DLL file=v6.2.22000.1 prod=v10.0.22000.1
  7FFAACD10000	C:\Windows\System32\GDI32.dll	GDI Client DLL file=v6.2.22000.832 prod=v10.0.22000.832
  7FFAACFC0000	C:\Windows\SYSTEM32\ntdll.dll	NT Layer DLL file=v6.2.22000.832 prod=v10.0.22000.832
}
```

