### PR TITLE
Fix faulty documentation in UiBuilder

### DIFF
--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -86,13 +86,13 @@ public sealed class UiBuilder : IDisposable
     public event Action AfterBuildFonts;
 
     /// <summary>
-    /// Gets or sets an action that is called when plugin UI or interface modifications are supposed to be hidden.
+    /// Gets or sets an action that is called when plugin UI or interface modifications are supposed to be shown.
     /// These may be fired consecutively.
     /// </summary>
     public event Action ShowUi;
 
     /// <summary>
-    /// Gets or sets an action that is called when plugin UI or interface modifications are supposed to be shown.
+    /// Gets or sets an action that is called when plugin UI or interface modifications are supposed to be hidden.
     /// These may be fired consecutively.
     /// </summary>
     public event Action HideUi;


### PR DESCRIPTION
`ShowUi` and `HideUi` have their documentation swapped.