### PR TITLE
fix: don't hide the plugin list when operations are in progress

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -1091,7 +1091,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
     private void DrawPluginCategoryContent()
     {
-        var ready = this.DrawPluginListLoading() && !this.AnyOperationInProgress;
+        var ready = this.DrawPluginListLoading();
         if (!this.categoryManager.IsSelectionValid || !ready)
         {
             return;


### PR DESCRIPTION
Fix the scrolling breaking when installing/enabling/disabling a plugin. I don't think this was necessary, as the installer keeps copies. This pretty much reverts the change made a while ago attempting to fix concurrency issues that still exist #1087.