### PR TITLE
ImGuiComponents IconButton Improvements

### DIFF
--- a/Dalamud/Interface/Components/ImGuiComponents.IconButton.cs
+++ b/Dalamud/Interface/Components/ImGuiComponents.IconButton.cs
@@ -55,7 +55,7 @@ public static partial class ImGuiComponents
     /// <param name="hoveredColor">The color of the button when hovered.</param>
     /// <returns>Indicator if button is clicked.</returns>
     public static bool IconButton(int id, FontAwesomeIcon icon, Vector4? defaultColor = null, Vector4? activeColor = null, Vector4? hoveredColor = null)
-        => IconButton($"{icon.ToIconString()}{id}", defaultColor, activeColor, hoveredColor);
+        => IconButton($"{icon.ToIconString()}##{id}", defaultColor, activeColor, hoveredColor);
 
     /// <summary>
     /// IconButton component to use an icon as a button with color options.

--- a/Dalamud/Interface/Components/ImGuiComponents.IconButton.cs
+++ b/Dalamud/Interface/Components/ImGuiComponents.IconButton.cs
@@ -29,6 +29,15 @@ public static partial class ImGuiComponents
     /// <summary>
     /// IconButton component to use an icon as a button.
     /// </summary>
+    /// <param name="id">The ID of the button.</param>
+    /// <param name="icon">The icon for the button.</param>
+    /// <returns>Indicator if button is clicked.</returns>
+    public static bool IconButton(string id, FontAwesomeIcon icon)
+        => IconButton(id, icon, null, null, null);
+
+    /// <summary>
+    /// IconButton component to use an icon as a button.
+    /// </summary>
     /// <param name="iconText">Text already containing the icon string.</param>
     /// <returns>Indicator if button is clicked.</returns>
     public static bool IconButton(string iconText)
@@ -55,6 +64,18 @@ public static partial class ImGuiComponents
     /// <param name="hoveredColor">The color of the button when hovered.</param>
     /// <returns>Indicator if button is clicked.</returns>
     public static bool IconButton(int id, FontAwesomeIcon icon, Vector4? defaultColor = null, Vector4? activeColor = null, Vector4? hoveredColor = null)
+        => IconButton($"{icon.ToIconString()}##{id}", defaultColor, activeColor, hoveredColor);
+
+    /// <summary>
+    /// IconButton component to use an icon as a button with color options.
+    /// </summary>
+    /// <param name="id">The ID of the button.</param>
+    /// <param name="icon">The icon for the button.</param>
+    /// <param name="defaultColor">The default color of the button.</param>
+    /// <param name="activeColor">The color of the button when active.</param>
+    /// <param name="hoveredColor">The color of the button when hovered.</param>
+    /// <returns>Indicator if button is clicked.</returns>
+    public static bool IconButton(string id, FontAwesomeIcon icon, Vector4? defaultColor = null, Vector4? activeColor = null, Vector4? hoveredColor = null)
         => IconButton($"{icon.ToIconString()}##{id}", defaultColor, activeColor, hoveredColor);
 
     /// <summary>


### PR DESCRIPTION
Fixes IconButtons caravan issue, we (folks in dalamud-dev discord channel) believe the missing `##` separators cause the caravan issue by improperly formatting the iconstring.

Adds overloads that allow for using strings as ID's for IconButtons, this allows for nicer syntax:

```cs
if( IconButton( "Favorites Button", FontAwesomeIcon.Heart ) )
{
    // do stuff
}
```