### PR TITLE
Add internal exception handling for event delegates

### DIFF
--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -9,6 +9,7 @@ using Dalamud.Game.Network.Internal;
 using Dalamud.Hooking;
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
+using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using Serilog;
 
@@ -145,7 +146,7 @@ namespace Dalamud.Game.ClientState
         private IntPtr SetupTerritoryTypeDetour(IntPtr manager, ushort terriType)
         {
             this.TerritoryType = terriType;
-            this.TerritoryChanged?.Invoke(this, terriType);
+            this.TerritoryChanged?.Raise(this, terriType);
 
             Log.Debug("TerritoryType changed: {0}", terriType);
 
@@ -154,7 +155,7 @@ namespace Dalamud.Game.ClientState
 
         private void NetworkHandlersOnCfPop(object sender, Lumina.Excel.GeneratedSheets.ContentFinderCondition e)
         {
-            this.CfPop?.Invoke(this, e);
+            this.CfPop?.Raise(this, e);
         }
 
         private void FrameworkOnOnUpdateEvent(Framework framework1)
@@ -171,7 +172,7 @@ namespace Dalamud.Game.ClientState
                 Log.Debug("Is login");
                 this.lastConditionNone = false;
                 this.IsLoggedIn = true;
-                this.Login?.Invoke(this, null);
+                this.Login?.Raise(this, null);
                 gameGui.ResetUiHideState();
             }
 
@@ -180,7 +181,7 @@ namespace Dalamud.Game.ClientState
                 Log.Debug("Is logout");
                 this.lastConditionNone = true;
                 this.IsLoggedIn = false;
-                this.Logout?.Invoke(this, null);
+                this.Logout?.Raise(this, null);
                 gameGui.ResetUiHideState();
             }
 
@@ -193,11 +194,11 @@ namespace Dalamud.Game.ClientState
 
                 if (this.IsPvP)
                 {
-                    this.EnterPvP?.Invoke();
+                    this.EnterPvP?.Raise();
                 }
                 else
                 {
-                    this.LeavePvP?.Invoke();
+                    this.LeavePvP?.Raise();
                 }
             }
         }

--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -146,7 +146,7 @@ namespace Dalamud.Game.ClientState
         private IntPtr SetupTerritoryTypeDetour(IntPtr manager, ushort terriType)
         {
             this.TerritoryType = terriType;
-            this.TerritoryChanged?.Raise(this, terriType);
+            this.TerritoryChanged?.InvokeSafely(this, terriType);
 
             Log.Debug("TerritoryType changed: {0}", terriType);
 
@@ -155,7 +155,7 @@ namespace Dalamud.Game.ClientState
 
         private void NetworkHandlersOnCfPop(object sender, Lumina.Excel.GeneratedSheets.ContentFinderCondition e)
         {
-            this.CfPop?.Raise(this, e);
+            this.CfPop?.InvokeSafely(this, e);
         }
 
         private void FrameworkOnOnUpdateEvent(Framework framework1)
@@ -172,7 +172,7 @@ namespace Dalamud.Game.ClientState
                 Log.Debug("Is login");
                 this.lastConditionNone = false;
                 this.IsLoggedIn = true;
-                this.Login?.Raise(this, null);
+                this.Login?.InvokeSafely(this, null);
                 gameGui.ResetUiHideState();
             }
 
@@ -181,7 +181,7 @@ namespace Dalamud.Game.ClientState
                 Log.Debug("Is logout");
                 this.lastConditionNone = true;
                 this.IsLoggedIn = false;
-                this.Logout?.Raise(this, null);
+                this.Logout?.InvokeSafely(this, null);
                 gameGui.ResetUiHideState();
             }
 
@@ -194,11 +194,11 @@ namespace Dalamud.Game.ClientState
 
                 if (this.IsPvP)
                 {
-                    this.EnterPvP?.Raise();
+                    this.EnterPvP?.InvokeSafely();
                 }
                 else
                 {
-                    this.LeavePvP?.Raise();
+                    this.LeavePvP?.InvokeSafely();
                 }
             }
         }

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -415,7 +415,7 @@ namespace Dalamud.Game
                 }
                 else
                 {
-                    this.Update?.Raise(this);
+                    this.Update?.InvokeSafely(this);
                 }
             }
 

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -362,63 +362,64 @@ namespace Dalamud.Game
                 this.LastUpdate = DateTime.Now;
                 this.LastUpdateUTC = DateTime.UtcNow;
 
