### PR TITLE
fix: only check FileDialog location existence during navigation

### DIFF
--- a/Dalamud/Interface/ImGuiFileDialog/DriveListLoader.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/DriveListLoader.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -10,14 +10,12 @@ namespace Dalamud.Interface.ImGuiFileDialog;
 /// </summary>
 internal class DriveListLoader
 {
-    private bool initialized;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="DriveListLoader"/> class.
     /// </summary>
     public DriveListLoader()
     {
-        this.Drives = ImmutableArray<DriveInfo>.Empty;
+        this.Drives = Array.Empty<DriveInfo>();
     }
 
     /// <summary>
@@ -50,24 +48,7 @@ internal class DriveListLoader
     private async Task InitDrives()
     {
         // Force async to avoid this being invoked synchronously unless it's awaited.
-        // Putting this after the GetDrives call (inside the loop) keeps this on the
-        // UI thread sometimes.
         await Task.Yield();
-
-        var drives = ImmutableArray<DriveInfo>.Empty;
-        foreach (var drive in DriveInfo.GetDrives())
-        {
-            drives = drives.Add(drive);
-            if (!this.initialized)
-            {
-                // Show results as soon as they load initially, but otherwise keep
-                // the existing drive list
-                this.Drives = drives;
-            }
-        }
-
-        // Replace the whole drive list
-        this.Drives = drives;
-        this.initialized = true;
+        this.Drives = DriveInfo.GetDrives();
     }
 }

--- a/Dalamud/Interface/ImGuiFileDialog/DriveListLoader.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/DriveListLoader.cs
@@ -49,6 +49,11 @@ internal class DriveListLoader
 
     private async Task InitDrives()
     {
+        // Force async to avoid this being invoked synchronously unless it's awaited.
+        // Putting this after the GetDrives call (inside the loop) keeps this on the
+        // UI thread sometimes.
+        await Task.Yield();
+
         var drives = ImmutableArray<DriveInfo>.Empty;
         foreach (var drive in DriveInfo.GetDrives())
         {
@@ -59,9 +64,6 @@ internal class DriveListLoader
                 // the existing drive list
                 this.Drives = drives;
             }
-
-            // Force async to avoid this being invoked synchronously unless it's awaited
-            await Task.Yield();
         }
 
         // Replace the whole drive list

--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.Structs.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.Structs.cs
@@ -31,7 +31,6 @@ public partial class FileDialog
             this.Text = text;
             this.Location = location;
             this.Icon = icon;
-            this.Exists = !this.Location.IsNullOrEmpty() && Directory.Exists(this.Location);
         }
 
         public string Text { get; init; }
@@ -39,8 +38,6 @@ public partial class FileDialog
         public string Location { get; init; }
 
         public FontAwesomeIcon Icon { get; init; }
-
-        public bool Exists { get; init; }
 
         public bool CheckExistence()
             => !this.Location.IsNullOrEmpty() && Directory.Exists(this.Location);

--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.UI.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.UI.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Numerics;
 
+using Dalamud.Utility;
 using ImGuiNET;
 
 namespace Dalamud.Interface.ImGuiFileDialog;
@@ -316,7 +317,7 @@ public partial class FileDialog
             ImGui.SetCursorPosY(ImGui.GetCursorPosY() + Scaled(5));
 
             var idx = 0;
-            foreach (var qa in this.GetDrives().Concat(this.quickAccess).Where(qa => qa.Exists))
+            foreach (var qa in this.GetDrives().Concat(this.quickAccess).Where(qa => !qa.Location.IsNullOrEmpty()))
             {
                 ImGui.PushID(idx++);
                 ImGui.SetCursorPosX(Scaled(25));


### PR DESCRIPTION
Even when `GetDrives` is async, the FileDialog code still checks for drive existence on the UI thread, causing the same blocking issues. This changes FileDialog to only check for location existence when actually navigating to a location.