### PR TITLE
feat: reload dev plugin manifest when disabling

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -2089,6 +2089,11 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
 
                         Task.Run(() =>
                         {
+                            if (plugin.IsDev)
+                            {
+                                plugin.ReloadManifest();
+                            }
+
                             var unloadTask = Task.Run(() => plugin.UnloadAsync())
                                                  .ContinueWith(this.DisplayErrorContinuation, Locs.ErrorModal_UnloadFail(plugin.Name));
 


### PR DESCRIPTION
Basically should reload every time the manifest is going to be saved for dev plugins, as the manifest could have changed.