### PR TITLE
Adding PartyFinderPayload to Dalamud.Game.Text

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/Payload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payload.cs
@@ -168,6 +168,12 @@ public abstract partial class Payload
                             payload = new DalamudLinkPayload();
                             break;
 
+                        case EmbeddedInfoType.PartyFinderNotificationLink:
+                        // this is handled by PartyFinderPayload, so let this fall through
+                        case EmbeddedInfoType.PartyFinderLink:
+                            payload = new PartyFinderPayload();
+                            break;
+
                         case EmbeddedInfoType.LinkTerminator:
                         // this has no custom handling and so needs to fallthrough to ensure it is captured
                         default:
@@ -268,9 +274,19 @@ public abstract partial class Payload
         QuestLink = 0x05,
 
         /// <summary>
+        /// The link to the party finder search conditions.
+        /// </summary>
+        PartyFinderNotificationLink = 0x08,
+
+        /// <summary>
         /// A status effect.
         /// </summary>
         Status = 0x09,
+
+        /// <summary>
+        /// The link to a party finder listing.
+        /// </summary>
+        PartyFinderLink = 0x0A,
 
         /// <summary>
         /// A custom Dalamud link.

--- a/Dalamud/Game/Text/SeStringHandling/PayloadType.cs
+++ b/Dalamud/Game/Text/SeStringHandling/PayloadType.cs
@@ -79,4 +79,9 @@ public enum PayloadType
     /// An SeString payload representing a doublewide SE hypen.
     /// </summary>
     SeHyphen,
