### PR TITLE
Add SeString.Parse(byte* ) method

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -131,6 +131,25 @@ namespace Dalamud.Game.Text.SeStringHandling
 
         /// <summary>
         /// Parse a binary game message into an SeString.
+        /// Searches for null terminator to calculate string length.
+        /// </summary>
+        /// <param name="ptr">Pointer to the string's data in memory.</param>
+        /// <returns>An SeString containing parsed Payload objects for each payload in the data.</returns>
+        public static unsafe SeString Parse(byte* ptr)
+        {
+            if (ptr == null)
+                return Empty;
+
+            var countPtr = ptr;
+            while (*countPtr != 0) countPtr++;
+
+            var len = (int)(countPtr - ptr);
+
+            return Parse(ptr, len);
+        }
+
+        /// <summary>
+        /// Parse a binary game message into an SeString.
         /// </summary>
         /// <param name="data">Binary message payload data in SE's internal format.</param>
         /// <returns>An SeString containing parsed Payload objects for each payload in the data.</returns>


### PR DESCRIPTION
Add a method to generate a SeString from a byte* of unknown length by searching for and counting the number of characters until the null terminator.