### PR TITLE
Don't allow object table in PvP

### DIFF
--- a/Dalamud/Interface/Internal/Windows/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/DataWindow.cs
@@ -450,6 +450,10 @@ internal class DataWindow : Window
         {
             ImGui.TextUnformatted("LocalPlayer null.");
         }
+        else if (clientState.IsPvPExcludingDen)
+        {
+            ImGui.TextUnformatted("Cannot access object table while in PvP.");
+        }
         else
         {
             stateString += $"ObjectTableLen: {objectTable.Length}\n";


### PR DESCRIPTION
## Changes

Prevents the object table from `/xldata` from being drawn when the condition `ClientState.IsPvPExcludingDen` is met.

## Rationale

This change was made to prevent players seeing other players through the wall by using `/xldata`'s *"draw characters on screen"* functionality. I understand that this is a relatively niche and random thing to be adjusted, but it still felt like it should be done to prevent cheating as we also enforce similar restrictions on plugins with similar in-world abilities.

## Additional Information

These changes have been tested & verified working locally before this PR was made. If this kind of restriction is felt un-needed please feel free to just close this PR and ignore these changes. If any adjustments are wanted let me know.