### PR TITLE
Destroy clipper each frame

### DIFF
--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -331,6 +331,7 @@ internal class ConsoleWindow : Window, IDisposable
             }
 
             clipper.End();
+            clipper.Destroy();
         }
 
         ImGui.PopFont();


### PR DESCRIPTION
This stops a memory leak from happening, as far as I can see the clipper should be destroyed as it's being created in the same draw call.

Discussion around this occurred in #plugin-dev