### PR TITLE
Add Happy Eyeballs Support

### DIFF
--- a/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
+++ b/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 using Dalamud.Game.Network.Internal.MarketBoardUploaders.Universalis.Types;
 using Dalamud.Game.Network.Structures;
-using Dalamud.Utility;
+using Dalamud.Networking.Http;
 using Newtonsoft.Json;
 using Serilog;
 
@@ -21,6 +21,8 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
     // private const string ApiBase = "https://127.0.0.1:443";
 
     private const string ApiKey = "GGD6RdSfGyRiHM5WDnAo0Nj9Nv7aC5NDhMj3BebT";
+
+    private readonly HttpClient httpClient = Service<HappyHttpClient>.Get().SharedHttpClient;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UniversalisMarketBoardUploader"/> class.
@@ -97,7 +99,7 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
         var uploadPath = "/upload";
         var uploadData = JsonConvert.SerializeObject(uploadObject);
         Log.Verbose("{ListingPath}: {ListingUpload}", uploadPath, uploadData);
-        await Util.HttpClient.PostAsync($"{ApiBase}{uploadPath}/{ApiKey}", new StringContent(uploadData, Encoding.UTF8, "application/json"));
+        await this.httpClient.PostAsync($"{ApiBase}{uploadPath}/{ApiKey}", new StringContent(uploadData, Encoding.UTF8, "application/json"));
 
         // ====================================================================================
 
@@ -133,7 +135,7 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
         var taxUpload = JsonConvert.SerializeObject(taxUploadObject);
         Log.Verbose("{TaxPath}: {TaxUpload}", taxPath, taxUpload);
 
-        await Util.HttpClient.PostAsync($"{ApiBase}{taxPath}/{ApiKey}", new StringContent(taxUpload, Encoding.UTF8, "application/json"));
+        await this.httpClient.PostAsync($"{ApiBase}{taxPath}/{ApiKey}", new StringContent(taxUpload, Encoding.UTF8, "application/json"));
 
         // ====================================================================================
 
@@ -175,7 +177,7 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
         message.Headers.Add("Authorization", ApiKey);
         message.Content = content;
 
-        await Util.HttpClient.SendAsync(message);
+        await this.httpClient.SendAsync(message);
 
         // ====================================================================================
 

--- a/Dalamud/Interface/Internal/Windows/BranchSwitcherWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/BranchSwitcherWindow.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
 
 using Dalamud.Configuration.Internal;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Windowing;
+using Dalamud.Networking.Http;
 using ImGuiNET;
 using Newtonsoft.Json;
 
