### PR TITLE
feat: reload dev plugin manifest when enabling

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -2118,6 +2118,11 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
                             this.enableDisableStatus = OperationStatus.InProgress;
                             this.loadingIndicatorKind = LoadingIndicatorKind.EnablingSingle;
 
+                            if (plugin.IsDev)
+                            {
+                                plugin.ReloadManifest();
+                            }
+
                             var enableTask = Task.Run(() => plugin.Enable())
                                                  .ContinueWith(this.DisplayErrorContinuation,
                                                                Locs.ErrorModal_EnableFail(plugin.Name));

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -288,11 +288,7 @@ internal class LocalPlugin : IDisposable
             if (reloading && this.IsDev)
             {
                 // Reload the manifest in-case there were changes here too.
-                var manifestDevFile = LocalPluginManifest.GetManifestFile(this.DllFile);
-                if (manifestDevFile.Exists)
-                {
-                    this.Manifest = LocalPluginManifest.Load(manifestDevFile);
-                }
+                this.ReloadManifest();
             }
 
             switch (this.State)
@@ -625,6 +621,22 @@ internal class LocalPlugin : IDisposable
     {
         this.Manifest.ScheduledForDeletion = status;
         this.SaveManifest();
+    }
+
+    /// <summary>
+    /// Reload the manifest if it exists, preserve the internal Disabled state.
+    /// </summary>
+    public void ReloadManifest()
+    {
+        var manifest = LocalPluginManifest.GetManifestFile(this.DllFile);
+        if (manifest.Exists)
+        {
+            var isDisabled = this.IsDisabled; // saving the internal state because it could have been deleted
+            this.Manifest = LocalPluginManifest.Load(manifest);
+            this.Manifest.Disabled = isDisabled;
+
+            this.SaveManifest();
+        }
     }
 
     private static void SetupLoaderConfig(LoaderConfig config)


### PR DESCRIPTION
Preserving internal Disabled state on reload, otherwise Dalamud breaks elsewhere. E.g. if the plugin was disabled and Disabled == true got deleted, it would then be Disabled == false after the reload, which isn't ideal. Maybe could only update the fields that are actually present in the new manifest, but not sure how to do that with the current LocalPluginManifest setup.