-                try
+                this.runOnNextTickTaskList.RemoveAll(x => x.Run());
+
+                if (StatsEnabled && this.Update != null)
                 {
-                    this.runOnNextTickTaskList.RemoveAll(x => x.Run());
+                    // Stat Tracking for Framework Updates
+                    var invokeList = this.Update.GetInvocationList();
+                    var notUpdated = StatsHistory.Keys.ToList();
 
-                    if (StatsEnabled && this.Update != null)
+                    // Individually invoke OnUpdate handlers and time them.
+                    foreach (var d in invokeList)
                     {
-                        // Stat Tracking for Framework Updates
-                        var invokeList = this.Update.GetInvocationList();
-                        var notUpdated = StatsHistory.Keys.ToList();
-
-                        // Individually invoke OnUpdate handlers and time them.
-                        foreach (var d in invokeList)
+                        statsStopwatch.Restart();
+                        try
                         {
-                            statsStopwatch.Restart();
                             d.Method.Invoke(d.Target, new object[] { this });
-                            statsStopwatch.Stop();
-
-                            var key = $"{d.Target}::{d.Method.Name}";
-                            if (notUpdated.Contains(key))
-                                notUpdated.Remove(key);
-
-                            if (!StatsHistory.ContainsKey(key))
-                                StatsHistory.Add(key, new List<double>());
-
-                            StatsHistory[key].Add(statsStopwatch.Elapsed.TotalMilliseconds);
-
-                            if (StatsHistory[key].Count > 1000)
-                            {
-                                StatsHistory[key].RemoveRange(0, StatsHistory[key].Count - 1000);
-                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, "Exception while dispatching Framework::Update event.");
                         }
 
-                        // Cleanup handlers that are no longer being called
-                        foreach (var key in notUpdated)
+                        statsStopwatch.Stop();
+
+                        var key = $"{d.Target}::{d.Method.Name}";
+                        if (notUpdated.Contains(key))
+                            notUpdated.Remove(key);
+
+                        if (!StatsHistory.ContainsKey(key))
+                            StatsHistory.Add(key, new List<double>());
+
+                        StatsHistory[key].Add(statsStopwatch.Elapsed.TotalMilliseconds);
+
+                        if (StatsHistory[key].Count > 1000)
                         {
-                            if (StatsHistory[key].Count > 0)
-                            {
-                                StatsHistory[key].RemoveAt(0);
-                            }
-                            else
-                            {
-                                StatsHistory.Remove(key);
-                            }
+                            StatsHistory[key].RemoveRange(0, StatsHistory[key].Count - 1000);
                         }
                     }
-                    else
+
+                    // Cleanup handlers that are no longer being called
+                    foreach (var key in notUpdated)
                     {
-                        this.Update?.Invoke(this);
+                        if (StatsHistory[key].Count > 0)
+                        {
+                            StatsHistory[key].RemoveAt(0);
+                        }
+                        else
+                        {
+                            StatsHistory.Remove(key);
+                        }
                     }
                 }
-                catch (Exception ex)
+                else
                 {
-                    Log.Error(ex, "Exception while dispatching Framework::Update event.");
+                    this.Update?.Raise(this);
                 }
             }
 
-            original:
+        original:
             return this.updateHook.OriginalDisposeSafe(framework);
         }
 

--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -466,14 +466,7 @@ namespace Dalamud.Game.Gui
                 var itemId = (ulong)Marshal.ReadInt32(hoverState, 0x138);
                 this.HoveredItem = itemId;
 
-                try
-                {
-                    this.HoveredItemChanged?.Invoke(this, itemId);
-                }
-                catch (Exception e)
-                {
-                    Log.Error(e, "Could not dispatch HoveredItemChanged event.");
-                }
+                this.HoveredItemChanged?.Raise(this, itemId);
 
                 Log.Verbose("HoverItemId:{0} this:{1}", itemId, hoverState.ToInt64().ToString("X"));
             }
