### PR TITLE
Prevent BuildLookupTable crash

### DIFF
--- a/Dalamud/Interface/GameFonts/GameFontManager.cs
+++ b/Dalamud/Interface/GameFonts/GameFontManager.cs
@@ -163,7 +163,7 @@ namespace Dalamud.Interface.GameFonts
                     font->FrequentKerningPairs.Ref<float>(i) /= fontScale;
             }
 
-            if (rebuildLookupTable)
+            if (rebuildLookupTable && fontPtr.Glyphs.Size > 0)
                 fontPtr.BuildLookupTable();
         }
 

--- a/Dalamud/Interface/ImGuiHelpers.cs
+++ b/Dalamud/Interface/ImGuiHelpers.cs
@@ -220,7 +220,7 @@ namespace Dalamud.Interface
                 }
             }
 
-            if (rebuildLookupTable)
+            if (rebuildLookupTable && target.Value!.Glyphs.Size > 0)
                 target.Value!.BuildLookupTable();
         }
 

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -816,7 +816,7 @@ namespace Dalamud.Interface.Internal
                 for (int i = 0, i_ = ioFonts.ConfigData.Size; i < i_; i++)
                 {
                     var config = ioFonts.ConfigData[i];
-                    config.RasterizerGamma = config.RasterizerGamma * fontGamma;
+                    config.RasterizerGamma *= fontGamma;
                 }
 
                 Log.Verbose("[FONT] ImGui.IO.Build will be called.");
@@ -876,7 +876,15 @@ namespace Dalamud.Interface.Internal
                 for (int i = 0, i_ = ioFonts.Fonts.Size; i < i_; i++)
                 {
                     var font = ioFonts.Fonts[i];
-                    font.FallbackChar = Fallback1Codepoint;
+                    if (font.Glyphs.Size == 0)
+                    {
+                        Log.Warning("[FONT] Font has no glyph: {0}", font.GetDebugName());
+                        continue;
+                    }
+
+                    if (font.FindGlyphNoFallback(Fallback1Codepoint).NativePtr != null)
+                        font.FallbackChar = Fallback1Codepoint;
+
                     font.BuildLookupTable();
                 }
 

--- a/DalamudCrashHandler/DalamudCrashHandler.cpp
+++ b/DalamudCrashHandler/DalamudCrashHandler.cpp
@@ -444,6 +444,9 @@ int main() {
         const auto arg = std::wstring_view(args[i]);
         if (launcherArgs) {
             launcherArgs->emplace_back(arg);
+            if (arg == L"--veh-full") {
+                fullDump = true;
+            }
         } else if (constexpr wchar_t pwszArgPrefix[] = L"--process-handle="; arg.starts_with(pwszArgPrefix)) {
             g_hProcess = reinterpret_cast<HANDLE>(std::wcstoull(&arg[ARRAYSIZE(pwszArgPrefix) - 1], nullptr, 0));
         } else if (constexpr wchar_t pwszArgPrefix[] = L"--exception-info-pipe-read-handle="; arg.starts_with(pwszArgPrefix)) {
@@ -452,8 +455,6 @@ int main() {
             assetDir = arg.substr(ARRAYSIZE(pwszArgPrefix) - 1);
         } else if (constexpr wchar_t pwszArgPrefix[] = L"--log-directory="; arg.starts_with(pwszArgPrefix)) {
             logDir = arg.substr(ARRAYSIZE(pwszArgPrefix) - 1);
-        } else if (arg == L"--veh-full") {
-            fullDump = true;
         } else if (arg == L"--") {
             launcherArgs.emplace();
         } else {

--- a/DalamudCrashHandler/DalamudCrashHandler.cpp
+++ b/DalamudCrashHandler/DalamudCrashHandler.cpp
@@ -432,6 +432,7 @@ int main() {
     HANDLE hPipeRead = nullptr;
     std::filesystem::path assetDir, logDir;
     std::optional<std::vector<std::wstring>> launcherArgs;
+    auto fullDump = false;
     
     std::vector<std::wstring> args;
     if (int argc = 0; const auto argv = CommandLineToArgvW(GetCommandLineW(), &argc)) {
@@ -451,6 +452,8 @@ int main() {
             assetDir = arg.substr(ARRAYSIZE(pwszArgPrefix) - 1);
         } else if (constexpr wchar_t pwszArgPrefix[] = L"--log-directory="; arg.starts_with(pwszArgPrefix)) {
             logDir = arg.substr(ARRAYSIZE(pwszArgPrefix) - 1);
+        } else if (arg == L"--veh-full") {
+            fullDump = true;
         } else if (arg == L"--") {
             launcherArgs.emplace();
         } else {
@@ -544,7 +547,7 @@ int main() {
                 }
 
                 std::unique_ptr<std::remove_pointer_t<HANDLE>, decltype(&CloseHandle)> hDumpFilePtr(hDumpFile, &CloseHandle);
-                if (!MiniDumpWriteDump(g_hProcess, dwProcessId, hDumpFile, static_cast<MINIDUMP_TYPE>(MiniDumpWithDataSegs | MiniDumpWithModuleHeaders), &mdmp_info, nullptr, nullptr)) {
+                if (!MiniDumpWriteDump(g_hProcess, dwProcessId, hDumpFile, fullDump ? MiniDumpWithFullMemory : static_cast<MINIDUMP_TYPE>(MiniDumpWithDataSegs | MiniDumpWithModuleHeaders), &mdmp_info, nullptr, nullptr)) {
                     std::wcerr << (dumpError = std::format(L"MiniDumpWriteDump(0x{:x}, {}, 0x{:x}({}), MiniDumpWithFullMemory, ..., nullptr, nullptr) error: 0x{:x}", reinterpret_cast<size_t>(g_hProcess), dwProcessId, reinterpret_cast<size_t>(hDumpFile), dumpPath.wstring(), GetLastError())) << std::endl;
                     break;
                 }


### PR DESCRIPTION
https://github.com/goatcorp/gc-imgui/blob/640dae5de1d059bd0ce957a6a2b6385d8b81efa0/imgui_draw.cpp#L3439-L3451

The most possible cause of crashing at L3448 is that the font having no glyphs, or memory being corrupted. This attempts to prevent the case of the former one.

Also, make `--veh-full` work for DalamudCrashHandler.