### PR TITLE
Update FFXIVClientStructs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,10 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout Dalamud
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Define VERSION

--- a/Dalamud/EntryPoint.cs
+++ b/Dalamud/EntryPoint.cs
@@ -177,7 +177,7 @@ public sealed class EntryPoint
                 InitSymbolHandler(info);
 
             var dalamud = new Dalamud(info, configuration, mainThreadContinueEvent);
-            Log.Information("This is Dalamud - Core: {GitHash}, CS: {CsGitHash}", Util.GetGitHash(), Util.GetGitHashClientStructs());
+            Log.Information("This is Dalamud - Core: {GitHash}, CS: {CsGitHash} [{CsVersion}]", Util.GetGitHash(), Util.GetGitHashClientStructs(), FFXIVClientStructs.Interop.Resolver.Version);
 
             dalamud.WaitForUnload();
 

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -697,7 +697,7 @@ internal class DalamudInterface : IDisposable, IServiceType
 
                     ImGui.MenuItem(Util.AssemblyVersion, false);
                     ImGui.MenuItem(startInfo.GameVersion?.ToString() ?? "Unknown version", false);
-                    ImGui.MenuItem($"D: {Util.GetGitHash()} CS: {Util.GetGitHashClientStructs()}", false);
+                    ImGui.MenuItem($"D: {Util.GetGitHash()} CS: {Util.GetGitHashClientStructs()} [{FFXIVClientStructs.Interop.Resolver.Version}]", false);
                     ImGui.MenuItem($"CLR: {Environment.Version}", false);
 
                     ImGui.EndMenu();


### PR DESCRIPTION
git checkout action in `main.yml` has been changed to use `fetch-depth: 0` due to FFXIVClientStructs needing it to build