@@ -515,14 +508,7 @@ namespace Dalamud.Game.Gui
             this.HoveredAction.ActionKind = actionKind;
             this.HoveredAction.BaseActionID = actionId;
             this.HoveredAction.ActionID = (uint)Marshal.ReadInt32(hoverState, 0x3C);
-            try
-            {
-                this.HoveredActionChanged?.Invoke(this, this.HoveredAction);
-            }
-            catch (Exception e)
-            {
-                Log.Error(e, "Could not dispatch HoveredItemChanged event.");
-            }
+            this.HoveredActionChanged?.Raise(this, this.HoveredAction);
 
             Log.Verbose("HoverActionId: {0}/{1} this:{2}", actionKind, actionId, hoverState.ToInt64().ToString("X"));
         }
@@ -562,14 +548,7 @@ namespace Dalamud.Game.Gui
             // TODO(goat): We should read this from memory directly, instead of relying on catching every toggle.
             this.GameUiHidden = !this.GameUiHidden;
 
-            try
-            {
-                this.UiHideToggled?.Invoke(this, this.GameUiHidden);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error on OnUiHideToggled event dispatch");
-            }
+            this.UiHideToggled?.Raise(this, this.GameUiHidden);
 
             Log.Debug("UiHide toggled: {0}", this.GameUiHidden);
 

--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -466,7 +466,7 @@ namespace Dalamud.Game.Gui
                 var itemId = (ulong)Marshal.ReadInt32(hoverState, 0x138);
                 this.HoveredItem = itemId;
 
-                this.HoveredItemChanged?.Raise(this, itemId);
+                this.HoveredItemChanged?.InvokeSafely(this, itemId);
 
                 Log.Verbose("HoverItemId:{0} this:{1}", itemId, hoverState.ToInt64().ToString("X"));
             }
@@ -508,7 +508,7 @@ namespace Dalamud.Game.Gui
             this.HoveredAction.ActionKind = actionKind;
             this.HoveredAction.BaseActionID = actionId;
             this.HoveredAction.ActionID = (uint)Marshal.ReadInt32(hoverState, 0x3C);
-            this.HoveredActionChanged?.Raise(this, this.HoveredAction);
+            this.HoveredActionChanged?.InvokeSafely(this, this.HoveredAction);
 
             Log.Verbose("HoverActionId: {0}/{1} this:{2}", actionKind, actionId, hoverState.ToInt64().ToString("X"));
         }
@@ -548,7 +548,7 @@ namespace Dalamud.Game.Gui
             // TODO(goat): We should read this from memory directly, instead of relying on catching every toggle.
             this.GameUiHidden = !this.GameUiHidden;
 
-            this.UiHideToggled?.Raise(this, this.GameUiHidden);
+            this.UiHideToggled?.InvokeSafely(this, this.GameUiHidden);
 
             Log.Debug("UiHide toggled: {0}", this.GameUiHidden);
 

--- a/Dalamud/Game/Network/Internal/NetworkHandlers.cs
+++ b/Dalamud/Game/Network/Internal/NetworkHandlers.cs
@@ -288,7 +288,7 @@ namespace Dalamud.Game.Network.Internal
                     Service<ChatGui>.GetNullable()?.Print($"Duty pop: {cfcName}");
                 }
 
-                this.CfPop?.Invoke(this, cfCondition);
+                this.CfPop?.Raise(this, cfCondition);
             }).ContinueWith((task) => Log.Error(task.Exception, "CfPop.Invoke failed."), TaskContinuationOptions.OnlyOnFaulted);
         }
     }

--- a/Dalamud/Game/Network/Internal/NetworkHandlers.cs
+++ b/Dalamud/Game/Network/Internal/NetworkHandlers.cs
@@ -288,7 +288,7 @@ namespace Dalamud.Game.Network.Internal
                     Service<ChatGui>.GetNullable()?.Print($"Duty pop: {cfcName}");
                 }
 
