### PR TITLE
Improve WorldToScreen-ing points in front but off to the side

### DIFF
--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -184,8 +184,18 @@ public sealed unsafe class GameGui : IDisposable, IServiceType
     /// </summary>
     /// <param name="worldPos">Coordinates in the world.</param>
     /// <param name="screenPos">Converted coordinates.</param>
-    /// <returns>True if worldPos corresponds to a position in front of the camera.</returns>
+    /// <returns>True if worldPos corresponds to a position in front of the camera and screenPos is in the viewport.</returns>
     public bool WorldToScreen(Vector3 worldPos, out Vector2 screenPos)
+        => this.WorldToScreen(worldPos, out screenPos, out var inView) && inView;
+
+    /// <summary>
+    /// Converts in-world coordinates to screen coordinates (upper left corner origin).
+    /// </summary>
+    /// <param name="worldPos">Coordinates in the world.</param>
+    /// <param name="screenPos">Converted coordinates.</param>
+    /// <param name="inView">True if screenPos corresponds to a position inside the camera viewport.</param>
+    /// <returns>True if worldPos corresponds to a position in front of the camera.</returns>
+    public bool WorldToScreen(Vector3 worldPos, out Vector2 screenPos, out bool inView)
     {
         // Get base object with matrices
         var matrixSingleton = this.getMatrixSingleton();
@@ -203,9 +213,12 @@ public sealed unsafe class GameGui : IDisposable, IServiceType
         screenPos.X = (0.5f * width * (screenPos.X + 1f)) + windowPos.X;
         screenPos.Y = (0.5f * height * (1f - screenPos.Y)) + windowPos.Y;
 
-        return pCoords.Z > 0 &&
-               screenPos.X > windowPos.X && screenPos.X < windowPos.X + width &&
-               screenPos.Y > windowPos.Y && screenPos.Y < windowPos.Y + height;
+        var inFront = pCoords.Z > 0;
+        inView = inFront &&
+                 screenPos.X > windowPos.X && screenPos.X < windowPos.X + width &&
+                 screenPos.Y > windowPos.Y && screenPos.Y < windowPos.Y + height;
+
+        return inFront;
     }
 
     /// <summary>


### PR DESCRIPTION
Would've loved to show an example, but I didn't get any pics or gifs before the patch hit, so...

This PR splits the logic statement at the end of `WorldToScreen` apart into two, allowing for the user of that method to only care if something's "in front". This is important if you want to f.e. draw a line that goes from a world point that's on-screen to another one that's still in front of the camera, but off to the side of the screen. The previous (current) "screen culling" behavior of that method makes it impossible.

I've tested this change myself for months now using a plugin that's still in-dev and a stupid reflection hack to get the matrix singleton myself, with a slightly different signature:

```cs
public void WorldToScreen(Vector3 worldPos, out Vector2 screenPos, out bool inView, out bool inFront)
```

```cs
inFront = pCoords.Z > 0;
inView = inFront &&
    screenPos.X > windowPos.X && screenPos.X < windowPos.X + width &&
    screenPos.Y > windowPos.Y && screenPos.Y < windowPos.Y + height;
```

```cs
Service.GameGuiExt.WorldToScreen(target.Position, out Vector2 to, out bool isToInView, out bool isToInFront);

if ((Service.Config.CullAggressively && !isToInView) || !isToInFront)
{
    continue;
}
```

I've decided to keep the old behavior in tact with the existing overload and adjusted the documentation to match the existing behavior accordingly, to try to avoid surprising anyone else who used that method and relied on the "screen culling" behavior. Using the overload with the additional out param and even just discarding it works fine for getting offscreen-but-infront points.

**TL;DR:** in front != in view, ~~valve~~ pls fix