### PR TITLE
Add IsDead boolean property to Character

### DIFF
--- a/Dalamud/Game/ClientState/Objects/Types/Character.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/Character.cs
@@ -100,6 +100,11 @@ public unsafe class Character : GameObject
     public ExcelResolver<OnlineStatus> OnlineStatus => new(this.Struct->OnlineStatus);
 
     /// <summary>
+    /// Gets a value indicating whether the character is dead or alive.
+    /// </summary>
+    public bool IsDead => this.Struct->EventState == 2;
+
+    /// <summary>
     /// Gets the status flags.
     /// </summary>
     public StatusFlags StatusFlags => (StatusFlags)this.Struct->StatusFlags;

--- a/Dalamud/Game/ClientState/Objects/Types/Character.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/Character.cs
@@ -100,11 +100,6 @@ public unsafe class Character : GameObject
     public ExcelResolver<OnlineStatus> OnlineStatus => new(this.Struct->OnlineStatus);
 
     /// <summary>
-    /// Gets a value indicating whether the character is dead or alive.
-    /// </summary>
-    public bool IsDead => this.Struct->EventState == 2;
-
-    /// <summary>
     /// Gets the status flags.
     /// </summary>
     public StatusFlags StatusFlags => (StatusFlags)this.Struct->StatusFlags;

--- a/Dalamud/Game/ClientState/Objects/Types/GameObject.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/GameObject.cs
@@ -135,6 +135,11 @@ public unsafe partial class GameObject
     public byte YalmDistanceZ => this.Struct->YalmDistanceFromPlayerZ;
 
     /// <summary>
+    /// Gets a value indicating whether the object is dead or alive.
+    /// </summary>
+    public bool IsDead => this.Struct->IsDead();
+
+    /// <summary>
     /// Gets the position of this <see cref="GameObject" />.
     /// </summary>
     public Vector3 Position => new(this.Struct->Position.X, this.Struct->Position.Y, this.Struct->Position.Z);


### PR DESCRIPTION
`EventState == 2` is used to check that a character is dead.
While functionally similar to checking whether the target's HP is zero, this is the correct way to check it based on how it is handled in the client (refer to `Client::Game::Character::Character_IsDead`).