### PR TITLE
Add GameConfig service

### DIFF
--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <PropertyGroup Label="Feature">
-        <DalamudVersion>7.4.7.3</DalamudVersion>
+        <DalamudVersion>7.4.7.4</DalamudVersion>
         <Description>XIV Launcher addon framework</Description>
         <AssemblyVersion>$(DalamudVersion)</AssemblyVersion>
         <Version>$(DalamudVersion)</Version>

--- a/Dalamud/Game/Config/ConfigOptionNotFoundException.cs
+++ b/Dalamud/Game/Config/ConfigOptionNotFoundException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Dalamud.Game.Config;
+
+/// <summary>
+/// An exception thrown when a matching config option is not present in the config section.
+/// </summary>
+public class ConfigOptionNotFoundException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigOptionNotFoundException"/> class.
+    /// </summary>
+    /// <param name="sectionName">Name of the section being accessed.</param>
+    /// <param name="configOptionName">Name of the config option that was not found.</param>
+    public ConfigOptionNotFoundException(string sectionName, string configOptionName)
+        : base($"The option '{configOptionName}' is not available in {sectionName}.")
+    {
+    }
+}

--- a/Dalamud/Game/Config/GameConfig.cs
+++ b/Dalamud/Game/Config/GameConfig.cs
@@ -16,7 +16,7 @@ namespace Dalamud.Game.Config;
 /// </summary>
 [InterfaceVersion("1.0")]
 [PluginInterface]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 public sealed class GameConfig : IServiceType
 {
     [ServiceManager.ServiceConstructor]
@@ -24,7 +24,7 @@ public sealed class GameConfig : IServiceType
     {
         framework.RunOnTick(() =>
         {
-            Log.Information("[GameConfig] Initalizing");
+            Log.Verbose("[GameConfig] Initalizing");
             var csFramework = FFXIVClientStructs.FFXIV.Client.System.Framework.Framework.Instance();
             var commonConfig = &csFramework->SystemConfig.CommonSystemConfig;
             this.System = new GameConfigSection("System", framework, &commonConfig->ConfigBase);
@@ -113,7 +113,7 @@ public sealed class GameConfig : IServiceType
             this.SectionName = sectionName;
             this.framework = framework;
             this.GetConfigBase = getConfigBase;
-            Log.Information("[GameConfig] Initalizing {SectionName} with {ConfigCount} entries.", this.SectionName, this.ConfigCount);
+            Log.Verbose("[GameConfig] Initalizing {SectionName} with {ConfigCount} entries.", this.SectionName, this.ConfigCount);
         }
 
         /// <summary>

--- a/Dalamud/Game/Config/GameConfig.cs
+++ b/Dalamud/Game/Config/GameConfig.cs
@@ -9,7 +9,7 @@ using Dalamud.Memory;
 using FFXIVClientStructs.FFXIV.Common.Configuration;
 using Serilog;
 
-namespace Dalamud.Game;
+namespace Dalamud.Game.Config;
 
 /// <summary>
 /// This class represents the game's configuration.

--- a/Dalamud/Game/Config/GameConfig.cs
+++ b/Dalamud/Game/Config/GameConfig.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
-using Dalamud.Memory;
-
-using FFXIVClientStructs.FFXIV.Common.Configuration;
 using Serilog;
 
 namespace Dalamud.Game.Config;
@@ -29,7 +24,7 @@ public sealed class GameConfig : IServiceType
             var commonConfig = &csFramework->SystemConfig.CommonSystemConfig;
             this.System = new GameConfigSection("System", framework, &commonConfig->ConfigBase);
             this.UiConfig = new GameConfigSection("UiConfig", framework, &commonConfig->UiConfig);
-            this.UiControl = new GameConfigSection("UiControl", framework, () => this.UiConfig.TryGetBool("PadMode", out var padMode) && padMode ? &commonConfig->UiControlConfig + 1 : &commonConfig->UiControlConfig);
+            this.UiControl = new GameConfigSection("UiControl", framework, () => this.UiConfig.TryGetBool("PadMode", out var padMode) && padMode ? &commonConfig->UiControlGamepadConfig : &commonConfig->UiControlConfig);
         });
     }
 
@@ -49,402 +44,218 @@ public sealed class GameConfig : IServiceType
     public GameConfigSection UiControl { get; private set; }
 
     /// <summary>
-    /// An exception thrown when a matching config option is not present in the config section.
+    /// Attempts to get a boolean config value from the System section.
     /// </summary>
-    public class ConfigOptionNotFoundException : Exception
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigOptionNotFoundException"/> class.
-        /// </summary>
-        /// <param name="sectionName">Name of the section being accessed.</param>
-        /// <param name="configOptionName">Name of the config option that was not found.</param>
-        public ConfigOptionNotFoundException(string sectionName, string configOptionName)
-            : base($"The option '{configOptionName}' is not available in {sectionName}.")
-        {
-        }
-    }
+    /// <param name="option">Option to get the value of.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(SystemConfigOption option, out bool value) => this.System.TryGet(option.GetName(), out value);
 
     /// <summary>
-    /// An exception thrown when attempting to assign a value to a config option with the wrong type.
+    /// Attempts to get a uint config value from the System section.
     /// </summary>
-    public class IncorrectConfigTypeException : Exception
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IncorrectConfigTypeException"/> class.
-        /// </summary>
-        /// <param name="sectionName">Name of the section being accessed.</param>
-        /// <param name="configOptionName">Name of the config option that was not found.</param>
-        /// <param name="correctType">The correct type for the config option.</param>
-        /// <param name="incorrectType">The type that was attempted.</param>
-        public IncorrectConfigTypeException(string sectionName, string configOptionName, ConfigType correctType, ConfigType incorrectType)
-            : base($"The option '{configOptionName}' in {sectionName} is of the type {correctType}. Assigning {incorrectType} is invalid.")
-        {
-        }
-    }
+    /// <param name="option">Option to get the value of.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(SystemConfigOption option, out uint value) => this.System.TryGet(option.GetName(), out value);
 
     /// <summary>
-    /// Represents a section of the game config and contains helper functions for accessing and setting values.
+    /// Attempts to get a float config value from the System section.
     /// </summary>
-    public class GameConfigSection
-    {
-        private readonly Framework framework;
-        private readonly Dictionary<string, uint> indexMap = new();
-        private readonly Dictionary<uint, string> nameMap = new();
+    /// <param name="option">Option to get the value of.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(SystemConfigOption option, out float value) => this.System.TryGet(option.GetName(), out value);
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GameConfigSection"/> class.
-        /// </summary>
-        /// <param name="sectionName">Name of the section.</param>
-        /// <param name="framework">The framework service.</param>
-        /// <param name="configBase">Unmanaged ConfigBase instance.</param>
-        internal unsafe GameConfigSection(string sectionName, Framework framework, ConfigBase* configBase)
-            : this(sectionName, framework, () => configBase)
-        {
-        }
+    /// <summary>
+    /// Attempts to get a string config value from the System section.
+    /// </summary>
+    /// <param name="option">Option to get the value of.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(SystemConfigOption option, out string value) => this.System.TryGet(option.GetName(), out value);
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GameConfigSection"/> class.
-        /// </summary>
-        /// <param name="sectionName">Name of the section.</param>
-        /// <param name="framework">The framework service.</param>
-        /// <param name="getConfigBase">A function that determines which ConfigBase instance should be used.</param>
-        internal GameConfigSection(string sectionName, Framework framework, GetConfigBaseDelegate getConfigBase)
-        {
-            this.SectionName = sectionName;
-            this.framework = framework;
-            this.GetConfigBase = getConfigBase;
-            Log.Verbose("[GameConfig] Initalizing {SectionName} with {ConfigCount} entries.", this.SectionName, this.ConfigCount);
-        }
+    /// <summary>
+    /// Attempts to get a boolean config value from the UiConfig section.
+    /// </summary>
+    /// <param name="option">Option to get the value of.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(UiConfigOption option, out bool value) => this.UiConfig.TryGet(option.GetName(), out value);
 
-        /// <summary>
-        /// Delegate that gets the struct the section accesses.
-        /// </summary>
-        /// <returns>Pointer to unmanaged ConfigBase.</returns>
-        internal unsafe delegate ConfigBase* GetConfigBaseDelegate();
+    /// <summary>
+    /// Attempts to get a uint config value from the UiConfig section.
+    /// </summary>
+    /// <param name="option">Option to get the value of.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(UiConfigOption option, out uint value) => this.UiConfig.TryGet(option.GetName(), out value);
 
-        /// <summary>
-        /// Gets the number of config entries contained within the section.
-        /// Some entries may be empty with no data.
-        /// </summary>
-        public unsafe uint ConfigCount => this.GetConfigBase()->ConfigCount;
+    /// <summary>
+    /// Attempts to get a float config value from the UiConfig section.
+    /// </summary>
+    /// <param name="option">Option to get the value of.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(UiConfigOption option, out float value) => this.UiConfig.TryGet(option.GetName(), out value);
 
-        /// <summary>
-        /// Gets the name of the config section.
-        /// </summary>
-        public string SectionName { get; }
+    /// <summary>
+    /// Attempts to get a string config value from the UiConfig section.
+    /// </summary>
+    /// <param name="option">Option to get the value of.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(UiConfigOption option, out string value) => this.UiControl.TryGet(option.GetName(), out value);
 
-        private GetConfigBaseDelegate GetConfigBase { get; }
+    /// <summary>
+    /// Attempts to get a boolean config value from the UiControl section.
+    /// </summary>
+    /// <param name="option">Option to get the value of.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(UiControlOption option, out bool value) => this.UiControl.TryGet(option.GetName(), out value);
 
-        /// <summary>
-        /// Attempts to get a boolean config option.
-        /// </summary>
-        /// <param name="name">Name of the config option.</param>
-        /// <param name="value">The returned value of the config option.</param>
-        /// <returns>A value representing the success.</returns>
-        public unsafe bool TryGetBool(string name, out bool value) {
-            value = false;
-            if (!this.TryGetIndex(name, out var index))
-            {
-                return false;
-            }
+    /// <summary>
+    /// Attempts to get a uint config value from the UiControl section.
+    /// </summary>
+    /// <param name="option">Option to get the value of.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(UiControlOption option, out uint value) => this.UiControl.TryGet(option.GetName(), out value);
 
-            if (!this.TryGetEntry(index, out var entry))
-            {
-                return false;
-            }
+    /// <summary>
+    /// Attempts to get a float config value from the UiControl section.
+    /// </summary>
+    /// <param name="option">Option to get the value of.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(UiControlOption option, out float value) => this.UiControl.TryGet(option.GetName(), out value);
 
-            value = entry->Value.UInt != 0;
-            return true;
-        }
+    /// <summary>
+    /// Attempts to get a string config value from the UiControl section.
+    /// </summary>
+    /// <param name="option">Option to get the value of.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(UiControlOption option, out string value) => this.System.TryGet(option.GetName(), out value);
 
-        /// <summary>
-        /// Get a boolean config option.
-        /// </summary>
-        /// <param name="name">Name of the config option.</param>
-        /// <returns>Value of the config option.</returns>
-        /// <exception cref="ConfigOptionNotFoundException">Thrown if the config option is not found.</exception>
-        public bool GetBool(string name) {
-            if (!this.TryGetBool(name, out var value))
-            {
-                throw new ConfigOptionNotFoundException(this.SectionName, name);
-            }
+    /// <summary>
+    /// Set a boolean config option in the System config section.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="option">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public void Set(SystemConfigOption option, bool value) => this.System.Set(option.GetName(), value);
 
-            return value;
-        }
+    /// <summary>
+    /// Set a unsigned integer config option in the System config section.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="option">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public void Set(SystemConfigOption option, uint value) => this.System.Set(option.GetName(), value);
 
-        /// <summary>
-        /// Set a boolean config option.
-        /// Note: Not all config options will be be immediately reflected in the game.
-        /// </summary>
-        /// <param name="name">Name of the config option.</param>
-        /// <param name="value">New value of the config option.</param>
-        /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
-        /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
-        public unsafe void Set(string name, bool value) {
-            if (!this.TryGetIndex(name, out var index))
-            {
-                throw new ConfigOptionNotFoundException(this.SectionName, name);
-            }
+    /// <summary>
+    /// Set a float config option in the System config section.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="option">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public void Set(SystemConfigOption option, float value) => this.System.Set(option.GetName(), value);
 
-            if (!this.TryGetEntry(index, out var entry))
-            {
-                throw new UnreachableException($"An unexpected error was encountered setting {name} in {this.SectionName}");
-            }
+    /// <summary>
+    /// Set a string config option in the System config section.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="option">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public void Set(SystemConfigOption option, string value) => this.System.Set(option.GetName(), value);
 
-            if ((ConfigType)entry->Type != ConfigType.UInt)
-            {
-                throw new IncorrectConfigTypeException(this.SectionName, name, (ConfigType)entry->Type, ConfigType.UInt);
-            }
+    /// <summary>
+    /// Set a boolean config option in the UiConfig section.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="option">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public void Set(UiConfigOption option, bool value) => this.UiConfig.Set(option.GetName(), value);
 
-            entry->SetValue(value ? 1U : 0U);
-        }
+    /// <summary>
+    /// Set a unsigned integer config option in the UiConfig section.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="option">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public void Set(UiConfigOption option, uint value) => this.UiConfig.Set(option.GetName(), value);
 
-        /// <summary>
-        /// Attempts to get an unsigned integer config value.
-        /// </summary>
-        /// <param name="name">Name of the config option.</param>
-        /// <param name="value">The returned value of the config option.</param>
-        /// <returns>A value representing the success.</returns>
-        public unsafe bool TryGetUInt(string name, out uint value) {
-            value = 0;
-            if (!this.TryGetIndex(name, out var index))
-            {
-                return false;
-            }
+    /// <summary>
+    /// Set a float config option in the UiConfig section.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="option">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public void Set(UiConfigOption option, float value) => this.UiConfig.Set(option.GetName(), value);
 
-            if (!this.TryGetEntry(index, out var entry))
-            {
-                return false;
-            }
+    /// <summary>
+    /// Set a string config option in the UiConfig section.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="option">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public void Set(UiConfigOption option, string value) => this.UiConfig.Set(option.GetName(), value);
 
-            value = entry->Value.UInt;
-            return true;
-        }
+    /// <summary>
+    /// Set a boolean config option in the UiControl config section.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="option">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public void Set(UiControlOption option, bool value) => this.UiControl.Set(option.GetName(), value);
 
-        /// <summary>
-        /// Get an unsigned integer config option.
-        /// </summary>
-        /// <param name="name">Name of the config option.</param>
-        /// <returns>Value of the config option.</returns>
-        /// <exception cref="ConfigOptionNotFoundException">Thrown if the config option is not found.</exception>
-        public uint GetUInt(string name) {
-            if (!this.TryGetUInt(name, out var value))
-            {
-                throw new ConfigOptionNotFoundException(this.SectionName, name);
-            }
+    /// <summary>
+    /// Set a uint config option in the UiControl config section.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="option">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public void Set(UiControlOption option, uint value) => this.UiControl.Set(option.GetName(), value);
 
-            return value;
-        }
+    /// <summary>
+    /// Set a float config option in the UiControl config section.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="option">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public void Set(UiControlOption option, float value) => this.UiControl.Set(option.GetName(), value);
 
-        /// <summary>
-        /// Set an unsigned integer config option.
-        /// Note: Not all config options will be be immediately reflected in the game.
-        /// </summary>
-        /// <param name="name">Name of the config option.</param>
-        /// <param name="value">New value of the config option.</param>
-        /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
-        /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
-        public unsafe void Set(string name, uint value) {
-            this.framework.RunOnFrameworkThread(() => {
-                if (!this.TryGetIndex(name, out var index))
-                {
-                    throw new ConfigOptionNotFoundException(this.SectionName, name);
-                }
-
-                if (!this.TryGetEntry(index, out var entry))
-                {
-                    throw new UnreachableException($"An unexpected error was encountered setting {name} in {this.SectionName}");
-                }
-
-                if ((ConfigType)entry->Type != ConfigType.UInt)
-                {
-                    throw new IncorrectConfigTypeException(this.SectionName, name, (ConfigType)entry->Type, ConfigType.UInt);
-                }
-
-                entry->SetValue(value);
-            });
-        }
-
-        /// <summary>
-        /// Attempts to get a float config value.
-        /// </summary>
-        /// <param name="name">Name of the config option.</param>
-        /// <param name="value">The returned value of the config option.</param>
-        /// <returns>A value representing the success.</returns>
-        public unsafe bool TryGetFloat(string name, out float value) {
-            value = 0;
-            if (!this.TryGetIndex(name, out var index))
-            {
-                return false;
-            }
-
-            if (!this.TryGetEntry(index, out var entry))
-            {
-                return false;
-            }
-
-            value = entry->Value.Float;
-            return true;
-        }
-
-        /// <summary>
-        /// Get a float config option.
-        /// </summary>
-        /// <param name="name">Name of the config option.</param>
-        /// <returns>Value of the config option.</returns>
-        /// <exception cref="ConfigOptionNotFoundException">Thrown if the config option is not found.</exception>
-        public float GetFloat(string name) {
-            if (!this.TryGetFloat(name, out var value))
-            {
-                throw new ConfigOptionNotFoundException(this.SectionName, name);
-            }
-
-            return value;
-        }
-
-        /// <summary>
-        /// Set a float config option.
-        /// Note: Not all config options will be be immediately reflected in the game.
-        /// </summary>
-        /// <param name="name">Name of the config option.</param>
-        /// <param name="value">New value of the config option.</param>
-        /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
-        /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
-        public unsafe void Set(string name, float value) {
-            this.framework.RunOnFrameworkThread(() => {
-                if (!this.TryGetIndex(name, out var index))
-                {
-                    throw new ConfigOptionNotFoundException(this.SectionName, name);
-                }
-
-                if (!this.TryGetEntry(index, out var entry))
-                {
-                    throw new UnreachableException($"An unexpected error was encountered setting {name} in {this.SectionName}");
-                }
-
-                if ((ConfigType)entry->Type != ConfigType.Float)
-                {
-                    throw new IncorrectConfigTypeException(this.SectionName, name, (ConfigType)entry->Type, ConfigType.Float);
-                }
-
-                entry->SetValue(value);
-            });
-        }
-
-        /// <summary>
-        /// Attempts to get a string config value.
-        /// </summary>
-        /// <param name="name">Name of the config option.</param>
-        /// <param name="value">The returned value of the config option.</param>
-        /// <returns>A value representing the success.</returns>
-        public unsafe bool TryGetString(string name, out string value) {
-            value = string.Empty;
-            if (!this.TryGetIndex(name, out var index))
-            {
-                return false;
-            }
-
-            if (!this.TryGetEntry(index, out var entry))
-            {
-                return false;
-            }
-
-            if (entry->Type != 4)
-            {
-                return false;
-            }
-
-            if (entry->Value.String == null)
-            {
-                return false;
-            }
-
-            value = entry->Value.String->ToString();
-            return true;
-        }
-
-        /// <summary>
-        /// Get a string config option.
-        /// </summary>
-        /// <param name="name">Name of the config option.</param>
-        /// <returns>Value of the config option.</returns>
-        /// <exception cref="ConfigOptionNotFoundException">Thrown if the config option is not found.</exception>
-        public string GetString(string name) {
-            if (!this.TryGetString(name, out var value))
-            {
-                throw new ConfigOptionNotFoundException(this.SectionName, name);
-            }
-
-            return value;
-        }
-
-        /// <summary>
-        /// Set a string config option.
-        /// Note: Not all config options will be be immediately reflected in the game.
-        /// </summary>
-        /// <param name="name">Name of the config option.</param>
-        /// <param name="value">New value of the config option.</param>
-        /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
-        /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
-        public unsafe void Set(string name, string value) {
-            this.framework.RunOnFrameworkThread(() => {
-                if (!this.TryGetIndex(name, out var index))
-                {
-                    throw new ConfigOptionNotFoundException(this.SectionName, name);
-                }
-
-                if (!this.TryGetEntry(index, out var entry))
-                {
-                    throw new UnreachableException($"An unexpected error was encountered setting {name} in {this.SectionName}");
-                }
-
-                if ((ConfigType)entry->Type != ConfigType.String)
-                {
-                    throw new IncorrectConfigTypeException(this.SectionName, name, (ConfigType)entry->Type, ConfigType.String);
-                }
-
-                entry->SetValue(value);
-            });
-        }
-
-        private unsafe bool TryGetIndex(string name, out uint index) {
-            if (this.indexMap.TryGetValue(name, out index))
-            {
-                return true;
-            }
-
-            var configBase = this.GetConfigBase();
-            var e = configBase->ConfigEntry;
-            for (var i = 0U; i < configBase->ConfigCount; i++, e++) {
-                if (e->Name == null)
-                {
-                    continue;
-                }
-
-                var eName = MemoryHelper.ReadStringNullTerminated(new IntPtr(e->Name));
-                if (eName.Equals(name)) {
-                    this.indexMap.TryAdd(name, i);
-                    this.nameMap.TryAdd(i, name);
-                    index = i;
-                    return true;
-                }
-            }
-
-            index = 0;
-            return false;
-        }
-
-        private unsafe bool TryGetEntry(uint index, out ConfigEntry* entry) {
-            entry = null;
-            var configBase = this.GetConfigBase();
-            if (configBase->ConfigEntry == null || index >= configBase->ConfigCount)
-            {
-                return false;
-            }
-
-            entry = configBase->ConfigEntry;
-            entry += index;
-            return true;
-        }
-    }
+    /// <summary>
+    /// Set a string config option in the UiControl config section.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="option">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public void Set(UiControlOption option, string value) => this.UiControl.Set(option.GetName(), value);
 }

--- a/Dalamud/Game/Config/GameConfigEnumExtensions.cs
+++ b/Dalamud/Game/Config/GameConfigEnumExtensions.cs
@@ -1,0 +1,39 @@
+﻿using Dalamud.Utility;
+
+namespace Dalamud.Game.Config;
+
+/// <summary>
+/// Helper functions for accessing GameConfigOptions.
+/// </summary>
+internal static class GameConfigEnumExtensions
+{
+    /// <summary>
+    /// Gets the name of a SystemConfigOption from it's attribute.
+    /// </summary>
+    /// <param name="systemConfigOption">The SystemConfigOption.</param>
+    /// <returns>Name of the option.</returns>
+    public static string GetName(this SystemConfigOption systemConfigOption)
+    {
+        return systemConfigOption.GetAttribute<GameConfigOptionAttribute>()?.Name ?? $"{systemConfigOption}";
+    }
+
+    /// <summary>
+    /// Gets the name of a UiConfigOption from it's attribute.
+    /// </summary>
+    /// <param name="uiConfigOption">The UiConfigOption.</param>
+    /// <returns>Name of the option.</returns>
+    public static string GetName(this UiConfigOption uiConfigOption)
+    {
+        return uiConfigOption.GetAttribute<GameConfigOptionAttribute>()?.Name ?? $"{uiConfigOption}";
+    }
+
+    /// <summary>
+    /// Gets the name of a UiControlOption from it's attribute.
+    /// </summary>
+    /// <param name="uiControlOption">The UiControlOption.</param>
+    /// <returns>Name of the option.</returns>
+    public static string GetName(this UiControlOption uiControlOption)
+    {
+        return uiControlOption.GetAttribute<GameConfigOptionAttribute>()?.Name ?? $"{uiControlOption}";
+    }
+}

--- a/Dalamud/Game/Config/GameConfigOptionAttribute.cs
+++ b/Dalamud/Game/Config/GameConfigOptionAttribute.cs
@@ -1,0 +1,40 @@
+using System;
+
+using FFXIVClientStructs.FFXIV.Common.Configuration;
+
+namespace Dalamud.Game.Config;
+
+/// <summary>
+/// An attribute for defining GameConfig options.
+/// </summary>
+[AttributeUsage(AttributeTargets.Field)]
+public class GameConfigOptionAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GameConfigOptionAttribute"/> class.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <param name="type">The type of the config option.</param>
+    /// <param name="settable">False if the game does not take changes to the config option.</param>
+    public GameConfigOptionAttribute(string name, ConfigType type, bool settable = true)
+    {
+        this.Name = name;
+        this.Type = type;
+        this.Settable = settable;
+    }
+
+    /// <summary>
+    /// Gets the Name of the config option.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the type of the config option.
+    /// </summary>
+    public ConfigType Type { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the config option will update immediately or not.
+    /// </summary>
+    public bool Settable { get; }
+}

