### PR TITLE
Update MonoMod.RuntimeDetour to reorg 23.1.2-prerelease.1

### DIFF
--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -70,7 +70,7 @@
         <PackageReference Include="Lumina" Version="3.10.0" />
         <PackageReference Include="Lumina.Excel" Version="6.3.1" />
         <PackageReference Include="MinSharp" Version="1.0.4" />
-        <PackageReference Include="MonoMod.RuntimeDetour" Version="21.10.10.01" />
+        <PackageReference Include="MonoModReorg.RuntimeDetour" Version="23.1.2-prerelease.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
         <PackageReference Include="Serilog" Version="2.11.0" />
         <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
@@ -107,6 +107,14 @@
         <ItemGroup>
             <ContentWithTargetPath Include="$(ProjectDepsFilePath)" CopyToOutputDirectory="PreserveNewest" TargetPath="$(ProjectDepsFileName)" />
             <ContentWithTargetPath Include="$(ProjectRuntimeConfigFilePath)" CopyToOutputDirectory="PreserveNewest" TargetPath="$(ProjectRuntimeConfigFileName)" />
+        </ItemGroup>
+    </Target>
+
+    <Target Name="ChangeAliasesOfNugetRefs" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
+        <ItemGroup>
+            <ReferencePath Condition="'%(FileName)' == 'MonoMod.Iced'">
+                <Aliases>monomod</Aliases>
+            </ReferencePath>
         </ItemGroup>
     </Target>
 


### PR DESCRIPTION
This PR updates the RuntimeDetour dependency to a prerelease version of the reorganization branch, fixing the broken `Assembly.Location` hook on .NET 7.

Huge thanks to DaNike for picking up the ball I dropped and for spearheading the RuntimeDetour rewrite with .NET 7 support.

As usual, please feel free to ping me on your Discord server or stop by in the MonoMod Discord (linked in the readme on GitHub), should there be any oddities such as Wine causing problems again 🙂