### PR TITLE
Adding the option to not display Dalamud's welcome message on signin

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -153,6 +153,11 @@ internal sealed class DalamudConfiguration : IServiceType
     public bool ToggleUiHideDuringGpose { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether or not a message containing Dalamud's current version and the number of loaded plugins should be sent at login.
+    /// </summary>
+    public bool PrintDalamudWelcomeMsg { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets a value indicating whether or not a message containing detailed plugin information should be sent at login.
     /// </summary>
     public bool PrintPluginsWelcomeMsg { get; set; } = true;

--- a/Dalamud/Game/ChatHandlers.cs
+++ b/Dalamud/Game/ChatHandlers.cs
@@ -243,8 +243,10 @@ public class ChatHandlers : IServiceType
 
         var assemblyVersion = Assembly.GetAssembly(typeof(ChatHandlers)).GetName().Version.ToString();
 
-        chatGui.Print(string.Format(Loc.Localize("DalamudWelcome", "Dalamud vD{0} loaded."), assemblyVersion)
-                      + string.Format(Loc.Localize("PluginsWelcome", " {0} plugin(s) loaded."), pluginManager.InstalledPlugins.Count(x => x.IsLoaded)));
+        if (this.configuration.PrintDalamudWelcomeMsg) {
+            chatGui.Print(string.Format(Loc.Localize("DalamudWelcome", "Dalamud vD{0} loaded."), assemblyVersion)
+                          + string.Format(Loc.Localize("PluginsWelcome", " {0} plugin(s) loaded."), pluginManager.InstalledPlugins.Count(x => x.IsLoaded)));
+        }
 
         if (this.configuration.PrintPluginsWelcomeMsg)
         {

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabGeneral.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabGeneral.cs
@@ -51,6 +51,12 @@ public class SettingsTabGeneral : SettingsTab
             (v, c) => c.DutyFinderChatMessage = v),
 
         new SettingsEntry<bool>(
+            Loc.Localize("DalamudSettingsPrintDalamudWelcomeMsg", "Display Dalamud's welcome message"),
+            Loc.Localize("DalamudSettingsPrintDalamudWelcomeMsgHint", "Display Dalamud's welcome message in FFXIV chat when logging in with a character."),
+            c => c.PrintDalamudWelcomeMsg,
+            (v, c) => c.PrintDalamudWelcomeMsg = v),
+
+        new SettingsEntry<bool>(
             Loc.Localize("DalamudSettingsPrintPluginsWelcomeMsg", "Display loaded plugins in the welcome message"),
             Loc.Localize("DalamudSettingsPrintPluginsWelcomeMsgHint", "Display loaded plugins in FFXIV chat when logging in with a character."),
             c => c.PrintPluginsWelcomeMsg,


### PR DESCRIPTION
It has been brought to my attention that a few people seem to want the option to be able to remove that welcome message from popping up in their chat every time they sign in, the default is set to true as to not change any of the current behaviors that would be expected