-                this.CfPop?.Raise(this, cfCondition);
+                this.CfPop?.InvokeSafely(this, cfCondition);
             }).ContinueWith((task) => Log.Error(task.Exception, "CfPop.Invoke failed."), TaskContinuationOptions.OnlyOnFaulted);
         }
     }

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -773,7 +773,7 @@ namespace Dalamud.Interface.Internal
                 var customFontFirstConfigIndex = ioFonts.ConfigData.Size;
 
                 Log.Verbose("[FONT] Invoke OnBuildFonts");
-                this.BuildFonts?.Raise();
+                this.BuildFonts?.InvokeSafely();
                 Log.Verbose("[FONT] OnBuildFonts OK!");
 
                 for (int i = customFontFirstConfigIndex, i_ = ioFonts.ConfigData.Size; i < i_; i++)
@@ -881,7 +881,7 @@ namespace Dalamud.Interface.Internal
                 }
 
                 Log.Verbose("[FONT] Invoke OnAfterBuildFonts");
-                this.AfterBuildFonts?.Raise();
+                this.AfterBuildFonts?.InvokeSafely();
                 Log.Verbose("[FONT] OnAfterBuildFonts OK!");
 
                 if (ioFonts.Fonts[0].NativePtr != DefaultFont.NativePtr)
@@ -978,7 +978,7 @@ namespace Dalamud.Interface.Internal
             Log.Verbose($"Calling resizebuffers swap@{swapChain.ToInt64():X}{bufferCount} {width} {height} {newFormat} {swapChainFlags}");
 #endif
 
-            this.ResizeBuffers?.Raise();
+            this.ResizeBuffers?.InvokeSafely();
 
             // We have to ensure we're working with the main swapchain,
             // as viewports might be resizing as well

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -1105,7 +1105,7 @@ namespace Dalamud.Interface.Internal
             var snap = ImGuiManagedAsserts.GetSnapshot();
 
             if (this.IsDispatchingEvents)
-                this.Draw?.Raise();
+                this.Draw?.Invoke();
 
             ImGuiManagedAsserts.ReportProblems("Dalamud Core", snap);
 

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -773,7 +773,7 @@ namespace Dalamud.Interface.Internal
                 var customFontFirstConfigIndex = ioFonts.ConfigData.Size;
 
                 Log.Verbose("[FONT] Invoke OnBuildFonts");
-                this.BuildFonts?.Invoke();
+                this.BuildFonts?.Raise();
                 Log.Verbose("[FONT] OnBuildFonts OK!");
 
                 for (int i = customFontFirstConfigIndex, i_ = ioFonts.ConfigData.Size; i < i_; i++)
@@ -881,7 +881,7 @@ namespace Dalamud.Interface.Internal
                 }
 
                 Log.Verbose("[FONT] Invoke OnAfterBuildFonts");
-                this.AfterBuildFonts?.Invoke();
+                this.AfterBuildFonts?.Raise();
                 Log.Verbose("[FONT] OnAfterBuildFonts OK!");
 
                 if (ioFonts.Fonts[0].NativePtr != DefaultFont.NativePtr)
@@ -978,7 +978,7 @@ namespace Dalamud.Interface.Internal
             Log.Verbose($"Calling resizebuffers swap@{swapChain.ToInt64():X}{bufferCount} {width} {height} {newFormat} {swapChainFlags}");
 #endif
 
-            this.ResizeBuffers?.Invoke();
+            this.ResizeBuffers?.Raise();
 
             // We have to ensure we're working with the main swapchain,
             // as viewports might be resizing as well
@@ -1105,7 +1105,7 @@ namespace Dalamud.Interface.Internal
             var snap = ImGuiManagedAsserts.GetSnapshot();
 
             if (this.IsDispatchingEvents)
-                this.Draw?.Invoke();
+                this.Draw?.Raise();
 
             ImGuiManagedAsserts.ReportProblems("Dalamud Core", snap);
 

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -393,7 +393,7 @@ namespace Dalamud.Interface
         /// </summary>
         internal void OpenConfig()
         {
-            this.OpenConfigUi?.Raise();
+            this.OpenConfigUi?.InvokeSafely();
         }
 
         /// <summary>