@@ -40,7 +40,7 @@ public class BranchSwitcherWindow : Window
     {
         Task.Run(async () =>
         {
-            using var client = new HttpClient();
+            var client = Service<HappyHttpClient>.Get().SharedHttpClient;
             this.branches = await client.GetFromJsonAsync<Dictionary<string, VersionEntry>>(BranchInfoUrl);
             Debug.Assert(this.branches != null, "this.branches != null");
 

--- a/Dalamud/Interface/Internal/Windows/PluginImageCache.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginImageCache.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Dalamud.Game;
+using Dalamud.Networking.Http;
 using Dalamud.Plugin.Internal;
 using Dalamud.Plugin.Internal.Types;
 using Dalamud.Utility;
@@ -47,6 +48,9 @@ internal class PluginImageCache : IDisposable, IServiceType
 
     [ServiceManager.ServiceDependency]
     private readonly InterfaceManager.InterfaceManagerWithScene imWithScene = Service<InterfaceManager.InterfaceManagerWithScene>.Get();
+
+    [ServiceManager.ServiceDependency]
+    private readonly HappyHttpClient happyHttpClient = Service<HappyHttpClient>.Get();
 
     private readonly BlockingCollection<Tuple<ulong, Func<Task>>> downloadQueue = new();
     private readonly BlockingCollection<Func<Task>> loadQueue = new();
@@ -535,7 +539,7 @@ internal class PluginImageCache : IDisposable, IServiceType
         var bytes = await this.RunInDownloadQueue<byte[]?>(
                         async () =>
                         {
-                            var data = await Util.HttpClient.GetAsync(url);
+                            var data = await this.happyHttpClient.SharedHttpClient.GetAsync(url);
                             if (data.StatusCode == HttpStatusCode.NotFound)
                                 return null;
 
@@ -627,7 +631,9 @@ internal class PluginImageCache : IDisposable, IServiceType
                 var bytes = await this.RunInDownloadQueue<byte[]?>(
                                 async () =>
                                 {
-                                    var data = await Util.HttpClient.GetAsync(url);
+                                    var httpClient = Service<HappyHttpClient>.Get().SharedHttpClient;
+
+                                    var data = await httpClient.GetAsync(url);
                                     if (data.StatusCode == HttpStatusCode.NotFound)
                                         return null;
 

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/DalamudChangelogManager.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/DalamudChangelogManager.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Net.Http.Json;
-using System.Threading;
 using System.Threading.Tasks;
-
+using Dalamud.Networking.Http;
 using Dalamud.Plugin.Internal;
 using Dalamud.Utility;
-using Serilog;
 
 namespace Dalamud.Interface.Internal.Windows.PluginInstaller;
 
@@ -42,7 +39,7 @@ internal class DalamudChangelogManager
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public async Task ReloadChangelogAsync()
     {
-        using var client = new HttpClient();
+        var client = Service<HappyHttpClient>.Get().SharedHttpClient;
         this.Changelogs = null;
 
         var dalamudChangelogs = await client.GetFromJsonAsync<List<DalamudChangelog>>(DalamudChangelogUrl);

--- a/Dalamud/Networking/Http/HappyEyeballsCallback.cs
+++ b/Dalamud/Networking/Http/HappyEyeballsCallback.cs
@@ -87,6 +87,12 @@ public class HappyEyeballsCallback : IDisposable
             return this.forcedAddressFamily.Value;
         }
 
+        // Force IPv4 if IPv6 support isn't detected to avoid the resolution delay.
+        if (!Socket.OSSupportsIPv6)
+        {
+            return AddressFamily.InterNetwork;
+        }
+
         if (this.addressFamilyCache.TryGetValue(context.DnsEndPoint, out var cachedValue))
         {
             // TODO: Find some way to delete this after a while.

--- a/Dalamud/Networking/Http/HappyEyeballsCallback.cs
+++ b/Dalamud/Networking/Http/HappyEyeballsCallback.cs
@@ -17,7 +17,7 @@ namespace Dalamud.Networking.Http;
 ///
 /// Each instance of this class tracks its own state.
 /// </summary>
-public class HappyEyeballsCallback
+public class HappyEyeballsCallback : IDisposable
 {
     private readonly Dictionary<DnsEndPoint, AddressFamily> addressFamilyCache = new();
 
@@ -25,7 +25,7 @@ public class HappyEyeballsCallback
     private readonly int ipv4WaitMillis;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="HappyHttpSocketsCallback"/> class.
+    /// Initializes a new instance of the <see cref="HappyEyeballsCallback"/> class.
     /// </summary>
     /// <param name="forcedAddressFamily">Optional override to force a specific AddressFamily.</param>
     /// <param name="ipv4WaitMillis">Time to wait before initiating the IPv4 request.</param>
@@ -33,6 +33,14 @@ public class HappyEyeballsCallback
     {
         this.forcedAddressFamily = forcedAddressFamily;
         this.ipv4WaitMillis = ipv4WaitMillis;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        this.addressFamilyCache.Clear();
+
+        GC.SuppressFinalize(this);
     }
 
     /// <summary>

--- a/Dalamud/Networking/Http/HappyEyeballsCallback.cs
+++ b/Dalamud/Networking/Http/HappyEyeballsCallback.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dalamud.Networking.Http;
+
+// Inspired by and adapted from https://github.com/jellyfin/jellyfin/pull/8598
+
+/// <summary>
+/// A class to provide a <see cref="SocketsHttpHandler.ConnectCallback"/> method (and tracked state) to implement a
+/// variant of the Happy Eyeballs algorithm for HTTP connections to dual-stack servers.
+///
+/// Each instance of this class tracks its own state.
+/// </summary>
+public class HappyEyeballsCallback
+{
+    private readonly Dictionary<DnsEndPoint, AddressFamily> addressFamilyCache = new();
+
+    private readonly AddressFamily? forcedAddressFamily;
+    private readonly int ipv4WaitMillis;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HappyHttpSocketsCallback"/> class.
+    /// </summary>
+    /// <param name="forcedAddressFamily">Optional override to force a specific AddressFamily.</param>
+    /// <param name="ipv4WaitMillis">Time to wait before initiating the IPv4 request.</param>
+    public HappyEyeballsCallback(AddressFamily? forcedAddressFamily = null, int ipv4WaitMillis = 100)
+    {
+        this.forcedAddressFamily = forcedAddressFamily;
+        this.ipv4WaitMillis = ipv4WaitMillis;
+    }
+
+    /// <summary>
+    /// The connection callback to provide to a <see cref="SocketsHttpHandler"/>.
+    /// </summary>
+    /// <param name="context">The context for an HTTP connection.</param>
+    /// <param name="token">The cancellation token to abort this request.</param>
+    /// <returns>Returns a Stream for consumption by HttpClient.</returns>
+    public async ValueTask<Stream> ConnectCallback(SocketsHttpConnectionContext context, CancellationToken token)
+    {
+        var addressFamilyOverride = this.GetAddressFamilyOverride(context);
+
+        if (addressFamilyOverride.HasValue)
+        {
+            return this.AttemptConnection(addressFamilyOverride.Value, context, token).GetAwaiter().GetResult();
+        }
+
+        using var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(token);
+        var tryV6 = this.AttemptConnection(AddressFamily.InterNetworkV6, context, linkedToken.Token);
+        var tryV4 = this.AttemptConnection(AddressFamily.InterNetwork, context, linkedToken.Token, this.ipv4WaitMillis);
+
+        var victor = await Task.WhenAny(tryV6, tryV4).ConfigureAwait(false);
+        if (victor.IsCompletedSuccessfully)
+        {
+            var victorStream = victor.GetAwaiter().GetResult();
+
+            this.addressFamilyCache[context.DnsEndPoint] = victorStream.Socket.AddressFamily;
+
+            return victorStream;
+        }
+
+        // The loser can still fail, but we'll wait for it.
+        // If it succeeds, cache the result. If not, just throw the exception up the chain.
+        var loser = victor == tryV6 ? tryV4 : tryV6;
+        var loserStream = loser.GetAwaiter().GetResult();
+
+        this.addressFamilyCache[context.DnsEndPoint] = loserStream.Socket.AddressFamily;
+
+        return loserStream;
+    }
+
+    private AddressFamily? GetAddressFamilyOverride(SocketsHttpConnectionContext context)
+    {
+        if (this.forcedAddressFamily.HasValue)
+        {
+            return this.forcedAddressFamily.Value;
+        }
+
+        if (this.addressFamilyCache.TryGetValue(context.DnsEndPoint, out var cachedValue))
+        {
+            // TODO: Find some way to delete this after a while. It shouldn't stick around _forever_.
+            return cachedValue;
+        }
+
+        return null;
+    }
+
+    private async Task<NetworkStream> AttemptConnection(
+        AddressFamily family, SocketsHttpConnectionContext context, CancellationToken token, int delayMillis = 0)
+    {
+        if (delayMillis > 0)
+        {
+            await Task.Delay(delayMillis, token);
+            token.ThrowIfCancellationRequested();
+        }
+
+        var socket = new Socket(family, SocketType.Stream, ProtocolType.Tcp)
+        {
+            NoDelay = true,
+        };
+
+        try
+        {
+            await socket.ConnectAsync(context.DnsEndPoint, token).ConfigureAwait(false);
+            return new NetworkStream(socket, ownsSocket: true);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    }
+}

--- a/Dalamud/Networking/Http/HappyHttpClient.cs
+++ b/Dalamud/Networking/Http/HappyHttpClient.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using Dalamud.IoC;
+
+namespace Dalamud.Networking.Http;
+
+/// <summary>
+/// A service to help build and manage HttpClients with some semblance of Happy Eyeballs (RFC 8305 - IPv4 fallback)
+/// awareness.
+/// </summary>
+[PluginInterface]
+[ServiceManager.BlockingEarlyLoadedService]
+public class HappyHttpClient : IDisposable, IServiceType
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HappyHttpClient"/> class.
+    ///
+    /// A service to talk to the Smileton Loporrits to build an HTTP Client aware of Happy Eyeballs.
+    /// </summary>
+    [ServiceManager.ServiceConstructor]
+    private HappyHttpClient()
+    {
+        this.SharedSocketsHandler = new SocketsHttpHandler
+        {
+            AutomaticDecompression = DecompressionMethods.All,
+            ConnectCallback = new HappyEyeballsCallback().ConnectCallback,
+        };
+
+        this.SharedHttpClient = new HttpClient(this.SharedSocketsHandler, false);
+    }
+
+    /// <summary>
+    /// Gets a <see cref="HttpClient"/> meant to be shared across all (standard) requests made by the application,
+    /// where custom configurations are not required.
+    ///
+    /// May or may not have been properly tested by the Loporrits.
+    /// </summary>
+    public HttpClient SharedHttpClient { get; }
+
+    /// <summary>
+    /// Gets a <see cref="SocketsHttpHandler"/> meant to be shared across any custom <see cref="HttpClient"/>s that
+    /// need to be made in other parts of the application.
+    ///
+    /// This handler comes pre-loaded with a common <see cref="HappyEyeballsCallback"/> for your convenience.
+    /// </summary>
+    public SocketsHttpHandler SharedSocketsHandler { get; }
+
+    /// <inheritdoc/>
+    void IDisposable.Dispose()
+    {
+        this.SharedHttpClient.Dispose();
+        this.SharedSocketsHandler.Dispose();
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -22,6 +22,7 @@ using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Interface.Internal;
 using Dalamud.IoC.Internal;
 using Dalamud.Logging.Internal;
+using Dalamud.Networking.Http;
 using Dalamud.Plugin.Internal.Exceptions;
 using Dalamud.Plugin.Internal.Types;
 using Dalamud.Utility;
@@ -76,6 +77,9 @@ Thanks and have fun!";
 
     [ServiceManager.ServiceDependency]
     private readonly DalamudStartInfo startInfo = Service<DalamudStartInfo>.Get();
+
+    [ServiceManager.ServiceDependency]
+    private readonly HappyHttpClient happyHttpClient = Service<HappyHttpClient>.Get();
 
     [ServiceManager.ServiceConstructor]
     private PluginManager()
@@ -732,7 +736,7 @@ Thanks and have fun!";
         var downloadUrl = useTesting ? repoManifest.DownloadLinkTesting : repoManifest.DownloadLinkInstall;
         var version = useTesting ? repoManifest.TestingAssemblyVersion : repoManifest.AssemblyVersion;
 
-        var response = await Util.HttpClient.GetAsync(downloadUrl);
+        var response = await this.happyHttpClient.SharedHttpClient.GetAsync(downloadUrl);
         response.EnsureSuccessStatusCode();
 
         var outputDir = new DirectoryInfo(Path.Combine(this.pluginDirectory.FullName, repoManifest.InternalName, version?.ToString() ?? string.Empty));

--- a/Dalamud/Plugin/Internal/Types/PluginRepository.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -25,7 +26,11 @@ internal class PluginRepository
 
     private static readonly ModuleLog Log = new("PLUGINR");
 
-    private static readonly HttpClient HttpClient = new(Service<HappyHttpClient>.Get().SharedSocketsHandler)
+    private static readonly HttpClient HttpClient = new(new SocketsHttpHandler
+    {
+        AutomaticDecompression = DecompressionMethods.All,
+        ConnectCallback = Service<HappyHttpClient>.Get().SharedHappyEyeballsCallback.ConnectCallback,
+    })
     {
         Timeout = TimeSpan.FromSeconds(20),
         DefaultRequestHeaders =

--- a/Dalamud/Plugin/Internal/Types/PluginRepository.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginRepository.cs
@@ -8,6 +8,7 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
 using Dalamud.Logging.Internal;
+using Dalamud.Networking.Http;
 using Newtonsoft.Json;
 
 namespace Dalamud.Plugin.Internal.Types;
@@ -24,7 +25,7 @@ internal class PluginRepository
 
     private static readonly ModuleLog Log = new("PLUGINR");
 
-    private static readonly HttpClient HttpClient = new()
+    private static readonly HttpClient HttpClient = new(Service<HappyHttpClient>.Get().SharedSocketsHandler)
     {
         Timeout = TimeSpan.FromSeconds(20),
         DefaultRequestHeaders =

--- a/Dalamud/Support/BugBait.cs
+++ b/Dalamud/Support/BugBait.cs
@@ -1,7 +1,7 @@
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-
+using Dalamud.Networking.Http;
 using Dalamud.Plugin.Internal.Types;
 using Dalamud.Utility;
 using Newtonsoft.Json;
@@ -42,9 +42,11 @@ internal static class BugBait
         {
             model.Exception = Troubleshooting.LastException == null ? "Was included, but none happened" : Troubleshooting.LastException?.ToString();
         }
+        
+        var httpClient = Service<HappyHttpClient>.Get().SharedHttpClient;
 
         var postContent = new StringContent(JsonConvert.SerializeObject(model), Encoding.UTF8, "application/json");
-        var response = await Util.HttpClient.PostAsync(BugBaitUrl, postContent);
+        var response = await httpClient.PostAsync(BugBaitUrl, postContent);
 
         response.EnsureSuccessStatusCode();
     }

--- a/Dalamud/Utility/AsyncUtils.cs
+++ b/Dalamud/Utility/AsyncUtils.cs
@@ -20,14 +20,12 @@ public static class AsyncUtils
     /// <typeparam name="T">The return type of all raced tasks.</typeparam>
     /// <exception cref="AggregateException">Thrown when all tasks given to this method fail.</exception>
     /// <returns>Returns the first task that completes, according to <see cref="Task{TResult}.IsCompletedSuccessfully"/>.</returns>
-    public static Task<T> FirstSuccessfulTask<T>(IEnumerable<Task<T>> tasks)
+    public static Task<T> FirstSuccessfulTask<T>(ICollection<Task<T>> tasks)
     {
-        var taskList = tasks.ToList();
-
         var tcs = new TaskCompletionSource<T>();
-        var remainingTasks = taskList.Count;
+        var remainingTasks = tasks.Count;
 
-        foreach (var task in taskList)
+        foreach (var task in tasks)
         {
             task.ContinueWith(t =>
             {
@@ -37,7 +35,7 @@ public static class AsyncUtils
                 }
                 else if (Interlocked.Decrement(ref remainingTasks) == 0)
                 {
-                    tcs.SetException(new AggregateException(taskList.SelectMany(f => f.Exception?.InnerExceptions)));
+                    tcs.SetException(new AggregateException(tasks.SelectMany(f => f.Exception?.InnerExceptions)));
                 }
             });
         }

--- a/Dalamud/Utility/AsyncUtils.cs
+++ b/Dalamud/Utility/AsyncUtils.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dalamud.Utility;
+
+/// <summary>
+/// A set of utilities around and for better asynchronous behavior.
+/// </summary>
+public static class AsyncUtils
+{
+    /// <summary>
+    /// Race a set of tasks, returning either the first to succeed or an aggregate of all exceptions. This helper does
+    /// not perform any automatic cancellation of losing tasks.
+    /// </summary>
+    /// <remarks>Derived from <a href="https://stackoverflow.com/a/37529395">this StackOverflow post</a>.</remarks>
+    /// <param name="tasks">A list of tasks to race.</param>
+    /// <typeparam name="T">The return type of all raced tasks.</typeparam>
+    /// <exception cref="AggregateException">Thrown when all tasks given to this method fail.</exception>
+    /// <returns>Returns the first task that completes, according to <see cref="Task{TResult}.IsCompletedSuccessfully"/>.</returns>
+    public static Task<T> FirstSuccessfulTask<T>(IEnumerable<Task<T>> tasks)
+    {
+        var taskList = tasks.ToList();
+
+        var tcs = new TaskCompletionSource<T>();
+        var remainingTasks = taskList.Count;
+
+        foreach (var task in taskList)
+        {
+            task.ContinueWith(t =>
+            {
+                if (task.IsCompletedSuccessfully)
+                {
+                    tcs.TrySetResult(t.Result);
+                }
+                else if (Interlocked.Decrement(ref remainingTasks) == 0)
+                {
+                    tcs.SetException(new AggregateException(taskList.SelectMany(f => f.Exception?.InnerExceptions)));
+                }
+            });
+        }
+
+        return tcs.Task;
+    }
+}

--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -16,6 +16,7 @@ using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Logging.Internal;
+using Dalamud.Networking.Http;
 using ImGuiNET;
 using Microsoft.Win32;
 using Serilog;
@@ -38,7 +39,8 @@ public static class Util
     /// Gets an httpclient for usage.
     /// Do NOT await this.
     /// </summary>
-    public static HttpClient HttpClient { get; } = new();
+    [Obsolete($"Use Service<{nameof(HappyHttpClient)}> instead.")]
+    public static HttpClient HttpClient { get; } = Service<HappyHttpClient>.Get().SharedHttpClient;
 
     /// <summary>
     /// Gets the assembly version of Dalamud.


### PR DESCRIPTION
This pull request aims to solve a number of issues related to bad IPv6 compatibility, especially an inability to load Kamori when one's ISP hiccups. This is done by implementing a variant of the Happy Eyeballs algorithm, as described in [RFC 8305](https://www.rfc-editor.org/rfc/rfc8305). The specific implementation we're using here was derived from [a pull request to the `jellyfin` project](https://github.com/jellyfin/jellyfin/pull/8598), with some tweaks that hopefully would help our use case.

This pull request provides a new class meant for public consumption: `HappyEyeballsCallback`. This class provides a `ConnectCallback` method that can be assigned to a [`SocketsHttpHandler`](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.socketshttphandler?view=net-7.0) when creating an [`HttpClient`](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?view=net-7.0). `HappyEyeballsCallback` implements the following behavior:

1. If set, the `forcedAddressFamily` will be used and all evaluation will be skipped.
2. The callback will check for a cached `AddressFamily` for the DNS name being used. If it exists, the cached value is used and future steps will be skipped.
3. The callback will race an IPv4 and IPv6 connection attempt (with the IPv4 connection delayed by a configurable time period, defaulting to 100ms).
4. The first successful connection attempt to complete will return and be cached for that hostname for the rest of the session. If no connection succeeds, the error propagates up the chain.

When a connection is successfully established, the resulting `AddressFamily` is cached for that DNS hostname and all future connections for the life of the application will use that `AddressFamily`. 

The `HappyEyeballsCallback` class provides state in the form of the DNS/AddressFamily cache, which can (but does not have to be) shared between multiple `HttpClient`s if desired. Plugin developers should normally create and maintain their own callback with their own state.

This pull request also adds a new service, the `HappyHttpClient`, which is intended to be shared between all Dalamud subsystems that can use a common `HttpClient` and obsoletes `Util.HttpClient`. Further, all uses of `Util.HttpClient` and any new non-customized `HttpClient`s are replaced with references to the `HttpClient` provided by this service.

This pull request, if merged, fixes #1186.