+
+    /// <summary>
+    /// An SeString payload representing a party finder link.
+    /// </summary>
+    PartyFinder,
 }

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/PartyFinderPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/PartyFinderPayload.cs
@@ -76,6 +76,12 @@ namespace Dalamud.Game.Text.SeStringHandling.Payloads
         public override PayloadType Type => PayloadType.PartyFinder;
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"{this.Type} - ListingId: {this.ListingId}, PartyFinderLinkType: {this.LinkType}";
+        }
+
+        /// <inheritdoc/>
         protected override void DecodeImpl(BinaryReader reader, long endOfStream)
         {
             // 0x01 here indicates a party finder notification, which needs to be handled uniquely

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/PartyFinderPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/PartyFinderPayload.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+using Lumina.Extensions;
+using Newtonsoft.Json;
+
+namespace Dalamud.Game.Text.SeStringHandling.Payloads
+{
+    /// <summary>
+    /// An SeString Payload representing an interactable party finder link.
+    /// </summary>
+    public class PartyFinderPayload : Payload
+    {
+        /// <summary>
+        /// Delimiting byte for party finder payload flags.
+        /// </summary>
+        // at least that's what i think it is... in any case, this works.
+        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "This is preferred.")]
+        protected const byte FLAG_DELIMITER = 0x01;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartyFinderPayload"/> class.
+        /// Creates a payload representing an interactable party finder link for the specified party finder listing.
+        /// </summary>
+        /// <param name="listingId">The listing ID of the party finder listing.</param>
+        /// <param name="type">The party finder link type that should be encoded with this link.</param>
+        public PartyFinderPayload(uint listingId, PartyFinderLinkType type)
+        {
+            this.ListingId = listingId;
+            this.LinkType = type;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartyFinderPayload"/> class.
+        /// Creates a payload representing an interactable party finder notification link.
+        /// </summary>
+        public PartyFinderPayload()
+        {
+        }
+
+        /// <summary>
+        /// Represents the flags in a party finder link.
+        /// </summary>
+        public enum PartyFinderLinkType
+        {
+            /// <summary>
+            /// Indicates that the party finder link is for a party that is limited to the host's home world.
+            /// </summary>
+            LimitedToHomeWorld = 0xF3,
+
+            /// <summary>
+            /// Indicates that the party finder link is for the "Display advanced search results in log." option.
+            /// </summary>
+            PartyFinderNotification = 0xFF,
+
+            /// <summary>
+            /// Indicates that the party finder link type was unspecified. Only for internal use. Not used by SE and omitted from encoding.
+            /// </summary>
+            NotSpecified = 0x00,
+        }
+
+        /// <summary>
+        /// Gets the party finder listing ID.
+        /// </summary>
+        [JsonProperty]
+        public uint ListingId { get; private set; }
+
+        /// <summary>
+        /// Gets the link type.
+        /// </summary>
+        [JsonProperty]
+        public PartyFinderLinkType LinkType { get; private set; } = PartyFinderLinkType.PartyFinderNotification;
+
+        /// <inheritdoc/>
+        public override PayloadType Type => PayloadType.PartyFinder;
+
+        /// <inheritdoc/>
+        protected override void DecodeImpl(BinaryReader reader, long endOfStream)
+        {
+            // 0x01 here indicates a party finder notification, which needs to be handled uniquely
+            if (reader.PeekByte() == 0x01)
+            {
+                this.LinkType = PartyFinderLinkType.PartyFinderNotification;
+                return;
+            }
+
+            this.ListingId = GetInteger(reader);
+
+            // throw away always 0x01
+            reader.ReadByte();
+
+            // if the next byte is 0xF3 then this listing is limited to home world
+            byte nextByte = reader.ReadByte();
+            switch (nextByte)
+            {
+                case (byte)PartyFinderLinkType.LimitedToHomeWorld:
+                    this.LinkType = PartyFinderLinkType.LimitedToHomeWorld;
+                    break;
+
+                // if this byte is just the flag delimiter, then nothing was specified.
+                case FLAG_DELIMITER:
+                    this.LinkType = PartyFinderLinkType.NotSpecified;
+                    break;
+
+                default:
+                    Serilog.Log.Information($"Unrecognized PartyFinderLinkType code {nextByte} (Hex - {nextByte:X2})");
+                    break;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override byte[] EncodeImpl()
+        {
+            // if the link type is notification, just use premade payload data since it's always the same.
+            // i have no idea why it is formatted like this, but it is how it is.
+            // note it is identical to the link terminator payload except the embedded info type is 0x08
+            if (this.LinkType == PartyFinderLinkType.PartyFinderNotification) return new byte[] { 0x02, 0x27, 0x07, 0x08, 0x01, 0x01, 0x01, 0xFF, 0x01, 0x03, };
+
+            // back to our regularly scheduled programming...
+            var listingIDBytes = MakeInteger(this.ListingId);
+            bool isFlagSpecified = this.LinkType != PartyFinderLinkType.NotSpecified;
+
+            var chunkLen = listingIDBytes.Length + 4;
+            // 1 more byte for the type flag if it is specified
+            if (isFlagSpecified) chunkLen++;
+
+            var bytes = new List<byte>()
+            {
+                START_BYTE, (byte)SeStringChunkType.Interactable, (byte)chunkLen, (byte)EmbeddedInfoType.PartyFinderLink,
+            };
+
+            bytes.AddRange(listingIDBytes);
+
+            bytes.Add(FLAG_DELIMITER);
+
+            if (isFlagSpecified) bytes.Add((byte)this.LinkType);
+
+            bytes.Add(FLAG_DELIMITER);
+
+            bytes.Add(END_BYTE);
+
+            return bytes.ToArray();
+        }
+    }
+}

--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -315,6 +315,51 @@ public class SeString
     }
 
     /// <summary>
+    /// Creates an SeString representing an entire payload chain that can be used to link party finder listings in the chat log.
+    /// </summary>
+    /// <param name="listingId">The listing ID of the party finder entry.</param>
+    /// <param name="recruiterName">The name of the recruiter.</param>
+    /// <param name="isCrossWorld">Whether the listing is limited to the current world or not.</param>
+    /// <returns>An SeString containing all the payloads necessary to display a party finder link in the chat log.</returns>
+    public static SeString CreatePartyFinderLink(uint listingId, string recruiterName, bool isCrossWorld = false)
+    {
+        var payloads = new List<Payload>()
+        {
+            new PartyFinderPayload(listingId, isCrossWorld ? PartyFinderPayload.PartyFinderLinkType.NotSpecified : PartyFinderPayload.PartyFinderLinkType.LimitedToHomeWorld),
+            // ->
+            new TextPayload($"Looking for Party ({recruiterName})"),
+        };
+
+        payloads.InsertRange(1, TextArrowPayloads);
+
+        if (isCrossWorld)
+            payloads.Add(new IconPayload(BitmapFontIcon.CrossWorld));
+
+        payloads.Add(RawPayload.LinkTerminator);
+
+        return new SeString(payloads);
+    }
+
+    /// <summary>
+    /// Creates an SeString representing an entire payload chain that can be used to link the party finder search conditions.
+    /// </summary>
+    /// <param name="message">The text that should be displayed for the link.</param>
+    /// <returns>An SeString containing all the payloads necessary to display a link to the party finder search conditions.</returns>
+    public static SeString CreatePartyFinderSearchConditionsLink(string message)
+    {
+        var payloads = new List<Payload>()
+        {
+            new PartyFinderPayload(),
+            // ->
+            new TextPayload(message),
+        };
+        payloads.InsertRange(1, TextArrowPayloads);
+        payloads.Add(RawPayload.LinkTerminator);
+
+        return new SeString(payloads);
+    }
+
+    /// <summary>
     /// Creates a SeString from a json. (For testing - not recommended for production use.)
     /// </summary>
     /// <param name="json">A serialized SeString produced by ToJson() <see cref="ToJson"/>.</param>

--- a/Dalamud/Game/Text/SeStringHandling/SeStringBuilder.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeStringBuilder.cs
@@ -187,6 +187,20 @@ public class SeStringBuilder
     public SeStringBuilder AddStatusLink(uint statusId) => this.Add(new StatusPayload(statusId));
 
     /// <summary>
+    /// Add a link to the party finder search conditions to the builder.
+    /// </summary>
+    /// <returns>The current builder.</returns>
+    public SeStringBuilder AddPartyFinderSearchConditionsLink() => this.Add(new PartyFinderPayload());
+
+    /// <summary>
+    /// Add a party finder listing link to the builder.
+    /// </summary>
+    /// <param name="id">The listing ID of the party finder listing.</param>
+    /// <param name="isCrossWorld">Whether the listing is limited to the recruiting world.</param>
+    /// <returns>The current builder.</returns>
+    public SeStringBuilder AddPartyFinderLink(uint id, bool isCrossWorld = false) => this.Add(new PartyFinderPayload(id, isCrossWorld ? PartyFinderPayload.PartyFinderLinkType.NotSpecified : PartyFinderPayload.PartyFinderLinkType.LimitedToHomeWorld));
+
+    /// <summary>
     /// Add a payload to the builder.
     /// </summary>
     /// <param name="payload">The payload to add.</param>


### PR DESCRIPTION
I've done testing and it looks like all party finder chat link payloads have the following format
```
[1 byte]  Start byte (0x02)
[1 byte]  SeStringChunkType.Interactable (0x27)
[1 byte]  Number of following bytes.
[1 byte]  Embedded info type 0x0A
[3 bytes] Party finder ID encoded as SE integer
[1 byte]  Always 0x01.
[1 byte]  0xF3 if recruitment is limited to home world. Omitted otherwise.
[1 byte]  Always 0x01.
[1 byte]  End byte. (0x03)
```
and like other links they are terminated with `02 27 07 CF 01 01 01 FF 01 03`. I do not understand why the `01 01` or `01 F3 01` occurs at the end. My best guess is the `0x01`s delimit a section of flags, but the only flag I have seen after testing many party finders is `0xF3` denoting that recruitment is limited to home world.

The other type of party finder link comes from the periodic notifications about parties matching search conditions. The link for these is always the, what I call "empty interactable payload," which normally terminates links, except the embedded info type byte (normally `0xCF` for link terminators) is `0x08`.

Herein, I implement the `PartyFinderPayload` class as well as update some associated enums and methods in other classes to make it fit the conventions and rest of the library.