--- a/Dalamud/Game/Config/GameConfigSection.cs
+++ b/Dalamud/Game/Config/GameConfigSection.cs
@@ -1,0 +1,407 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Dalamud.Memory;
+using FFXIVClientStructs.FFXIV.Common.Configuration;
+using Serilog;
+
+namespace Dalamud.Game.Config;
+
+/// <summary>
+/// Represents a section of the game config and contains helper functions for accessing and setting values.
+/// </summary>
+public class GameConfigSection
+{
+    private readonly Framework framework;
+    private readonly Dictionary<string, uint> indexMap = new();
+    private readonly Dictionary<uint, string> nameMap = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GameConfigSection"/> class.
+    /// </summary>
+    /// <param name="sectionName">Name of the section.</param>
+    /// <param name="framework">The framework service.</param>
+    /// <param name="configBase">Unmanaged ConfigBase instance.</param>
+    internal unsafe GameConfigSection(string sectionName, Framework framework, ConfigBase* configBase)
+        : this(sectionName, framework, () => configBase)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GameConfigSection"/> class.
+    /// </summary>
+    /// <param name="sectionName">Name of the section.</param>
+    /// <param name="framework">The framework service.</param>
+    /// <param name="getConfigBase">A function that determines which ConfigBase instance should be used.</param>
+    internal GameConfigSection(string sectionName, Framework framework, GetConfigBaseDelegate getConfigBase)
+    {
+        this.SectionName = sectionName;
+        this.framework = framework;
+        this.GetConfigBase = getConfigBase;
+        Log.Verbose("[GameConfig] Initalizing {SectionName} with {ConfigCount} entries.", this.SectionName, this.ConfigCount);
+    }
+
+    /// <summary>
+    /// Delegate that gets the struct the section accesses.
+    /// </summary>
+    /// <returns>Pointer to unmanaged ConfigBase.</returns>
+    internal unsafe delegate ConfigBase* GetConfigBaseDelegate();
+
+    /// <summary>
+    /// Gets the number of config entries contained within the section.
+    /// Some entries may be empty with no data.
+    /// </summary>
+    public unsafe uint ConfigCount => this.GetConfigBase()->ConfigCount;
+
+    /// <summary>
+    /// Gets the name of the config section.
+    /// </summary>
+    public string SectionName { get; }
+
+    private GetConfigBaseDelegate GetConfigBase { get; }
+
+    /// <summary>
+    /// Attempts to get a boolean config option.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public unsafe bool TryGetBool(string name, out bool value) {
+        value = false;
+        if (!this.TryGetIndex(name, out var index))
+        {
+            return false;
+        }
+
+        if (!this.TryGetEntry(index, out var entry))
+        {
+            return false;
+        }
+
+        value = entry->Value.UInt != 0;
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to get a boolean config option.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(string name, out bool value) => this.TryGetBool(name, out value);
+
+    /// <summary>
+    /// Get a boolean config option.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <returns>Value of the config option.</returns>
+    /// <exception cref="ConfigOptionNotFoundException">Thrown if the config option is not found.</exception>
+    public bool GetBool(string name) {
+        if (!this.TryGetBool(name, out var value))
+        {
+            throw new ConfigOptionNotFoundException(this.SectionName, name);
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Set a boolean config option.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public unsafe void Set(string name, bool value) {
+        if (!this.TryGetIndex(name, out var index))
+        {
+            throw new ConfigOptionNotFoundException(this.SectionName, name);
+        }
+
+        if (!this.TryGetEntry(index, out var entry))
+        {
+            throw new UnreachableException($"An unexpected error was encountered setting {name} in {this.SectionName}");
+        }
+
+        if ((ConfigType)entry->Type != ConfigType.UInt)
+        {
+            throw new IncorrectConfigTypeException(this.SectionName, name, (ConfigType)entry->Type, ConfigType.UInt);
+        }
+
+        entry->SetValue(value ? 1U : 0U);
+    }
+
+    /// <summary>
+    /// Attempts to get an unsigned integer config value.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public unsafe bool TryGetUInt(string name, out uint value) {
+        value = 0;
+        if (!this.TryGetIndex(name, out var index))
+        {
+            return false;
+        }
+
+        if (!this.TryGetEntry(index, out var entry))
+        {
+            return false;
+        }
+
+        value = entry->Value.UInt;
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to get an unsigned integer config value.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(string name, out uint value) => this.TryGetUInt(name, out value);
+
+    /// <summary>
+    /// Get an unsigned integer config option.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <returns>Value of the config option.</returns>
+    /// <exception cref="ConfigOptionNotFoundException">Thrown if the config option is not found.</exception>
+    public uint GetUInt(string name) {
+        if (!this.TryGetUInt(name, out var value))
+        {
+            throw new ConfigOptionNotFoundException(this.SectionName, name);
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Set an unsigned integer config option.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public unsafe void Set(string name, uint value) {
+        this.framework.RunOnFrameworkThread(() => {
+            if (!this.TryGetIndex(name, out var index))
+            {
+                throw new ConfigOptionNotFoundException(this.SectionName, name);
+            }
+
+            if (!this.TryGetEntry(index, out var entry))
+            {
+                throw new UnreachableException($"An unexpected error was encountered setting {name} in {this.SectionName}");
+            }
+
+            if ((ConfigType)entry->Type != ConfigType.UInt)
+            {
+                throw new IncorrectConfigTypeException(this.SectionName, name, (ConfigType)entry->Type, ConfigType.UInt);
+            }
+
+            entry->SetValue(value);
+        });
+    }
+
+    /// <summary>
+    /// Attempts to get a float config value.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public unsafe bool TryGetFloat(string name, out float value) {
+        value = 0;
+        if (!this.TryGetIndex(name, out var index))
+        {
+            return false;
+        }
+
+        if (!this.TryGetEntry(index, out var entry))
+        {
+            return false;
+        }
+
+        value = entry->Value.Float;
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to get a float config value.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(string name, out float value) => this.TryGetFloat(name, out value);
+
+    /// <summary>
+    /// Get a float config option.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <returns>Value of the config option.</returns>
+    /// <exception cref="ConfigOptionNotFoundException">Thrown if the config option is not found.</exception>
+    public float GetFloat(string name) {
+        if (!this.TryGetFloat(name, out var value))
+        {
+            throw new ConfigOptionNotFoundException(this.SectionName, name);
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Set a float config option.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public unsafe void Set(string name, float value) {
+        this.framework.RunOnFrameworkThread(() => {
+            if (!this.TryGetIndex(name, out var index))
+            {
+                throw new ConfigOptionNotFoundException(this.SectionName, name);
+            }
+
+            if (!this.TryGetEntry(index, out var entry))
+            {
+                throw new UnreachableException($"An unexpected error was encountered setting {name} in {this.SectionName}");
+            }
+
+            if ((ConfigType)entry->Type != ConfigType.Float)
+            {
+                throw new IncorrectConfigTypeException(this.SectionName, name, (ConfigType)entry->Type, ConfigType.Float);
+            }
+
+            entry->SetValue(value);
+        });
+    }
+
+    /// <summary>
+    /// Attempts to get a string config value.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public unsafe bool TryGetString(string name, out string value) {
+        value = string.Empty;
+        if (!this.TryGetIndex(name, out var index))
+        {
+            return false;
+        }
+
+        if (!this.TryGetEntry(index, out var entry))
+        {
+            return false;
+        }
+
+        if (entry->Type != 4)
+        {
+            return false;
+        }
+
+        if (entry->Value.String == null)
+        {
+            return false;
+        }
+
+        value = entry->Value.String->ToString();
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to get a string config value.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <param name="value">The returned value of the config option.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(string name, out string value) => this.TryGetString(name, out value);
+
+    /// <summary>
+    /// Get a string config option.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <returns>Value of the config option.</returns>
+    /// <exception cref="ConfigOptionNotFoundException">Thrown if the config option is not found.</exception>
+    public string GetString(string name) {
+        if (!this.TryGetString(name, out var value))
+        {
+            throw new ConfigOptionNotFoundException(this.SectionName, name);
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Set a string config option.
+    /// Note: Not all config options will be be immediately reflected in the game.
+    /// </summary>
+    /// <param name="name">Name of the config option.</param>
+    /// <param name="value">New value of the config option.</param>
+    /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+    /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+    public unsafe void Set(string name, string value) {
+        this.framework.RunOnFrameworkThread(() => {
+            if (!this.TryGetIndex(name, out var index))
+            {
+                throw new ConfigOptionNotFoundException(this.SectionName, name);
+            }
+
+            if (!this.TryGetEntry(index, out var entry))
+            {
+                throw new UnreachableException($"An unexpected error was encountered setting {name} in {this.SectionName}");
+            }
+
+            if ((ConfigType)entry->Type != ConfigType.String)
+            {
+                throw new IncorrectConfigTypeException(this.SectionName, name, (ConfigType)entry->Type, ConfigType.String);
+            }
+
+            entry->SetValue(value);
+        });
+    }
+
+    private unsafe bool TryGetIndex(string name, out uint index) {
+        if (this.indexMap.TryGetValue(name, out index))
+        {
+            return true;
+        }
+
+        var configBase = this.GetConfigBase();
+        var e = configBase->ConfigEntry;
+        for (var i = 0U; i < configBase->ConfigCount; i++, e++) {
+            if (e->Name == null)
+            {
+                continue;
+            }
+
+            var eName = MemoryHelper.ReadStringNullTerminated(new IntPtr(e->Name));
+            if (eName.Equals(name)) {
+                this.indexMap.TryAdd(name, i);
+                this.nameMap.TryAdd(i, name);
+                index = i;
+                return true;
+            }
+        }
+
+        index = 0;
+        return false;
+    }
+
+    private unsafe bool TryGetEntry(uint index, out ConfigEntry* entry) {
+        entry = null;
+        var configBase = this.GetConfigBase();
+        if (configBase->ConfigEntry == null || index >= configBase->ConfigCount)
+        {
+            return false;
+        }
+
+        entry = configBase->ConfigEntry;
+        entry += index;
+        return true;
+    }
+}

--- a/Dalamud/Game/Config/IncorrectConfigTypeException.cs
+++ b/Dalamud/Game/Config/IncorrectConfigTypeException.cs
@@ -1,0 +1,23 @@
+using System;
+
+using FFXIVClientStructs.FFXIV.Common.Configuration;
+
+namespace Dalamud.Game.Config;
+
+/// <summary>
+/// An exception thrown when attempting to assign a value to a config option with the wrong type.
+/// </summary>
+public class IncorrectConfigTypeException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IncorrectConfigTypeException"/> class.
+    /// </summary>
+    /// <param name="sectionName">Name of the section being accessed.</param>
+    /// <param name="configOptionName">Name of the config option that was not found.</param>
+    /// <param name="correctType">The correct type for the config option.</param>
+    /// <param name="incorrectType">The type that was attempted.</param>
+    public IncorrectConfigTypeException(string sectionName, string configOptionName, ConfigType correctType, ConfigType incorrectType)
+        : base($"The option '{configOptionName}' in {sectionName} is of the type {correctType}. Assigning {incorrectType} is invalid.")
+    {
+    }
+}

--- a/Dalamud/Game/Config/SystemConfigOption.cs
+++ b/Dalamud/Game/Config/SystemConfigOption.cs
@@ -1,0 +1,1385 @@
+﻿using FFXIVClientStructs.FFXIV.Common.Configuration;
+
+namespace Dalamud.Game.Config;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable IdentifierTypo
+// ReSharper disable CommentTypo
+
+/// <summary>
+/// Config options in the System section.
+/// </summary>
+public enum SystemConfigOption
+{
+    /// <summary>
+    /// System option with the internal name GuidVersion.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GuidVersion", ConfigType.UInt)]
+    GuidVersion,
+
+    /// <summary>
+    /// System option with the internal name ConfigVersion.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ConfigVersion", ConfigType.UInt)]
+    ConfigVersion,
+
+    /// <summary>
+    /// System option with the internal name Language.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Language", ConfigType.UInt)]
+    Language,
+
+    /// <summary>
+    /// System option with the internal name Region.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Region", ConfigType.UInt)]
+    Region,
+
+    /// <summary>
+    /// System option with the internal name UPnP.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("UPnP", ConfigType.UInt)]
+    UPnP,
+
+    /// <summary>
+    /// System option with the internal name Port.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Port", ConfigType.UInt)]
+    Port,
+
+    /// <summary>
+    /// System option with the internal name LastLogin0.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LastLogin0", ConfigType.UInt)]
+    LastLogin0,
+
+    /// <summary>
+    /// System option with the internal name LastLogin1.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LastLogin1", ConfigType.UInt)]
+    LastLogin1,
+
+    /// <summary>
+    /// System option with the internal name WorldId.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("WorldId", ConfigType.UInt)]
+    WorldId,
+
+    /// <summary>
+    /// System option with the internal name ServiceIndex.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ServiceIndex", ConfigType.UInt)]
+    ServiceIndex,
+
+    /// <summary>
+    /// System option with the internal name DktSessionId.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("DktSessionId", ConfigType.String)]
+    DktSessionId,
+
+    /// <summary>
+    /// System option with the internal name MainAdapter.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("MainAdapter", ConfigType.String)]
+    MainAdapter,
+
+    /// <summary>
+    /// System option with the internal name ScreenLeft.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ScreenLeft", ConfigType.UInt)]
+    ScreenLeft,
+
+    /// <summary>
+    /// System option with the internal name ScreenTop.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ScreenTop", ConfigType.UInt)]
+    ScreenTop,
+
+    /// <summary>
+    /// System option with the internal name ScreenWidth.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ScreenWidth", ConfigType.UInt)]
+    ScreenWidth,
+
+    /// <summary>
+    /// System option with the internal name ScreenHeight.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ScreenHeight", ConfigType.UInt)]
+    ScreenHeight,
+
+    /// <summary>
+    /// System option with the internal name ScreenMode.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ScreenMode", ConfigType.UInt)]
+    ScreenMode,
+
+    /// <summary>
+    /// System option with the internal name FullScreenWidth.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FullScreenWidth", ConfigType.UInt)]
+    FullScreenWidth,
+
+    /// <summary>
+    /// System option with the internal name FullScreenHeight.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FullScreenHeight", ConfigType.UInt)]
+    FullScreenHeight,
+
+    /// <summary>
+    /// System option with the internal name Refreshrate.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Refreshrate", ConfigType.UInt)]
+    Refreshrate,
+
+    /// <summary>
+    /// System option with the internal name Fps.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Fps", ConfigType.UInt)]
+    Fps,
+
+    /// <summary>
+    /// System option with the internal name AntiAliasing.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AntiAliasing", ConfigType.UInt)]
+    AntiAliasing,
+
+    /// <summary>
+    /// System option with the internal name FPSInActive.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FPSInActive", ConfigType.UInt)]
+    FPSInActive,
+
+    /// <summary>
+    /// System option with the internal name ResoMouseDrag.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ResoMouseDrag", ConfigType.UInt)]
+    ResoMouseDrag,
+
+    /// <summary>
+    /// System option with the internal name MouseOpeLimit.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseOpeLimit", ConfigType.UInt)]
+    MouseOpeLimit,
+
+    /// <summary>
+    /// System option with the internal name LangSelectSub.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LangSelectSub", ConfigType.UInt)]
+    LangSelectSub,
+
+    /// <summary>
+    /// System option with the internal name Gamma.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Gamma", ConfigType.UInt)]
+    Gamma,
+
+    /// <summary>
+    /// System option with the internal name UiBaseScale.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("UiBaseScale", ConfigType.UInt)]
+    UiBaseScale,
+
+    /// <summary>
+    /// System option with the internal name CharaLight.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CharaLight", ConfigType.UInt)]
+    CharaLight,
+
+    /// <summary>
+    /// System option with the internal name UiHighScale.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("UiHighScale", ConfigType.UInt)]
+    UiHighScale,
+
+    /// <summary>
+    /// System option with the internal name TextureFilterQuality.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TextureFilterQuality", ConfigType.UInt)]
+    TextureFilterQuality,
+
+    /// <summary>
+    /// System option with the internal name TextureAnisotropicQuality.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TextureAnisotropicQuality", ConfigType.UInt)]
+    TextureAnisotropicQuality,
+
+    /// <summary>
+    /// System option with the internal name SSAO.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SSAO", ConfigType.UInt)]
+    SSAO,
+
+    /// <summary>
+    /// System option with the internal name Glare.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Glare", ConfigType.UInt)]
+    Glare,
+
+    /// <summary>
+    /// System option with the internal name DistortionWater.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("DistortionWater", ConfigType.UInt)]
+    DistortionWater,
+
+    /// <summary>
+    /// System option with the internal name DepthOfField.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("DepthOfField", ConfigType.UInt)]
+    DepthOfField,
+
+    /// <summary>
+    /// System option with the internal name RadialBlur.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("RadialBlur", ConfigType.UInt)]
+    RadialBlur,
+
+    /// <summary>
+    /// System option with the internal name Vignetting.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Vignetting", ConfigType.UInt)]
+    Vignetting,
+
+    /// <summary>
+    /// System option with the internal name GrassQuality.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GrassQuality", ConfigType.UInt)]
+    GrassQuality,
+
+    /// <summary>
+    /// System option with the internal name TranslucentQuality.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TranslucentQuality", ConfigType.UInt)]
+    TranslucentQuality,
+
+    /// <summary>
+    /// System option with the internal name ShadowVisibilityType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowVisibilityType", ConfigType.UInt)]
+    ShadowVisibilityType,
+
+    /// <summary>
+    /// System option with the internal name ShadowSoftShadowType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowSoftShadowType", ConfigType.UInt)]
+    ShadowSoftShadowType,
+
+    /// <summary>
+    /// System option with the internal name ShadowTextureSizeType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowTextureSizeType", ConfigType.UInt)]
+    ShadowTextureSizeType,
+
+    /// <summary>
+    /// System option with the internal name ShadowCascadeCountType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowCascadeCountType", ConfigType.UInt)]
+    ShadowCascadeCountType,
+
+    /// <summary>
+    /// System option with the internal name LodType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LodType", ConfigType.UInt)]
+    LodType,
+
+    /// <summary>
+    /// System option with the internal name StreamingType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("StreamingType", ConfigType.UInt)]
+    StreamingType,
+
+    /// <summary>
+    /// System option with the internal name GeneralQuality.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GeneralQuality", ConfigType.UInt)]
+    GeneralQuality,
+
+    /// <summary>
+    /// System option with the internal name OcclusionCulling.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("OcclusionCulling", ConfigType.UInt)]
+    OcclusionCulling,
+
+    /// <summary>
+    /// System option with the internal name ShadowLOD.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowLOD", ConfigType.UInt)]
+    ShadowLOD,
+
+    /// <summary>
+    /// System option with the internal name PhysicsType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PhysicsType", ConfigType.UInt)]
+    PhysicsType,
+
+    /// <summary>
+    /// System option with the internal name MapResolution.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MapResolution", ConfigType.UInt)]
+    MapResolution,
+
+    /// <summary>
+    /// System option with the internal name ShadowVisibilityTypeSelf.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowVisibilityTypeSelf", ConfigType.UInt)]
+    ShadowVisibilityTypeSelf,
+
+    /// <summary>
+    /// System option with the internal name ShadowVisibilityTypeParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowVisibilityTypeParty", ConfigType.UInt)]
+    ShadowVisibilityTypeParty,
+
+    /// <summary>
+    /// System option with the internal name ShadowVisibilityTypeOther.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowVisibilityTypeOther", ConfigType.UInt)]
+    ShadowVisibilityTypeOther,
+
+    /// <summary>
+    /// System option with the internal name ShadowVisibilityTypeEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowVisibilityTypeEnemy", ConfigType.UInt)]
+    ShadowVisibilityTypeEnemy,
+
+    /// <summary>
+    /// System option with the internal name PhysicsTypeSelf.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PhysicsTypeSelf", ConfigType.UInt)]
+    PhysicsTypeSelf,
+
+    /// <summary>
+    /// System option with the internal name PhysicsTypeParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PhysicsTypeParty", ConfigType.UInt)]
+    PhysicsTypeParty,
+
+    /// <summary>
+    /// System option with the internal name PhysicsTypeOther.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PhysicsTypeOther", ConfigType.UInt)]
+    PhysicsTypeOther,
+
+    /// <summary>
+    /// System option with the internal name PhysicsTypeEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PhysicsTypeEnemy", ConfigType.UInt)]
+    PhysicsTypeEnemy,
+
+    /// <summary>
+    /// System option with the internal name ReflectionType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ReflectionType", ConfigType.UInt)]
+    ReflectionType,
+
+    /// <summary>
+    /// System option with the internal name ScreenShotImageType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ScreenShotImageType", ConfigType.UInt)]
+    ScreenShotImageType,
+
+    /// <summary>
+    /// System option with the internal name IsSoundDisable.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSoundDisable", ConfigType.UInt)]
+    IsSoundDisable,
+
+    /// <summary>
+    /// System option with the internal name IsSoundAlways.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSoundAlways", ConfigType.UInt)]
+    IsSoundAlways,
+
+    /// <summary>
+    /// System option with the internal name IsSoundBgmAlways.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSoundBgmAlways", ConfigType.UInt)]
+    IsSoundBgmAlways,
+
+    /// <summary>
+    /// System option with the internal name IsSoundSeAlways.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSoundSeAlways", ConfigType.UInt)]
+    IsSoundSeAlways,
+
+    /// <summary>
+    /// System option with the internal name IsSoundVoiceAlways.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSoundVoiceAlways", ConfigType.UInt)]
+    IsSoundVoiceAlways,
+
+    /// <summary>
+    /// System option with the internal name IsSoundSystemAlways.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSoundSystemAlways", ConfigType.UInt)]
+    IsSoundSystemAlways,
+
+    /// <summary>
+    /// System option with the internal name IsSoundEnvAlways.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSoundEnvAlways", ConfigType.UInt)]
+    IsSoundEnvAlways,
+
+    /// <summary>
+    /// System option with the internal name IsSoundPerformAlways.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSoundPerformAlways", ConfigType.UInt)]
+    IsSoundPerformAlways,
+
+    /// <summary>
+    /// System option with the internal name PadGuid.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PadGuid", ConfigType.UInt)]
+    PadGuid,
+
+    /// <summary>
+    /// System option with the internal name InstanceGuid.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("InstanceGuid", ConfigType.String)]
+    InstanceGuid,
+
+    /// <summary>
+    /// System option with the internal name ProductGuid.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("ProductGuid", ConfigType.String)]
+    ProductGuid,
+
+    /// <summary>
+    /// System option with the internal name DeadArea.
+    /// This option is a Float.
+    /// </summary>
+    [GameConfigOption("DeadArea", ConfigType.Float)]
+    DeadArea,
+
+    /// <summary>
+    /// System option with the internal name Alias.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("Alias", ConfigType.String)]
+    Alias,
+
+    /// <summary>
+    /// System option with the internal name AlwaysInput.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AlwaysInput", ConfigType.UInt)]
+    AlwaysInput,
+
+    /// <summary>
+    /// System option with the internal name ForceFeedBack.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ForceFeedBack", ConfigType.UInt)]
+    ForceFeedBack,
+
+    /// <summary>
+    /// System option with the internal name PadPovInput.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PadPovInput", ConfigType.UInt)]
+    PadPovInput,
+
+    /// <summary>
+    /// System option with the internal name PadMode.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PadMode", ConfigType.UInt)]
+    PadMode,
+
+    /// <summary>
+    /// System option with the internal name PadAvailable.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PadAvailable", ConfigType.UInt)]
+    PadAvailable,
+
+    /// <summary>
+    /// System option with the internal name PadReverseConfirmCancel.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PadReverseConfirmCancel", ConfigType.UInt)]
+    PadReverseConfirmCancel,
+
+    /// <summary>
+    /// System option with the internal name PadSelectButtonIcon.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PadSelectButtonIcon", ConfigType.UInt)]
+    PadSelectButtonIcon,
+
+    /// <summary>
+    /// System option with the internal name PadMouseMode.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PadMouseMode", ConfigType.UInt)]
+    PadMouseMode,
+
+    /// <summary>
+    /// System option with the internal name TextPasteEnable.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TextPasteEnable", ConfigType.UInt)]
+    TextPasteEnable,
+
+    /// <summary>
+    /// System option with the internal name EnablePsFunction.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("EnablePsFunction", ConfigType.UInt)]
+    EnablePsFunction,
+
+    /// <summary>
+    /// System option with the internal name WaterWet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("WaterWet", ConfigType.UInt)]
+    WaterWet,
+
+    /// <summary>
+    /// System option with the internal name DisplayObjectLimitType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("DisplayObjectLimitType", ConfigType.UInt)]
+    DisplayObjectLimitType,
+
+    /// <summary>
+    /// System option with the internal name WindowDispNum.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("WindowDispNum", ConfigType.UInt)]
+    WindowDispNum,
+
+    /// <summary>
+    /// System option with the internal name ScreenShotDir.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("ScreenShotDir", ConfigType.String)]
+    ScreenShotDir,
+
+    /// <summary>
+    /// System option with the internal name AntiAliasing_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AntiAliasing_DX11", ConfigType.UInt)]
+    AntiAliasing_DX11,
+
+    /// <summary>
+    /// System option with the internal name TextureFilterQuality_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TextureFilterQuality_DX11", ConfigType.UInt)]
+    TextureFilterQuality_DX11,
+
+    /// <summary>
+    /// System option with the internal name TextureAnisotropicQuality_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TextureAnisotropicQuality_DX11", ConfigType.UInt)]
+    TextureAnisotropicQuality_DX11,
+
+    /// <summary>
+    /// System option with the internal name SSAO_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SSAO_DX11", ConfigType.UInt)]
+    SSAO_DX11,
+
+    /// <summary>
+    /// System option with the internal name Glare_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Glare_DX11", ConfigType.UInt)]
+    Glare_DX11,
+
+    /// <summary>
+    /// System option with the internal name DistortionWater_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("DistortionWater_DX11", ConfigType.UInt)]
+    DistortionWater_DX11,
+
+    /// <summary>
+    /// System option with the internal name DepthOfField_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("DepthOfField_DX11", ConfigType.UInt)]
+    DepthOfField_DX11,
+
+    /// <summary>
+    /// System option with the internal name RadialBlur_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("RadialBlur_DX11", ConfigType.UInt)]
+    RadialBlur_DX11,
+
+    /// <summary>
+    /// System option with the internal name Vignetting_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Vignetting_DX11", ConfigType.UInt)]
+    Vignetting_DX11,
+
+    /// <summary>
+    /// System option with the internal name GrassQuality_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GrassQuality_DX11", ConfigType.UInt)]
+    GrassQuality_DX11,
+
+    /// <summary>
+    /// System option with the internal name TranslucentQuality_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TranslucentQuality_DX11", ConfigType.UInt)]
+    TranslucentQuality_DX11,
+
+    /// <summary>
+    /// System option with the internal name ShadowSoftShadowType_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowSoftShadowType_DX11", ConfigType.UInt)]
+    ShadowSoftShadowType_DX11,
+
+    /// <summary>
+    /// System option with the internal name ShadowTextureSizeType_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowTextureSizeType_DX11", ConfigType.UInt)]
+    ShadowTextureSizeType_DX11,
+
+    /// <summary>
+    /// System option with the internal name ShadowCascadeCountType_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowCascadeCountType_DX11", ConfigType.UInt)]
+    ShadowCascadeCountType_DX11,
+
+    /// <summary>
+    /// System option with the internal name LodType_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LodType_DX11", ConfigType.UInt)]
+    LodType_DX11,
+
+    /// <summary>
+    /// System option with the internal name OcclusionCulling_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("OcclusionCulling_DX11", ConfigType.UInt)]
+    OcclusionCulling_DX11,
+
+    /// <summary>
+    /// System option with the internal name ShadowLOD_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowLOD_DX11", ConfigType.UInt)]
+    ShadowLOD_DX11,
+
+    /// <summary>
+    /// System option with the internal name MapResolution_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MapResolution_DX11", ConfigType.UInt)]
+    MapResolution_DX11,
+
+    /// <summary>
+    /// System option with the internal name ShadowVisibilityTypeSelf_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowVisibilityTypeSelf_DX11", ConfigType.UInt)]
+    ShadowVisibilityTypeSelf_DX11,
+
+    /// <summary>
+    /// System option with the internal name ShadowVisibilityTypeParty_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowVisibilityTypeParty_DX11", ConfigType.UInt)]
+    ShadowVisibilityTypeParty_DX11,
+
+    /// <summary>
+    /// System option with the internal name ShadowVisibilityTypeOther_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowVisibilityTypeOther_DX11", ConfigType.UInt)]
+    ShadowVisibilityTypeOther_DX11,
+
+    /// <summary>
+    /// System option with the internal name ShadowVisibilityTypeEnemy_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShadowVisibilityTypeEnemy_DX11", ConfigType.UInt)]
+    ShadowVisibilityTypeEnemy_DX11,
+
+    /// <summary>
+    /// System option with the internal name PhysicsTypeSelf_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PhysicsTypeSelf_DX11", ConfigType.UInt)]
+    PhysicsTypeSelf_DX11,
+
+    /// <summary>
+    /// System option with the internal name PhysicsTypeParty_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PhysicsTypeParty_DX11", ConfigType.UInt)]
+    PhysicsTypeParty_DX11,
+
+    /// <summary>
+    /// System option with the internal name PhysicsTypeOther_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PhysicsTypeOther_DX11", ConfigType.UInt)]
+    PhysicsTypeOther_DX11,
+
+    /// <summary>
+    /// System option with the internal name PhysicsTypeEnemy_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PhysicsTypeEnemy_DX11", ConfigType.UInt)]
+    PhysicsTypeEnemy_DX11,
+
+    /// <summary>
+    /// System option with the internal name ReflectionType_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ReflectionType_DX11", ConfigType.UInt)]
+    ReflectionType_DX11,
+
+    /// <summary>
+    /// System option with the internal name WaterWet_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("WaterWet_DX11", ConfigType.UInt)]
+    WaterWet_DX11,
+
+    /// <summary>
+    /// System option with the internal name ParallaxOcclusion_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ParallaxOcclusion_DX11", ConfigType.UInt)]
+    ParallaxOcclusion_DX11,
+
+    /// <summary>
+    /// System option with the internal name Tessellation_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Tessellation_DX11", ConfigType.UInt)]
+    Tessellation_DX11,
+
+    /// <summary>
+    /// System option with the internal name GlareRepresentation_DX11.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GlareRepresentation_DX11", ConfigType.UInt)]
+    GlareRepresentation_DX11,
+
+    /// <summary>
+    /// System option with the internal name UiSystemEnlarge.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("UiSystemEnlarge", ConfigType.UInt)]
+    UiSystemEnlarge,
+
+    /// <summary>
+    /// System option with the internal name SoundPadSeType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundPadSeType", ConfigType.UInt)]
+    SoundPadSeType,
+
+    /// <summary>
+    /// System option with the internal name SoundPad.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundPad", ConfigType.UInt)]
+    SoundPad,
+
+    /// <summary>
+    /// System option with the internal name IsSoundPad.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSoundPad", ConfigType.UInt)]
+    IsSoundPad,
+
+    /// <summary>
+    /// System option with the internal name TouchPadMouse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TouchPadMouse", ConfigType.UInt)]
+    TouchPadMouse,
+
+    /// <summary>
+    /// System option with the internal name TouchPadCursorSpeed.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TouchPadCursorSpeed", ConfigType.UInt)]
+    TouchPadCursorSpeed,
+
+    /// <summary>
+    /// System option with the internal name TouchPadButtonExtension.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TouchPadButtonExtension", ConfigType.UInt)]
+    TouchPadButtonExtension,
+
+    /// <summary>
+    /// System option with the internal name TouchPadButton_Left.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TouchPadButton_Left", ConfigType.UInt)]
+    TouchPadButton_Left,
+
+    /// <summary>
+    /// System option with the internal name TouchPadButton_Right.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TouchPadButton_Right", ConfigType.UInt)]
+    TouchPadButton_Right,
+
+    /// <summary>
+    /// System option with the internal name RemotePlayRearTouchpadEnable.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("RemotePlayRearTouchpadEnable", ConfigType.UInt)]
+    RemotePlayRearTouchpadEnable,
+
+    /// <summary>
+    /// System option with the internal name SupportButtonAutorunEnable.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SupportButtonAutorunEnable", ConfigType.UInt)]
+    SupportButtonAutorunEnable,
+
+    /// <summary>
+    /// System option with the internal name R3ButtonWindowScalingEnable.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("R3ButtonWindowScalingEnable", ConfigType.UInt)]
+    R3ButtonWindowScalingEnable,
+
+    /// <summary>
+    /// System option with the internal name AutoAfkSwitchingTime.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AutoAfkSwitchingTime", ConfigType.UInt)]
+    AutoAfkSwitchingTime,
+
+    /// <summary>
+    /// System option with the internal name AutoChangeCameraMode.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AutoChangeCameraMode", ConfigType.UInt)]
+    AutoChangeCameraMode,
+
+    /// <summary>
+    /// System option with the internal name AccessibilitySoundVisualEnable.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AccessibilitySoundVisualEnable", ConfigType.UInt)]
+    AccessibilitySoundVisualEnable,
+
+    /// <summary>
+    /// System option with the internal name AccessibilitySoundVisualDispSize.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AccessibilitySoundVisualDispSize", ConfigType.UInt)]
+    AccessibilitySoundVisualDispSize,
+
+    /// <summary>
+    /// System option with the internal name AccessibilitySoundVisualPermeabilityRate.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AccessibilitySoundVisualPermeabilityRate", ConfigType.UInt)]
+    AccessibilitySoundVisualPermeabilityRate,
+
+    /// <summary>
+    /// System option with the internal name AccessibilityColorBlindFilterEnable.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AccessibilityColorBlindFilterEnable", ConfigType.UInt)]
+    AccessibilityColorBlindFilterEnable,
+
+    /// <summary>
+    /// System option with the internal name AccessibilityColorBlindFilterType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AccessibilityColorBlindFilterType", ConfigType.UInt)]
+    AccessibilityColorBlindFilterType,
+
+    /// <summary>
+    /// System option with the internal name AccessibilityColorBlindFilterStrength.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AccessibilityColorBlindFilterStrength", ConfigType.UInt)]
+    AccessibilityColorBlindFilterStrength,
+
+    /// <summary>
+    /// System option with the internal name MouseAutoFocus.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseAutoFocus", ConfigType.UInt)]
+    MouseAutoFocus,
+
+    /// <summary>
+    /// System option with the internal name FPSDownAFK.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FPSDownAFK", ConfigType.UInt)]
+    FPSDownAFK,
+
+    /// <summary>
+    /// System option with the internal name IdlingCameraAFK.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IdlingCameraAFK", ConfigType.UInt)]
+    IdlingCameraAFK,
+
+    /// <summary>
+    /// System option with the internal name MouseSpeed.
+    /// This option is a Float.
+    /// </summary>
+    [GameConfigOption("MouseSpeed", ConfigType.Float)]
+    MouseSpeed,
+
+    /// <summary>
+    /// System option with the internal name CameraZoom.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CameraZoom", ConfigType.UInt)]
+    CameraZoom,
+
+    /// <summary>
+    /// System option with the internal name DynamicRezoType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("DynamicRezoType", ConfigType.UInt)]
+    DynamicRezoType,
+
+    /// <summary>
+    /// System option with the internal name Is3DAudio.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Is3DAudio", ConfigType.UInt)]
+    Is3DAudio,
+
+    /// <summary>
+    /// System option with the internal name BattleEffect.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("BattleEffect", ConfigType.UInt)]
+    BattleEffect,
+
+    /// <summary>
+    /// System option with the internal name BGEffect.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("BGEffect", ConfigType.UInt)]
+    BGEffect,
+
+    /// <summary>
+    /// System option with the internal name ColorThemeType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorThemeType", ConfigType.UInt)]
+    ColorThemeType,
+
+    /// <summary>
+    /// System option with the internal name SystemMouseOperationSoftOn.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SystemMouseOperationSoftOn", ConfigType.UInt)]
+    SystemMouseOperationSoftOn,
+
+    /// <summary>
+    /// System option with the internal name SystemMouseOperationTrajectory.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SystemMouseOperationTrajectory", ConfigType.UInt)]
+    SystemMouseOperationTrajectory,
+
+    /// <summary>
+    /// System option with the internal name SystemMouseOperationCursorScaling.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SystemMouseOperationCursorScaling", ConfigType.UInt)]
+    SystemMouseOperationCursorScaling,
+
+    /// <summary>
+    /// System option with the internal name HardwareCursorSize.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HardwareCursorSize", ConfigType.UInt)]
+    HardwareCursorSize,
+
+    /// <summary>
+    /// System option with the internal name UiAssetType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("UiAssetType", ConfigType.UInt)]
+    UiAssetType,
+
+    /// <summary>
+    /// System option with the internal name FellowshipShowNewNotice.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FellowshipShowNewNotice", ConfigType.UInt)]
+    FellowshipShowNewNotice,
+
+    /// <summary>
+    /// System option with the internal name CutsceneMovieVoice.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CutsceneMovieVoice", ConfigType.UInt)]
+    CutsceneMovieVoice,
+
+    /// <summary>
+    /// System option with the internal name CutsceneMovieCaption.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CutsceneMovieCaption", ConfigType.UInt)]
+    CutsceneMovieCaption,
+
+    /// <summary>
+    /// System option with the internal name CutsceneMovieOpening.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CutsceneMovieOpening", ConfigType.UInt)]
+    CutsceneMovieOpening,
+
+    /// <summary>
+    /// System option with the internal name SoundMaster.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundMaster", ConfigType.UInt)]
+    SoundMaster,
+
+    /// <summary>
+    /// System option with the internal name SoundBgm.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundBgm", ConfigType.UInt)]
+    SoundBgm,
+
+    /// <summary>
+    /// System option with the internal name SoundSe.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundSe", ConfigType.UInt)]
+    SoundSe,
+
+    /// <summary>
+    /// System option with the internal name SoundVoice.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundVoice", ConfigType.UInt)]
+    SoundVoice,
+
+    /// <summary>
+    /// System option with the internal name SoundEnv.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundEnv", ConfigType.UInt)]
+    SoundEnv,
+
+    /// <summary>
+    /// System option with the internal name SoundSystem.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundSystem", ConfigType.UInt)]
+    SoundSystem,
+
+    /// <summary>
+    /// System option with the internal name SoundPerform.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundPerform", ConfigType.UInt)]
+    SoundPerform,
+
+    /// <summary>
+    /// System option with the internal name SoundPlayer.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundPlayer", ConfigType.UInt)]
+    SoundPlayer,
+
+    /// <summary>
+    /// System option with the internal name SoundParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundParty", ConfigType.UInt)]
+    SoundParty,
+
+    /// <summary>
+    /// System option with the internal name SoundOther.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundOther", ConfigType.UInt)]
+    SoundOther,
+
+    /// <summary>
+    /// System option with the internal name IsSndMaster.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSndMaster", ConfigType.UInt)]
+    IsSndMaster,
+
+    /// <summary>
+    /// System option with the internal name IsSndBgm.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSndBgm", ConfigType.UInt)]
+    IsSndBgm,
+
+    /// <summary>
+    /// System option with the internal name IsSndSe.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSndSe", ConfigType.UInt)]
+    IsSndSe,
+
+    /// <summary>
+    /// System option with the internal name IsSndVoice.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSndVoice", ConfigType.UInt)]
+    IsSndVoice,
+
+    /// <summary>
+    /// System option with the internal name IsSndEnv.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSndEnv", ConfigType.UInt)]
+    IsSndEnv,
+
+    /// <summary>
+    /// System option with the internal name IsSndSystem.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSndSystem", ConfigType.UInt)]
+    IsSndSystem,
+
+    /// <summary>
+    /// System option with the internal name IsSndPerform.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsSndPerform", ConfigType.UInt)]
+    IsSndPerform,
+
+    /// <summary>
+    /// System option with the internal name SoundDolby.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundDolby", ConfigType.UInt)]
+    SoundDolby,
+
+    /// <summary>
+    /// System option with the internal name SoundMicpos.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundMicpos", ConfigType.UInt)]
+    SoundMicpos,
+
+    /// <summary>
+    /// System option with the internal name SoundChocobo.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundChocobo", ConfigType.UInt)]
+    SoundChocobo,
+
+    /// <summary>
+    /// System option with the internal name SoundFieldBattle.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundFieldBattle", ConfigType.UInt)]
+    SoundFieldBattle,
+
+    /// <summary>
+    /// System option with the internal name SoundCfTimeCount.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundCfTimeCount", ConfigType.UInt)]
+    SoundCfTimeCount,
+
+    /// <summary>
+    /// System option with the internal name SoundHousing.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundHousing", ConfigType.UInt)]
+    SoundHousing,
+
+    /// <summary>
+    /// System option with the internal name SoundEqualizerType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SoundEqualizerType", ConfigType.UInt)]
+    SoundEqualizerType,
+
+    /// <summary>
+    /// System option with the internal name PadButton_L2.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("PadButton_L2", ConfigType.String)]
+    PadButton_L2,
+
+    /// <summary>
+    /// System option with the internal name PadButton_R2.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("PadButton_R2", ConfigType.String)]
+    PadButton_R2,
+
+    /// <summary>
+    /// System option with the internal name PadButton_L1.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("PadButton_L1", ConfigType.String)]
+    PadButton_L1,
+
+    /// <summary>
+    /// System option with the internal name PadButton_R1.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("PadButton_R1", ConfigType.String)]
+    PadButton_R1,
+
+    /// <summary>
+    /// System option with the internal name PadButton_Triangle.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("PadButton_Triangle", ConfigType.String)]
+    PadButton_Triangle,
+
+    /// <summary>
+    /// System option with the internal name PadButton_Circle.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("PadButton_Circle", ConfigType.String)]
+    PadButton_Circle,
+
+    /// <summary>
+    /// System option with the internal name PadButton_Cross.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("PadButton_Cross", ConfigType.String)]
+    PadButton_Cross,
+
+    /// <summary>
+    /// System option with the internal name PadButton_Square.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("PadButton_Square", ConfigType.String)]
+    PadButton_Square,
+
+    /// <summary>
+    /// System option with the internal name PadButton_Select.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("PadButton_Select", ConfigType.String)]
+    PadButton_Select,
+
+    /// <summary>
+    /// System option with the internal name PadButton_Start.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("PadButton_Start", ConfigType.String)]
+    PadButton_Start,
+
+    /// <summary>
+    /// System option with the internal name PadButton_LS.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("PadButton_LS", ConfigType.String)]
+    PadButton_LS,
+
+    /// <summary>
+    /// System option with the internal name PadButton_RS.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("PadButton_RS", ConfigType.String)]
+    PadButton_RS,
+
+    /// <summary>
+    /// System option with the internal name PadButton_L3.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("PadButton_L3", ConfigType.String)]
+    PadButton_L3,
+
+    /// <summary>
+    /// System option with the internal name PadButton_R3.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("PadButton_R3", ConfigType.String)]
+    PadButton_R3,
+}

--- a/Dalamud/Game/Config/UiConfigOption.cs
+++ b/Dalamud/Game/Config/UiConfigOption.cs
@@ -1,0 +1,3317 @@
+﻿using FFXIVClientStructs.FFXIV.Common.Configuration;
+
+namespace Dalamud.Game.Config;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable IdentifierTypo
+// ReSharper disable CommentTypo
+
+/// <summary>
+/// Config options in the UiConfig section.
+/// </summary>
+public enum UiConfigOption
+{
+    /// <summary>
+    /// System option with the internal name BattleEffectSelf.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("BattleEffectSelf", ConfigType.UInt)]
+    BattleEffectSelf,
+
+    /// <summary>
+    /// System option with the internal name BattleEffectParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("BattleEffectParty", ConfigType.UInt)]
+    BattleEffectParty,
+
+    /// <summary>
+    /// System option with the internal name BattleEffectOther.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("BattleEffectOther", ConfigType.UInt)]
+    BattleEffectOther,
+
+    /// <summary>
+    /// System option with the internal name BattleEffectPvPEnemyPc.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("BattleEffectPvPEnemyPc", ConfigType.UInt)]
+    BattleEffectPvPEnemyPc,
+
+    /// <summary>
+    /// System option with the internal name PadMode.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PadMode", ConfigType.UInt)]
+    PadMode,
+
+    /// <summary>
+    /// System option with the internal name WeaponAutoPutAway.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("WeaponAutoPutAway", ConfigType.UInt)]
+    WeaponAutoPutAway,
+
+    /// <summary>
+    /// System option with the internal name WeaponAutoPutAwayTime.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("WeaponAutoPutAwayTime", ConfigType.UInt)]
+    WeaponAutoPutAwayTime,
+
+    /// <summary>
+    /// System option with the internal name LipMotionType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LipMotionType", ConfigType.UInt)]
+    LipMotionType,
+
+    /// <summary>
+    /// System option with the internal name FirstPersonDefaultYAngle.
+    /// This option is a Float.
+    /// </summary>
+    [GameConfigOption("FirstPersonDefaultYAngle", ConfigType.Float)]
+    FirstPersonDefaultYAngle,
+
+    /// <summary>
+    /// System option with the internal name FirstPersonDefaultZoom.
+    /// This option is a Float.
+    /// </summary>
+    [GameConfigOption("FirstPersonDefaultZoom", ConfigType.Float)]
+    FirstPersonDefaultZoom,
+
+    /// <summary>
+    /// System option with the internal name FirstPersonDefaultDistance.
+    /// This option is a Float.
+    /// </summary>
+    [GameConfigOption("FirstPersonDefaultDistance", ConfigType.Float)]
+    FirstPersonDefaultDistance,
+
+    /// <summary>
+    /// System option with the internal name ThirdPersonDefaultYAngle.
+    /// This option is a Float.
+    /// </summary>
+    [GameConfigOption("ThirdPersonDefaultYAngle", ConfigType.Float)]
+    ThirdPersonDefaultYAngle,
+
+    /// <summary>
+    /// System option with the internal name ThirdPersonDefaultZoom.
+    /// This option is a Float.
+    /// </summary>
+    [GameConfigOption("ThirdPersonDefaultZoom", ConfigType.Float)]
+    ThirdPersonDefaultZoom,
+
+    /// <summary>
+    /// System option with the internal name ThirdPersonDefaultDistance.
+    /// This option is a Float.
+    /// </summary>
+    [GameConfigOption("ThirdPersonDefaultDistance", ConfigType.Float)]
+    ThirdPersonDefaultDistance,
+
+    /// <summary>
+    /// System option with the internal name LockonDefaultYAngle.
+    /// This option is a Float.
+    /// </summary>
+    [GameConfigOption("LockonDefaultYAngle", ConfigType.Float)]
+    LockonDefaultYAngle,
+
+    /// <summary>
+    /// System option with the internal name LockonDefaultZoom.
+    /// This option is a Float.
+    /// </summary>
+    [GameConfigOption("LockonDefaultZoom", ConfigType.Float)]
+    LockonDefaultZoom,
+
+    /// <summary>
+    /// System option with the internal name CameraProductionOfAction.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CameraProductionOfAction", ConfigType.UInt)]
+    CameraProductionOfAction,
+
+    /// <summary>
+    /// System option with the internal name FPSCameraInterpolationType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FPSCameraInterpolationType", ConfigType.UInt)]
+    FPSCameraInterpolationType,
+
+    /// <summary>
+    /// System option with the internal name FPSCameraVerticalInterpolation.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FPSCameraVerticalInterpolation", ConfigType.UInt)]
+    FPSCameraVerticalInterpolation,
+
+    /// <summary>
+    /// System option with the internal name LegacyCameraCorrectionFix.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LegacyCameraCorrectionFix", ConfigType.UInt)]
+    LegacyCameraCorrectionFix,
+
+    /// <summary>
+    /// System option with the internal name LegacyCameraType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LegacyCameraType", ConfigType.UInt)]
+    LegacyCameraType,
+
+    /// <summary>
+    /// System option with the internal name EventCameraAutoControl.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("EventCameraAutoControl", ConfigType.UInt)]
+    EventCameraAutoControl,
+
+    /// <summary>
+    /// System option with the internal name CameraLookBlinkType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CameraLookBlinkType", ConfigType.UInt)]
+    CameraLookBlinkType,
+
+    /// <summary>
+    /// System option with the internal name IdleEmoteTime.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IdleEmoteTime", ConfigType.UInt)]
+    IdleEmoteTime,
+
+    /// <summary>
+    /// System option with the internal name IdleEmoteRandomType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IdleEmoteRandomType", ConfigType.UInt)]
+    IdleEmoteRandomType,
+
+    /// <summary>
+    /// System option with the internal name CutsceneSkipIsShip.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CutsceneSkipIsShip", ConfigType.UInt)]
+    CutsceneSkipIsShip,
+
+    /// <summary>
+    /// System option with the internal name CutsceneSkipIsContents.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CutsceneSkipIsContents", ConfigType.UInt)]
+    CutsceneSkipIsContents,
+
+    /// <summary>
+    /// System option with the internal name CutsceneSkipIsHousing.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CutsceneSkipIsHousing", ConfigType.UInt)]
+    CutsceneSkipIsHousing,
+
+    /// <summary>
+    /// System option with the internal name PetTargetOffInCombat.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PetTargetOffInCombat", ConfigType.UInt)]
+    PetTargetOffInCombat,
+
+    /// <summary>
+    /// System option with the internal name GroundTargetFPSPosX.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GroundTargetFPSPosX", ConfigType.UInt)]
+    GroundTargetFPSPosX,
+
+    /// <summary>
+    /// System option with the internal name GroundTargetFPSPosY.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GroundTargetFPSPosY", ConfigType.UInt)]
+    GroundTargetFPSPosY,
+
+    /// <summary>
+    /// System option with the internal name GroundTargetTPSPosX.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GroundTargetTPSPosX", ConfigType.UInt)]
+    GroundTargetTPSPosX,
+
+    /// <summary>
+    /// System option with the internal name GroundTargetTPSPosY.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GroundTargetTPSPosY", ConfigType.UInt)]
+    GroundTargetTPSPosY,
+
+    /// <summary>
+    /// System option with the internal name TargetDisableAnchor.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TargetDisableAnchor", ConfigType.UInt)]
+    TargetDisableAnchor,
+
+    /// <summary>
+    /// System option with the internal name TargetCircleClickFilterEnableNearestCursor.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TargetCircleClickFilterEnableNearestCursor", ConfigType.UInt)]
+    TargetCircleClickFilterEnableNearestCursor,
+
+    /// <summary>
+    /// System option with the internal name TargetEnableMouseOverSelect.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TargetEnableMouseOverSelect", ConfigType.UInt)]
+    TargetEnableMouseOverSelect,
+
+    /// <summary>
+    /// System option with the internal name GroundTargetCursorCorrectType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GroundTargetCursorCorrectType", ConfigType.UInt)]
+    GroundTargetCursorCorrectType,
+
+    /// <summary>
+    /// System option with the internal name GroundTargetActionExcuteType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GroundTargetActionExcuteType", ConfigType.UInt)]
+    GroundTargetActionExcuteType,
+
+    /// <summary>
+    /// System option with the internal name AutoNearestTarget.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AutoNearestTarget", ConfigType.UInt)]
+    AutoNearestTarget,
+
+    /// <summary>
+    /// System option with the internal name AutoNearestTargetType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AutoNearestTargetType", ConfigType.UInt)]
+    AutoNearestTargetType,
+
+    /// <summary>
+    /// System option with the internal name RightClickExclusionPC.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("RightClickExclusionPC", ConfigType.UInt)]
+    RightClickExclusionPC,
+
+    /// <summary>
+    /// System option with the internal name RightClickExclusionBNPC.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("RightClickExclusionBNPC", ConfigType.UInt)]
+    RightClickExclusionBNPC,
+
+    /// <summary>
+    /// System option with the internal name RightClickExclusionMinion.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("RightClickExclusionMinion", ConfigType.UInt)]
+    RightClickExclusionMinion,
+
+    /// <summary>
+    /// System option with the internal name TurnSpeed.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TurnSpeed", ConfigType.UInt)]
+    TurnSpeed,
+
+    /// <summary>
+    /// System option with the internal name FootEffect.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FootEffect", ConfigType.UInt)]
+    FootEffect,
+
+    /// <summary>
+    /// System option with the internal name LegacySeal.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LegacySeal", ConfigType.UInt)]
+    LegacySeal,
+
+    /// <summary>
+    /// System option with the internal name GBarrelDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GBarrelDisp", ConfigType.UInt)]
+    GBarrelDisp,
+
+    /// <summary>
+    /// System option with the internal name EgiMirageTypeGaruda.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("EgiMirageTypeGaruda", ConfigType.UInt)]
+    EgiMirageTypeGaruda,
+
+    /// <summary>
+    /// System option with the internal name EgiMirageTypeTitan.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("EgiMirageTypeTitan", ConfigType.UInt)]
+    EgiMirageTypeTitan,
+
+    /// <summary>
+    /// System option with the internal name EgiMirageTypeIfrit.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("EgiMirageTypeIfrit", ConfigType.UInt)]
+    EgiMirageTypeIfrit,
+
+    /// <summary>
+    /// System option with the internal name BahamutSize.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("BahamutSize", ConfigType.UInt)]
+    BahamutSize,
+
+    /// <summary>
+    /// System option with the internal name PetMirageTypeCarbuncleSupport.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PetMirageTypeCarbuncleSupport", ConfigType.UInt)]
+    PetMirageTypeCarbuncleSupport,
+
+    /// <summary>
+    /// System option with the internal name PhoenixSize.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PhoenixSize", ConfigType.UInt)]
+    PhoenixSize,
+
+    /// <summary>
+    /// System option with the internal name GarudaSize.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GarudaSize", ConfigType.UInt)]
+    GarudaSize,
+
+    /// <summary>
+    /// System option with the internal name TitanSize.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TitanSize", ConfigType.UInt)]
+    TitanSize,
+
+    /// <summary>
+    /// System option with the internal name IfritSize.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IfritSize", ConfigType.UInt)]
+    IfritSize,
+
+    /// <summary>
+    /// System option with the internal name TimeMode.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TimeMode", ConfigType.UInt)]
+    TimeMode,
+
+    /// <summary>
+    /// System option with the internal name Time12.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Time12", ConfigType.UInt)]
+    Time12,
+
+    /// <summary>
+    /// System option with the internal name TimeEorzea.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TimeEorzea", ConfigType.UInt)]
+    TimeEorzea,
+
+    /// <summary>
+    /// System option with the internal name TimeLocal.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TimeLocal", ConfigType.UInt)]
+    TimeLocal,
+
+    /// <summary>
+    /// System option with the internal name TimeServer.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TimeServer", ConfigType.UInt)]
+    TimeServer,
+
+    /// <summary>
+    /// System option with the internal name ActiveLS_H.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ActiveLS_H", ConfigType.UInt)]
+    ActiveLS_H,
+
+    /// <summary>
+    /// System option with the internal name ActiveLS_L.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ActiveLS_L", ConfigType.UInt)]
+    ActiveLS_L,
+
+    /// <summary>
+    /// System option with the internal name HotbarLock.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarLock", ConfigType.UInt)]
+    HotbarLock,
+
+    /// <summary>
+    /// System option with the internal name HotbarDispRecastTime.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarDispRecastTime", ConfigType.UInt)]
+    HotbarDispRecastTime,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossContentsActionEnableInput.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossContentsActionEnableInput", ConfigType.UInt)]
+    HotbarCrossContentsActionEnableInput,
+
+    /// <summary>
+    /// System option with the internal name HotbarDispRecastTimeDispType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarDispRecastTimeDispType", ConfigType.UInt)]
+    HotbarDispRecastTimeDispType,
+
+    /// <summary>
+    /// System option with the internal name ExHotbarChangeHotbar1.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ExHotbarChangeHotbar1", ConfigType.UInt)]
+    ExHotbarChangeHotbar1,
+
+    /// <summary>
+    /// System option with the internal name HotbarCommon01.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCommon01", ConfigType.UInt)]
+    HotbarCommon01,
+
+    /// <summary>
+    /// System option with the internal name HotbarCommon02.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCommon02", ConfigType.UInt)]
+    HotbarCommon02,
+
+    /// <summary>
+    /// System option with the internal name HotbarCommon03.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCommon03", ConfigType.UInt)]
+    HotbarCommon03,
+
+    /// <summary>
+    /// System option with the internal name HotbarCommon04.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCommon04", ConfigType.UInt)]
+    HotbarCommon04,
+
+    /// <summary>
+    /// System option with the internal name HotbarCommon05.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCommon05", ConfigType.UInt)]
+    HotbarCommon05,
+
+    /// <summary>
+    /// System option with the internal name HotbarCommon06.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCommon06", ConfigType.UInt)]
+    HotbarCommon06,
+
+    /// <summary>
+    /// System option with the internal name HotbarCommon07.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCommon07", ConfigType.UInt)]
+    HotbarCommon07,
+
+    /// <summary>
+    /// System option with the internal name HotbarCommon08.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCommon08", ConfigType.UInt)]
+    HotbarCommon08,
+
+    /// <summary>
+    /// System option with the internal name HotbarCommon09.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCommon09", ConfigType.UInt)]
+    HotbarCommon09,
+
+    /// <summary>
+    /// System option with the internal name HotbarCommon10.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCommon10", ConfigType.UInt)]
+    HotbarCommon10,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossCommon01.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossCommon01", ConfigType.UInt)]
+    HotbarCrossCommon01,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossCommon02.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossCommon02", ConfigType.UInt)]
+    HotbarCrossCommon02,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossCommon03.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossCommon03", ConfigType.UInt)]
+    HotbarCrossCommon03,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossCommon04.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossCommon04", ConfigType.UInt)]
+    HotbarCrossCommon04,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossCommon05.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossCommon05", ConfigType.UInt)]
+    HotbarCrossCommon05,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossCommon06.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossCommon06", ConfigType.UInt)]
+    HotbarCrossCommon06,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossCommon07.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossCommon07", ConfigType.UInt)]
+    HotbarCrossCommon07,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossCommon08.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossCommon08", ConfigType.UInt)]
+    HotbarCrossCommon08,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossHelpDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossHelpDisp", ConfigType.UInt)]
+    HotbarCrossHelpDisp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossOperation.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossOperation", ConfigType.UInt)]
+    HotbarCrossOperation,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossDisp", ConfigType.UInt)]
+    HotbarCrossDisp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossLock.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossLock", ConfigType.UInt)]
+    HotbarCrossLock,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossUsePadGuide.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossUsePadGuide", ConfigType.UInt)]
+    HotbarCrossUsePadGuide,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossActiveSet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossActiveSet", ConfigType.UInt)]
+    HotbarCrossActiveSet,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossActiveSetPvP.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossActiveSetPvP", ConfigType.UInt)]
+    HotbarCrossActiveSetPvP,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsAuto.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsAuto", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsAuto,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustom.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustom", ConfigType.UInt)]
+    HotbarCrossSetChangeCustom,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet1.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet1", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet1,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet2.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet2", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet2,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet3.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet3", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet3,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet4.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet4", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet4,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet5.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet5", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet5,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet6.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet6", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet6,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet7.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet7", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet7,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet8.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet8", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet8,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSword.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSword", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSword,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet1.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet1", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet1,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet2.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet2", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet2,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet3.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet3", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet3,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet4.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet4", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet4,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet5.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet5", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet5,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet6.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet6", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet6,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet7.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet7", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet7,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet8.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet8", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet8,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossAdvancedSetting.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossAdvancedSetting", ConfigType.UInt)]
+    HotbarCrossAdvancedSetting,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossAdvancedSettingLeft.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossAdvancedSettingLeft", ConfigType.UInt)]
+    HotbarCrossAdvancedSettingLeft,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossAdvancedSettingRight.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossAdvancedSettingRight", ConfigType.UInt)]
+    HotbarCrossAdvancedSettingRight,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetPvpModeActive.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetPvpModeActive", ConfigType.UInt)]
+    HotbarCrossSetPvpModeActive,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomPvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomPvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomPvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsAutoPvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsAutoPvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsAutoPvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet1Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet1Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet1Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet2Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet2Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet2Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet3Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet3Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet3Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet4Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet4Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet4Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet5Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet5Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet5Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet6Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet6Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet6Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet7Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet7Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet7Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomSet8Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomSet8Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomSet8Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordPvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordPvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordPvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet1Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet1Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet1Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet2Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet2Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet2Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet3Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet3Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet3Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet4Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet4Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet4Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet5Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet5Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet5Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet6Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet6Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet6Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet7Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet7Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet7Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossSetChangeCustomIsSwordSet8Pvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossSetChangeCustomIsSwordSet8Pvp", ConfigType.UInt)]
+    HotbarCrossSetChangeCustomIsSwordSet8Pvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossAdvancedSettingPvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossAdvancedSettingPvp", ConfigType.UInt)]
+    HotbarCrossAdvancedSettingPvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossAdvancedSettingLeftPvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossAdvancedSettingLeftPvp", ConfigType.UInt)]
+    HotbarCrossAdvancedSettingLeftPvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossAdvancedSettingRightPvp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossAdvancedSettingRightPvp", ConfigType.UInt)]
+    HotbarCrossAdvancedSettingRightPvp,
+
+    /// <summary>
+    /// System option with the internal name HotbarWXHBEnable.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarWXHBEnable", ConfigType.UInt)]
+    HotbarWXHBEnable,
+
+    /// <summary>
+    /// System option with the internal name HotbarWXHBSetLeft.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarWXHBSetLeft", ConfigType.UInt)]
+    HotbarWXHBSetLeft,
+
+    /// <summary>
+    /// System option with the internal name HotbarWXHBSetRight.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarWXHBSetRight", ConfigType.UInt)]
+    HotbarWXHBSetRight,
+
+    /// <summary>
+    /// System option with the internal name HotbarWXHBEnablePvP.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarWXHBEnablePvP", ConfigType.UInt)]
+    HotbarWXHBEnablePvP,
+
+    /// <summary>
+    /// System option with the internal name HotbarWXHBSetLeftPvP.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarWXHBSetLeftPvP", ConfigType.UInt)]
+    HotbarWXHBSetLeftPvP,
+
+    /// <summary>
+    /// System option with the internal name HotbarWXHBSetRightPvP.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarWXHBSetRightPvP", ConfigType.UInt)]
+    HotbarWXHBSetRightPvP,
+
+    /// <summary>
+    /// System option with the internal name HotbarWXHB8Button.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarWXHB8Button", ConfigType.UInt)]
+    HotbarWXHB8Button,
+
+    /// <summary>
+    /// System option with the internal name HotbarWXHB8ButtonPvP.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarWXHB8ButtonPvP", ConfigType.UInt)]
+    HotbarWXHB8ButtonPvP,
+
+    /// <summary>
+    /// System option with the internal name HotbarWXHBSetInputTime.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarWXHBSetInputTime", ConfigType.UInt)]
+    HotbarWXHBSetInputTime,
+
+    /// <summary>
+    /// System option with the internal name HotbarWXHBDisplay.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarWXHBDisplay", ConfigType.UInt)]
+    HotbarWXHBDisplay,
+
+    /// <summary>
+    /// System option with the internal name HotbarWXHBFreeLayout.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarWXHBFreeLayout", ConfigType.UInt)]
+    HotbarWXHBFreeLayout,
+
+    /// <summary>
+    /// System option with the internal name HotbarXHBActiveTransmissionAlpha.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarXHBActiveTransmissionAlpha", ConfigType.UInt)]
+    HotbarXHBActiveTransmissionAlpha,
+
+    /// <summary>
+    /// System option with the internal name HotbarXHBAlphaDefault.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarXHBAlphaDefault", ConfigType.UInt)]
+    HotbarXHBAlphaDefault,
+
+    /// <summary>
+    /// System option with the internal name HotbarXHBAlphaActiveSet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarXHBAlphaActiveSet", ConfigType.UInt)]
+    HotbarXHBAlphaActiveSet,
+
+    /// <summary>
+    /// System option with the internal name HotbarXHBAlphaInactiveSet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarXHBAlphaInactiveSet", ConfigType.UInt)]
+    HotbarXHBAlphaInactiveSet,
+
+    /// <summary>
+    /// System option with the internal name HotbarWXHBInputOnce.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarWXHBInputOnce", ConfigType.UInt)]
+    HotbarWXHBInputOnce,
+
+    /// <summary>
+    /// System option with the internal name IdlingCameraSwitchType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IdlingCameraSwitchType", ConfigType.UInt)]
+    IdlingCameraSwitchType,
+
+    /// <summary>
+    /// System option with the internal name PlateType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PlateType", ConfigType.UInt)]
+    PlateType,
+
+    /// <summary>
+    /// System option with the internal name PlateDispHPBar.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PlateDispHPBar", ConfigType.UInt)]
+    PlateDispHPBar,
+
+    /// <summary>
+    /// System option with the internal name PlateDisableMaxHPBar.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PlateDisableMaxHPBar", ConfigType.UInt)]
+    PlateDisableMaxHPBar,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpSizeType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpSizeType", ConfigType.UInt)]
+    NamePlateHpSizeType,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorSelf.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorSelf", ConfigType.UInt)]
+    NamePlateColorSelf,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeSelf.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeSelf", ConfigType.UInt)]
+    NamePlateEdgeSelf,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeSelf.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeSelf", ConfigType.UInt)]
+    NamePlateDispTypeSelf,
+
+    /// <summary>
+    /// System option with the internal name NamePlateNameTypeSelf.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateNameTypeSelf", ConfigType.UInt)]
+    NamePlateNameTypeSelf,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeSelf.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeSelf", ConfigType.UInt)]
+    NamePlateHpTypeSelf,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorSelfBuddy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorSelfBuddy", ConfigType.UInt)]
+    NamePlateColorSelfBuddy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeSelfBuddy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeSelfBuddy", ConfigType.UInt)]
+    NamePlateEdgeSelfBuddy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeSelfBuddy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeSelfBuddy", ConfigType.UInt)]
+    NamePlateDispTypeSelfBuddy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeSelfBuddy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeSelfBuddy", ConfigType.UInt)]
+    NamePlateHpTypeSelfBuddy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorSelfPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorSelfPet", ConfigType.UInt)]
+    NamePlateColorSelfPet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeSelfPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeSelfPet", ConfigType.UInt)]
+    NamePlateEdgeSelfPet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeSelfPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeSelfPet", ConfigType.UInt)]
+    NamePlateDispTypeSelfPet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeSelfPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeSelfPet", ConfigType.UInt)]
+    NamePlateHpTypeSelfPet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorParty", ConfigType.UInt)]
+    NamePlateColorParty,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeParty", ConfigType.UInt)]
+    NamePlateEdgeParty,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeParty", ConfigType.UInt)]
+    NamePlateDispTypeParty,
+
+    /// <summary>
+    /// System option with the internal name NamePlateNameTypeParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateNameTypeParty", ConfigType.UInt)]
+    NamePlateNameTypeParty,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeParty", ConfigType.UInt)]
+    NamePlateHpTypeParty,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypePartyPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypePartyPet", ConfigType.UInt)]
+    NamePlateDispTypePartyPet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypePartyPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypePartyPet", ConfigType.UInt)]
+    NamePlateHpTypePartyPet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypePartyBuddy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypePartyBuddy", ConfigType.UInt)]
+    NamePlateDispTypePartyBuddy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypePartyBuddy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypePartyBuddy", ConfigType.UInt)]
+    NamePlateHpTypePartyBuddy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorAlliance", ConfigType.UInt)]
+    NamePlateColorAlliance,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeAlliance", ConfigType.UInt)]
+    NamePlateEdgeAlliance,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeAlliance", ConfigType.UInt)]
+    NamePlateDispTypeAlliance,
+
+    /// <summary>
+    /// System option with the internal name NamePlateNameTypeAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateNameTypeAlliance", ConfigType.UInt)]
+    NamePlateNameTypeAlliance,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeAlliance", ConfigType.UInt)]
+    NamePlateHpTypeAlliance,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeAlliancePet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeAlliancePet", ConfigType.UInt)]
+    NamePlateDispTypeAlliancePet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeAlliancePet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeAlliancePet", ConfigType.UInt)]
+    NamePlateHpTypeAlliancePet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorOther.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorOther", ConfigType.UInt)]
+    NamePlateColorOther,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeOther.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeOther", ConfigType.UInt)]
+    NamePlateEdgeOther,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeOther.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeOther", ConfigType.UInt)]
+    NamePlateDispTypeOther,
+
+    /// <summary>
+    /// System option with the internal name NamePlateNameTypeOther.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateNameTypeOther", ConfigType.UInt)]
+    NamePlateNameTypeOther,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeOther.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeOther", ConfigType.UInt)]
+    NamePlateHpTypeOther,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeOtherPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeOtherPet", ConfigType.UInt)]
+    NamePlateDispTypeOtherPet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeOtherPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeOtherPet", ConfigType.UInt)]
+    NamePlateHpTypeOtherPet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeOtherBuddy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeOtherBuddy", ConfigType.UInt)]
+    NamePlateDispTypeOtherBuddy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeOtherBuddy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeOtherBuddy", ConfigType.UInt)]
+    NamePlateHpTypeOtherBuddy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorUnengagedEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorUnengagedEnemy", ConfigType.UInt)]
+    NamePlateColorUnengagedEnemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeUnengagedEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeUnengagedEnemy", ConfigType.UInt)]
+    NamePlateEdgeUnengagedEnemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeUnengagedEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeUnengagedEnemy", ConfigType.UInt)]
+    NamePlateDispTypeUnengagedEnemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeUnengagedEmemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeUnengagedEmemy", ConfigType.UInt)]
+    NamePlateHpTypeUnengagedEmemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorEngagedEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorEngagedEnemy", ConfigType.UInt)]
+    NamePlateColorEngagedEnemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeEngagedEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeEngagedEnemy", ConfigType.UInt)]
+    NamePlateEdgeEngagedEnemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeEngagedEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeEngagedEnemy", ConfigType.UInt)]
+    NamePlateDispTypeEngagedEnemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeEngagedEmemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeEngagedEmemy", ConfigType.UInt)]
+    NamePlateHpTypeEngagedEmemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorClaimedEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorClaimedEnemy", ConfigType.UInt)]
+    NamePlateColorClaimedEnemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeClaimedEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeClaimedEnemy", ConfigType.UInt)]
+    NamePlateEdgeClaimedEnemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeClaimedEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeClaimedEnemy", ConfigType.UInt)]
+    NamePlateDispTypeClaimedEnemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeClaimedEmemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeClaimedEmemy", ConfigType.UInt)]
+    NamePlateHpTypeClaimedEmemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorUnclaimedEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorUnclaimedEnemy", ConfigType.UInt)]
+    NamePlateColorUnclaimedEnemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeUnclaimedEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeUnclaimedEnemy", ConfigType.UInt)]
+    NamePlateEdgeUnclaimedEnemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeUnclaimedEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeUnclaimedEnemy", ConfigType.UInt)]
+    NamePlateDispTypeUnclaimedEnemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeUnclaimedEmemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeUnclaimedEmemy", ConfigType.UInt)]
+    NamePlateHpTypeUnclaimedEmemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorNpc.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorNpc", ConfigType.UInt)]
+    NamePlateColorNpc,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeNpc.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeNpc", ConfigType.UInt)]
+    NamePlateEdgeNpc,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeNpc.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeNpc", ConfigType.UInt)]
+    NamePlateDispTypeNpc,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeNpc.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeNpc", ConfigType.UInt)]
+    NamePlateHpTypeNpc,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorObject.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorObject", ConfigType.UInt)]
+    NamePlateColorObject,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeObject.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeObject", ConfigType.UInt)]
+    NamePlateEdgeObject,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeObject.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeObject", ConfigType.UInt)]
+    NamePlateDispTypeObject,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeObject.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeObject", ConfigType.UInt)]
+    NamePlateHpTypeObject,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorMinion.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorMinion", ConfigType.UInt)]
+    NamePlateColorMinion,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeMinion.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeMinion", ConfigType.UInt)]
+    NamePlateEdgeMinion,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeMinion.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeMinion", ConfigType.UInt)]
+    NamePlateDispTypeMinion,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorOtherBuddy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorOtherBuddy", ConfigType.UInt)]
+    NamePlateColorOtherBuddy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeOtherBuddy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeOtherBuddy", ConfigType.UInt)]
+    NamePlateEdgeOtherBuddy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorOtherPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorOtherPet", ConfigType.UInt)]
+    NamePlateColorOtherPet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateEdgeOtherPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateEdgeOtherPet", ConfigType.UInt)]
+    NamePlateEdgeOtherPet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateNameTitleTypeSelf.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateNameTitleTypeSelf", ConfigType.UInt)]
+    NamePlateNameTitleTypeSelf,
+
+    /// <summary>
+    /// System option with the internal name NamePlateNameTitleTypeParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateNameTitleTypeParty", ConfigType.UInt)]
+    NamePlateNameTitleTypeParty,
+
+    /// <summary>
+    /// System option with the internal name NamePlateNameTitleTypeAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateNameTitleTypeAlliance", ConfigType.UInt)]
+    NamePlateNameTitleTypeAlliance,
+
+    /// <summary>
+    /// System option with the internal name NamePlateNameTitleTypeOther.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateNameTitleTypeOther", ConfigType.UInt)]
+    NamePlateNameTitleTypeOther,
+
+    /// <summary>
+    /// System option with the internal name NamePlateNameTitleTypeFriend.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateNameTitleTypeFriend", ConfigType.UInt)]
+    NamePlateNameTitleTypeFriend,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorFriend.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorFriend", ConfigType.UInt)]
+    NamePlateColorFriend,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorFriendEdge.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorFriendEdge", ConfigType.UInt)]
+    NamePlateColorFriendEdge,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeFriend.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeFriend", ConfigType.UInt)]
+    NamePlateDispTypeFriend,
+
+    /// <summary>
+    /// System option with the internal name NamePlateNameTypeFriend.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateNameTypeFriend", ConfigType.UInt)]
+    NamePlateNameTypeFriend,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeFriend.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeFriend", ConfigType.UInt)]
+    NamePlateHpTypeFriend,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeFriendPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeFriendPet", ConfigType.UInt)]
+    NamePlateDispTypeFriendPet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeFriendPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeFriendPet", ConfigType.UInt)]
+    NamePlateHpTypeFriendPet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeFriendBuddy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeFriendBuddy", ConfigType.UInt)]
+    NamePlateDispTypeFriendBuddy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeFriendBuddy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeFriendBuddy", ConfigType.UInt)]
+    NamePlateHpTypeFriendBuddy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorLim.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorLim", ConfigType.UInt)]
+    NamePlateColorLim,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorLimEdge.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorLimEdge", ConfigType.UInt)]
+    NamePlateColorLimEdge,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorGri.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorGri", ConfigType.UInt)]
+    NamePlateColorGri,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorGriEdge.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorGriEdge", ConfigType.UInt)]
+    NamePlateColorGriEdge,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorUld.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorUld", ConfigType.UInt)]
+    NamePlateColorUld,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorUldEdge.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorUldEdge", ConfigType.UInt)]
+    NamePlateColorUldEdge,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorHousingFurniture.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorHousingFurniture", ConfigType.UInt)]
+    NamePlateColorHousingFurniture,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorHousingFurnitureEdge.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorHousingFurnitureEdge", ConfigType.UInt)]
+    NamePlateColorHousingFurnitureEdge,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeHousingFurniture.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeHousingFurniture", ConfigType.UInt)]
+    NamePlateDispTypeHousingFurniture,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorHousingField.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorHousingField", ConfigType.UInt)]
+    NamePlateColorHousingField,
+
+    /// <summary>
+    /// System option with the internal name NamePlateColorHousingFieldEdge.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateColorHousingFieldEdge", ConfigType.UInt)]
+    NamePlateColorHousingFieldEdge,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeHousingField.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeHousingField", ConfigType.UInt)]
+    NamePlateDispTypeHousingField,
+
+    /// <summary>
+    /// System option with the internal name NamePlateNameTypePvPEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateNameTypePvPEnemy", ConfigType.UInt)]
+    NamePlateNameTypePvPEnemy,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeFeast.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeFeast", ConfigType.UInt)]
+    NamePlateDispTypeFeast,
+
+    /// <summary>
+    /// System option with the internal name NamePlateNameTypeFeast.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateNameTypeFeast", ConfigType.UInt)]
+    NamePlateNameTypeFeast,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeFeast.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeFeast", ConfigType.UInt)]
+    NamePlateHpTypeFeast,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispTypeFeastPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispTypeFeastPet", ConfigType.UInt)]
+    NamePlateDispTypeFeastPet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateHpTypeFeastPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateHpTypeFeastPet", ConfigType.UInt)]
+    NamePlateHpTypeFeastPet,
+
+    /// <summary>
+    /// System option with the internal name NamePlateNameTitleTypeFeast.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateNameTitleTypeFeast", ConfigType.UInt)]
+    NamePlateNameTitleTypeFeast,
+
+    /// <summary>
+    /// System option with the internal name NamePlateDispSize.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NamePlateDispSize", ConfigType.UInt)]
+    NamePlateDispSize,
+
+    /// <summary>
+    /// System option with the internal name ActiveInfo.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ActiveInfo", ConfigType.UInt)]
+    ActiveInfo,
+
+    /// <summary>
+    /// System option with the internal name PartyList.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PartyList", ConfigType.UInt)]
+    PartyList,
+
+    /// <summary>
+    /// System option with the internal name PartyListStatus.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PartyListStatus", ConfigType.UInt)]
+    PartyListStatus,
+
+    /// <summary>
+    /// System option with the internal name PartyListStatusTimer.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PartyListStatusTimer", ConfigType.UInt)]
+    PartyListStatusTimer,
+
+    /// <summary>
+    /// System option with the internal name EnemyList.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("EnemyList", ConfigType.UInt)]
+    EnemyList,
+
+    /// <summary>
+    /// System option with the internal name TargetInfo.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TargetInfo", ConfigType.UInt)]
+    TargetInfo,
+
+    /// <summary>
+    /// System option with the internal name Gil.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Gil", ConfigType.UInt)]
+    Gil,
+
+    /// <summary>
+    /// System option with the internal name DTR.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("DTR", ConfigType.UInt)]
+    DTR,
+
+    /// <summary>
+    /// System option with the internal name PlayerInfo.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PlayerInfo", ConfigType.UInt)]
+    PlayerInfo,
+
+    /// <summary>
+    /// System option with the internal name NaviMap.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NaviMap", ConfigType.UInt)]
+    NaviMap,
+
+    /// <summary>
+    /// System option with the internal name Help.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Help", ConfigType.UInt)]
+    Help,
+
+    /// <summary>
+    /// System option with the internal name CrossMainHelp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CrossMainHelp", ConfigType.UInt)]
+    CrossMainHelp,
+
+    /// <summary>
+    /// System option with the internal name HousingLocatePreview.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HousingLocatePreview", ConfigType.UInt)]
+    HousingLocatePreview,
+
+    /// <summary>
+    /// System option with the internal name Log.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("Log", ConfigType.UInt)]
+    Log,
+
+    /// <summary>
+    /// System option with the internal name LogTell.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogTell", ConfigType.UInt)]
+    LogTell,
+
+    /// <summary>
+    /// System option with the internal name LogFontSize.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogFontSize", ConfigType.UInt)]
+    LogFontSize,
+
+    /// <summary>
+    /// System option with the internal name LogTabName2.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("LogTabName2", ConfigType.String)]
+    LogTabName2,
+
+    /// <summary>
+    /// System option with the internal name LogTabName3.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("LogTabName3", ConfigType.String)]
+    LogTabName3,
+
+    /// <summary>
+    /// System option with the internal name LogTabFilter0.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogTabFilter0", ConfigType.UInt)]
+    LogTabFilter0,
+
+    /// <summary>
+    /// System option with the internal name LogTabFilter1.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogTabFilter1", ConfigType.UInt)]
+    LogTabFilter1,
+
+    /// <summary>
+    /// System option with the internal name LogTabFilter2.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogTabFilter2", ConfigType.UInt)]
+    LogTabFilter2,
+
+    /// <summary>
+    /// System option with the internal name LogTabFilter3.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogTabFilter3", ConfigType.UInt)]
+    LogTabFilter3,
+
+    /// <summary>
+    /// System option with the internal name LogChatFilter.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogChatFilter", ConfigType.UInt)]
+    LogChatFilter,
+
+    /// <summary>
+    /// System option with the internal name LogEnableErrMsgLv1.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogEnableErrMsgLv1", ConfigType.UInt)]
+    LogEnableErrMsgLv1,
+
+    /// <summary>
+    /// System option with the internal name LogNameType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogNameType", ConfigType.UInt)]
+    LogNameType,
+
+    /// <summary>
+    /// System option with the internal name LogTimeDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogTimeDisp", ConfigType.UInt)]
+    LogTimeDisp,
+
+    /// <summary>
+    /// System option with the internal name LogTimeSettingType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogTimeSettingType", ConfigType.UInt)]
+    LogTimeSettingType,
+
+    /// <summary>
+    /// System option with the internal name LogTimeDispType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogTimeDispType", ConfigType.UInt)]
+    LogTimeDispType,
+
+    /// <summary>
+    /// System option with the internal name IsLogTell.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogTell", ConfigType.UInt)]
+    IsLogTell,
+
+    /// <summary>
+    /// System option with the internal name IsLogParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogParty", ConfigType.UInt)]
+    IsLogParty,
+
+    /// <summary>
+    /// System option with the internal name LogParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogParty", ConfigType.UInt)]
+    LogParty,
+
+    /// <summary>
+    /// System option with the internal name IsLogAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogAlliance", ConfigType.UInt)]
+    IsLogAlliance,
+
+    /// <summary>
+    /// System option with the internal name LogAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogAlliance", ConfigType.UInt)]
+    LogAlliance,
+
+    /// <summary>
+    /// System option with the internal name IsLogFc.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogFc", ConfigType.UInt)]
+    IsLogFc,
+
+    /// <summary>
+    /// System option with the internal name LogFc.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogFc", ConfigType.UInt)]
+    LogFc,
+
+    /// <summary>
+    /// System option with the internal name IsLogPvpTeam.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogPvpTeam", ConfigType.UInt)]
+    IsLogPvpTeam,
+
+    /// <summary>
+    /// System option with the internal name LogPvpTeam.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogPvpTeam", ConfigType.UInt)]
+    LogPvpTeam,
+
+    /// <summary>
+    /// System option with the internal name IsLogLs1.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogLs1", ConfigType.UInt)]
+    IsLogLs1,
+
+    /// <summary>
+    /// System option with the internal name LogLs1.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogLs1", ConfigType.UInt)]
+    LogLs1,
+
+    /// <summary>
+    /// System option with the internal name IsLogLs2.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogLs2", ConfigType.UInt)]
+    IsLogLs2,
+
+    /// <summary>
+    /// System option with the internal name LogLs2.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogLs2", ConfigType.UInt)]
+    LogLs2,
+
+    /// <summary>
+    /// System option with the internal name IsLogLs3.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogLs3", ConfigType.UInt)]
+    IsLogLs3,
+
+    /// <summary>
+    /// System option with the internal name LogLs3.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogLs3", ConfigType.UInt)]
+    LogLs3,
+
+    /// <summary>
+    /// System option with the internal name IsLogLs4.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogLs4", ConfigType.UInt)]
+    IsLogLs4,
+
+    /// <summary>
+    /// System option with the internal name LogLs4.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogLs4", ConfigType.UInt)]
+    LogLs4,
+
+    /// <summary>
+    /// System option with the internal name IsLogLs5.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogLs5", ConfigType.UInt)]
+    IsLogLs5,
+
+    /// <summary>
+    /// System option with the internal name LogLs5.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogLs5", ConfigType.UInt)]
+    LogLs5,
+
+    /// <summary>
+    /// System option with the internal name IsLogLs6.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogLs6", ConfigType.UInt)]
+    IsLogLs6,
+
+    /// <summary>
+    /// System option with the internal name LogLs6.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogLs6", ConfigType.UInt)]
+    LogLs6,
+
+    /// <summary>
+    /// System option with the internal name IsLogLs7.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogLs7", ConfigType.UInt)]
+    IsLogLs7,
+
+    /// <summary>
+    /// System option with the internal name LogLs7.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogLs7", ConfigType.UInt)]
+    LogLs7,
+
+    /// <summary>
+    /// System option with the internal name IsLogLs8.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogLs8", ConfigType.UInt)]
+    IsLogLs8,
+
+    /// <summary>
+    /// System option with the internal name LogLs8.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogLs8", ConfigType.UInt)]
+    LogLs8,
+
+    /// <summary>
+    /// System option with the internal name IsLogBeginner.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogBeginner", ConfigType.UInt)]
+    IsLogBeginner,
+
+    /// <summary>
+    /// System option with the internal name LogBeginner.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogBeginner", ConfigType.UInt)]
+    LogBeginner,
+
+    /// <summary>
+    /// System option with the internal name IsLogCwls.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogCwls", ConfigType.UInt)]
+    IsLogCwls,
+
+    /// <summary>
+    /// System option with the internal name IsLogCwls2.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogCwls2", ConfigType.UInt)]
+    IsLogCwls2,
+
+    /// <summary>
+    /// System option with the internal name IsLogCwls3.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogCwls3", ConfigType.UInt)]
+    IsLogCwls3,
+
+    /// <summary>
+    /// System option with the internal name IsLogCwls4.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogCwls4", ConfigType.UInt)]
+    IsLogCwls4,
+
+    /// <summary>
+    /// System option with the internal name IsLogCwls5.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogCwls5", ConfigType.UInt)]
+    IsLogCwls5,
+
+    /// <summary>
+    /// System option with the internal name IsLogCwls6.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogCwls6", ConfigType.UInt)]
+    IsLogCwls6,
+
+    /// <summary>
+    /// System option with the internal name IsLogCwls7.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogCwls7", ConfigType.UInt)]
+    IsLogCwls7,
+
+    /// <summary>
+    /// System option with the internal name IsLogCwls8.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsLogCwls8", ConfigType.UInt)]
+    IsLogCwls8,
+
+    /// <summary>
+    /// System option with the internal name LogCwls.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogCwls", ConfigType.UInt)]
+    LogCwls,
+
+    /// <summary>
+    /// System option with the internal name LogCwls2.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogCwls2", ConfigType.UInt)]
+    LogCwls2,
+
+    /// <summary>
+    /// System option with the internal name LogCwls3.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogCwls3", ConfigType.UInt)]
+    LogCwls3,
+
+    /// <summary>
+    /// System option with the internal name LogCwls4.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogCwls4", ConfigType.UInt)]
+    LogCwls4,
+
+    /// <summary>
+    /// System option with the internal name LogCwls5.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogCwls5", ConfigType.UInt)]
+    LogCwls5,
+
+    /// <summary>
+    /// System option with the internal name LogCwls6.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogCwls6", ConfigType.UInt)]
+    LogCwls6,
+
+    /// <summary>
+    /// System option with the internal name LogCwls7.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogCwls7", ConfigType.UInt)]
+    LogCwls7,
+
+    /// <summary>
+    /// System option with the internal name LogCwls8.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogCwls8", ConfigType.UInt)]
+    LogCwls8,
+
+    /// <summary>
+    /// System option with the internal name LogRecastActionErrDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogRecastActionErrDisp", ConfigType.UInt)]
+    LogRecastActionErrDisp,
+
+    /// <summary>
+    /// System option with the internal name LogPermeationRate.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogPermeationRate", ConfigType.UInt)]
+    LogPermeationRate,
+
+    /// <summary>
+    /// System option with the internal name LogFontSizeForm.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogFontSizeForm", ConfigType.UInt)]
+    LogFontSizeForm,
+
+    /// <summary>
+    /// System option with the internal name LogItemLinkEnableType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogItemLinkEnableType", ConfigType.UInt)]
+    LogItemLinkEnableType,
+
+    /// <summary>
+    /// System option with the internal name LogFontSizeLog2.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogFontSizeLog2", ConfigType.UInt)]
+    LogFontSizeLog2,
+
+    /// <summary>
+    /// System option with the internal name LogTimeDispLog2.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogTimeDispLog2", ConfigType.UInt)]
+    LogTimeDispLog2,
+
+    /// <summary>
+    /// System option with the internal name LogPermeationRateLog2.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogPermeationRateLog2", ConfigType.UInt)]
+    LogPermeationRateLog2,
+
+    /// <summary>
+    /// System option with the internal name LogFontSizeLog3.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogFontSizeLog3", ConfigType.UInt)]
+    LogFontSizeLog3,
+
+    /// <summary>
+    /// System option with the internal name LogTimeDispLog3.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogTimeDispLog3", ConfigType.UInt)]
+    LogTimeDispLog3,
+
+    /// <summary>
+    /// System option with the internal name LogPermeationRateLog3.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogPermeationRateLog3", ConfigType.UInt)]
+    LogPermeationRateLog3,
+
+    /// <summary>
+    /// System option with the internal name LogFontSizeLog4.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogFontSizeLog4", ConfigType.UInt)]
+    LogFontSizeLog4,
+
+    /// <summary>
+    /// System option with the internal name LogTimeDispLog4.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogTimeDispLog4", ConfigType.UInt)]
+    LogTimeDispLog4,
+
+    /// <summary>
+    /// System option with the internal name LogPermeationRateLog4.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogPermeationRateLog4", ConfigType.UInt)]
+    LogPermeationRateLog4,
+
+    /// <summary>
+    /// System option with the internal name LogFlyingHeightMaxErrDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogFlyingHeightMaxErrDisp", ConfigType.UInt)]
+    LogFlyingHeightMaxErrDisp,
+
+    /// <summary>
+    /// System option with the internal name LogCrossWorldName.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogCrossWorldName", ConfigType.UInt)]
+    LogCrossWorldName,
+
+    /// <summary>
+    /// System option with the internal name LogDragResize.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LogDragResize", ConfigType.UInt)]
+    LogDragResize,
+
+    /// <summary>
+    /// System option with the internal name ChatType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ChatType", ConfigType.UInt)]
+    ChatType,
+
+    /// <summary>
+    /// System option with the internal name ShopSell.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShopSell", ConfigType.UInt)]
+    ShopSell,
+
+    /// <summary>
+    /// System option with the internal name ColorSay.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorSay", ConfigType.UInt)]
+    ColorSay,
+
+    /// <summary>
+    /// System option with the internal name ColorShout.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorShout", ConfigType.UInt)]
+    ColorShout,
+
+    /// <summary>
+    /// System option with the internal name ColorTell.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorTell", ConfigType.UInt)]
+    ColorTell,
+
+    /// <summary>
+    /// System option with the internal name ColorParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorParty", ConfigType.UInt)]
+    ColorParty,
+
+    /// <summary>
+    /// System option with the internal name ColorAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorAlliance", ConfigType.UInt)]
+    ColorAlliance,
+
+    /// <summary>
+    /// System option with the internal name ColorLS1.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorLS1", ConfigType.UInt)]
+    ColorLS1,
+
+    /// <summary>
+    /// System option with the internal name ColorLS2.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorLS2", ConfigType.UInt)]
+    ColorLS2,
+
+    /// <summary>
+    /// System option with the internal name ColorLS3.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorLS3", ConfigType.UInt)]
+    ColorLS3,
+
+    /// <summary>
+    /// System option with the internal name ColorLS4.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorLS4", ConfigType.UInt)]
+    ColorLS4,
+
+    /// <summary>
+    /// System option with the internal name ColorLS5.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorLS5", ConfigType.UInt)]
+    ColorLS5,
+
+    /// <summary>
+    /// System option with the internal name ColorLS6.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorLS6", ConfigType.UInt)]
+    ColorLS6,
+
+    /// <summary>
+    /// System option with the internal name ColorLS7.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorLS7", ConfigType.UInt)]
+    ColorLS7,
+
+    /// <summary>
+    /// System option with the internal name ColorLS8.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorLS8", ConfigType.UInt)]
+    ColorLS8,
+
+    /// <summary>
+    /// System option with the internal name ColorFCompany.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorFCompany", ConfigType.UInt)]
+    ColorFCompany,
+
+    /// <summary>
+    /// System option with the internal name ColorPvPGroup.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorPvPGroup", ConfigType.UInt)]
+    ColorPvPGroup,
+
+    /// <summary>
+    /// System option with the internal name ColorPvPGroupAnnounce.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorPvPGroupAnnounce", ConfigType.UInt)]
+    ColorPvPGroupAnnounce,
+
+    /// <summary>
+    /// System option with the internal name ColorBeginner.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorBeginner", ConfigType.UInt)]
+    ColorBeginner,
+
+    /// <summary>
+    /// System option with the internal name ColorEmoteUser.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorEmoteUser", ConfigType.UInt)]
+    ColorEmoteUser,
+
+    /// <summary>
+    /// System option with the internal name ColorEmote.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorEmote", ConfigType.UInt)]
+    ColorEmote,
+
+    /// <summary>
+    /// System option with the internal name ColorYell.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorYell", ConfigType.UInt)]
+    ColorYell,
+
+    /// <summary>
+    /// System option with the internal name ColorBeginnerAnnounce.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorBeginnerAnnounce", ConfigType.UInt)]
+    ColorBeginnerAnnounce,
+
+    /// <summary>
+    /// System option with the internal name ColorCWLS.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorCWLS", ConfigType.UInt)]
+    ColorCWLS,
+
+    /// <summary>
+    /// System option with the internal name ColorCWLS2.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorCWLS2", ConfigType.UInt)]
+    ColorCWLS2,
+
+    /// <summary>
+    /// System option with the internal name ColorCWLS3.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorCWLS3", ConfigType.UInt)]
+    ColorCWLS3,
+
+    /// <summary>
+    /// System option with the internal name ColorCWLS4.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorCWLS4", ConfigType.UInt)]
+    ColorCWLS4,
+
+    /// <summary>
+    /// System option with the internal name ColorCWLS5.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorCWLS5", ConfigType.UInt)]
+    ColorCWLS5,
+
+    /// <summary>
+    /// System option with the internal name ColorCWLS6.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorCWLS6", ConfigType.UInt)]
+    ColorCWLS6,
+
+    /// <summary>
+    /// System option with the internal name ColorCWLS7.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorCWLS7", ConfigType.UInt)]
+    ColorCWLS7,
+
+    /// <summary>
+    /// System option with the internal name ColorCWLS8.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorCWLS8", ConfigType.UInt)]
+    ColorCWLS8,
+
+    /// <summary>
+    /// System option with the internal name ColorAttackSuccess.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorAttackSuccess", ConfigType.UInt)]
+    ColorAttackSuccess,
+
+    /// <summary>
+    /// System option with the internal name ColorAttackFailure.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorAttackFailure", ConfigType.UInt)]
+    ColorAttackFailure,
+
+    /// <summary>
+    /// System option with the internal name ColorAction.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorAction", ConfigType.UInt)]
+    ColorAction,
+
+    /// <summary>
+    /// System option with the internal name ColorItem.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorItem", ConfigType.UInt)]
+    ColorItem,
+
+    /// <summary>
+    /// System option with the internal name ColorCureGive.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorCureGive", ConfigType.UInt)]
+    ColorCureGive,
+
+    /// <summary>
+    /// System option with the internal name ColorBuffGive.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorBuffGive", ConfigType.UInt)]
+    ColorBuffGive,
+
+    /// <summary>
+    /// System option with the internal name ColorDebuffGive.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorDebuffGive", ConfigType.UInt)]
+    ColorDebuffGive,
+
+    /// <summary>
+    /// System option with the internal name ColorEcho.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorEcho", ConfigType.UInt)]
+    ColorEcho,
+
+    /// <summary>
+    /// System option with the internal name ColorSysMsg.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorSysMsg", ConfigType.UInt)]
+    ColorSysMsg,
+
+    /// <summary>
+    /// System option with the internal name ColorFCAnnounce.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorFCAnnounce", ConfigType.UInt)]
+    ColorFCAnnounce,
+
+    /// <summary>
+    /// System option with the internal name ColorSysBattle.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorSysBattle", ConfigType.UInt)]
+    ColorSysBattle,
+
+    /// <summary>
+    /// System option with the internal name ColorSysGathering.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorSysGathering", ConfigType.UInt)]
+    ColorSysGathering,
+
+    /// <summary>
+    /// System option with the internal name ColorSysErr.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorSysErr", ConfigType.UInt)]
+    ColorSysErr,
+
+    /// <summary>
+    /// System option with the internal name ColorNpcSay.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorNpcSay", ConfigType.UInt)]
+    ColorNpcSay,
+
+    /// <summary>
+    /// System option with the internal name ColorItemNotice.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorItemNotice", ConfigType.UInt)]
+    ColorItemNotice,
+
+    /// <summary>
+    /// System option with the internal name ColorGrowup.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorGrowup", ConfigType.UInt)]
+    ColorGrowup,
+
+    /// <summary>
+    /// System option with the internal name ColorLoot.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorLoot", ConfigType.UInt)]
+    ColorLoot,
+
+    /// <summary>
+    /// System option with the internal name ColorCraft.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorCraft", ConfigType.UInt)]
+    ColorCraft,
+
+    /// <summary>
+    /// System option with the internal name ColorGathering.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ColorGathering", ConfigType.UInt)]
+    ColorGathering,
+
+    /// <summary>
+    /// System option with the internal name ShopConfirm.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShopConfirm", ConfigType.UInt)]
+    ShopConfirm,
+
+    /// <summary>
+    /// System option with the internal name ShopConfirmMateria.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShopConfirmMateria", ConfigType.UInt)]
+    ShopConfirmMateria,
+
+    /// <summary>
+    /// System option with the internal name ShopConfirmExRare.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShopConfirmExRare", ConfigType.UInt)]
+    ShopConfirmExRare,
+
+    /// <summary>
+    /// System option with the internal name ShopConfirmSpiritBondMax.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ShopConfirmSpiritBondMax", ConfigType.UInt)]
+    ShopConfirmSpiritBondMax,
+
+    /// <summary>
+    /// System option with the internal name ItemSortItemCategory.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ItemSortItemCategory", ConfigType.UInt)]
+    ItemSortItemCategory,
+
+    /// <summary>
+    /// System option with the internal name ItemSortEquipLevel.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ItemSortEquipLevel", ConfigType.UInt)]
+    ItemSortEquipLevel,
+
+    /// <summary>
+    /// System option with the internal name ItemSortItemLevel.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ItemSortItemLevel", ConfigType.UInt)]
+    ItemSortItemLevel,
+
+    /// <summary>
+    /// System option with the internal name ItemSortItemStack.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ItemSortItemStack", ConfigType.UInt)]
+    ItemSortItemStack,
+
+    /// <summary>
+    /// System option with the internal name ItemSortTidyingType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ItemSortTidyingType", ConfigType.UInt)]
+    ItemSortTidyingType,
+
+    /// <summary>
+    /// System option with the internal name ItemNoArmoryMaskOff.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ItemNoArmoryMaskOff", ConfigType.UInt)]
+    ItemNoArmoryMaskOff,
+
+    /// <summary>
+    /// System option with the internal name InfoSettingDispWorldNameType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("InfoSettingDispWorldNameType", ConfigType.UInt)]
+    InfoSettingDispWorldNameType,
+
+    /// <summary>
+    /// System option with the internal name TargetNamePlateNameType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TargetNamePlateNameType", ConfigType.UInt)]
+    TargetNamePlateNameType,
+
+    /// <summary>
+    /// System option with the internal name FocusTargetNamePlateNameType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FocusTargetNamePlateNameType", ConfigType.UInt)]
+    FocusTargetNamePlateNameType,
+
+    /// <summary>
+    /// System option with the internal name ItemDetailTemporarilySwitch.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ItemDetailTemporarilySwitch", ConfigType.UInt)]
+    ItemDetailTemporarilySwitch,
+
+    /// <summary>
+    /// System option with the internal name ItemDetailTemporarilySwitchKey.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ItemDetailTemporarilySwitchKey", ConfigType.UInt)]
+    ItemDetailTemporarilySwitchKey,
+
+    /// <summary>
+    /// System option with the internal name ItemDetailTemporarilyHide.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ItemDetailTemporarilyHide", ConfigType.UInt)]
+    ItemDetailTemporarilyHide,
+
+    /// <summary>
+    /// System option with the internal name ItemDetailTemporarilyHideKey.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ItemDetailTemporarilyHideKey", ConfigType.UInt)]
+    ItemDetailTemporarilyHideKey,
+
+    /// <summary>
+    /// System option with the internal name ToolTipDispSize.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ToolTipDispSize", ConfigType.UInt)]
+    ToolTipDispSize,
+
+    /// <summary>
+    /// System option with the internal name RecommendLoginDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("RecommendLoginDisp", ConfigType.UInt)]
+    RecommendLoginDisp,
+
+    /// <summary>
+    /// System option with the internal name RecommendAreaChangeDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("RecommendAreaChangeDisp", ConfigType.UInt)]
+    RecommendAreaChangeDisp,
+
+    /// <summary>
+    /// System option with the internal name PlayGuideLoginDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PlayGuideLoginDisp", ConfigType.UInt)]
+    PlayGuideLoginDisp,
+
+    /// <summary>
+    /// System option with the internal name PlayGuideAreaChangeDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PlayGuideAreaChangeDisp", ConfigType.UInt)]
+    PlayGuideAreaChangeDisp,
+
+    /// <summary>
+    /// System option with the internal name MapPadOperationYReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MapPadOperationYReverse", ConfigType.UInt)]
+    MapPadOperationYReverse,
+
+    /// <summary>
+    /// System option with the internal name MapPadOperationXReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MapPadOperationXReverse", ConfigType.UInt)]
+    MapPadOperationXReverse,
+
+    /// <summary>
+    /// System option with the internal name MapDispSize.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MapDispSize", ConfigType.UInt)]
+    MapDispSize,
+
+    /// <summary>
+    /// System option with the internal name FlyTextDispSize.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FlyTextDispSize", ConfigType.UInt)]
+    FlyTextDispSize,
+
+    /// <summary>
+    /// System option with the internal name PopUpTextDispSize.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PopUpTextDispSize", ConfigType.UInt)]
+    PopUpTextDispSize,
+
+    /// <summary>
+    /// System option with the internal name DetailDispDelayType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("DetailDispDelayType", ConfigType.UInt)]
+    DetailDispDelayType,
+
+    /// <summary>
+    /// System option with the internal name PartyListSortTypeTank.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PartyListSortTypeTank", ConfigType.UInt)]
+    PartyListSortTypeTank,
+
+    /// <summary>
+    /// System option with the internal name PartyListSortTypeHealer.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PartyListSortTypeHealer", ConfigType.UInt)]
+    PartyListSortTypeHealer,
+
+    /// <summary>
+    /// System option with the internal name PartyListSortTypeDps.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PartyListSortTypeDps", ConfigType.UInt)]
+    PartyListSortTypeDps,
+
+    /// <summary>
+    /// System option with the internal name PartyListSortTypeOther.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PartyListSortTypeOther", ConfigType.UInt)]
+    PartyListSortTypeOther,
+
+    /// <summary>
+    /// System option with the internal name RatioHpDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("RatioHpDisp", ConfigType.UInt)]
+    RatioHpDisp,
+
+    /// <summary>
+    /// System option with the internal name BuffDispType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("BuffDispType", ConfigType.UInt)]
+    BuffDispType,
+
+    /// <summary>
+    /// System option with the internal name ContentsFinderListSortType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ContentsFinderListSortType", ConfigType.UInt)]
+    ContentsFinderListSortType,
+
+    /// <summary>
+    /// System option with the internal name ContentsFinderSupplyEnable.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ContentsFinderSupplyEnable", ConfigType.UInt)]
+    ContentsFinderSupplyEnable,
+
+    /// <summary>
+    /// System option with the internal name EnemyListCastbarEnable.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("EnemyListCastbarEnable", ConfigType.UInt)]
+    EnemyListCastbarEnable,
+
+    /// <summary>
+    /// System option with the internal name AchievementAppealLoginDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AchievementAppealLoginDisp", ConfigType.UInt)]
+    AchievementAppealLoginDisp,
+
+    /// <summary>
+    /// System option with the internal name ContentsFinderUseLangTypeJA.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ContentsFinderUseLangTypeJA", ConfigType.UInt)]
+    ContentsFinderUseLangTypeJA,
+
+    /// <summary>
+    /// System option with the internal name ContentsFinderUseLangTypeEN.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ContentsFinderUseLangTypeEN", ConfigType.UInt)]
+    ContentsFinderUseLangTypeEN,
+
+    /// <summary>
+    /// System option with the internal name ContentsFinderUseLangTypeDE.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ContentsFinderUseLangTypeDE", ConfigType.UInt)]
+    ContentsFinderUseLangTypeDE,
+
+    /// <summary>
+    /// System option with the internal name ContentsFinderUseLangTypeFR.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ContentsFinderUseLangTypeFR", ConfigType.UInt)]
+    ContentsFinderUseLangTypeFR,
+
+    /// <summary>
+    /// System option with the internal name ItemInventryWindowSizeType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ItemInventryWindowSizeType", ConfigType.UInt)]
+    ItemInventryWindowSizeType,
+
+    /// <summary>
+    /// System option with the internal name ItemInventryRetainerWindowSizeType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ItemInventryRetainerWindowSizeType", ConfigType.UInt)]
+    ItemInventryRetainerWindowSizeType,
+
+    /// <summary>
+    /// System option with the internal name BattleTalkShowFace.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("BattleTalkShowFace", ConfigType.UInt)]
+    BattleTalkShowFace,
+
+    /// <summary>
+    /// System option with the internal name BannerContentsDispType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("BannerContentsDispType", ConfigType.UInt)]
+    BannerContentsDispType,
+
+    /// <summary>
+    /// System option with the internal name BannerContentsNotice.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("BannerContentsNotice", ConfigType.UInt)]
+    BannerContentsNotice,
+
+    /// <summary>
+    /// System option with the internal name MipDispType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MipDispType", ConfigType.UInt)]
+    MipDispType,
+
+    /// <summary>
+    /// System option with the internal name BannerContentsOrderType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("BannerContentsOrderType", ConfigType.UInt)]
+    BannerContentsOrderType,
+
+    /// <summary>
+    /// System option with the internal name EmoteTextType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("EmoteTextType", ConfigType.UInt)]
+    EmoteTextType,
+
+    /// <summary>
+    /// System option with the internal name IsEmoteSe.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("IsEmoteSe", ConfigType.UInt)]
+    IsEmoteSe,
+
+    /// <summary>
+    /// System option with the internal name EmoteSeType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("EmoteSeType", ConfigType.UInt)]
+    EmoteSeType,
+
+    /// <summary>
+    /// System option with the internal name PartyFinderNewArrivalDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PartyFinderNewArrivalDisp", ConfigType.UInt)]
+    PartyFinderNewArrivalDisp,
+
+    /// <summary>
+    /// System option with the internal name GPoseTargetFilterNPCLookAt.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GPoseTargetFilterNPCLookAt", ConfigType.UInt)]
+    GPoseTargetFilterNPCLookAt,
+
+    /// <summary>
+    /// System option with the internal name GPoseMotionFilterAction.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GPoseMotionFilterAction", ConfigType.UInt)]
+    GPoseMotionFilterAction,
+
+    /// <summary>
+    /// System option with the internal name LsListSortPriority.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LsListSortPriority", ConfigType.UInt)]
+    LsListSortPriority,
+
+    /// <summary>
+    /// System option with the internal name FriendListSortPriority.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FriendListSortPriority", ConfigType.UInt)]
+    FriendListSortPriority,
+
+    /// <summary>
+    /// System option with the internal name FriendListFilterType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FriendListFilterType", ConfigType.UInt)]
+    FriendListFilterType,
+
+    /// <summary>
+    /// System option with the internal name FriendListSortType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FriendListSortType", ConfigType.UInt)]
+    FriendListSortType,
+
+    /// <summary>
+    /// System option with the internal name LetterListFilterType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LetterListFilterType", ConfigType.UInt)]
+    LetterListFilterType,
+
+    /// <summary>
+    /// System option with the internal name LetterListSortType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LetterListSortType", ConfigType.UInt)]
+    LetterListSortType,
+
+    /// <summary>
+    /// System option with the internal name ContentsReplayEnable.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ContentsReplayEnable", ConfigType.UInt)]
+    ContentsReplayEnable,
+
+    /// <summary>
+    /// System option with the internal name MouseWheelOperationUp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseWheelOperationUp", ConfigType.UInt)]
+    MouseWheelOperationUp,
+
+    /// <summary>
+    /// System option with the internal name MouseWheelOperationDown.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseWheelOperationDown", ConfigType.UInt)]
+    MouseWheelOperationDown,
+
+    /// <summary>
+    /// System option with the internal name MouseWheelOperationCtrlUp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseWheelOperationCtrlUp", ConfigType.UInt)]
+    MouseWheelOperationCtrlUp,
+
+    /// <summary>
+    /// System option with the internal name MouseWheelOperationCtrlDown.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseWheelOperationCtrlDown", ConfigType.UInt)]
+    MouseWheelOperationCtrlDown,
+
+    /// <summary>
+    /// System option with the internal name MouseWheelOperationAltUp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseWheelOperationAltUp", ConfigType.UInt)]
+    MouseWheelOperationAltUp,
+
+    /// <summary>
+    /// System option with the internal name MouseWheelOperationAltDown.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseWheelOperationAltDown", ConfigType.UInt)]
+    MouseWheelOperationAltDown,
+
+    /// <summary>
+    /// System option with the internal name MouseWheelOperationShiftUp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseWheelOperationShiftUp", ConfigType.UInt)]
+    MouseWheelOperationShiftUp,
+
+    /// <summary>
+    /// System option with the internal name MouseWheelOperationShiftDown.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseWheelOperationShiftDown", ConfigType.UInt)]
+    MouseWheelOperationShiftDown,
+
+    /// <summary>
+    /// System option with the internal name TelepoTicketUseType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TelepoTicketUseType", ConfigType.UInt)]
+    TelepoTicketUseType,
+
+    /// <summary>
+    /// System option with the internal name TelepoTicketGilSetting.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TelepoTicketGilSetting", ConfigType.UInt)]
+    TelepoTicketGilSetting,
+
+    /// <summary>
+    /// System option with the internal name PvPFrontlinesGCFree.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PvPFrontlinesGCFree", ConfigType.UInt)]
+    PvPFrontlinesGCFree,
+}

--- a/Dalamud/Game/Config/UiControlOption.cs
+++ b/Dalamud/Game/Config/UiControlOption.cs
@@ -1,0 +1,1280 @@
+﻿using FFXIVClientStructs.FFXIV.Common.Configuration;
+
+namespace Dalamud.Game.Config;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable IdentifierTypo
+// ReSharper disable CommentTypo
+
+/// <summary>
+/// Config options in the UiControl section.
+/// </summary>
+public enum UiControlOption
+{
+    /// <summary>
+    /// System option with the internal name AutoChangePointOfView.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AutoChangePointOfView", ConfigType.UInt)]
+    AutoChangePointOfView,
+
+    /// <summary>
+    /// System option with the internal name KeyboardCameraInterpolationType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("KeyboardCameraInterpolationType", ConfigType.UInt)]
+    KeyboardCameraInterpolationType,
+
+    /// <summary>
+    /// System option with the internal name KeyboardCameraVerticalInterpolation.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("KeyboardCameraVerticalInterpolation", ConfigType.UInt)]
+    KeyboardCameraVerticalInterpolation,
+
+    /// <summary>
+    /// System option with the internal name TiltOffset.
+    /// This option is a Float.
+    /// </summary>
+    [GameConfigOption("TiltOffset", ConfigType.Float)]
+    TiltOffset,
+
+    /// <summary>
+    /// System option with the internal name KeyboardSpeed.
+    /// This option is a Float.
+    /// </summary>
+    [GameConfigOption("KeyboardSpeed", ConfigType.Float)]
+    KeyboardSpeed,
+
+    /// <summary>
+    /// System option with the internal name PadSpeed.
+    /// This option is a Float.
+    /// </summary>
+    [GameConfigOption("PadSpeed", ConfigType.Float)]
+    PadSpeed,
+
+    /// <summary>
+    /// System option with the internal name PadFpsXReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PadFpsXReverse", ConfigType.UInt)]
+    PadFpsXReverse,
+
+    /// <summary>
+    /// System option with the internal name PadFpsYReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PadFpsYReverse", ConfigType.UInt)]
+    PadFpsYReverse,
+
+    /// <summary>
+    /// System option with the internal name PadTpsXReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PadTpsXReverse", ConfigType.UInt)]
+    PadTpsXReverse,
+
+    /// <summary>
+    /// System option with the internal name PadTpsYReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PadTpsYReverse", ConfigType.UInt)]
+    PadTpsYReverse,
+
+    /// <summary>
+    /// System option with the internal name MouseFpsXReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseFpsXReverse", ConfigType.UInt)]
+    MouseFpsXReverse,
+
+    /// <summary>
+    /// System option with the internal name MouseFpsYReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseFpsYReverse", ConfigType.UInt)]
+    MouseFpsYReverse,
+
+    /// <summary>
+    /// System option with the internal name MouseTpsXReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseTpsXReverse", ConfigType.UInt)]
+    MouseTpsXReverse,
+
+    /// <summary>
+    /// System option with the internal name MouseTpsYReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseTpsYReverse", ConfigType.UInt)]
+    MouseTpsYReverse,
+
+    /// <summary>
+    /// System option with the internal name MouseCharaViewRotYReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseCharaViewRotYReverse", ConfigType.UInt)]
+    MouseCharaViewRotYReverse,
+
+    /// <summary>
+    /// System option with the internal name MouseCharaViewRotXReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseCharaViewRotXReverse", ConfigType.UInt)]
+    MouseCharaViewRotXReverse,
+
+    /// <summary>
+    /// System option with the internal name MouseCharaViewMoveYReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseCharaViewMoveYReverse", ConfigType.UInt)]
+    MouseCharaViewMoveYReverse,
+
+    /// <summary>
+    /// System option with the internal name MouseCharaViewMoveXReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MouseCharaViewMoveXReverse", ConfigType.UInt)]
+    MouseCharaViewMoveXReverse,
+
+    /// <summary>
+    /// System option with the internal name PADCharaViewRotYReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PADCharaViewRotYReverse", ConfigType.UInt)]
+    PADCharaViewRotYReverse,
+
+    /// <summary>
+    /// System option with the internal name PADCharaViewRotXReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PADCharaViewRotXReverse", ConfigType.UInt)]
+    PADCharaViewRotXReverse,
+
+    /// <summary>
+    /// System option with the internal name PADCharaViewMoveYReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PADCharaViewMoveYReverse", ConfigType.UInt)]
+    PADCharaViewMoveYReverse,
+
+    /// <summary>
+    /// System option with the internal name PADCharaViewMoveXReverse.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PADCharaViewMoveXReverse", ConfigType.UInt)]
+    PADCharaViewMoveXReverse,
+
+    /// <summary>
+    /// System option with the internal name FlyingControlType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FlyingControlType", ConfigType.UInt)]
+    FlyingControlType,
+
+    /// <summary>
+    /// System option with the internal name FlyingLegacyAutorun.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FlyingLegacyAutorun", ConfigType.UInt)]
+    FlyingLegacyAutorun,
+
+    /// <summary>
+    /// System option with the internal name AutoFaceTargetOnAction.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AutoFaceTargetOnAction", ConfigType.UInt)]
+    AutoFaceTargetOnAction,
+
+    /// <summary>
+    /// System option with the internal name SelfClick.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("SelfClick", ConfigType.UInt)]
+    SelfClick,
+
+    /// <summary>
+    /// System option with the internal name NoTargetClickCancel.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NoTargetClickCancel", ConfigType.UInt)]
+    NoTargetClickCancel,
+
+    /// <summary>
+    /// System option with the internal name AutoTarget.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AutoTarget", ConfigType.UInt)]
+    AutoTarget,
+
+    /// <summary>
+    /// System option with the internal name TargetTypeSelect.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TargetTypeSelect", ConfigType.UInt)]
+    TargetTypeSelect,
+
+    /// <summary>
+    /// System option with the internal name AutoLockOn.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AutoLockOn", ConfigType.UInt)]
+    AutoLockOn,
+
+    /// <summary>
+    /// System option with the internal name CircleBattleModeAutoChange.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleBattleModeAutoChange", ConfigType.UInt)]
+    CircleBattleModeAutoChange,
+
+    /// <summary>
+    /// System option with the internal name CircleIsCustom.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleIsCustom", ConfigType.UInt)]
+    CircleIsCustom,
+
+    /// <summary>
+    /// System option with the internal name CircleSwordDrawnIsActive.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSwordDrawnIsActive", ConfigType.UInt)]
+    CircleSwordDrawnIsActive,
+
+    /// <summary>
+    /// System option with the internal name CircleSwordDrawnNonPartyPc.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSwordDrawnNonPartyPc", ConfigType.UInt)]
+    CircleSwordDrawnNonPartyPc,
+
+    /// <summary>
+    /// System option with the internal name CircleSwordDrawnParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSwordDrawnParty", ConfigType.UInt)]
+    CircleSwordDrawnParty,
+
+    /// <summary>
+    /// System option with the internal name CircleSwordDrawnEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSwordDrawnEnemy", ConfigType.UInt)]
+    CircleSwordDrawnEnemy,
+
+    /// <summary>
+    /// System option with the internal name CircleSwordDrawnAggro.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSwordDrawnAggro", ConfigType.UInt)]
+    CircleSwordDrawnAggro,
+
+    /// <summary>
+    /// System option with the internal name CircleSwordDrawnNpcOrObject.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSwordDrawnNpcOrObject", ConfigType.UInt)]
+    CircleSwordDrawnNpcOrObject,
+
+    /// <summary>
+    /// System option with the internal name CircleSwordDrawnMinion.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSwordDrawnMinion", ConfigType.UInt)]
+    CircleSwordDrawnMinion,
+
+    /// <summary>
+    /// System option with the internal name CircleSwordDrawnDutyEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSwordDrawnDutyEnemy", ConfigType.UInt)]
+    CircleSwordDrawnDutyEnemy,
+
+    /// <summary>
+    /// System option with the internal name CircleSwordDrawnPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSwordDrawnPet", ConfigType.UInt)]
+    CircleSwordDrawnPet,
+
+    /// <summary>
+    /// System option with the internal name CircleSwordDrawnAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSwordDrawnAlliance", ConfigType.UInt)]
+    CircleSwordDrawnAlliance,
+
+    /// <summary>
+    /// System option with the internal name CircleSwordDrawnMark.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSwordDrawnMark", ConfigType.UInt)]
+    CircleSwordDrawnMark,
+
+    /// <summary>
+    /// System option with the internal name CircleSheathedIsActive.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSheathedIsActive", ConfigType.UInt)]
+    CircleSheathedIsActive,
+
+    /// <summary>
+    /// System option with the internal name CircleSheathedNonPartyPc.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSheathedNonPartyPc", ConfigType.UInt)]
+    CircleSheathedNonPartyPc,
+
+    /// <summary>
+    /// System option with the internal name CircleSheathedParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSheathedParty", ConfigType.UInt)]
+    CircleSheathedParty,
+
+    /// <summary>
+    /// System option with the internal name CircleSheathedEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSheathedEnemy", ConfigType.UInt)]
+    CircleSheathedEnemy,
+
+    /// <summary>
+    /// System option with the internal name CircleSheathedAggro.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSheathedAggro", ConfigType.UInt)]
+    CircleSheathedAggro,
+
+    /// <summary>
+    /// System option with the internal name CircleSheathedNpcOrObject.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSheathedNpcOrObject", ConfigType.UInt)]
+    CircleSheathedNpcOrObject,
+
+    /// <summary>
+    /// System option with the internal name CircleSheathedMinion.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSheathedMinion", ConfigType.UInt)]
+    CircleSheathedMinion,
+
+    /// <summary>
+    /// System option with the internal name CircleSheathedDutyEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSheathedDutyEnemy", ConfigType.UInt)]
+    CircleSheathedDutyEnemy,
+
+    /// <summary>
+    /// System option with the internal name CircleSheathedPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSheathedPet", ConfigType.UInt)]
+    CircleSheathedPet,
+
+    /// <summary>
+    /// System option with the internal name CircleSheathedAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSheathedAlliance", ConfigType.UInt)]
+    CircleSheathedAlliance,
+
+    /// <summary>
+    /// System option with the internal name CircleSheathedMark.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleSheathedMark", ConfigType.UInt)]
+    CircleSheathedMark,
+
+    /// <summary>
+    /// System option with the internal name CircleClickIsActive.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleClickIsActive", ConfigType.UInt)]
+    CircleClickIsActive,
+
+    /// <summary>
+    /// System option with the internal name CircleClickNonPartyPc.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleClickNonPartyPc", ConfigType.UInt)]
+    CircleClickNonPartyPc,
+
+    /// <summary>
+    /// System option with the internal name CircleClickParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleClickParty", ConfigType.UInt)]
+    CircleClickParty,
+
+    /// <summary>
+    /// System option with the internal name CircleClickEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleClickEnemy", ConfigType.UInt)]
+    CircleClickEnemy,
+
+    /// <summary>
+    /// System option with the internal name CircleClickAggro.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleClickAggro", ConfigType.UInt)]
+    CircleClickAggro,
+
+    /// <summary>
+    /// System option with the internal name CircleClickNpcOrObject.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleClickNpcOrObject", ConfigType.UInt)]
+    CircleClickNpcOrObject,
+
+    /// <summary>
+    /// System option with the internal name CircleClickMinion.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleClickMinion", ConfigType.UInt)]
+    CircleClickMinion,
+
+    /// <summary>
+    /// System option with the internal name CircleClickDutyEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleClickDutyEnemy", ConfigType.UInt)]
+    CircleClickDutyEnemy,
+
+    /// <summary>
+    /// System option with the internal name CircleClickPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleClickPet", ConfigType.UInt)]
+    CircleClickPet,
+
+    /// <summary>
+    /// System option with the internal name CircleClickAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleClickAlliance", ConfigType.UInt)]
+    CircleClickAlliance,
+
+    /// <summary>
+    /// System option with the internal name CircleClickMark.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleClickMark", ConfigType.UInt)]
+    CircleClickMark,
+
+    /// <summary>
+    /// System option with the internal name CircleXButtonIsActive.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleXButtonIsActive", ConfigType.UInt)]
+    CircleXButtonIsActive,
+
+    /// <summary>
+    /// System option with the internal name CircleXButtonNonPartyPc.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleXButtonNonPartyPc", ConfigType.UInt)]
+    CircleXButtonNonPartyPc,
+
+    /// <summary>
+    /// System option with the internal name CircleXButtonParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleXButtonParty", ConfigType.UInt)]
+    CircleXButtonParty,
+
+    /// <summary>
+    /// System option with the internal name CircleXButtonEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleXButtonEnemy", ConfigType.UInt)]
+    CircleXButtonEnemy,
+
+    /// <summary>
+    /// System option with the internal name CircleXButtonAggro.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleXButtonAggro", ConfigType.UInt)]
+    CircleXButtonAggro,
+
+    /// <summary>
+    /// System option with the internal name CircleXButtonNpcOrObject.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleXButtonNpcOrObject", ConfigType.UInt)]
+    CircleXButtonNpcOrObject,
+
+    /// <summary>
+    /// System option with the internal name CircleXButtonMinion.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleXButtonMinion", ConfigType.UInt)]
+    CircleXButtonMinion,
+
+    /// <summary>
+    /// System option with the internal name CircleXButtonDutyEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleXButtonDutyEnemy", ConfigType.UInt)]
+    CircleXButtonDutyEnemy,
+
+    /// <summary>
+    /// System option with the internal name CircleXButtonPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleXButtonPet", ConfigType.UInt)]
+    CircleXButtonPet,
+
+    /// <summary>
+    /// System option with the internal name CircleXButtonAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleXButtonAlliance", ConfigType.UInt)]
+    CircleXButtonAlliance,
+
+    /// <summary>
+    /// System option with the internal name CircleXButtonMark.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleXButtonMark", ConfigType.UInt)]
+    CircleXButtonMark,
+
+    /// <summary>
+    /// System option with the internal name CircleYButtonIsActive.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleYButtonIsActive", ConfigType.UInt)]
+    CircleYButtonIsActive,
+
+    /// <summary>
+    /// System option with the internal name CircleYButtonNonPartyPc.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleYButtonNonPartyPc", ConfigType.UInt)]
+    CircleYButtonNonPartyPc,
+
+    /// <summary>
+    /// System option with the internal name CircleYButtonParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleYButtonParty", ConfigType.UInt)]
+    CircleYButtonParty,
+
+    /// <summary>
+    /// System option with the internal name CircleYButtonEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleYButtonEnemy", ConfigType.UInt)]
+    CircleYButtonEnemy,
+
+    /// <summary>
+    /// System option with the internal name CircleYButtonAggro.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleYButtonAggro", ConfigType.UInt)]
+    CircleYButtonAggro,
+
+    /// <summary>
+    /// System option with the internal name CircleYButtonNpcOrObject.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleYButtonNpcOrObject", ConfigType.UInt)]
+    CircleYButtonNpcOrObject,
+
+    /// <summary>
+    /// System option with the internal name CircleYButtonMinion.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleYButtonMinion", ConfigType.UInt)]
+    CircleYButtonMinion,
+
+    /// <summary>
+    /// System option with the internal name CircleYButtonDutyEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleYButtonDutyEnemy", ConfigType.UInt)]
+    CircleYButtonDutyEnemy,
+
+    /// <summary>
+    /// System option with the internal name CircleYButtonPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleYButtonPet", ConfigType.UInt)]
+    CircleYButtonPet,
+
+    /// <summary>
+    /// System option with the internal name CircleYButtonAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleYButtonAlliance", ConfigType.UInt)]
+    CircleYButtonAlliance,
+
+    /// <summary>
+    /// System option with the internal name CircleYButtonMark.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleYButtonMark", ConfigType.UInt)]
+    CircleYButtonMark,
+
+    /// <summary>
+    /// System option with the internal name CircleBButtonIsActive.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleBButtonIsActive", ConfigType.UInt)]
+    CircleBButtonIsActive,
+
+    /// <summary>
+    /// System option with the internal name CircleBButtonNonPartyPc.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleBButtonNonPartyPc", ConfigType.UInt)]
+    CircleBButtonNonPartyPc,
+
+    /// <summary>
+    /// System option with the internal name CircleBButtonParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleBButtonParty", ConfigType.UInt)]
+    CircleBButtonParty,
+
+    /// <summary>
+    /// System option with the internal name CircleBButtonEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleBButtonEnemy", ConfigType.UInt)]
+    CircleBButtonEnemy,
+
+    /// <summary>
+    /// System option with the internal name CircleBButtonAggro.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleBButtonAggro", ConfigType.UInt)]
+    CircleBButtonAggro,
+
+    /// <summary>
+    /// System option with the internal name CircleBButtonNpcOrObject.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleBButtonNpcOrObject", ConfigType.UInt)]
+    CircleBButtonNpcOrObject,
+
+    /// <summary>
+    /// System option with the internal name CircleBButtonMinion.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleBButtonMinion", ConfigType.UInt)]
+    CircleBButtonMinion,
+
+    /// <summary>
+    /// System option with the internal name CircleBButtonDutyEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleBButtonDutyEnemy", ConfigType.UInt)]
+    CircleBButtonDutyEnemy,
+
+    /// <summary>
+    /// System option with the internal name CircleBButtonPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleBButtonPet", ConfigType.UInt)]
+    CircleBButtonPet,
+
+    /// <summary>
+    /// System option with the internal name CircleBButtonAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleBButtonAlliance", ConfigType.UInt)]
+    CircleBButtonAlliance,
+
+    /// <summary>
+    /// System option with the internal name CircleBButtonMark.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleBButtonMark", ConfigType.UInt)]
+    CircleBButtonMark,
+
+    /// <summary>
+    /// System option with the internal name CircleAButtonIsActive.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleAButtonIsActive", ConfigType.UInt)]
+    CircleAButtonIsActive,
+
+    /// <summary>
+    /// System option with the internal name CircleAButtonNonPartyPc.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleAButtonNonPartyPc", ConfigType.UInt)]
+    CircleAButtonNonPartyPc,
+
+    /// <summary>
+    /// System option with the internal name CircleAButtonParty.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleAButtonParty", ConfigType.UInt)]
+    CircleAButtonParty,
+
+    /// <summary>
+    /// System option with the internal name CircleAButtonEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleAButtonEnemy", ConfigType.UInt)]
+    CircleAButtonEnemy,
+
+    /// <summary>
+    /// System option with the internal name CircleAButtonAggro.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleAButtonAggro", ConfigType.UInt)]
+    CircleAButtonAggro,
+
+    /// <summary>
+    /// System option with the internal name CircleAButtonNpcOrObject.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleAButtonNpcOrObject", ConfigType.UInt)]
+    CircleAButtonNpcOrObject,
+
+    /// <summary>
+    /// System option with the internal name CircleAButtonMinion.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleAButtonMinion", ConfigType.UInt)]
+    CircleAButtonMinion,
+
+    /// <summary>
+    /// System option with the internal name CircleAButtonDutyEnemy.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleAButtonDutyEnemy", ConfigType.UInt)]
+    CircleAButtonDutyEnemy,
+
+    /// <summary>
+    /// System option with the internal name CircleAButtonPet.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleAButtonPet", ConfigType.UInt)]
+    CircleAButtonPet,
+
+    /// <summary>
+    /// System option with the internal name CircleAButtonAlliance.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleAButtonAlliance", ConfigType.UInt)]
+    CircleAButtonAlliance,
+
+    /// <summary>
+    /// System option with the internal name CircleAButtonMark.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CircleAButtonMark", ConfigType.UInt)]
+    CircleAButtonMark,
+
+    /// <summary>
+    /// System option with the internal name GroundTargetType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GroundTargetType", ConfigType.UInt)]
+    GroundTargetType,
+
+    /// <summary>
+    /// System option with the internal name GroundTargetCursorSpeed.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GroundTargetCursorSpeed", ConfigType.UInt)]
+    GroundTargetCursorSpeed,
+
+    /// <summary>
+    /// System option with the internal name TargetCircleType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TargetCircleType", ConfigType.UInt)]
+    TargetCircleType,
+
+    /// <summary>
+    /// System option with the internal name TargetLineType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TargetLineType", ConfigType.UInt)]
+    TargetLineType,
+
+    /// <summary>
+    /// System option with the internal name LinkLineType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LinkLineType", ConfigType.UInt)]
+    LinkLineType,
+
+    /// <summary>
+    /// System option with the internal name ObjectBorderingType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ObjectBorderingType", ConfigType.UInt)]
+    ObjectBorderingType,
+
+    /// <summary>
+    /// System option with the internal name MoveMode.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MoveMode", ConfigType.UInt)]
+    MoveMode,
+
+    /// <summary>
+    /// System option with the internal name HotbarDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarDisp", ConfigType.UInt)]
+    HotbarDisp,
+
+    /// <summary>
+    /// System option with the internal name HotbarEmptyVisible.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarEmptyVisible", ConfigType.UInt)]
+    HotbarEmptyVisible,
+
+    /// <summary>
+    /// System option with the internal name HotbarNoneSlotDisp01.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarNoneSlotDisp01", ConfigType.UInt)]
+    HotbarNoneSlotDisp01,
+
+    /// <summary>
+    /// System option with the internal name HotbarNoneSlotDisp02.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarNoneSlotDisp02", ConfigType.UInt)]
+    HotbarNoneSlotDisp02,
+
+    /// <summary>
+    /// System option with the internal name HotbarNoneSlotDisp03.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarNoneSlotDisp03", ConfigType.UInt)]
+    HotbarNoneSlotDisp03,
+
+    /// <summary>
+    /// System option with the internal name HotbarNoneSlotDisp04.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarNoneSlotDisp04", ConfigType.UInt)]
+    HotbarNoneSlotDisp04,
+
+    /// <summary>
+    /// System option with the internal name HotbarNoneSlotDisp05.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarNoneSlotDisp05", ConfigType.UInt)]
+    HotbarNoneSlotDisp05,
+
+    /// <summary>
+    /// System option with the internal name HotbarNoneSlotDisp06.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarNoneSlotDisp06", ConfigType.UInt)]
+    HotbarNoneSlotDisp06,
+
+    /// <summary>
+    /// System option with the internal name HotbarNoneSlotDisp07.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarNoneSlotDisp07", ConfigType.UInt)]
+    HotbarNoneSlotDisp07,
+
+    /// <summary>
+    /// System option with the internal name HotbarNoneSlotDisp08.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarNoneSlotDisp08", ConfigType.UInt)]
+    HotbarNoneSlotDisp08,
+
+    /// <summary>
+    /// System option with the internal name HotbarNoneSlotDisp09.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarNoneSlotDisp09", ConfigType.UInt)]
+    HotbarNoneSlotDisp09,
+
+    /// <summary>
+    /// System option with the internal name HotbarNoneSlotDisp10.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarNoneSlotDisp10", ConfigType.UInt)]
+    HotbarNoneSlotDisp10,
+
+    /// <summary>
+    /// System option with the internal name HotbarNoneSlotDispEX.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarNoneSlotDispEX", ConfigType.UInt)]
+    HotbarNoneSlotDispEX,
+
+    /// <summary>
+    /// System option with the internal name ExHotbarSetting.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ExHotbarSetting", ConfigType.UInt)]
+    ExHotbarSetting,
+
+    /// <summary>
+    /// System option with the internal name HotbarExHotbarUseSetting.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarExHotbarUseSetting", ConfigType.UInt)]
+    HotbarExHotbarUseSetting,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossUseEx.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossUseEx", ConfigType.UInt)]
+    HotbarCrossUseEx,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossUseExDirection.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossUseExDirection", ConfigType.UInt)]
+    HotbarCrossUseExDirection,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossDispType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossDispType", ConfigType.UInt)]
+    HotbarCrossDispType,
+
+    /// <summary>
+    /// System option with the internal name PartyListSoloOff.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PartyListSoloOff", ConfigType.UInt)]
+    PartyListSoloOff,
+
+    /// <summary>
+    /// System option with the internal name HowTo.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HowTo", ConfigType.UInt)]
+    HowTo,
+
+    /// <summary>
+    /// System option with the internal name HousingFurnitureBindConfirm.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HousingFurnitureBindConfirm", ConfigType.UInt)]
+    HousingFurnitureBindConfirm,
+
+    /// <summary>
+    /// System option with the internal name DirectChat.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("DirectChat", ConfigType.UInt)]
+    DirectChat,
+
+    /// <summary>
+    /// System option with the internal name CharaParamDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("CharaParamDisp", ConfigType.UInt)]
+    CharaParamDisp,
+
+    /// <summary>
+    /// System option with the internal name LimitBreakGaugeDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("LimitBreakGaugeDisp", ConfigType.UInt)]
+    LimitBreakGaugeDisp,
+
+    /// <summary>
+    /// System option with the internal name ScenarioTreeDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ScenarioTreeDisp", ConfigType.UInt)]
+    ScenarioTreeDisp,
+
+    /// <summary>
+    /// System option with the internal name ScenarioTreeCompleteDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ScenarioTreeCompleteDisp", ConfigType.UInt)]
+    ScenarioTreeCompleteDisp,
+
+    /// <summary>
+    /// System option with the internal name HotbarCrossDispAlways.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarCrossDispAlways", ConfigType.UInt)]
+    HotbarCrossDispAlways,
+
+    /// <summary>
+    /// System option with the internal name ExpDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ExpDisp", ConfigType.UInt)]
+    ExpDisp,
+
+    /// <summary>
+    /// System option with the internal name InventryStatusDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("InventryStatusDisp", ConfigType.UInt)]
+    InventryStatusDisp,
+
+    /// <summary>
+    /// System option with the internal name DutyListDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("DutyListDisp", ConfigType.UInt)]
+    DutyListDisp,
+
+    /// <summary>
+    /// System option with the internal name NaviMapDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("NaviMapDisp", ConfigType.UInt)]
+    NaviMapDisp,
+
+    /// <summary>
+    /// System option with the internal name GilStatusDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("GilStatusDisp", ConfigType.UInt)]
+    GilStatusDisp,
+
+    /// <summary>
+    /// System option with the internal name InfoSettingDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("InfoSettingDisp", ConfigType.UInt)]
+    InfoSettingDisp,
+
+    /// <summary>
+    /// System option with the internal name InfoSettingDispType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("InfoSettingDispType", ConfigType.UInt)]
+    InfoSettingDispType,
+
+    /// <summary>
+    /// System option with the internal name TargetInfoDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TargetInfoDisp", ConfigType.UInt)]
+    TargetInfoDisp,
+
+    /// <summary>
+    /// System option with the internal name EnemyListDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("EnemyListDisp", ConfigType.UInt)]
+    EnemyListDisp,
+
+    /// <summary>
+    /// System option with the internal name FocusTargetDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FocusTargetDisp", ConfigType.UInt)]
+    FocusTargetDisp,
+
+    /// <summary>
+    /// System option with the internal name ItemDetailDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ItemDetailDisp", ConfigType.UInt)]
+    ItemDetailDisp,
+
+    /// <summary>
+    /// System option with the internal name ActionDetailDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ActionDetailDisp", ConfigType.UInt)]
+    ActionDetailDisp,
+
+    /// <summary>
+    /// System option with the internal name DetailTrackingType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("DetailTrackingType", ConfigType.UInt)]
+    DetailTrackingType,
+
+    /// <summary>
+    /// System option with the internal name ToolTipDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ToolTipDisp", ConfigType.UInt)]
+    ToolTipDisp,
+
+    /// <summary>
+    /// System option with the internal name MapPermeationRate.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MapPermeationRate", ConfigType.UInt)]
+    MapPermeationRate,
+
+    /// <summary>
+    /// System option with the internal name MapOperationType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MapOperationType", ConfigType.UInt)]
+    MapOperationType,
+
+    /// <summary>
+    /// System option with the internal name PartyListDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PartyListDisp", ConfigType.UInt)]
+    PartyListDisp,
+
+    /// <summary>
+    /// System option with the internal name PartyListNameType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PartyListNameType", ConfigType.UInt)]
+    PartyListNameType,
+
+    /// <summary>
+    /// System option with the internal name FlyTextDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FlyTextDisp", ConfigType.UInt)]
+    FlyTextDisp,
+
+    /// <summary>
+    /// System option with the internal name MapPermeationMode.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MapPermeationMode", ConfigType.UInt)]
+    MapPermeationMode,
+
+    /// <summary>
+    /// System option with the internal name AllianceList1Disp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AllianceList1Disp", ConfigType.UInt)]
+    AllianceList1Disp,
+
+    /// <summary>
+    /// System option with the internal name AllianceList2Disp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("AllianceList2Disp", ConfigType.UInt)]
+    AllianceList2Disp,
+
+    /// <summary>
+    /// System option with the internal name TargetInfoSelfBuff.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TargetInfoSelfBuff", ConfigType.UInt)]
+    TargetInfoSelfBuff,
+
+    /// <summary>
+    /// System option with the internal name PopUpTextDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PopUpTextDisp", ConfigType.UInt)]
+    PopUpTextDisp,
+
+    /// <summary>
+    /// System option with the internal name ContentsInfoDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ContentsInfoDisp", ConfigType.UInt)]
+    ContentsInfoDisp,
+
+    /// <summary>
+    /// System option with the internal name DutyListHideWhenCntInfoDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("DutyListHideWhenCntInfoDisp", ConfigType.UInt)]
+    DutyListHideWhenCntInfoDisp,
+
+    /// <summary>
+    /// System option with the internal name DutyListNumDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("DutyListNumDisp", ConfigType.UInt)]
+    DutyListNumDisp,
+
+    /// <summary>
+    /// System option with the internal name InInstanceContentDutyListDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("InInstanceContentDutyListDisp", ConfigType.UInt)]
+    InInstanceContentDutyListDisp,
+
+    /// <summary>
+    /// System option with the internal name InPublicContentDutyListDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("InPublicContentDutyListDisp", ConfigType.UInt)]
+    InPublicContentDutyListDisp,
+
+    /// <summary>
+    /// System option with the internal name ContentsInfoJoiningRequestDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ContentsInfoJoiningRequestDisp", ConfigType.UInt)]
+    ContentsInfoJoiningRequestDisp,
+
+    /// <summary>
+    /// System option with the internal name ContentsInfoJoiningRequestSituationDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("ContentsInfoJoiningRequestSituationDisp", ConfigType.UInt)]
+    ContentsInfoJoiningRequestSituationDisp,
+
+    /// <summary>
+    /// System option with the internal name HotbarDispSetNum.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarDispSetNum", ConfigType.UInt)]
+    HotbarDispSetNum,
+
+    /// <summary>
+    /// System option with the internal name HotbarDispSetChangeType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarDispSetChangeType", ConfigType.UInt)]
+    HotbarDispSetChangeType,
+
+    /// <summary>
+    /// System option with the internal name HotbarDispSetDragType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarDispSetDragType", ConfigType.UInt)]
+    HotbarDispSetDragType,
+
+    /// <summary>
+    /// System option with the internal name MainCommandType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MainCommandType", ConfigType.UInt)]
+    MainCommandType,
+
+    /// <summary>
+    /// System option with the internal name MainCommandDisp.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MainCommandDisp", ConfigType.UInt)]
+    MainCommandDisp,
+
+    /// <summary>
+    /// System option with the internal name MainCommandDragShortcut.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MainCommandDragShortcut", ConfigType.UInt)]
+    MainCommandDragShortcut,
+
+    /// <summary>
+    /// System option with the internal name HotbarDispLookNum.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarDispLookNum", ConfigType.UInt)]
+    HotbarDispLookNum,
+}

--- a/Dalamud/Game/GameConfig.cs
+++ b/Dalamud/Game/GameConfig.cs
@@ -1,0 +1,446 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Dalamud.IoC;
+using Dalamud.IoC.Internal;
+using Dalamud.Memory;
+
+using FFXIVClientStructs.FFXIV.Common.Configuration;
+using Serilog;
+
+namespace Dalamud.Game;
+
+/// <summary>
+/// This class represents the game's configuration.
+/// </summary>
+[InterfaceVersion("1.0")]
+[PluginInterface]
+[ServiceManager.BlockingEarlyLoadedService]
+public sealed class GameConfig : IServiceType
+{
+    [ServiceManager.ServiceConstructor]
+    private unsafe GameConfig(Framework framework)
+    {
+        framework.RunOnTick(() =>
+        {
+            Log.Information("[GameConfig] Initalizing");
+            var csFramework = FFXIVClientStructs.FFXIV.Client.System.Framework.Framework.Instance();
+            var commonConfig = &csFramework->SystemConfig.CommonSystemConfig;
+            this.System = new GameConfigSection("System", framework, &commonConfig->ConfigBase);
+            this.UiConfig = new GameConfigSection("UiConfig", framework, &commonConfig->UiConfig);
+            this.UiControl = new GameConfigSection("UiControl", framework, () => this.UiConfig.TryGetBool("PadMode", out var padMode) && padMode ? &commonConfig->UiControlConfig + 1 : &commonConfig->UiControlConfig);
+        });
+    }
+
+    /// <summary>
+    /// Gets the collection of config options that persist between characters.
+    /// </summary>
+    public GameConfigSection System { get; private set; }
+
+    /// <summary>
+    /// Gets the collection of config options that are character specific.
+    /// </summary>
+    public GameConfigSection UiConfig { get; private set; }
+
+    /// <summary>
+    /// Gets the collection of config options that are control mode specific. (Mouse & Keyboard / Gamepad).
+    /// </summary>
+    public GameConfigSection UiControl { get; private set; }
+
+    /// <summary>
+    /// An exception thrown when a matching config option is not present in the config section.
+    /// </summary>
+    public class ConfigOptionNotFoundException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigOptionNotFoundException"/> class.
+        /// </summary>
+        /// <param name="sectionName">Name of the section being accessed.</param>
+        /// <param name="configOptionName">Name of the config option that was not found.</param>
+        public ConfigOptionNotFoundException(string sectionName, string configOptionName)
+            : base($"The option '{configOptionName}' is not available in {sectionName}.")
+        {
+        }
+    }
+
+    /// <summary>
+    /// An exception thrown when attempting to assign a value to a config option with the wrong type.
+    /// </summary>
+    public class IncorrectConfigTypeException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IncorrectConfigTypeException"/> class.
+        /// </summary>
+        /// <param name="sectionName">Name of the section being accessed.</param>
+        /// <param name="configOptionName">Name of the config option that was not found.</param>
+        /// <param name="correctType">The correct type for the config option.</param>
+        /// <param name="incorrectType">The type that was attempted.</param>
+        public IncorrectConfigTypeException(string sectionName, string configOptionName, ConfigType correctType, ConfigType incorrectType)
+            : base($"The option '{configOptionName}' in {sectionName} is of the type {correctType}. Assigning {incorrectType} is invalid.")
+        {
+        }
+    }
+
+    /// <summary>
+    /// Represents a section of the game config and contains helper functions for accessing and setting values.
+    /// </summary>
+    public class GameConfigSection
+    {
+        private readonly Framework framework;
+        private readonly Dictionary<string, uint> indexMap = new();
+        private readonly Dictionary<uint, string> nameMap = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GameConfigSection"/> class.
+        /// </summary>
+        /// <param name="sectionName">Name of the section.</param>
+        /// <param name="framework">The framework service.</param>
+        /// <param name="configBase">Unmanaged ConfigBase instance.</param>
+        internal unsafe GameConfigSection(string sectionName, Framework framework, ConfigBase* configBase)
+            : this(sectionName, framework, () => configBase)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GameConfigSection"/> class.
+        /// </summary>
+        /// <param name="sectionName">Name of the section.</param>
+        /// <param name="framework">The framework service.</param>
+        /// <param name="getConfigBase">A function that determines which ConfigBase instance should be used.</param>
+        internal GameConfigSection(string sectionName, Framework framework, GetConfigBaseDelegate getConfigBase)
+        {
+            this.SectionName = sectionName;
+            this.framework = framework;
+            this.GetConfigBase = getConfigBase;
+            Log.Information("[GameConfig] Initalizing {SectionName} with {ConfigCount} entries.", this.SectionName, this.ConfigCount);
+        }
+
+        /// <summary>
+        /// Delegate that gets the struct the section accesses.
+        /// </summary>
+        /// <returns>Pointer to unmanaged ConfigBase.</returns>
+        internal unsafe delegate ConfigBase* GetConfigBaseDelegate();
+
+        /// <summary>
+        /// Gets the number of config entries contained within the section.
+        /// Some entries may be empty with no data.
+        /// </summary>
+        public unsafe uint ConfigCount => this.GetConfigBase()->ConfigCount;
+
+        /// <summary>
+        /// Gets the name of the config section.
+        /// </summary>
+        public string SectionName { get; }
+
+        private GetConfigBaseDelegate GetConfigBase { get; }
+
+        /// <summary>
+        /// Attempts to get a boolean config option.
+        /// </summary>
+        /// <param name="name">Name of the config option.</param>
+        /// <param name="value">The returned value of the config option.</param>
+        /// <returns>A value representing the success.</returns>
+        public unsafe bool TryGetBool(string name, out bool value) {
+            value = false;
+            if (!this.TryGetIndex(name, out var index))
+            {
+                return false;
+            }
+
+            if (!this.TryGetEntry(index, out var entry))
+            {
+                return false;
+            }
+
+            value = entry->Value.UInt != 0;
+            return true;
+        }
+
+        /// <summary>
+        /// Get a boolean config option.
+        /// </summary>
+        /// <param name="name">Name of the config option.</param>
+        /// <returns>Value of the config option.</returns>
+        /// <exception cref="ConfigOptionNotFoundException">Thrown if the config option is not found.</exception>
+        public bool GetBool(string name) {
+            if (!this.TryGetBool(name, out var value))
+            {
+                throw new ConfigOptionNotFoundException(this.SectionName, name);
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Set a boolean config option.
+        /// </summary>
+        /// <param name="name">Name of the config option.</param>
+        /// <param name="value">New value of the config option.</param>
+        /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+        /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+        public unsafe void Set(string name, bool value) {
+            if (!this.TryGetIndex(name, out var index))
+            {
+                throw new ConfigOptionNotFoundException(this.SectionName, name);
+            }
+
+            if (!this.TryGetEntry(index, out var entry))
+            {
+                throw new UnreachableException($"An unexpected error was encountered setting {name} in {this.SectionName}");
+            }
+
+            if ((ConfigType)entry->Type != ConfigType.UInt)
+            {
+                throw new IncorrectConfigTypeException(this.SectionName, name, (ConfigType)entry->Type, ConfigType.UInt);
+            }
+
+            entry->SetValue(value ? 1U : 0U);
+        }
+
+        /// <summary>
+        /// Attempts to get an unsigned integer config value.
+        /// </summary>
+        /// <param name="name">Name of the config option.</param>
+        /// <param name="value">The returned value of the config option.</param>
+        /// <returns>A value representing the success.</returns>
+        public unsafe bool TryGetUInt(string name, out uint value) {
+            value = 0;
+            if (!this.TryGetIndex(name, out var index))
+            {
+                return false;
+            }
+
+            if (!this.TryGetEntry(index, out var entry))
+            {
+                return false;
+            }
+
+            value = entry->Value.UInt;
+            return true;
+        }
+
+        /// <summary>
+        /// Get an unsigned integer config option.
+        /// </summary>
+        /// <param name="name">Name of the config option.</param>
+        /// <returns>Value of the config option.</returns>
+        /// <exception cref="ConfigOptionNotFoundException">Thrown if the config option is not found.</exception>
+        public uint GetUInt(string name) {
+            if (!this.TryGetUInt(name, out var value))
+            {
+                throw new ConfigOptionNotFoundException(this.SectionName, name);
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Set an unsigned integer config option.
+        /// </summary>
+        /// <param name="name">Name of the config option.</param>
+        /// <param name="value">New value of the config option.</param>
+        /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+        /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+        public unsafe void Set(string name, uint value) {
+            this.framework.RunOnFrameworkThread(() => {
+                if (!this.TryGetIndex(name, out var index))
+                {
+                    throw new ConfigOptionNotFoundException(this.SectionName, name);
+                }
+
+                if (!this.TryGetEntry(index, out var entry))
+                {
+                    throw new UnreachableException($"An unexpected error was encountered setting {name} in {this.SectionName}");
+                }
+
+                if ((ConfigType)entry->Type != ConfigType.UInt)
+                {
+                    throw new IncorrectConfigTypeException(this.SectionName, name, (ConfigType)entry->Type, ConfigType.UInt);
+                }
+
+                entry->SetValue(value);
+            });
+        }
+
+        /// <summary>
+        /// Attempts to get a float config value.
+        /// </summary>
+        /// <param name="name">Name of the config option.</param>
+        /// <param name="value">The returned value of the config option.</param>
+        /// <returns>A value representing the success.</returns>
+        public unsafe bool TryGetFloat(string name, out float value) {
+            value = 0;
+            if (!this.TryGetIndex(name, out var index))
+            {
+                return false;
+            }
+
+            if (!this.TryGetEntry(index, out var entry))
+            {
+                return false;
+            }
+
+            value = entry->Value.Float;
+            return true;
+        }
+
+        /// <summary>
+        /// Get a float config option.
+        /// </summary>
+        /// <param name="name">Name of the config option.</param>
+        /// <returns>Value of the config option.</returns>
+        /// <exception cref="ConfigOptionNotFoundException">Thrown if the config option is not found.</exception>
+        public float GetFloat(string name) {
+            if (!this.TryGetFloat(name, out var value))
+            {
+                throw new ConfigOptionNotFoundException(this.SectionName, name);
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Set a float config option.
+        /// </summary>
+        /// <param name="name">Name of the config option.</param>
+        /// <param name="value">New value of the config option.</param>
+        /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+        /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+        public unsafe void Set(string name, float value) {
+            this.framework.RunOnFrameworkThread(() => {
+                if (!this.TryGetIndex(name, out var index))
+                {
+                    throw new ConfigOptionNotFoundException(this.SectionName, name);
+                }
+
+                if (!this.TryGetEntry(index, out var entry))
+                {
+                    throw new UnreachableException($"An unexpected error was encountered setting {name} in {this.SectionName}");
+                }
+
+                if ((ConfigType)entry->Type != ConfigType.Float)
+                {
+                    throw new IncorrectConfigTypeException(this.SectionName, name, (ConfigType)entry->Type, ConfigType.Float);
+                }
+
+                entry->SetValue(value);
+            });
+        }
+
+        /// <summary>
+        /// Attempts to get a string config value.
+        /// </summary>
+        /// <param name="name">Name of the config option.</param>
+        /// <param name="value">The returned value of the config option.</param>
+        /// <returns>A value representing the success.</returns>
+        public unsafe bool TryGetString(string name, out string value) {
+            value = string.Empty;
+            if (!this.TryGetIndex(name, out var index))
+            {
+                return false;
+            }
+
+            if (!this.TryGetEntry(index, out var entry))
+            {
+                return false;
+            }
+
+            if (entry->Type != 4)
+            {
+                return false;
+            }
+
+            if (entry->Value.String == null)
+            {
+                return false;
+            }
+
+            value = entry->Value.String->ToString();
+            return true;
+        }
+
+        /// <summary>
+        /// Get a string config option.
+        /// </summary>
+        /// <param name="name">Name of the config option.</param>
+        /// <returns>Value of the config option.</returns>
+        /// <exception cref="ConfigOptionNotFoundException">Thrown if the config option is not found.</exception>
+        public string GetString(string name) {
+            if (!this.TryGetString(name, out var value))
+            {
+                throw new ConfigOptionNotFoundException(this.SectionName, name);
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Set a string config option.
+        /// </summary>
+        /// <param name="name">Name of the config option.</param>
+        /// <param name="value">New value of the config option.</param>
+        /// <exception cref="ConfigOptionNotFoundException">Throw if the config option is not found.</exception>
+        /// <exception cref="UnreachableException">Thrown if the name of the config option is found, but the struct was not.</exception>
+        public unsafe void Set(string name, string value) {
+            this.framework.RunOnFrameworkThread(() => {
+                if (!this.TryGetIndex(name, out var index))
+                {
+                    throw new ConfigOptionNotFoundException(this.SectionName, name);
+                }
+
+                if (!this.TryGetEntry(index, out var entry))
+                {
+                    throw new UnreachableException($"An unexpected error was encountered setting {name} in {this.SectionName}");
+                }
+
+                if ((ConfigType)entry->Type != ConfigType.String)
+                {
+                    throw new IncorrectConfigTypeException(this.SectionName, name, (ConfigType)entry->Type, ConfigType.String);
+                }
+
+                entry->SetValue(value);
+            });
+        }
+
+        private unsafe bool TryGetIndex(string name, out uint index) {
+            if (this.indexMap.TryGetValue(name, out index))
+            {
+                return true;
+            }
+
+            var configBase = this.GetConfigBase();
+            var e = configBase->ConfigEntry;
+            for (var i = 0U; i < configBase->ConfigCount; i++, e++) {
+                if (e->Name == null)
+                {
+                    continue;
+                }
+
+                var eName = MemoryHelper.ReadStringNullTerminated(new IntPtr(e->Name));
+                if (eName.Equals(name)) {
+                    this.indexMap.TryAdd(name, i);
+                    this.nameMap.TryAdd(i, name);
+                    index = i;
+                    return true;
+                }
+            }
+
+            index = 0;
+            return false;
+        }
+
+        private unsafe bool TryGetEntry(uint index, out ConfigEntry* entry) {
+            entry = null;
+            var configBase = this.GetConfigBase();
+            if (configBase->ConfigEntry == null || index >= configBase->ConfigCount)
+            {
+                return false;
+            }
+
+            entry = configBase->ConfigEntry;
+            entry += index;
+            return true;
+        }
+    }
+}

--- a/Dalamud/Game/GameConfig.cs
+++ b/Dalamud/Game/GameConfig.cs
@@ -174,6 +174,7 @@ public sealed class GameConfig : IServiceType
 
         /// <summary>
         /// Set a boolean config option.
+        /// Note: Not all config options will be be immediately reflected in the game.
         /// </summary>
         /// <param name="name">Name of the config option.</param>
         /// <param name="value">New value of the config option.</param>
@@ -237,6 +238,7 @@ public sealed class GameConfig : IServiceType
 
         /// <summary>
         /// Set an unsigned integer config option.
+        /// Note: Not all config options will be be immediately reflected in the game.
         /// </summary>
         /// <param name="name">Name of the config option.</param>
         /// <param name="value">New value of the config option.</param>
@@ -302,6 +304,7 @@ public sealed class GameConfig : IServiceType
 
         /// <summary>
         /// Set a float config option.
+        /// Note: Not all config options will be be immediately reflected in the game.
         /// </summary>
         /// <param name="name">Name of the config option.</param>
         /// <param name="value">New value of the config option.</param>
@@ -377,6 +380,7 @@ public sealed class GameConfig : IServiceType
 
         /// <summary>
         /// Set a string config option.
+        /// Note: Not all config options will be be immediately reflected in the game.
         /// </summary>
         /// <param name="name">Name of the config option.</param>
         /// <param name="value">New value of the config option.</param>

--- a/Dalamud/Hooking/Internal/FunctionPointerVariableHook.cs
+++ b/Dalamud/Hooking/Internal/FunctionPointerVariableHook.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
 using Dalamud.Memory;
+using JetBrains.Annotations;
 
 namespace Dalamud.Hooking.Internal;
 
@@ -11,13 +13,22 @@ namespace Dalamud.Hooking.Internal;
 /// Manages a hook with MinHook.
 /// </summary>
 /// <typeparam name="T">Delegate type to represents a function prototype. This must be the same prototype as original function do.</typeparam>
-internal class FunctionPointerVariableHook<T> : Hook<T> where T : Delegate
+internal class FunctionPointerVariableHook<T> : Hook<T>
+    where T : Delegate
 {
-    private readonly IntPtr pfnOriginal;
-    private readonly T originalDelegate;
+    private readonly nint pfnDetour;
+
+    // Keep it referenced so that pfnDetour doesn't become invalidated.
+    [UsedImplicitly]
     private readonly T detourDelegate;
 
-    private bool enabled = false;
+    private readonly nint pfnThunk;
+    private readonly nint ppfnThunkJumpTarget;
+
+    private readonly nint pfnOriginal;
+    private readonly T originalDelegate;
+
+    private bool enabled;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FunctionPointerVariableHook{T}"/> class.
@@ -38,11 +49,50 @@ internal class FunctionPointerVariableHook<T> : Hook<T> where T : Delegate
             }
 
             if (!HookManager.MultiHookTracker.TryGetValue(this.Address, out var indexList))
-                indexList = HookManager.MultiHookTracker[this.Address] = new();
+            {
+                indexList = HookManager.MultiHookTracker[this.Address] = new List<IDalamudHook>();
+            }
+
+            this.detourDelegate = detour;
+            this.pfnDetour = Marshal.GetFunctionPointerForDelegate(detour);
+
+            unsafe
+            {
+                var pfnThunkBytes = (byte*)NativeFunctions.HeapAlloc(HookManager.NoFreeExecutableHeap, 0, 12);
+                if (pfnThunkBytes == null)
+                {
+                    throw new OutOfMemoryException("Failed to allocate memory for import hooks.");
+                }
+
+                // movabs rax, imm
+                pfnThunkBytes[0] = 0x48;
+                pfnThunkBytes[1] = 0xB8;
+
+                // jmp rax
+                pfnThunkBytes[10] = 0xFF;
+                pfnThunkBytes[11] = 0xE0;
+
+                this.pfnThunk = (nint)pfnThunkBytes;
+            }
+
+            this.ppfnThunkJumpTarget = this.pfnThunk + 2;
+
+            if (!NativeFunctions.VirtualProtect(
+                    this.Address,
+                    (UIntPtr)Marshal.SizeOf<IntPtr>(),
+                    MemoryProtection.ExecuteReadWrite,
+                    out var oldProtect))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
 
             this.pfnOriginal = Marshal.ReadIntPtr(this.Address);
             this.originalDelegate = Marshal.GetDelegateForFunctionPointer<T>(this.pfnOriginal);
-            this.detourDelegate = detour;
+            Marshal.WriteIntPtr(this.ppfnThunkJumpTarget, this.pfnOriginal);
+            Marshal.WriteIntPtr(this.Address, this.pfnThunk);
+
+            // This really should not fail, but then even if it does, whatever.
+            NativeFunctions.VirtualProtect(this.Address, (UIntPtr)Marshal.SizeOf<IntPtr>(), oldProtect, out _);
 
             // Add afterwards, so the hookIdent starts at 0.
             indexList.Add(this);
@@ -78,7 +128,9 @@ internal class FunctionPointerVariableHook<T> : Hook<T> where T : Delegate
     public override void Dispose()
     {
         if (this.IsDisposed)
+        {
             return;
+        }
 
         this.Disable();
 
@@ -93,16 +145,15 @@ internal class FunctionPointerVariableHook<T> : Hook<T> where T : Delegate
     {
         this.CheckDisposed();
 
-        if (!this.enabled)
+        if (this.enabled)
         {
-            lock (HookManager.HookEnableSyncRoot)
-            {
-                if (!NativeFunctions.VirtualProtect(this.Address, (UIntPtr)Marshal.SizeOf<IntPtr>(), MemoryProtection.ExecuteReadWrite, out var oldProtect))
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            return;
+        }
 
-                Marshal.WriteIntPtr(this.Address, Marshal.GetFunctionPointerForDelegate(this.detourDelegate));
-                NativeFunctions.VirtualProtect(this.Address, (UIntPtr)Marshal.SizeOf<IntPtr>(), oldProtect, out _);
-            }
+        lock (HookManager.HookEnableSyncRoot)
+        {
+            Marshal.WriteIntPtr(this.ppfnThunkJumpTarget, this.pfnDetour);
+            this.enabled = true;
         }
     }
 
@@ -111,16 +162,15 @@ internal class FunctionPointerVariableHook<T> : Hook<T> where T : Delegate
     {
         this.CheckDisposed();
 
-        if (this.enabled)
+        if (!this.enabled)
         {
-            lock (HookManager.HookEnableSyncRoot)
-            {
-                if (!NativeFunctions.VirtualProtect(this.Address, (UIntPtr)Marshal.SizeOf<IntPtr>(), MemoryProtection.ExecuteReadWrite, out var oldProtect))
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            return;
+        }
 
-                Marshal.WriteIntPtr(this.Address, this.pfnOriginal);
-                NativeFunctions.VirtualProtect(this.Address, (UIntPtr)Marshal.SizeOf<IntPtr>(), oldProtect, out _);
-            }
+        lock (HookManager.HookEnableSyncRoot)
+        {
+            Marshal.WriteIntPtr(this.ppfnThunkJumpTarget, this.pfnOriginal);
+            this.enabled = false;
         }
     }
 }

--- a/Dalamud/Hooking/Internal/HookManager.cs
+++ b/Dalamud/Hooking/Internal/HookManager.cs
@@ -16,6 +16,13 @@ namespace Dalamud.Hooking.Internal;
 [ServiceManager.EarlyLoadedService]
 internal class HookManager : IDisposable, IServiceType
 {
+    /// <summary>
+    /// Handle to an executable heap that we shall never free anything unless we can be absolutely sure that nothing is
+    /// referencing to it anymore.
+    /// </summary>
+    internal static readonly nint NoFreeExecutableHeap =
+        NativeFunctions.HeapCreate(NativeFunctions.HeapOptions.CreateEnableExecute, 0, 0);
+
     private static readonly ModuleLog Log = new("HM");
 
     [ServiceManager.ServiceConstructor]

--- a/Dalamud/Interface/Internal/Windows/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/DataWindow.cs
@@ -182,6 +182,7 @@ internal class DataWindow : Window
         Aetherytes,
         Dtr_Bar,
         UIColor,
+        DataShare,
     }
 
     /// <inheritdoc/>
@@ -377,6 +378,9 @@ internal class DataWindow : Window
 
                     case DataKind.UIColor:
                         this.DrawUIColor();
+                        break;
+                    case DataKind.DataShare:
+                        this.DrawDataShareTab();
                         break;
                 }
             }
@@ -1762,6 +1766,35 @@ internal class DataWindow : Window
             {
                 entry = dtrBar.Get(title, title);
             }
+        }
+    }
+
+    private void DrawDataShareTab()
+    {
+        if (!ImGui.BeginTable("###DataShareTable", 4, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg))
+            return;
+
+        try
+        {
+            ImGui.TableSetupColumn("Shared Tag");
+            ImGui.TableSetupColumn("Creator Assembly");
+            ImGui.TableSetupColumn("#", ImGuiTableColumnFlags.WidthFixed, 30 * ImGuiHelpers.GlobalScale);
+            ImGui.TableSetupColumn("Consumers");
+            ImGui.TableHeadersRow();
+            foreach (var share in Service<DataShare>.Get().GetAllShares())
+            {
+                ImGui.TableNextColumn();
+                ImGui.TextUnformatted(share.Tag);
+                ImGui.TableNextColumn();
+                ImGui.TextUnformatted(share.CreatorAssembly);
+                ImGui.TableNextColumn();
+                ImGui.TextUnformatted(share.Users.Length.ToString());
+                ImGui.TableNextColumn();
+                ImGui.TextUnformatted(string.Join(", ", share.Users));
+            }
+        } finally
+        {
+            ImGui.EndTable();
         }
     }
 

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/GameConfigAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/GameConfigAgingStep.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game;
+﻿using Dalamud.Game.Config;
 using ImGuiNET;
 
 namespace Dalamud.Interface.Internal.Windows.SelfTest.AgingSteps;

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/GameConfigAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/GameConfigAgingStep.cs
@@ -1,0 +1,107 @@
+﻿using Dalamud.Game;
+using ImGuiNET;
+
+namespace Dalamud.Interface.Internal.Windows.SelfTest.AgingSteps;
+
+/// <summary>
+/// Test of GameConfig.
+/// </summary>
+internal class GameConfigAgingStep : IAgingStep
+{
+    private bool started;
+    private bool isStartedLegacy;
+    private bool isSwitchedLegacy;
+    private bool isSwitchedStandard;
+
+    /// <inheritdoc/>
+    public string Name => "Test GameConfig";
+
+    /// <inheritdoc/>
+    public SelfTestStepResult RunStep()
+    {
+        var gameConfig = Service<GameConfig>.Get();
+
+        if (!gameConfig.UiControl.TryGetBool("MoveMode", out var isLegacy))
+        {
+            return SelfTestStepResult.Fail;
+        }
+
+        if (!this.started)
+        {
+            this.started = true;
+            this.isStartedLegacy = isLegacy;
+            return SelfTestStepResult.Waiting;
+        }
+
+        if (this.isStartedLegacy)
+        {
+            if (!this.isSwitchedStandard)
+            {
+                if (!isLegacy)
+                {
+                    this.isSwitchedStandard = true;
+                }
+                else
+                {
+                    ImGui.Text("Switch Movement Type to Standard");
+                }
+
+                return SelfTestStepResult.Waiting;
+            }
+
+            if (!this.isSwitchedLegacy)
+            {
+                if (isLegacy)
+                {
+                    this.isSwitchedLegacy = true;
+                }
+                else
+                {
+                    ImGui.Text("Switch Movement Type to Legacy");
+                }
+
+                return SelfTestStepResult.Waiting;
+            }
+        }
+        else
+        {
+             if (!this.isSwitchedLegacy)
+             {
+                 if (isLegacy)
+                 {
+                     this.isSwitchedLegacy = true;
+                 }
+                 else
+                 {
+                     ImGui.Text("Switch Movement Type to Legacy");
+                 }
+
+                 return SelfTestStepResult.Waiting;
+             }
+
+             if (!this.isSwitchedStandard)
+             {
+                 if (!isLegacy)
+                 {
+                     this.isSwitchedStandard = true;
+                 }
+                 else
+                 {
+                     ImGui.Text("Switch Movement Type to Standard");
+                 }
+
+                 return SelfTestStepResult.Waiting;
+             }
+        }
+
+        return SelfTestStepResult.Pass;
+    }
+
+    /// <inheritdoc/>
+    public void CleanUp()
+    {
+        this.isSwitchedLegacy = false;
+        this.isSwitchedStandard = false;
+        this.started = false;
+    }
+}

--- a/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
@@ -42,6 +42,7 @@ internal class SelfTestWindow : Window
             new PartyFinderAgingStep(),
             new HandledExceptionAgingStep(),
             new DutyStateAgingStep(),
+            new GameConfigAgingStep(),
             new LogoutEventAgingStep(),
         };
 

--- a/Dalamud/NativeFunctions.cs
+++ b/Dalamud/NativeFunctions.cs
@@ -1394,6 +1394,40 @@ internal static partial class NativeFunctions
     }
 
     /// <summary>
+    /// HEAP_* from heapapi
+    /// </summary>
+    [Flags]
+    public enum HeapOptions
+    {
+        /// <summary>
+        /// Serialized access is not used when the heap functions access this heap. This option applies to all
+        /// subsequent heap function calls. Alternatively, you can specify this option on individual heap function
+        /// calls. The low-fragmentation heap (LFH) cannot be enabled for a heap created with this option. A heap
+        /// created with this option cannot be locked.
+        /// </summary>
+        NoSerialize = 0x00000001,
+        
+        /// <summary>
+        /// The system raises an exception to indicate failure (for example, an out-of-memory condition) for calls to
+        /// HeapAlloc and HeapReAlloc instead of returning NULL.
+        /// </summary>
+        GenerateExceptions = 0x00000004,
+        
+        /// <summary>
+        /// The allocated memory will be initialized to zero. Otherwise, the memory is not initialized to zero.
+        /// </summary>
+        ZeroMemory = 0x00000008,
+    
+        /// <summary>
+        /// All memory blocks that are allocated from this heap allow code execution, if the hardware enforces data
+        /// execution prevention. Use this flag heap in applications that run code from the heap. If
+        /// HEAP_CREATE_ENABLE_EXECUTE is not specified and an application attempts to run code from a protected page,
+        /// the application receives an exception with the status code STATUS_ACCESS_VIOLATION.
+        /// </summary>
+        CreateEnableExecute = 0x00040000,
+    }
+
+    /// <summary>
     /// See https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-setevent
     /// Sets the specified event object to the signaled state.
     /// </summary>
@@ -1630,6 +1664,77 @@ internal static partial class NativeFunctions
     [DllImport("kernel32.dll")]
     public static extern IntPtr SetUnhandledExceptionFilter(IntPtr lpTopLevelExceptionFilter);
 
+    /// <summary>
+    /// HeapCreate - Creates a private heap object that can be used by the calling process.
+    /// The function reserves space in the virtual address space of the process and allocates
+    /// physical storage for a specified initial portion of this block.
+    /// Ref: https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapcreate
+    /// </summary>
+    /// <param name="flOptions">
+    /// The heap allocation options.
+    /// These options affect subsequent access to the new heap through calls to the heap functions.
+    /// </param>
+    /// <param name="dwInitialSize">
+    /// The initial size of the heap, in bytes.
+    ///
+    /// This value determines the initial amount of memory that is committed for the heap.
+    /// The value is rounded up to a multiple of the system page size. The value must be smaller than dwMaximumSize.
+    /// 
+    /// If this parameter is 0, the function commits one page. To determine the size of a page on the host computer,
+    /// use the GetSystemInfo function.
+    /// </param>
+    /// <param name="dwMaximumSize">
+    /// The maximum size of the heap, in bytes. The HeapCreate function rounds dwMaximumSize up to a multiple of the
+    /// system page size and then reserves a block of that size in the process's virtual address space for the heap.
+    /// If allocation requests made by the HeapAlloc or HeapReAlloc functions exceed the size specified by
+    /// dwInitialSize, the system commits additional pages of memory for the heap, up to the heap's maximum size.
+    /// 
+    /// If dwMaximumSize is not zero, the heap size is fixed and cannot grow beyond the maximum size. Also, the largest
+    /// memory block that can be allocated from the heap is slightly less than 512 KB for a 32-bit process and slightly
+    /// less than 1,024 KB for a 64-bit process. Requests to allocate larger blocks fail, even if the maximum size of
+    /// the heap is large enough to contain the block.
+    /// 
+    /// If dwMaximumSize is 0, the heap can grow in size. The heap's size is limited only by the available memory.
+    /// Requests to allocate memory blocks larger than the limit for a fixed-size heap do not automatically fail;
+    /// instead, the system calls the VirtualAlloc function to obtain the memory that is needed for large blocks.
+    /// Applications that need to allocate large memory blocks should set dwMaximumSize to 0.
+    /// </param>
+    /// <returns>
+    /// If the function succeeds, the return value is a handle to the newly created heap.
+    /// 
+    /// If the function fails, the return value is NULL. To get extended error information, call GetLastError.
+    /// </returns>
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern nint HeapCreate(HeapOptions flOptions, nuint dwInitialSize, nuint dwMaximumSize);
+    
+    /// <summary>
+    /// Allocates a block of memory from a heap. The allocated memory is not movable.
+    /// </summary>
+    /// <param name="hHeap">
+    /// A handle to the heap from which the memory will be allocated. This handle is returned by the HeapCreate or
+    /// GetProcessHeap function.
+    /// </param>
+    /// <param name="dwFlags">
+    /// The heap allocation options. Specifying any of these values will override the corresponding value specified when
+    /// the heap was created with HeapCreate. </param>
+    /// <param name="dwBytes">
+    /// The number of bytes to be allocated.
+    ///
+    /// If the heap specified by the hHeap parameter is a "non-growable" heap, dwBytes must be less than 0x7FFF8.
+    /// You create a non-growable heap by calling the HeapCreate function with a nonzero value.
+    /// </param>
+    /// <returns>
+    /// If the function succeeds, the return value is a pointer to the allocated memory block.
+    ///
+    /// If the function fails and you have not specified HEAP_GENERATE_EXCEPTIONS, the return value is NULL.
+    ///
+    /// If the function fails and you have specified HEAP_GENERATE_EXCEPTIONS, the function may generate either of the
+    /// exceptions listed in the following table. The particular exception depends upon the nature of the heap
+    /// corruption. For more information, see GetExceptionCode.
+    /// </returns>
+    [DllImport("kernel32.dll", SetLastError=false)]
+    public static extern nint HeapAlloc(nint hHeap, HeapOptions dwFlags, nuint dwBytes);
+    
     /// <summary>
     /// See https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualalloc.
     /// Reserves, commits, or changes the state of a region of pages in the virtual address space of the calling process.


### PR DESCRIPTION
This PR implements a new `GameConfig` service which will allow plugins to easily read and write config values from the game. 