### PR TITLE
Add enable and disable commands

### DIFF
--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -46,6 +46,7 @@ internal class DalamudInterface : IDisposable, IServiceType
 
     private static readonly ModuleLog Log = new("DUI");
 
+    public readonly PluginInstallerWindow PluginWindow;
     private readonly ChangelogWindow changelogWindow;
     private readonly ColorDemoWindow colorDemoWindow;
     private readonly ComponentDemoWindow componentDemoWindow;
@@ -54,7 +55,6 @@ internal class DalamudInterface : IDisposable, IServiceType
     private readonly ImeWindow imeWindow;
     private readonly ConsoleWindow consoleWindow;
     private readonly PluginStatWindow pluginStatWindow;
-    private readonly PluginInstallerWindow pluginWindow;
     private readonly SettingsWindow settingsWindow;
     private readonly SelfTestWindow selfTestWindow;
     private readonly StyleEditorWindow styleEditorWindow;
@@ -101,7 +101,7 @@ internal class DalamudInterface : IDisposable, IServiceType
         this.imeWindow = new ImeWindow() { IsOpen = false };
         this.consoleWindow = new ConsoleWindow() { IsOpen = configuration.LogOpenAtStartup };
         this.pluginStatWindow = new PluginStatWindow() { IsOpen = false };
-        this.pluginWindow = new PluginInstallerWindow(pluginImageCache) { IsOpen = false };
+        this.PluginWindow = new PluginInstallerWindow(pluginImageCache) { IsOpen = false };
         this.settingsWindow = new SettingsWindow() { IsOpen = false };
         this.selfTestWindow = new SelfTestWindow() { IsOpen = false };
         this.styleEditorWindow = new StyleEditorWindow() { IsOpen = false };
@@ -117,7 +117,7 @@ internal class DalamudInterface : IDisposable, IServiceType
         this.WindowSystem.AddWindow(this.imeWindow);
         this.WindowSystem.AddWindow(this.consoleWindow);
         this.WindowSystem.AddWindow(this.pluginStatWindow);
-        this.WindowSystem.AddWindow(this.pluginWindow);
+        this.WindowSystem.AddWindow(this.PluginWindow);
         this.WindowSystem.AddWindow(this.settingsWindow);
         this.WindowSystem.AddWindow(this.selfTestWindow);
         this.WindowSystem.AddWindow(this.styleEditorWindow);
@@ -184,7 +184,7 @@ internal class DalamudInterface : IDisposable, IServiceType
 
         this.changelogWindow.Dispose();
         this.consoleWindow.Dispose();
-        this.pluginWindow.Dispose();
+        this.PluginWindow.Dispose();
         this.titleScreenMenuWindow.Dispose();
 
         this.logoTexture.Dispose();
@@ -259,8 +259,8 @@ internal class DalamudInterface : IDisposable, IServiceType
     /// </summary>
     public void OpenPluginInstaller()
     {
-        this.pluginWindow.IsOpen = true;
-        this.pluginWindow.BringToFront();
+        this.PluginWindow.IsOpen = true;
+        this.PluginWindow.BringToFront();
     }
 
     /// <summary>
@@ -268,8 +268,8 @@ internal class DalamudInterface : IDisposable, IServiceType
     /// </summary>
     public void OpenPluginInstallerPluginChangelogs()
     {
-        this.pluginWindow.OpenPluginChangelogs();
-        this.pluginWindow.BringToFront();
+        this.PluginWindow.OpenPluginChangelogs();
+        this.PluginWindow.BringToFront();
     }
 
     /// <summary>
@@ -391,7 +391,7 @@ internal class DalamudInterface : IDisposable, IServiceType
     /// <summary>
     /// Toggles the <see cref="PluginInstallerWindow"/>.
     /// </summary>
-    public void TogglePluginInstallerWindow() => this.pluginWindow.Toggle();
+    public void TogglePluginInstallerWindow() => this.PluginWindow.Toggle();
 
     /// <summary>
     /// Toggles the <see cref="SettingsWindow"/>.
@@ -825,7 +825,7 @@ internal class DalamudInterface : IDisposable, IServiceType
 
                     if (ImGui.MenuItem("Clear cached images/icons"))
                     {
-                        this.pluginWindow?.ClearIconCache();
+                        this.PluginWindow?.ClearIconCache();
                     }
 
                     ImGui.Separator();

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -144,14 +144,14 @@ internal class PluginInstallerWindow : Window, IDisposable
         this.timeLoaded = DateTime.Now;
     }
 
-    private enum OperationStatus
+    public enum OperationStatus
     {
         Idle,
         InProgress,
         Complete,
     }
 
-    private enum LoadingIndicatorKind
+    public enum LoadingIndicatorKind
     {
         Unknown,
         EnablingSingle,
@@ -247,6 +247,26 @@ internal class PluginInstallerWindow : Window, IDisposable
         // Plugins category
         this.categoryManager.CurrentCategoryIdx = 2;
         this.IsOpen = true;
+    }
+
+    /// <summary>
+    /// Returns the current status of the installer.
+    /// </summary>
+    /// <returns>True if the installer is busy.</returns>
+    public bool IsBusy()
+    {
+        return this.AnyOperationInProgress && this.loadingIndicatorKind != LoadingIndicatorKind.Unknown;
+    }
+
+    /// <summary>
+    /// Set an progress status and indicator for the plugin installer, preventing accidental double actions.
+    /// </summary>
+    /// <param name="status">Status to set.</param>
+    /// <param name="indicator">Indicator to set.</param>
+    public void SetStatusAndIndicator(OperationStatus status, LoadingIndicatorKind indicator)
+    {
+        this.enableDisableStatus = status;
+        this.loadingIndicatorKind = indicator;
     }
 
     private void DrawProgressOverlay()

--- a/Dalamud/Plugin/PluginLoadReason.cs
+++ b/Dalamud/Plugin/PluginLoadReason.cs
@@ -29,4 +29,9 @@ public enum PluginLoadReason
     /// This plugin was loaded because the game was started or Dalamud was reinjected.
     /// </summary>
     Boot,
+
+    /// <summary>
+    /// This plugin was loaded because the user requested it via command
+    /// </summary>
+    Command,
 }


### PR DESCRIPTION
Adds two simple chat commands, /xlenable and /xldisable.
The commands take the full plugin name as argument and try to enable/disable said plugin.

The user will be informed with a chat message if the load/unload was successful.