### PR TITLE
fix: reset search when navigating into a FileDialog folder

### DIFF
--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.cs
@@ -258,6 +258,7 @@ public partial class FileDialog
 
     private void SetPath(string path)
     {
+        this.searchBuffer = string.Empty;
         this.selectedSideBar = string.Empty;
         this.currentPath = path;
         this.files.Clear();


### PR DESCRIPTION
Currently, using the search bar and navigating into a folder keeps the same search query, so you need to clear it if you want to actually choose a file inside the folder you were searching for. This clears the search bar when navigating into a folder.