### PR TITLE
add 24pt font scale

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
@@ -157,6 +157,14 @@ public class SettingsTabLook : SettingsTab
         }
 
         ImGui.SameLine();
+        if (ImGui.Button("24pt##DalamudSettingsGlobalUiScaleReset24"))
+        {
+            this.globalUiScale = 24.0f / 12.0f;
+            ImGui.GetIO().FontGlobalScale = this.globalUiScale;
+            interfaceManager.RebuildFonts();
+        }
+
+        ImGui.SameLine();
         if (ImGui.Button("36pt##DalamudSettingsGlobalUiScaleReset36"))
         {
             this.globalUiScale = 36.0f / 12.0f;


### PR DESCRIPTION
Super minor, but it always bugged me that there's not an easy way to set this to 2*default (2*12=24) for 200% scaling on 4K.