@@ -401,7 +401,7 @@ namespace Dalamud.Interface
         /// </summary>
         internal void NotifyHideUi()
         {
-            this.HideUi?.Raise();
+            this.HideUi?.InvokeSafely();
         }
 
         /// <summary>
@@ -409,7 +409,7 @@ namespace Dalamud.Interface
         /// </summary>
         internal void NotifyShowUi()
         {
-            this.ShowUi?.Raise();
+            this.ShowUi?.InvokeSafely();
         }
 
         private void OnDraw()
@@ -429,7 +429,7 @@ namespace Dalamud.Interface
                 if (!this.lastFrameUiHideState)
                 {
                     this.lastFrameUiHideState = true;
-                    this.HideUi?.Raise();
+                    this.HideUi?.InvokeSafely();
                 }
 
                 return;
@@ -438,7 +438,7 @@ namespace Dalamud.Interface
             if (this.lastFrameUiHideState)
             {
                 this.lastFrameUiHideState = false;
-                this.ShowUi?.Raise();
+                this.ShowUi?.InvokeSafely();
             }
 
             if (!this.interfaceManager.FontsReady)
@@ -471,7 +471,7 @@ namespace Dalamud.Interface
 
             try
             {
-                this.Draw?.Raise();
+                this.Draw?.InvokeSafely();
             }
             catch (Exception ex)
             {
@@ -504,17 +504,17 @@ namespace Dalamud.Interface
 
         private void OnBuildFonts()
         {
-            this.BuildFonts?.Raise();
+            this.BuildFonts?.InvokeSafely();
         }
 
         private void OnAfterBuildFonts()
         {
-            this.AfterBuildFonts?.Raise();
+            this.AfterBuildFonts?.InvokeSafely();
         }
 
         private void OnResizeBuffers()
         {
-            this.ResizeBuffers?.Raise();
+            this.ResizeBuffers?.InvokeSafely();
         }
     }
 }

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -10,6 +10,7 @@ using Dalamud.Interface.GameFonts;
 using Dalamud.Interface.Internal;
 using Dalamud.Interface.Internal.ManagedAsserts;
 using Dalamud.Interface.Internal.Notifications;
+using Dalamud.Utility;
 using ImGuiNET;
 using ImGuiScene;
 using Serilog;
@@ -392,7 +393,7 @@ namespace Dalamud.Interface
         /// </summary>
         internal void OpenConfig()
         {
-            this.OpenConfigUi?.Invoke();
+            this.OpenConfigUi?.Raise();
         }
 
         /// <summary>
@@ -400,7 +401,7 @@ namespace Dalamud.Interface
         /// </summary>
         internal void NotifyHideUi()
         {
-            this.HideUi?.Invoke();
+            this.HideUi?.Raise();
         }
 
         /// <summary>
@@ -408,7 +409,7 @@ namespace Dalamud.Interface
         /// </summary>
         internal void NotifyShowUi()
         {
-            this.ShowUi?.Invoke();
+            this.ShowUi?.Raise();
         }
 
         private void OnDraw()
@@ -428,7 +429,7 @@ namespace Dalamud.Interface
                 if (!this.lastFrameUiHideState)
                 {
                     this.lastFrameUiHideState = true;
-                    this.HideUi?.Invoke();
+                    this.HideUi?.Raise();
                 }
 
                 return;
@@ -437,7 +438,7 @@ namespace Dalamud.Interface
             if (this.lastFrameUiHideState)
             {
                 this.lastFrameUiHideState = false;
-                this.ShowUi?.Invoke();
+                this.ShowUi?.Raise();
             }
 
             if (!this.interfaceManager.FontsReady)
