### PR TITLE
Remove SignatureHelper.Initialise call

### DIFF
--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -422,8 +422,6 @@ internal class LocalPlugin : IDisposable
                 return;
             }
 
-            SignatureHelper.Initialise(this.instance);
-
             // In-case the manifest name was a placeholder. Can occur when no manifest was included.
             if (this.Manifest.Name.IsNullOrEmpty())
             {


### PR DESCRIPTION
This fixes #912.

Someone refactored this code and didn't seem to pay attention to the order I implemented this in, so now it runs *after* the ctor, not before. At this point, this should just be removed and devs can call `SignatureHelper.Initialise` themselves if they need to.

Ever since this was broken, it was impossible to use `SignatureHelper` in the main class, so this change in behaviour is not a breaking change.