### PR TITLE
Fix ImGui keyboard event

### DIFF
--- a/Dalamud/Game/ClientState/Keys/InputDevicePoll.cs
+++ b/Dalamud/Game/ClientState/Keys/InputDevicePoll.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+using Dalamud.Hooking;
+using Dalamud.Utility;
+
+namespace Dalamud.Game.ClientState.Keys;
+
+/// <summary>
+/// This class provides events related to game inputs.
+/// </summary>
+[ServiceManager.BlockingEarlyLoadedService]
+internal sealed class InputDevicePoll : IDisposable, IServiceType
+{
+    private readonly Hook<UpdateInputDelegate> updateInputHook;
+
+    /// <summary>
+    /// Raised when the game is about to poll inputs.
+    /// </summary>
+    public event Action? OnBeforePoll;
+
+    /// <summary>
+    /// Raised when the game polled inputs.
+    /// </summary>
+    public event Action? OnAfterPoll;
+
+    [ServiceManager.ServiceConstructor]
+    public InputDevicePoll(SigScanner sigScanner)
+    {
+        // Client::System::Framework::Framework_TaskUpdateInputDevice (names from FFXIVClientStructs) calls this function
+        // 48:83EC 48   | sub rsp,48 |
+        // 48:895C24 50 | mov qword ptr ss: [rsp+50],rbx |
+        // BA 1E000000  | mov edx,1E |
+        // 48:897424 58 | mov qword ptr ss: [rsp+58],rsi |
+        // 48:897C24 40 | mov qword ptr ss: [rsp+40],rdi |
+        // 48:8BF9      | mov rdi,rcx |
+        // 48:81C1 60040000 | add rcx,460 |
+        // 0F297424 30  | movaps xmmword ptr ss: [rsp+30],xmm6 |
+        // 0F28F1       | movaps xmm6,xmm1 |
+        // E8 0158FDFF  | call ffxiv_dx11.7FF6CDD89970 |
+        var updateInputAddr =
+            sigScanner.ScanText(
+                "48?????? 48???????? BA ????0000 48???????? 48???????? 48???? 4881C1????0000 0F???????? 0F???? E8");
+        this.updateInputHook = Hook<UpdateInputDelegate>.FromAddress(updateInputAddr, this.OnUpdateInput);
+        this.updateInputHook.Enable();
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate nint UpdateInputDelegate(nint a1, nint a2);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        this.updateInputHook.Dispose();
+    }
+
+    private nint OnUpdateInput(nint a1, nint a2)
+    {
+        this.OnBeforePoll?.InvokeSafely();
+        var ret = this.updateInputHook.Original(a1, a2);
+        this.OnAfterPoll?.InvokeSafely();
+
+        return ret;
+    }
+}

--- a/Dalamud/Game/ClientState/Keys/KeyCapture.State.cs
+++ b/Dalamud/Game/ClientState/Keys/KeyCapture.State.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Dalamud.Game.ClientState.Keys;
+
+partial class KeyCapture
+{
+    [Flags]
+    private enum State : byte
+    {
+        CaptureAll = 0x01,
+        CaptureAllSingleFrame = 0x02,
+        RestoreAllOnNextFrame = 0x04,
+    }
+}

--- a/Dalamud/Game/ClientState/Keys/KeyCapture.cs
+++ b/Dalamud/Game/ClientState/Keys/KeyCapture.cs
@@ -10,7 +10,7 @@ namespace Dalamud.Game.ClientState.Keys;
 [PluginInterface]
 [InterfaceVersion("1.0")]
 [ServiceManager.BlockingEarlyLoadedService]
