### PR TITLE
Fix Hook constructor not assigning address to a field.

### DIFF
--- a/Dalamud/Hooking/Hook.cs
+++ b/Dalamud/Hooking/Hook.cs
@@ -67,7 +67,7 @@ public class Hook<T> : IDisposable, IDalamudHook where T : Delegate
         if (EnvironmentConfiguration.DalamudForceMinHook)
             useMinHook = true;
 
-        address = HookManager.FollowJmp(address);
+        this.address = address = HookManager.FollowJmp(address);
         if (useMinHook)
             this.compatHookImpl = new MinHookHook<T>(address, detour, callingAssembly);
         else


### PR DESCRIPTION
Even though the constructor is marked as obsolete, and recommended alternative FromAddress is correct, this obsolete constructor is still used by SignatureHelper utility.