### PR TITLE
Added BattleNpcSubKind WeakSpot (BattleNpcPart) to BattleNpcSubKind enum

### DIFF
--- a/Dalamud/Game/ClientState/Objects/Enums/BattleNpcSubKind.cs
+++ b/Dalamud/Game/ClientState/Objects/Enums/BattleNpcSubKind.cs
@@ -10,6 +10,12 @@ public enum BattleNpcSubKind : byte
     /// </summary>
     None = 0,
 
+    ///<summary>
+    /// Weak Spots / Battle NPC parts
+    /// Eg: Titan's Heart (Naval), Tioman's left and right wing (Sohm Al), Golem Soulstone (The Sunken Temple of Qarn)
+    /// </summary>
+    BattleNpcPart = 1,
+
     /// <summary>
     /// BattleNpc representing a Pet.
     /// </summary>


### PR DESCRIPTION
Added BattleNpcSubKind WeakSpot (BattleNpcPart) to the BattleNpcSubKind.cs Enum with a bit of documentation of what it is.