### PR TITLE
[Fools23] Fix NPE on YesHealMe when reading characters in a CW Party

### DIFF
--- a/Dalamud/Fools/Plugins/YesHealMePluginWindow.cs
+++ b/Dalamud/Fools/Plugins/YesHealMePluginWindow.cs
@@ -19,14 +19,15 @@ public static class YesHealMePluginWindow
     private static readonly Vector2 Position = new(200, 200);
     private static readonly Vector2 Size = new(Length, SectionHeight);
 
-    private static IEnumerable<PlayerCharacter> Characters(PartyListAddon partyListAddon)
+    private static IEnumerable<PlayerCharacter?> Characters(PartyListAddon partyListAddon)
     {
             return partyListAddon.Any() ? partyListAddon.Select(pla => pla.PlayerCharacter) : new[] { Service<ClientState>.Get().LocalPlayer };
     }
 
-    private static List<PlayerCharacter> HurtingCharacters(IEnumerable<PlayerCharacter> characters)
+    private static List<PlayerCharacter> HurtingCharacters(IEnumerable<PlayerCharacter?> characters)
     {
         return characters
+               .Where(pc => pc is not null)
                .Where(pc => pc.CurrentHp < pc.MaxHp ||
                             Service<DalamudInterface>.Get()
                                                      .IsDevMenuOpen)


### PR DESCRIPTION
The pre-PR version doesn't crash the game or anything (just spams the log and shows nothing).