@@ -470,7 +471,7 @@ namespace Dalamud.Interface
 
             try
             {
-                this.Draw?.Invoke();
+                this.Draw?.Raise();
             }
             catch (Exception ex)
             {
@@ -503,17 +504,17 @@ namespace Dalamud.Interface
 
         private void OnBuildFonts()
         {
-            this.BuildFonts?.Invoke();
+            this.BuildFonts?.Raise();
         }
 
         private void OnAfterBuildFonts()
         {
-            this.AfterBuildFonts?.Invoke();
+            this.AfterBuildFonts?.Raise();
         }
 
         private void OnResizeBuffers()
         {
-            this.ResizeBuffers?.Invoke();
+            this.ResizeBuffers?.Raise();
         }
     }
 }

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1262,28 +1262,14 @@ internal partial class PluginManager : IDisposable, IServiceType
     {
         this.DetectAvailablePluginUpdates();
 
-        try
-        {
-            this.OnAvailablePluginsChanged?.Invoke();
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, $"Error notifying {nameof(this.OnAvailablePluginsChanged)}");
-        }
+        this.OnAvailablePluginsChanged?.Raise();
     }
 
     private void NotifyInstalledPluginsChanged()
     {
         this.DetectAvailablePluginUpdates();
 
-        try
-        {
-            this.OnInstalledPluginsChanged?.Invoke();
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, $"Error notifying {nameof(this.OnInstalledPluginsChanged)}");
-        }
+        this.OnInstalledPluginsChanged?.Raise();
     }
 
     private static class Locs

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1262,14 +1262,14 @@ internal partial class PluginManager : IDisposable, IServiceType
     {
         this.DetectAvailablePluginUpdates();
 
-        this.OnAvailablePluginsChanged?.Raise();
+        this.OnAvailablePluginsChanged?.InvokeSafely();
     }
 
     private void NotifyInstalledPluginsChanged()
     {
         this.DetectAvailablePluginUpdates();
 
-        this.OnInstalledPluginsChanged?.Raise();
+        this.OnInstalledPluginsChanged?.InvokeSafely();
     }
 
     private static class Locs

--- a/Dalamud/Utility/EventHandlerExtensions.cs
+++ b/Dalamud/Utility/EventHandlerExtensions.cs
@@ -20,14 +20,14 @@ namespace Dalamud.Utility
         /// <param name="eh">The EventHandler in question.</param>
         /// <param name="sender">Default sender for Invoke equivalent.</param>
         /// <param name="e">Default EventArgs for Invoke equivalent.</param>
-        public static void Raise(this EventHandler eh, object sender, EventArgs e)
+        public static void InvokeSafely(this EventHandler eh, object sender, EventArgs e)
         {
             if (eh == null)
                 return;
 
             foreach (var handler in eh.GetInvocationList().Cast<EventHandler>())
             {
-                HandleRaise(() => handler(sender, e));
+                HandleInvoke(() => handler(sender, e));
             }
         }
 
@@ -39,14 +39,14 @@ namespace Dalamud.Utility
         /// <param name="sender">Default sender for Invoke equivalent.</param>
         /// <param name="e">Default EventArgs for Invoke equivalent.</param>
         /// <typeparam name="T">Type of EventArgs.</typeparam>
-        public static void Raise<T>(this EventHandler<T> eh, object sender, T e)
+        public static void InvokeSafely<T>(this EventHandler<T> eh, object sender, T e)
         {
             if (eh == null)
                 return;
 
             foreach (var handler in eh.GetInvocationList().Cast<EventHandler<T>>())
             {
-                HandleRaise(() => handler(sender, e));
+                HandleInvoke(() => handler(sender, e));
             }
         }
 
@@ -55,14 +55,14 @@ namespace Dalamud.Utility
         /// of a thrown Exception inside of an invocation.
         /// </summary>
         /// <param name="act">The Action in question.</param>
-        public static void Raise(this Action act)
+        public static void InvokeSafely(this Action act)
         {
             if (act == null)
                 return;
 
             foreach (var action in act.GetInvocationList().Cast<Action>())
             {
-                HandleRaise(action);
+                HandleInvoke(action);
             }
         }
 
@@ -72,18 +72,18 @@ namespace Dalamud.Utility
         /// </summary>
         /// <param name="updateDelegate">The OnUpdateDelegate in question.</param>
         /// <param name="framework">Framework to be passed on to OnUpdateDelegate.</param>
