### PR TITLE
feat(network): Disable sales uploads for now

### DIFF
--- a/Dalamud/Game/Network/Internal/NetworkHandlers.cs
+++ b/Dalamud/Game/Network/Internal/NetworkHandlers.cs
@@ -234,9 +234,9 @@ internal class NetworkHandlers : IDisposable, IServiceType
         var startObservable = this.OnMarketBoardItemRequestStart();
         return Observable.When(
                              startObservable
-                                 .And(this.OnMarketBoardSalesBatch())
+                                 // .And(this.OnMarketBoardSalesBatch())
                                  .And(this.OnMarketBoardListingsBatch(startObservable))
-                                 .Then((request, sales, listings) => (request, sales, listings)))
+                                 .Then((request, listings) => (request, new List<MarketBoardHistory.MarketBoardHistoryListing>(), listings)))
                          .Where(this.ShouldUpload)
                          .Subscribe(
                              data =>


### PR DESCRIPTION
There's a data inconsistency where the wrong sales packet is being piped along, causing scrambled data in the API. I'm just disabling this for now while I fix it.