### PR TITLE
feat: load the FileDialog drive list asynchronously

### DIFF
--- a/Dalamud/Interface/ImGuiFileDialog/DriveListLoader.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/DriveListLoader.cs
@@ -8,7 +8,7 @@ namespace Dalamud.Interface.ImGuiFileDialog;
 /// <summary>
 /// A drive list loader. Thread-safety guaranteed.
 /// </summary>
-public class DriveListLoader
+internal class DriveListLoader
 {
     private bool initialized;
 

--- a/Dalamud/Interface/ImGuiFileDialog/DriveListLoader.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/DriveListLoader.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Dalamud.Interface.ImGuiFileDialog;
+
+/// <summary>
+/// A drive list loader. Thread-safety guaranteed.
+/// </summary>
+public class DriveListLoader
+{
+    private bool initialized;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DriveListLoader"/> class.
+    /// </summary>
+    public DriveListLoader()
+    {
+        this.Drives = ImmutableArray<DriveInfo>.Empty;
+    }
+
+    /// <summary>
+    /// Gets the drive list. This may be incomplete if the loader is still loading.
+    /// </summary>
+    public IReadOnlyList<DriveInfo> Drives { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether or not the loader is loading.
+    /// </summary>
+    public bool Loading { get; private set; }
+
+    /// <summary>
+    /// Loads the drive list, asynchronously.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public async Task LoadDrivesAsync()
+    {
+        this.Loading = true;
+        try
+        {
+            await this.InitDrives();
+        }
+        finally
+        {
+            this.Loading = false;
+        }
+    }
+
+    private async Task InitDrives()
+    {
+        var drives = ImmutableArray<DriveInfo>.Empty;
+        foreach (var drive in DriveInfo.GetDrives())
+        {
+            drives = drives.Add(drive);
+            if (!this.initialized)
+            {
+                // Show results as soon as they load initially, but otherwise keep
+                // the existing drive list
+                this.Drives = drives;
+            }
+
+            // Force async to avoid this being invoked synchronously unless it's awaited
+            await Task.Yield();
+        }
+
+        // Replace the whole drive list
+        this.Drives = drives;
+        this.initialized = true;
+    }
+}

--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.Files.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.Files.cs
@@ -12,11 +12,13 @@ public partial class FileDialog
 {
     private readonly object filesLock = new();
 
+    private readonly DriveListLoader driveListLoader = new();
+
     private List<FileStruct> files = new();
     private List<FileStruct> filteredFiles = new();
 
     private SortingField currentSortingField = SortingField.FileName;
-    private bool[] sortDescending = new[] { false, false, false, false };
+    private bool[] sortDescending = { false, false, false, false };
 
     private enum FileStructType
     {
@@ -296,12 +298,14 @@ public partial class FileDialog
         }
     }
 
+    private IEnumerable<SideBarItem> GetDrives()
+    {
+        return this.driveListLoader.Drives.Select(drive => new SideBarItem(drive.Name, drive.Name, FontAwesomeIcon.Server));
+    }
+
     private void SetupSideBar()
     {
-        foreach (var drive in DriveInfo.GetDrives())
-        {
-            this.drives.Add(new SideBarItem(drive.Name, drive.Name, FontAwesomeIcon.Server));
-        }
+        _ = this.driveListLoader.LoadDrivesAsync();
 
         var personal = Path.GetDirectoryName(Environment.GetFolderPath(Environment.SpecialFolder.Personal));
 

--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.UI.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.UI.cs
@@ -316,7 +316,7 @@ public partial class FileDialog
             ImGui.SetCursorPosY(ImGui.GetCursorPosY() + Scaled(5));
 
             var idx = 0;
-            foreach (var qa in this.drives.Concat(this.quickAccess).Where(qa => qa.Exists))
+            foreach (var qa in this.GetDrives().Concat(this.quickAccess).Where(qa => qa.Exists))
             {
                 ImGui.PushID(idx++);
                 ImGui.SetCursorPosX(Scaled(25));

--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.cs
@@ -52,7 +52,6 @@ public partial class FileDialog
     private float footerHeight = 0;
 
     private string selectedSideBar = string.Empty;
-    private List<SideBarItem> drives = new();
     private List<SideBarItem> quickAccess = new();
 
     /// <summary>


### PR DESCRIPTION
Should fix #1130.

This change makes FileDialog load the drive list asynchronously, so that slower network-mapped drives don't cause enumeration of the drive list to lock up the whole game. I wrote this so that the drive list can be enumerated while it's still loading, so it uses ImmutableArray boxed in IReadOnlyList to avoid exposing implementation details. `DriveListLoader.Drives` is only accessed once each frame, so this should have a negligible memory footprint.

If desired, this can be expanded to make use of `DriveListLoader.Loading` to communicate to the user that stuff is happening. Additionally, this supports reloading the drive list safely, if we ever want to do that.