### PR TITLE
Add UIColor to Dalamud Data window

### DIFF
--- a/Dalamud/Interface/Internal/Windows/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/DataWindow.cs
@@ -1734,13 +1734,13 @@ internal class DataWindow : Window
 
     private void DrawUIColor(UIColor color)
     {
-        ImGui.Text($"[{color.RowId:D3}]");
+        ImGui.Text($"[{color.RowId:D3}] ");
         ImGui.SameLine();
-        ImGui.TextColored(this.ConvertToVector4(color.Unknown2), $"Unknown2");
+        ImGui.TextColored(this.ConvertToVector4(color.Unknown2), $"Unknown2 ");
         ImGui.SameLine();
-        ImGui.TextColored(this.ConvertToVector4(color.UIForeground), "UIForeground");
+        ImGui.TextColored(this.ConvertToVector4(color.UIForeground), "UIForeground ");
         ImGui.SameLine();
-        ImGui.TextColored(this.ConvertToVector4(color.Unknown3), "Unknown3");
+        ImGui.TextColored(this.ConvertToVector4(color.Unknown3), "Unknown3 ");
         ImGui.SameLine();
         ImGui.TextColored(this.ConvertToVector4(color.UIGlow), "UIGlow");
     }

--- a/Dalamud/Interface/Internal/Windows/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/DataWindow.cs
@@ -40,9 +40,11 @@ using Dalamud.Plugin.Ipc.Internal;
 using Dalamud.Utility;
 using ImGuiNET;
 using ImGuiScene;
+using Lumina.Excel.GeneratedSheets;
 using Newtonsoft.Json;
 using PInvoke;
 using Serilog;
+using Condition = Dalamud.Game.ClientState.Conditions.Condition;
 
 namespace Dalamud.Interface.Internal.Windows;
 
@@ -169,6 +171,7 @@ internal class DataWindow : Window
         Hook,
         Aetherytes,
         Dtr_Bar,
+        UIColor,
     }
 
     /// <inheritdoc/>
@@ -195,6 +198,7 @@ internal class DataWindow : Window
             "ai" => "Addon Inspector",
             "at" => "Object Table", // Actor Table
             "ot" => "Object Table",
+            "uic" => "UIColor",
             _ => dataKind,
         };
 
@@ -355,6 +359,10 @@ internal class DataWindow : Window
 
                     case DataKind.Dtr_Bar:
                         this.DrawDtr();
+                        break;
+
+                    case DataKind.UIColor:
+                        this.DrawUIColor();
                         break;
                 }
             }
@@ -1711,6 +1719,40 @@ internal class DataWindow : Window
                 entry = dtrBar.Get(title, title);
             }
         }
+    }
+
+    private void DrawUIColor()
+    {
+        var colorSheet = Service<DataManager>.Get().GetExcelSheet<UIColor>();
+        if (colorSheet is null) return;
+
+        foreach (var color in colorSheet)
+        {
+            this.DrawUIColor(color);
+        }
+    }
+
+    private void DrawUIColor(UIColor color)
+    {
+        ImGui.Text($"[{color.RowId:D3}]");
+        ImGui.SameLine();
+        ImGui.TextColored(this.ConvertToVector4(color.Unknown2), $"Unknown2");
+        ImGui.SameLine();
+        ImGui.TextColored(this.ConvertToVector4(color.UIForeground), "UIForeground");
+        ImGui.SameLine();
+        ImGui.TextColored(this.ConvertToVector4(color.Unknown3), "Unknown3");
+        ImGui.SameLine();
+        ImGui.TextColored(this.ConvertToVector4(color.UIGlow), "UIGlow");
+    }
+
+    private Vector4 ConvertToVector4(uint color)
+    {
+        var r = (byte)(color >> 24);
+        var g = (byte)(color >> 16);
+        var b = (byte)(color >> 8);
+        var a = (byte)(color);
+
+        return new Vector4(r / 255.0f, g / 255.0f, b / 255.0f, a / 255.0f);
     }
 
     private async Task TestTaskInTaskDelay(CancellationToken token)


### PR DESCRIPTION
Adds a ingame browser for all the UIColor values useful for developers when picking colors for SeStrings.

This display is dynamic so it will match the available gamedata, no more referencing a super out of date chart.

![image](https://user-images.githubusercontent.com/9083275/215300991-05d85dc4-3871-4206-aaf4-dc3207ad0b4e.png)
