### PR TITLE
fix: Correctly handle MB pages with 0 listings

### DIFF
--- a/Dalamud/Game/Network/Internal/NetworkHandlers.cs
+++ b/Dalamud/Game/Network/Internal/NetworkHandlers.cs
@@ -192,6 +192,11 @@ internal class NetworkHandlers : IDisposable, IServiceType
         IObservable<MarketBoardCurrentOfferings> UntilBatchEnd(MarketBoardItemRequest request)
         {
             var totalPackets = Convert.ToInt32(Math.Ceiling((double)request.AmountToArrive / 10));
+            if (totalPackets == 0)
+            {
+                return Observable.Empty<MarketBoardCurrentOfferings>();
+            }
+
             return offeringsObservable
                    .Where(offerings => offerings.ItemListings.All(l => l.CatalogId == request.CatalogId))
                    .Skip(totalPackets - 1)


### PR DESCRIPTION
See title, this just adds handling for the common edge case where an item has 0 market board listings.