-public sealed partial class KeyCapture : IDisposable, IServiceType
+internal sealed partial class KeyCapture : IDisposable, IServiceType
 {
     private readonly InputDevicePoll mInputDevicePoll;
 

--- a/Dalamud/Game/ClientState/Keys/KeyCapture.cs
+++ b/Dalamud/Game/ClientState/Keys/KeyCapture.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+
+using Dalamud.IoC;
+using Dalamud.IoC.Internal;
+using MonoMod.Utils;
+
+namespace Dalamud.Game.ClientState.Keys;
+
+[PluginInterface]
+[InterfaceVersion("1.0")]
+[ServiceManager.BlockingEarlyLoadedService]
+public sealed partial class KeyCapture : IDisposable, IServiceType
+{
+    private readonly InputDevicePoll mInputDevicePoll;
+
+    private readonly SimulatedKeyState mSimulatedKeyState;
+
+    private readonly RawKeyState mRawKeyState;
+
+    private readonly List<ushort> mNextCaptureSet = new();
+
+    private readonly List<ushort> mNextRestoreSet = new();
+
+    private State mCaptureState;
+
+    [ServiceManager.ServiceConstructor]
+    private KeyCapture(InputDevicePoll devicePoll, SimulatedKeyState simulatedKeyState, RawKeyState rawKeyState)
+    {
+        this.mInputDevicePoll = devicePoll;
+        this.mSimulatedKeyState = simulatedKeyState;
+        this.mRawKeyState = rawKeyState;
+
+        this.mInputDevicePoll.OnBeforePoll += this.OnBeforeInputPoll;
+    }
+
+    /// <inheritdoc />
+    void IDisposable.Dispose()
+    {
+        this.mInputDevicePoll.OnBeforePoll -= this.OnBeforeInputPoll;
+    }
+
+    /// <summary>
+    /// Stop delivering inputs to the game indefinitely.
+    /// </summary>
+    /// <param name="doCapture">
+    /// If this is set to true then it will block all inputs.
+    /// To stop capturing, set this to false.
+    /// </param>
+    public void CaptureAll(bool doCapture = true)
+    {
+        this.mCaptureState = doCapture switch
+        {
+            true => this.mCaptureState | State.CaptureAll,
+            false => this.mCaptureState & ~State.CaptureAll,
+        };
+
+        if (!doCapture)
+        {
+            // Also queue restore so that the game can receive held inputs again.
+            this.mCaptureState |= State.RestoreAllOnNextFrame;
+        }
+    }
+
+    /// <summary>
+    /// Captures all keys for a single frame.
+    /// </summary>
+    public void CaptureAllSingleFrame()
+    {
+        this.mCaptureState |= State.CaptureAllSingleFrame;
+    }
+
+    /// <summary>
+    /// Captures a designated key for a single frame.
+    /// </summary>
+    /// <param name="vkCode">A virtual key code to capture.</param>
+    public void CaptureSingleFrame(ushort vkCode)
+    {
+        this.mNextCaptureSet.Add(vkCode);
+    }
+
+    private void OnBeforeInputPoll()
+    {
+        // Restore all keys
+        if (this.mCaptureState.HasFlag(State.RestoreAllOnNextFrame))
+        {
+            // Remove pending restore flag
+            this.mCaptureState &= ~State.RestoreAllOnNextFrame;
+
+            // Copy all simulated key states into actual buffer.
+            // Note that simulated key state is laid out very carefully so that
+            // it could just be memcpy'd in this situation.
+            this.mSimulatedKeyState.RawState.CopyTo(this.mRawKeyState.RawState);
+
+            // If restored all keys, there's no point of restoring individual keys.
+            this.mNextRestoreSet.Clear();
+        }
+
+        // Restore individual keys
+        foreach (var vkCode in this.mNextRestoreSet)
+        {
+            if (!this.mSimulatedKeyState.TryGetState(vkCode, out var state))
+            {
+                continue;
+            }
+
+            // Set key state to its original value
+            // Log.Verbose("restore: {VkCode} = {State}" vkCode, state);
+            this.mRawKeyState.SetState(vkCode, state);
+        }
+
+        this.mNextRestoreSet.Clear();
+
+        // Capture key states.
+        // Note that we process capturing **only after** finished restoring keys.
+        // This allows capturing to take higher precedence over restoring if they're queued on the same frame.
+        if (this.mCaptureState.HasFlag(State.CaptureAll))
+        {
+            // We clear game inputs here on every frame to block delivering any new inputs to the game
+            // because we didn't at DispatchMessage time.
+            //
+            // Thankfully zeroing ~1KB contiguous memory is very fast so we don't even need to touch WndProc hook at all.
+            this.mRawKeyState.RawState.Clear();
+
+            // If we captured all keys, there's no point of restoring individual keys.
+            this.mNextCaptureSet.Clear();
+        }
+
+        if (this.mCaptureState.Has(State.CaptureAllSingleFrame))
+        {
+            // Remove CaptureAllSingleFrame and Add RestoreAllOnNextFrame
+            this.mCaptureState = (this.mCaptureState | State.RestoreAllOnNextFrame) &
+                                 ~State.CaptureAllSingleFrame;
+            this.mRawKeyState.RawState.Clear();
+        }
+
+        // Capture individual keys
+        foreach (var vkCode in this.mNextCaptureSet)
+        {
+            if (!VirtualKeyExtensions.IsValidVirtualKey(vkCode))
+            {
+                continue;
+            }
+
+            // Release a key
+            this.mRawKeyState.SetState(vkCode, KeyStateFlag.None);
+            this.mNextRestoreSet.Add(vkCode);
+        }
+
+        this.mNextCaptureSet.Clear();
+    }
+}

--- a/Dalamud/Game/ClientState/Keys/KeyStateFlag.cs
+++ b/Dalamud/Game/ClientState/Keys/KeyStateFlag.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Dalamud.Game.ClientState.Keys;
+
+[Flags]
+public enum KeyStateFlag
+{
+    None = 0x00,
+    Down = 0x01,
+    JustPressed = 0x02,
+    JustReleased = 0x04,
+}

--- a/Dalamud/Game/ClientState/Keys/KeyStateIndex.cs
+++ b/Dalamud/Game/ClientState/Keys/KeyStateIndex.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+using Dalamud.Utility;
+using Serilog;
+
+namespace Dalamud.Game.ClientState.Keys;
+
+// TODO: this is probably safe to expose to plugins without major concerns
+// [PluginInterface]
+[ServiceManager.BlockingEarlyLoadedService]
+internal sealed class KeyStateIndex : IServiceType
+{
+    private const int InvalidKeyCode = 0;
+
+    private readonly unsafe byte* mVkIndex;
+
+    [ServiceManager.ServiceConstructor]
+    private unsafe KeyStateIndex(SigScanner sigScanner, ClientState clientState)
+    {
+        var moduleBaseAddress = sigScanner.Module.BaseAddress;
+        var addressResolver = clientState.AddressResolver;
+
+        this.mVkIndex = (byte*)(moduleBaseAddress + Marshal.ReadInt32(addressResolver.KeyboardStateIndexArray));
+        this.MaxValidKeyCode = this.AsSpan().Max();
+
+        Log.Verbose("VkIndex@{Address:X8}h (max={Max:X2}h)", (long)(nint)this.mVkIndex, this.MaxValidKeyCode);
+    }
+
+    /// <summary>
+    /// Gets the upper bound for the key code.
+    /// </summary>
+    public byte MaxValidKeyCode { get; }
+
+    /// <summary>
+    /// Translates a virtual key code from Windows into a key code which the game internally uses.
+    /// </summary>
+    /// <param name="vkCode">A virtual key to translate.</param>
+    /// <param name="keyCode">A reference to keyCode to receive the translated key code.</param>
+    /// <returns>
+    /// Returns true if this function successfully reads the key code, false otherwise.
+    /// </returns>
+    /// <remarks>
+    /// If this function returns false then the state of <see cref="keyCode"/> will be unspecified.
+    /// </remarks>
+    public bool TryGetKeyCode(ushort vkCode, out byte keyCode)
+    {
+        unsafe
+        {
+            keyCode = default;
+
+            if (!VirtualKeyExtensions.IsValidVirtualKey(vkCode))
+            {
+                return false;
+            }
+
+            keyCode = this.mVkIndex[vkCode];
+            if (keyCode == InvalidKeyCode)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    private unsafe ReadOnlySpan<byte> AsSpan() => new(this.mVkIndex, VirtualKeyExtensions.MaxValidCode + 1);
+}

--- a/Dalamud/Game/ClientState/Keys/RawKeyState.cs
+++ b/Dalamud/Game/ClientState/Keys/RawKeyState.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Serilog;
+
+namespace Dalamud.Game.ClientState.Keys;
+
+/// <summary>
+/// Exposes raw key states read by the game.
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="KeyState"/> this is actually writeable and thus should never be exposed to plugins.
+/// </remarks>
+[ServiceManager.BlockingEarlyLoadedService]
+internal sealed class RawKeyState : IServiceType
+{
+    private readonly KeyStateIndex mKeyIndex;
+
+    private readonly unsafe KeyStateFlag* mState;
+    private readonly int mStateLength;
+
+    [ServiceManager.ServiceConstructor]
+    private unsafe RawKeyState(SigScanner sigScanner, ClientState clientState, KeyStateIndex vkIndex)
+    {
+        this.mKeyIndex = vkIndex;
+
+        var moduleBaseAddress = sigScanner.Module.BaseAddress;
+        var addressResolver = clientState.AddressResolver;
+        this.mState = (KeyStateFlag*)(moduleBaseAddress + Marshal.ReadInt32(addressResolver.KeyboardState));
+        this.mStateLength = vkIndex.MaxValidKeyCode;
+
+        Log.Verbose("KeyState->Buffer@{Address:X8}h", (long)(nint)this.mState);
+    }
+
+    /// <summary>
+    /// Gets key state for all keys.
+    /// </summary>
+    // Note that MaxValidCode is inclusive (that is, actual length should be max+1)
+    public unsafe Span<KeyStateFlag> RawState => new(this.mState, this.mStateLength + 1);
+
+    /// <summary>
+    /// Sets a key state for a given virtual key.
+    /// </summary>
+    /// <param name="vkCode">The virtual key code to update.</param>
+    /// <param name="state">The key state to set.</param>
+    /// <remarks>
+    /// No-op if <see cref="vkCode"/> is invalid.
+    /// </remarks>
+    public void SetState(ushort vkCode, KeyStateFlag state)
+    {
+        unsafe
+        {
+            if (!this.mKeyIndex.TryGetKeyCode(vkCode, out var keyCode))
+            {
+                return;
+            }
+
+            this.mState[keyCode] = state;
+        }
+    }
+
+    /// <summary>
+    /// Gets state value for the key.
+    /// </summary>
+    /// <param name="vkCode">
+    /// The virtual key code to retrieve.
+    /// </param>
+    /// <param name="state"> 
+    /// If this function returns false, the state of this value is considered undefined.
+    /// </param>
+    /// <returns>
+    /// Returns true if the virtual key is invalid, false otherwise.
+    /// </returns>
+    public bool TryGetState(ushort vkCode, out KeyStateFlag state)
+    {
+        unsafe
+        {
+            state = default;
+
+            if (this.mKeyIndex.TryGetKeyCode(vkCode, out var keyCode))
+            {
+                return false;
+            }
+
+            state = this.mState[keyCode];
+            return true;
+        }
+    }
+}

--- a/Dalamud/Game/ClientState/Keys/SimulatedKeyState.cs
+++ b/Dalamud/Game/ClientState/Keys/SimulatedKeyState.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+
+using Serilog;
+
+namespace Dalamud.Game.ClientState.Keys;
+
+/// <summary>
+/// This service emulates key states based on inputs.
+/// </summary>
+[ServiceManager.BlockingEarlyLoadedService]
+internal sealed class SimulatedKeyState : IServiceType, IDisposable
+{
+    private readonly InputDevicePoll mInputDevicePoll;
+
+    private readonly KeyStateIndex mKeyIndex;
+
+    private readonly KeyStateFlag[] mRawState;
+
+    // This is based on the assumption that inputs don't change that much (maybe 1 or 2 per frame) on a single frame.
+    private readonly List<byte> mNextClearSet = new();
+
+    [ServiceManager.ServiceConstructor]
+    private SimulatedKeyState(InputDevicePoll devicePoll, KeyStateIndex keyIndex)
+    {
+        this.mInputDevicePoll = devicePoll;
+        this.mKeyIndex = keyIndex;
+        this.mRawState = new KeyStateFlag[keyIndex.MaxValidKeyCode + 1];
+
+        this.mInputDevicePoll.OnAfterPoll += this.OnAfterInputPoll;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the main window has focus.
+    /// </summary>
+    /// <remarks>
+    /// This value is used to release all keys when the window doesn't have focus.
+    /// </remarks>
+    public bool HasFocus { get; set; } = true;
+
+    /// <summary>
+    /// Gets the simulated key state for all keys.
+    /// </summary>
+    /// <remarks>
+    /// The order of keys is same as the game so that it just could be directly mem-copied into RawKeyState buffer.
+    /// </remarks>
+    public ReadOnlySpan<KeyStateFlag> RawState => this.mRawState;
+
+    /// <inheritdoc />
+    void IDisposable.Dispose()
+    {
+        this.mInputDevicePoll.OnAfterPoll -= this.OnAfterInputPoll;
+    }
+
+    /// <summary>
+    /// Reports a key stroke.
+    /// </summary>
+    /// <param name="vkCode">A virtual key code.</param>
+    /// <param name="down">True if the key is being held down. otherwise false.</param>
+    /// <remarks>
+    /// This function will be no-op if <see cref="vkCode"/> is invalid.
+    /// </remarks>
+    internal void AddKeyEvent(ushort vkCode, bool down)
+    {
+        if (!this.mKeyIndex.TryGetKeyCode(vkCode, out var keyCode))
+        {
+            return;
+        }
+
+        ref var state = ref this.mRawState[keyCode];
+
+        // Calculates a state value for the key stroke
+        if (down)
+        {
+            // Key is pressed
+            if (state.HasFlag(KeyStateFlag.Down))
+            {
+                // nothing to do if the key is already being pressed
+                return;
+            }
+
+            // Add Down and JustPressed
+            state |= KeyStateFlag.Down | KeyStateFlag.JustPressed;
+            this.mNextClearSet.Add(keyCode);
+        }
+        else
+        {
+            // Key is released
+            if (!state.HasFlag(KeyStateFlag.Down))
+            {
+                // nothing to do if the key is already released
+                return;
+            }
+
+            // Remove Down and add JustReleased flag.
+            state = (state & ~KeyStateFlag.Down) | KeyStateFlag.JustReleased;
+            this.mNextClearSet.Add(keyCode);
+        }
+
+        Log.Verbose("Translated key: (vk={VkCode:X2}h, kc={Key:X2})", vkCode, keyCode);
+        Log.Verbose("Simulated key state: (vk={VkCode:X2}h, down={Down}, state={State})", vkCode, down, state);
+    }
+
+    public bool TryGetState(ushort vkCode, out KeyStateFlag state)
+    {
+        state = default;
+
+        if (!this.mKeyIndex.TryGetKeyCode(vkCode, out var keyCode))
+        {
+            return false;
+        }
+
+        state = this.mRawState[keyCode];
+        return true;
+    }
+
+    private void OnAfterInputPoll()
+    {
+        // Release all keys if the game is out of focus.
+        if (!this.HasFocus)
+        {
+            // Apparently game also does similar thing btw.
+            // (rev8555434_2023/02/03_03:27:18 @ 1404A5DF0h)
+            // Log.Verbose("no focus, clear");
+            this.mRawState.AsSpan().Clear();
+        }
+
+        // Clear all JustXXX flags.
+        foreach (var keyCode in this.mNextClearSet)
+        {
+            // Remove JustPressed and JustReleased
+            this.mRawState[keyCode] &= ~(KeyStateFlag.JustPressed | KeyStateFlag.JustReleased);
+
+            // Log.Verbose("Remove {KeyCode:X2} flag, now {Flag}", keyCode, this.mRawState[keyCode]);
+        }
+
+        this.mNextClearSet.Clear();
+    }
+}

--- a/Dalamud/Game/ClientState/Keys/VirtualKeyExtensions.cs
+++ b/Dalamud/Game/ClientState/Keys/VirtualKeyExtensions.cs
@@ -7,6 +7,11 @@ namespace Dalamud.Game.ClientState.Keys;
 /// </summary>
 public static class VirtualKeyExtensions
 {
+    // The array is accessed in a way that this limit doesn't appear to exist
+    // but there is other state data past this point, and keys beyond here aren't
+    // generally valid for most things anyway
+    internal const int MaxValidCode = 0xF0;
+
     /// <summary>
     /// Get the fancy name associated with this key.
     /// </summary>
@@ -15,5 +20,10 @@ public static class VirtualKeyExtensions
     public static string GetFancyName(this VirtualKey key)
     {
         return key.GetAttribute<VirtualKeyAttribute>().FancyName;
+    }
+
+    internal static bool IsValidVirtualKey(ushort vkCode)
+    {
+        return vkCode <= MaxValidCode;
     }
 }

--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -575,8 +575,9 @@ public sealed unsafe class GameGui : IDisposable, IServiceType
 
     private char HandleImmDetour(IntPtr framework, char a2, byte a3)
     {
+        var io = ImGui.GetIO();
         var result = this.handleImmHook.Original(framework, a2, a3);
-        return ImGui.GetIO().WantTextInput
+        return (io.WantTextInput || io.WantCaptureKeyboard)
                    ? (char)0
                    : result;
     }

--- a/Dalamud/Utility/SpanExtensions.cs
+++ b/Dalamud/Utility/SpanExtensions.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace Dalamud.Utility;
+
+/// <summary>
+/// Provides helper methods for <see cref="Span{T}"/> class.
+/// </summary>
+internal static class SpanExtensions
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref readonly T Max<T>(this ReadOnlySpan<T> span)
+        where T : IComparisonOperators<T, T, bool>
+    {
+        // JIT inlining quirks
+        static void ThrowEx()
+        {
+            throw new ArgumentException("Span is empty", nameof(span));
+        }
+
+        if (span.IsEmpty)
+        {
+            ThrowEx();
+        }
+
+        ref readonly var max = ref span[0];
+
+        for (var i = 0; i < span.Length; i++)
+        {
+            if (max < span[i])
+            {
+                max = ref span[i];
+            }
+        }
+
+        return ref max;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref T Max<T>(this Span<T> span)
+        where T : IComparisonOperators<T, T, bool>
+    {
+        // JIT inlining quirks
+        static void ThrowEx()
+        {
+            throw new ArgumentException("Span is empty", nameof(span));
+        }
+
+        if (span.IsEmpty)
+        {
+            ThrowEx();
+        }
+
+        ref var max = ref span[0];
+
+        for (var i = 0; i < span.Length; i++)
+        {
+            if (max < span[i])
+            {
+                max = ref span[i];
+            }
+        }
+
+        return ref max;
+    }
+}


### PR DESCRIPTION
This addresses the issue where `io->WantCaptureKeyboard` or `ImGui.IsKeyPressed` does nothing unless `io.WantTextInput` is also set.

Changes in ImGuiScene is also needed. For that, please check out [this PR](https://github.com/goatcorp/ImGuiScene/pull/10).


## Clips

<table>
<th>Current behavior</th>
<th>After 4ad07f4</th>
<tr>
<td>

https://user-images.githubusercontent.com/1381835/222665515-a27ffbbd-bcfd-4aa7-8fcf-d7f5fdadd37e.mp4

(Notice `WantCaptureKeyboard` does nothing)


</td>

<td>

https://user-images.githubusercontent.com/1381835/222652744-b784dcc9-3179-439e-b7e0-bd1c05749dda.mp4

</td>

</tr>

<th>Issue after 4ad07f4</th>
<th>After d8f6de5 (final fix)</th>
<tr>
<td>

https://user-images.githubusercontent.com/1381835/222653282-a7de6ad7-fd85-4e4e-b01d-982571282ce0.mp4

</td>
<td>


https://user-images.githubusercontent.com/1381835/222653027-6e7b9a3f-27e0-4feb-be29-388d4e88b757.mp4


</td>


</tr>
</table>
