### PR TITLE
Fix `LoadBannedPlugins`

### DIFF
--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1273,7 +1273,7 @@ Thanks and have fun!";
         Debug.Assert(this.bannedPlugins != null, "this.bannedPlugins != null");
 
         if (this.LoadBannedPlugins)
-            return true;
+            return false;
 
         var config = Service<DalamudConfiguration>.Get();
 


### PR DESCRIPTION
Currently, enabling banned plugin loading will flag all plugins as banned. 