### PR TITLE
FunctionPointerVariableHook: use VirtualAlloc instead of HeapAlloc

### DIFF
--- a/Dalamud/Hooking/Internal/HookManager.cs
+++ b/Dalamud/Hooking/Internal/HookManager.cs
@@ -16,13 +16,6 @@ namespace Dalamud.Hooking.Internal;
 [ServiceManager.EarlyLoadedService]
 internal class HookManager : IDisposable, IServiceType
 {
-    /// <summary>
-    /// Handle to an executable heap that we shall never free anything unless we can be absolutely sure that nothing is
-    /// referencing to it anymore.
-    /// </summary>
-    internal static readonly nint NoFreeExecutableHeap =
-        NativeFunctions.HeapCreate(NativeFunctions.HeapOptions.CreateEnableExecute, 0, 0);
-
     private static readonly ModuleLog Log = new("HM");
 
     [ServiceManager.ServiceConstructor]


### PR DESCRIPTION
This fixes hooking CreateFile on WINE leading to crash, at least. Not sure about the crashes happening on Windows.