### PR TITLE
Add IsTesting to PluginInterface

### DIFF
--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -43,7 +43,7 @@ public sealed class DalamudPluginInterface : IDisposable
     /// <param name="reason">The reason the plugin was loaded.</param>
     /// <param name="isDev">A value indicating whether this is a dev plugin.</param>
     /// <param name="sourceRepository">The repository from which the plugin is installed.</param>
-    internal DalamudPluginInterface(string pluginName, FileInfo assemblyLocation, PluginLoadReason reason, bool isDev, string sourceRepository)
+    internal DalamudPluginInterface(string pluginName, FileInfo assemblyLocation, PluginLoadReason reason, bool isDev, LocalPluginManifest manifest)
     {
         var configuration = Service<DalamudConfiguration>.Get();
         var dataManager = Service<DataManager>.Get();
@@ -56,7 +56,8 @@ public sealed class DalamudPluginInterface : IDisposable
         this.configs = Service<PluginManager>.Get().PluginConfigs;
         this.Reason = reason;
         this.IsDev = isDev;
-        this.SourceRepository = isDev ? LocalPluginManifest.FlagDevPlugin : sourceRepository;
+        this.SourceRepository = isDev ? LocalPluginManifest.FlagDevPlugin : manifest.InstalledFromUrl;
+        this.IsTesting = manifest.Testing;
 
         this.LoadTime = DateTime.Now;
         this.LoadTimeUTC = DateTime.UtcNow;
@@ -97,7 +98,11 @@ public sealed class DalamudPluginInterface : IDisposable
     public PluginLoadReason Reason { get; }
 
     /// <summary>
-    /// Gets the custom repository from which this plugin is installed, <inheritdoc cref="LocalPluginManifest.FlagMainRepo"/>, or <inheritdoc cref="LocalPluginManifest.FlagDevPlugin"/>.
+    /// Gets the repository from which this plugin was installed.
+    ///
+    /// If a plugin was installed from the official/main repository, this will return the value of
+    /// <see cref="LocalPluginManifest.FlagMainRepo"/>. Developer plugins will return the value of
+    /// <see cref="LocalPluginManifest.FlagDevPlugin"/>.
     /// </summary>
     public string SourceRepository { get; }
 
@@ -105,6 +110,14 @@ public sealed class DalamudPluginInterface : IDisposable
     /// Gets a value indicating whether this is a dev plugin.
     /// </summary>
     public bool IsDev { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this is a testing release of a plugin.
+    /// </summary>
+    /// <remarks>
+    /// Dev plugins have undefined behavior for this value, but can be expected to return <c>false</c>.
+    /// </remarks>
+    public bool IsTesting { get; }
 
     /// <summary>
     /// Gets the time that this plugin was loaded.

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -42,7 +42,7 @@ public sealed class DalamudPluginInterface : IDisposable
     /// <param name="assemblyLocation">Location of the assembly.</param>
     /// <param name="reason">The reason the plugin was loaded.</param>
     /// <param name="isDev">A value indicating whether this is a dev plugin.</param>
-    /// <param name="sourceRepository">The repository from which the plugin is installed.</param>
+    /// <param name="manifest">The local manifest for this plugin.</param>
     internal DalamudPluginInterface(string pluginName, FileInfo assemblyLocation, PluginLoadReason reason, bool isDev, LocalPluginManifest manifest)
     {
         var configuration = Service<DalamudConfiguration>.Get();

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -15,7 +15,6 @@ using Dalamud.Logging.Internal;
 using Dalamud.Plugin.Internal.Exceptions;
 using Dalamud.Plugin.Internal.Loader;
 using Dalamud.Utility;
-using Dalamud.Utility.Signatures;
 
 namespace Dalamud.Plugin.Internal.Types;
 
@@ -397,11 +396,10 @@ internal class LocalPlugin : IDisposable
             }
 
             // Update the location for the Location and CodeBase patches
-            PluginManager.PluginLocations[this.pluginType.Assembly.FullName] =
-                new PluginPatchData(this.DllFile);
+            PluginManager.PluginLocations[this.pluginType.Assembly.FullName] = new PluginPatchData(this.DllFile);
 
             this.DalamudInterface =
-                new DalamudPluginInterface(this.pluginAssembly.GetName().Name!, this.DllFile, reason, this.IsDev, this.Manifest.InstalledFromUrl);
+                new DalamudPluginInterface(this.pluginAssembly.GetName().Name!, this.DllFile, reason, this.IsDev, this.Manifest);
 
             if (this.Manifest.LoadSync && this.Manifest.LoadRequiredState is 0 or 1)
             {


### PR DESCRIPTION
This pull request aims to add an `IsTesting` field to `DalamudPluginInterface`. This change will allow certain plugins to change their behavior for testing purposes such as enabling extra logging, adding test marks to UIs, or adding additional constraints or requirements to a user's experience.

As part of this change, the entire `LocalPluginManifest` is being passed into the plugin interface, but only the `IsTesting` flag is being exposed at this time.