### PR TITLE
Better local time for local builds

### DIFF
--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -146,7 +146,7 @@
     <Target Name="GetGitHashStub" BeforeTargets="WriteGitHash" Condition="'$(BuildHash)'=='' And '$(Configuration)'=='Debug'">
         <!-- Set the BuildHash property to contain some placeholder, if it wasn't already set.-->
         <PropertyGroup>
-            <LocalBuildText>Local build at $([System.DateTime]::Now.ToString(yyyyMMdd-hhmmss))</LocalBuildText>
+            <LocalBuildText>Local build at $([System.DateTime]::Now.ToString(yyyy-MM-dd HH:mm:ss))</LocalBuildText>
             <BuildHash>$(LocalBuildText)</BuildHash>
             <BuildHashClientStructs>???</BuildHashClientStructs>
         </PropertyGroup>


### PR DESCRIPTION
Using 24-hour clock and just prettifying💅.
Not sure if this has other implications, didn't find anything using it except the dev bar when using debug builds.
![😎](https://user-images.githubusercontent.com/33433913/220185952-70bf0a28-4706-4873-aabc-2caab54a121c.png)
