### PR TITLE
Prevent Territory with ID 0 being returned

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -304,7 +304,7 @@ public class SeString
         foreach (var place in matches)
         {
             var map = mapSheet.FirstOrDefault(row => row.PlaceName.Row == place.RowId);
-            if (map != null)
+            if (map != null && map.TerritoryType.Row != 0)
             {
                 return CreateMapLink(map.TerritoryType.Row, map.RowId, xCoord, yCoord, fudgeFactor);
             }


### PR DESCRIPTION
The function will fail in the specific case of "Mor Dhona" as FirstOrDefault returns a valid map with the PlaceName "Mor Dhona" but the TerritoryType ID 0.

With this check in place, it will return"Mor Dhona" map with TerritoryType ID 156