### PR TITLE
Minor Logging QoL

### DIFF
--- a/Dalamud/Logging/PluginLog.cs
+++ b/Dalamud/Logging/PluginLog.cs
@@ -27,7 +27,7 @@ public static class PluginLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public static void Log(Exception exception, string messageTemplate, params object[] values)
+    public static void Log(Exception? exception, string messageTemplate, params object[] values)
         => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Information, messageTemplate, exception, values);
 
     /// <summary>
@@ -44,7 +44,7 @@ public static class PluginLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public static void LogVerbose(Exception exception, string messageTemplate, params object[] values)
+    public static void LogVerbose(Exception? exception, string messageTemplate, params object[] values)
         => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Verbose, messageTemplate, exception, values);
 
     /// <summary>
@@ -61,7 +61,7 @@ public static class PluginLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public static void LogDebug(Exception exception, string messageTemplate, params object[] values)
+    public static void LogDebug(Exception? exception, string messageTemplate, params object[] values)
         => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Debug, messageTemplate, exception, values);
 
     /// <summary>
@@ -78,7 +78,7 @@ public static class PluginLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public static void LogInformation(Exception exception, string messageTemplate, params object[] values)
+    public static void LogInformation(Exception? exception, string messageTemplate, params object[] values)
         => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Information, messageTemplate, exception, values);
 
     /// <summary>
@@ -95,7 +95,7 @@ public static class PluginLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public static void LogWarning(Exception exception, string messageTemplate, params object[] values)
+    public static void LogWarning(Exception? exception, string messageTemplate, params object[] values)
         => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Warning, messageTemplate, exception, values);
 
     /// <summary>
@@ -112,7 +112,7 @@ public static class PluginLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public static void LogError(Exception exception, string messageTemplate, params object[] values)
+    public static void LogError(Exception? exception, string messageTemplate, params object[] values)
         => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Error, messageTemplate, exception, values);
 
     /// <summary>
@@ -129,7 +129,7 @@ public static class PluginLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public static void LogFatal(Exception exception, string messageTemplate, params object[] values)
+    public static void LogFatal(Exception? exception, string messageTemplate, params object[] values)
         => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Fatal, messageTemplate, exception, values);
 
     #endregion
@@ -150,7 +150,7 @@ public static class PluginLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public static void Verbose(Exception exception, string messageTemplate, params object[] values)
+    public static void Verbose(Exception? exception, string messageTemplate, params object[] values)
         => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Verbose, messageTemplate, exception, values);
 
     /// <summary>
@@ -167,7 +167,7 @@ public static class PluginLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public static void Debug(Exception exception, string messageTemplate, params object[] values)
+    public static void Debug(Exception? exception, string messageTemplate, params object[] values)
         => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Debug, messageTemplate, exception, values);
 
     /// <summary>
@@ -184,7 +184,7 @@ public static class PluginLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public static void Information(Exception exception, string messageTemplate, params object[] values)
+    public static void Information(Exception? exception, string messageTemplate, params object[] values)
         => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Information, messageTemplate, exception, values);
 
     /// <summary>
@@ -201,7 +201,7 @@ public static class PluginLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public static void Warning(Exception exception, string messageTemplate, params object[] values)
+    public static void Warning(Exception? exception, string messageTemplate, params object[] values)
         => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Warning, messageTemplate, exception, values);
 
     /// <summary>
@@ -218,7 +218,7 @@ public static class PluginLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public static void Error(Exception exception, string messageTemplate, params object[] values)
+    public static void Error(Exception? exception, string messageTemplate, params object[] values)
         => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Error, messageTemplate, exception, values);
 
     /// <summary>
@@ -235,7 +235,7 @@ public static class PluginLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public static void Fatal(Exception exception, string messageTemplate, params object[] values)
+    public static void Fatal(Exception? exception, string messageTemplate, params object[] values)
         => WriteLog(Assembly.GetCallingAssembly().GetName().Name, LogEventLevel.Fatal, messageTemplate, exception, values);
 
     #endregion

--- a/Dalamud/Logging/PluginLog.cs
+++ b/Dalamud/Logging/PluginLog.cs
@@ -240,6 +240,20 @@ public static class PluginLog
 
     #endregion
 
+    /// <summary>
+    /// Log a message to the in-game log, setting level at runtime.
+    /// </summary>
+    /// <remarks>
+    /// This method is primarily meant for interoperability with other logging systems that may want to be forwarded to
+    /// the PluginLog.
+    /// </remarks>
+    /// <param name="level">The log level for this message.</param>
+    /// <param name="exception">An exception (if any) to include in this log message.</param>
+    /// <param name="messageTemplate">The message template.</param>
+    /// <param name="values">Values to log.</param>
+    public static void LogRaw(LogEventLevel level, Exception? exception, string messageTemplate, params object[] values)
+        => WriteLog(Assembly.GetCallingAssembly().GetName().Name, level, messageTemplate, exception, values);
+
     private static ILogger GetPluginLogger(string? pluginName)
     {
         return Serilog.Log.ForContext("SourceContext", pluginName ?? string.Empty);


### PR DESCRIPTION
This pull request aims to add the following:

- A new `LogRaw()` method in `PluginLog` will allow plugin developers to specify log levels at runtime, allowing easier interoperability with other logging systems.
- Update all `Exception` arguments to be nullable, suppressing compiler warnings in cases where an exception may or may not be present.

If necessary, I have no qualms about dropping the Exception nullability change (will it affect API?).