### PR TITLE
Improve DutyState

### DIFF
--- a/Dalamud/Game/DutyState/DutyState.cs
+++ b/Dalamud/Game/DutyState/DutyState.cs
@@ -121,8 +121,15 @@ public unsafe class DutyState : IDisposable, IServiceType
                     this.DutyRecommenced.InvokeSafely(this, this.clientState.TerritoryType);
                     break;
 
+                // Duty Completed Flytext Shown
+                case 0x4000_0002 when !this.CompletedThisTerritory:
+                    this.IsDutyStarted = false;
+                    this.CompletedThisTerritory = true;
+                    this.DutyCompleted.InvokeSafely(this, this.clientState.TerritoryType);
+                    break;
+
                 // Duty Completed
-                case 0x4000_0003:
+                case 0x4000_0003 when !this.CompletedThisTerritory:
                     this.IsDutyStarted = false;
                     this.CompletedThisTerritory = true;
                     this.DutyCompleted.InvokeSafely(this, this.clientState.TerritoryType);


### PR DESCRIPTION
Adds 0x4000_0002 event to DutyState, this triggers when the DutyComplete Flytext is shown, this seems to be sent instead of 0x4000_0003 in places like MaskedCarnivale and Guildhests. 

For extra safety to prevent the this.DutyCompleted event from firing too much it will check for CompletedThisTerritory to make sure both network messages can't trigger the event at the same time.