### PR TITLE
Fix missing plugin names in log, filter quirk

### DIFF
--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -152,7 +152,10 @@ namespace Dalamud.Interface.Internal.Windows
             // Filter menu
             if (ImGui.BeginPopup("Filters"))
             {
-                ImGui.Checkbox("Enabled", ref this.isFiltered);
+                if (ImGui.Checkbox("Enabled", ref this.isFiltered))
+                {
+                    this.Refilter();
+                }
 
                 if (ImGui.InputTextWithHint("##filterText", "Text Filter", ref this.textFilter, 255, ImGuiInputTextFlags.EnterReturnsTrue))
                 {

--- a/Dalamud/Logging/Internal/SerilogEventSink.cs
+++ b/Dalamud/Logging/Internal/SerilogEventSink.cs
@@ -40,12 +40,6 @@ namespace Dalamud.Logging.Internal
         {
             var message = logEvent.RenderMessage(this.formatProvider);
 
-            if (logEvent.Properties.TryGetValue("SourceContext", out var sourceProp) &&
-                sourceProp is ScalarValue { Value: string source })
-            {
-                message = $"[{source}] {message}";
-            }
-
             if (logEvent.Exception != null)
             {
                 message += "\n" + logEvent.Exception;

--- a/Dalamud/Logging/PluginLog.cs
+++ b/Dalamud/Logging/PluginLog.cs
@@ -248,7 +248,14 @@ namespace Dalamud.Logging
         private static void WriteLog(string? pluginName, LogEventLevel level, string messageTemplate, Exception? exception = null, params object[] values)
         {
             var pluginLogger = GetPluginLogger(pluginName);
-            pluginLogger.Write(level, exception: exception, messageTemplate: messageTemplate, values);
+
+            // FIXME: Eventually, the `pluginName` tag should be removed from here and moved over to the actual log
+            //        formatter.
+            pluginLogger.Write(
+                level,
+                exception: exception,
+                messageTemplate: $"[{pluginName}] {messageTemplate}",
+                values);
         }
     }
 }


### PR DESCRIPTION
This pull request aims to fix a bug reported by Darkarchon where `dalamud.log` no longer contained `[PluginName]` tags for messages emitted by plugins. This PR also fixes a small bug where enabling the log filter in the console window would clear said console window.

There were a few ways to fix this bug, but the simple strategy of re-adding the `[PluginName]` tag was chosen for this fix primarily for its simplicity. That being said, this strategy does include a minor data smell: Serilog is now mutating the logs received from the plugin, and the plugin name is tracked twice: once in the `SourceContext` parameter and again in the actual plugin name. While this *probably* doesn't matter in the present, this could become interesting if alternate log formats (JSON) were to be used.

Other possible solutions to this problem were:

* Add a NuGet dependency on `Serilog.Expressions` and create a conditional log formatter to prepend messages with `[{SourceContext}]` if present.
* Convert all uses of Dalamud logs to properly set a `SourceContext` and just add the `[{SourceContext}]` tag at the formatter level.

While conversion of all Dalamud logs is *probably* a good idea regardless, I felt it was a bit out of scope for this bugfix and would just bog down this change in reviews for a pretty long time.