### PR TITLE
Add prevent_icmphandle_crashes xivfix

### DIFF
--- a/Dalamud.Boot/xivfixes.h
+++ b/Dalamud.Boot/xivfixes.h
@@ -7,6 +7,7 @@ namespace xivfixes {
     void redirect_openprocess(bool bApply);
     void backup_userdata_save(bool bApply);
     void clr_failfast_hijack(bool bApply);
+    void prevent_icmphandle_crashes(bool bApply);
 
     void apply_all(bool bApply);
 }

--- a/Dalamud.Injector/EntryPoint.cs
+++ b/Dalamud.Injector/EntryPoint.cs
@@ -325,7 +325,7 @@ namespace Dalamud.Injector
             startInfo.BootShowConsole = args.Contains("--console");
             startInfo.BootEnableEtw = args.Contains("--etw");
             startInfo.BootLogPath = GetLogPath("dalamud.boot", startInfo.LogName);
-            startInfo.BootEnabledGameFixes = new List<string> { "prevent_devicechange_crashes", "disable_game_openprocess_access_check", "redirect_openprocess", "backup_userdata_save", "clr_failfast_hijack" };
+            startInfo.BootEnabledGameFixes = new List<string> { "prevent_devicechange_crashes", "disable_game_openprocess_access_check", "redirect_openprocess", "backup_userdata_save", "clr_failfast_hijack", "prevent_icmphandle_crashes" };
             startInfo.BootDotnetOpenProcessHookMode = 0;
             startInfo.BootWaitMessageBox |= args.Contains("--msgbox1") ? 1 : 0;
             startInfo.BootWaitMessageBox |= args.Contains("--msgbox2") ? 2 : 0;


### PR DESCRIPTION
This fixes IPHLPAPI crashes in wine when connecting to the DC.

The game itself only checks against `NULL` and not `INVALID_HANDLE_VALUE` (as recommended by MSDN), which this fix fixes.
Windows already behaves exactly the same in this case (no segfault and returning `FALSE` in case of an `INVALID_HANDLE_VALUE` argument), so this has no functional impact there.