-        public static void Raise(this OnUpdateDelegate updateDelegate, Framework framework)
+        public static void InvokeSafely(this OnUpdateDelegate updateDelegate, Framework framework)
         {
             if (updateDelegate == null)
                 return;
 
             foreach (var action in updateDelegate.GetInvocationList().Cast<OnUpdateDelegate>())
             {
-                HandleRaise(() => action(framework));
+                HandleInvoke(() => action(framework));
             }
         }
 
-        private static void HandleRaise(Action act)
+        private static void HandleInvoke(Action act)
         {
             try
             {

--- a/Dalamud/Utility/EventHandlerExtensions.cs
+++ b/Dalamud/Utility/EventHandlerExtensions.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Linq;
+
+using Dalamud.Game;
+using Serilog;
+
+using static Dalamud.Game.Framework;
+
+namespace Dalamud.Utility
+{
+    /// <summary>
+    /// Extensions for Events.
+    /// </summary>
+    internal static class EventHandlerExtensions
+    {
+        /// <summary>
+        /// Replacement for Invoke() on EventHandlers to catch exceptions that stop event propagation in case
+        /// of a thrown Exception inside of an invocation.
+        /// </summary>
+        /// <param name="eh">The EventHandler in question.</param>
+        /// <param name="sender">Default sender for Invoke equivalent.</param>
+        /// <param name="e">Default EventArgs for Invoke equivalent.</param>
+        public static void Raise(this EventHandler eh, object sender, EventArgs e)
+        {
+            if (eh == null)
+                return;
+
+            foreach (var handler in eh.GetInvocationList().Cast<EventHandler>())
+            {
+                HandleRaise(() => handler(sender, e));
+            }
+        }
+
+        /// <summary>
+        /// Replacement for Invoke() on generic EventHandlers to catch exceptions that stop event propagation in case
+        /// of a thrown Exception inside of an invocation.
+        /// </summary>
+        /// <param name="eh">The EventHandler in question.</param>
+        /// <param name="sender">Default sender for Invoke equivalent.</param>
+        /// <param name="e">Default EventArgs for Invoke equivalent.</param>
+        /// <typeparam name="T">Type of EventArgs.</typeparam>
+        public static void Raise<T>(this EventHandler<T> eh, object sender, T e)
+        {
+            if (eh == null)
+                return;
+
+            foreach (var handler in eh.GetInvocationList().Cast<EventHandler<T>>())
+            {
+                HandleRaise(() => handler(sender, e));
+            }
+        }
+
+        /// <summary>
+        /// Replacement for Invoke() on event Actions to catch exceptions that stop event propagation in case
+        /// of a thrown Exception inside of an invocation.
+        /// </summary>
+        /// <param name="act">The Action in question.</param>
+        public static void Raise(this Action act)
+        {
+            if (act == null)
+                return;
+
+            foreach (var action in act.GetInvocationList().Cast<Action>())
+            {
+                HandleRaise(action);
+            }
+        }
+
+        /// <summary>
+        /// Replacement for Invoke() on OnUpdateDelegate to catch exceptions that stop event propagation in case
+        /// of a thrown Exception inside of an invocation.
+        /// </summary>
+        /// <param name="updateDelegate">The OnUpdateDelegate in question.</param>
+        /// <param name="framework">Framework to be passed on to OnUpdateDelegate.</param>
+        public static void Raise(this OnUpdateDelegate updateDelegate, Framework framework)
+        {
+            if (updateDelegate == null)
+                return;
+
+            foreach (var action in updateDelegate.GetInvocationList().Cast<OnUpdateDelegate>())
+            {
+                HandleRaise(() => action(framework));
+            }
+        }
+
+        private static void HandleRaise(Action act)
+        {
+            try
+            {
+                act();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Exception during raise of {handler}", act.Method);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds internal exception handling for `Invoke()` by replacing it with the `Raise()` extension method.
The idea is to continue plugin execution in case of a bad plugin causing an Exception in a subscribed event.

Raise is iterating over all event subscribers from the invocation list and in case of failure, will log an Exception, preventing it from bubbling upwards and continuing with the next subscriber, instead of halting after one Exception.

This implementation is per se incomplete and does not cover all existing event delegates in Dalamud. The principle to implement those would be the same, however I only covered the low hanging fruits and "most important" events.