### PR TITLE
Check for correct image size in Image/Icon Tester

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -1300,12 +1300,34 @@ namespace Dalamud.Interface.Internal.Windows.PluginInstaller
 
             ImGuiHelpers.ScaledDummy(20);
 
+            static void CheckImageSize(TextureWrap? image, int maxWidth, int maxHeight, bool requireSquare)
+            {
+                if (image == null)
+                    return;
+                if (image.Width > maxWidth || image.Height > maxHeight)
+                    ImGui.TextColored(ImGuiColors.DalamudRed, $"Image is larger than the maximum allowed resolution ({image.Width}x{image.Height} > {maxWidth}x{maxHeight})");
+                if (requireSquare && image.Width != image.Height)
+                    ImGui.TextColored(ImGuiColors.DalamudRed, $"Image must be square! Current size: {image.Width}x{image.Height}");
+            }
+
             ImGui.InputText("Icon Path", ref this.testerIconPath, 1000);
+            if (this.testerIcon != null)
+                CheckImageSize(this.testerIcon, PluginImageCache.PluginIconWidth, PluginImageCache.PluginIconHeight, true);
             ImGui.InputText("Image 1 Path", ref this.testerImagePaths[0], 1000);
+            if (this.testerImages?.Length > 0)
+                CheckImageSize(this.testerImages[0], PluginImageCache.PluginImageWidth, PluginImageCache.PluginImageHeight, false);
             ImGui.InputText("Image 2 Path", ref this.testerImagePaths[1], 1000);
+            if (this.testerImages?.Length > 1)
+                CheckImageSize(this.testerImages[1], PluginImageCache.PluginImageWidth, PluginImageCache.PluginImageHeight, false);
             ImGui.InputText("Image 3 Path", ref this.testerImagePaths[2], 1000);
+            if (this.testerImages?.Length > 2)
+                CheckImageSize(this.testerImages[2], PluginImageCache.PluginImageWidth, PluginImageCache.PluginImageHeight, false);
             ImGui.InputText("Image 4 Path", ref this.testerImagePaths[3], 1000);
+            if (this.testerImages?.Length > 3)
+                CheckImageSize(this.testerImages[3], PluginImageCache.PluginImageWidth, PluginImageCache.PluginImageHeight, false);
             ImGui.InputText("Image 5 Path", ref this.testerImagePaths[4], 1000);
+            if (this.testerImages?.Length > 4)
+                CheckImageSize(this.testerImages[4], PluginImageCache.PluginImageWidth, PluginImageCache.PluginImageHeight, false);
 
             var im = Service<InterfaceManager>.Get();
             if (ImGui.Button("Load"))


### PR DESCRIPTION
I tried to use the Image/Icon Tester to check if my images would show up in the Plugin installer. They worked in the Image/Icon Tester.

After releasing an update to my Plugin the images didn't show up and i got [this error](https://github.com/goatcorp/Dalamud/blob/eb12fe8b2a588d28152ee013ceddae19b3b5f643/Dalamud/Interface/Internal/Windows/PluginImageCache.cs#L337).

I don't think the maximum image size is documented anywhere (?). I could only find information on the [icon size](https://github.com/goatcorp/DalamudPlugins/blob/b1be8078d9bbabe943fbbdddd367dcfcec9df9f3/README.md?plain=1#L38)


I added a warning message in the Image/Icon Tester if the image is invalid. The error messages could be improved or made to look nicer, but this works.

![ffxiv_dx11_0175](https://user-images.githubusercontent.com/6453306/191040378-01e8454e-a0f1-44fa-bc3b-b0809e1bf6ca.png)


BTW: While developing neko fans i had the same error as [this](https://github.com/goatcorp/Dalamud/blob/eb12fe8b2a588d28152ee013ceddae19b3b5f643/Dalamud/Interface/Internal/Windows/PluginImageCache.cs#L309) and found out that you can reduce the likelihood of it failing by pausing Garbage Collection (see bad code [here](https://github.com/Meisterlala/NekoFans/blob/448b1dbceea050e2d3d7860eef2613d3249a93a3/Neko/NekoImage.cs#L149))