### PR TITLE
Remove support for legacy devplugins directory

### DIFF
--- a/Dalamud.Injector/EntryPoint.cs
+++ b/Dalamud.Injector/EntryPoint.cs
@@ -247,7 +247,6 @@ namespace Dalamud.Injector
             var workingDirectory = startInfo.WorkingDirectory;
             var configurationPath = startInfo.ConfigurationPath;
             var pluginDirectory = startInfo.PluginDirectory;
-            var defaultPluginDirectory = startInfo.DefaultPluginDirectory;
             var assetDirectory = startInfo.AssetDirectory;
             var delayInitializeMs = startInfo.DelayInitializeMs;
             var logName = startInfo.LogName;
@@ -262,8 +261,6 @@ namespace Dalamud.Injector
                     configurationPath = args[i][key.Length..];
                 else if (args[i].StartsWith(key = "--dalamud-plugin-directory="))
                     pluginDirectory = args[i][key.Length..];
-                else if (args[i].StartsWith(key = "--dalamud-dev-plugin-directory="))
-                    defaultPluginDirectory = args[i][key.Length..];
                 else if (args[i].StartsWith(key = "--dalamud-asset-directory="))
                     assetDirectory = args[i][key.Length..];
                 else if (args[i].StartsWith(key = "--dalamud-delay-initialize="))
@@ -287,7 +284,6 @@ namespace Dalamud.Injector
             workingDirectory ??= Directory.GetCurrentDirectory();
             configurationPath ??= Path.Combine(xivlauncherDir, "dalamudConfig.json");
             pluginDirectory ??= Path.Combine(xivlauncherDir, "installedPlugins");
-            defaultPluginDirectory ??= Path.Combine(xivlauncherDir, "devPlugins");
             assetDirectory ??= Path.Combine(xivlauncherDir, "dalamudAssets", "dev");
 
             ClientLanguage clientLanguage;
@@ -313,7 +309,6 @@ namespace Dalamud.Injector
             startInfo.WorkingDirectory = workingDirectory;
             startInfo.ConfigurationPath = configurationPath;
             startInfo.PluginDirectory = pluginDirectory;
-            startInfo.DefaultPluginDirectory = defaultPluginDirectory;
             startInfo.AssetDirectory = assetDirectory;
             startInfo.Language = clientLanguage;
             startInfo.DelayInitializeMs = delayInitializeMs;

--- a/Dalamud.Injector/EntryPoint.cs
+++ b/Dalamud.Injector/EntryPoint.cs
@@ -362,7 +362,7 @@ namespace Dalamud.Injector
             }
 
             Console.WriteLine("Specifying dalamud start info: [--dalamud-working-directory=path] [--dalamud-configuration-path=path]");
-            Console.WriteLine("                               [--dalamud-plugin-directory=path] [--dalamud-dev-plugin-directory=path]");
+            Console.WriteLine("                               [--dalamud-plugin-directory=path]");
             Console.WriteLine("                               [--dalamud-asset-directory=path] [--dalamud-delay-initialize=0(ms)]");
             Console.WriteLine("                               [--dalamud-client-language=0-3|j(apanese)|e(nglish)|d|g(erman)|f(rench)]");
 

--- a/Dalamud/DalamudStartInfo.cs
+++ b/Dalamud/DalamudStartInfo.cs
@@ -30,7 +30,6 @@ public record DalamudStartInfo : IServiceType
         this.ConfigurationPath = other.ConfigurationPath;
         this.LogName = other.LogName;
         this.PluginDirectory = other.PluginDirectory;
-        this.DefaultPluginDirectory = other.DefaultPluginDirectory;
         this.AssetDirectory = other.AssetDirectory;
         this.Language = other.Language;
         this.GameVersion = other.GameVersion;
@@ -71,11 +70,6 @@ public record DalamudStartInfo : IServiceType
     /// Gets or sets the path to the directory for installed plugins.
     /// </summary>
     public string? PluginDirectory { get; set; }
-
-    /// <summary>
-    /// Gets or sets the path to the directory for developer plugins.
-    /// </summary>
-    public string? DefaultPluginDirectory { get; set; }
 
     /// <summary>
     /// Gets or sets the path to core Dalamud assets.

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
@@ -67,7 +67,7 @@ public class DevPluginsSettingsEntry : SettingsEntry
             }
         }
 
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsDevPluginLocationsHint", "Add additional dev plugin load locations.\nThese can be either the directory or DLL path."));
+        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsDevPluginLocationsHint", "Add dev plugin load locations.\nThese can be either the directory or DLL path."));
 
         ImGuiHelpers.ScaledDummy(5);
 

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -57,15 +57,6 @@ internal partial class PluginManager : IDisposable, IServiceType
     /// </summary>
     public const int PluginWaitBeforeFreeDefault = 1000; // upped from 500ms, seems more stable
 
-    private const string DevPluginsDisclaimerFilename = "DONT_USE_THIS_FOLDER.txt";
-
-    private const string DevPluginsDisclaimerText = @"Hey!
-The devPlugins folder is deprecated and will be removed soon. Please don't use it anymore for plugin development.
-Instead, open the Dalamud settings and add the path to your plugins build output folder as a dev plugin location.
-Remove your devPlugin from this folder.
-
-Thanks and have fun!";
-
     private static readonly ModuleLog Log = new("PLUGINM");
 
     private readonly object pluginListLock = new();
@@ -88,17 +79,9 @@ Thanks and have fun!";
     private PluginManager()
     {
         this.pluginDirectory = new DirectoryInfo(this.startInfo.PluginDirectory!);
-        this.devPluginDirectory = new DirectoryInfo(this.startInfo.DefaultPluginDirectory!);
 
         if (!this.pluginDirectory.Exists)
             this.pluginDirectory.Create();
-
-        if (!this.devPluginDirectory.Exists)
-            this.devPluginDirectory.Create();
-
-        var disclaimerFileName = Path.Combine(this.devPluginDirectory.FullName, DevPluginsDisclaimerFilename);
-        if (!File.Exists(disclaimerFileName))
-            File.WriteAllText(disclaimerFileName, DevPluginsDisclaimerText);
 
         this.SafeMode = EnvironmentConfiguration.DalamudNoPlugins || this.configuration.PluginSafeMode || this.startInfo.NoLoadPlugins;
 
@@ -394,9 +377,6 @@ Thanks and have fun!";
         if (!this.pluginDirectory.Exists)
             this.pluginDirectory.Create();
 
-        if (!this.devPluginDirectory.Exists)
-            this.devPluginDirectory.Create();
-
         // Add installed plugins. These are expected to be in a specific format so we can look for exactly that.
         foreach (var pluginDir in this.pluginDirectory.GetDirectories())
         {
@@ -437,7 +417,7 @@ Thanks and have fun!";
         }
 
         // devPlugins are more freeform. Look for any dll and hope to get lucky.
-        var devDllFiles = this.devPluginDirectory.GetFiles("*.dll", SearchOption.AllDirectories).ToList();
+        var devDllFiles = new List<FileInfo>();
 
         foreach (var setting in this.configuration.DevPluginLoadLocations)
         {
@@ -660,11 +640,8 @@ Thanks and have fun!";
     /// </summary>
     public void ScanDevPlugins()
     {
-        if (!this.devPluginDirectory.Exists)
-            this.devPluginDirectory.Create();
-
         // devPlugins are more freeform. Look for any dll and hope to get lucky.
-        var devDllFiles = this.devPluginDirectory.GetFiles("*.dll", SearchOption.AllDirectories).ToList();
+        var devDllFiles = new List<FileInfo>();
 
         foreach (var setting in this.configuration.DevPluginLoadLocations)
         {


### PR DESCRIPTION
As of Patch 6.4, we've noticed an increase in crashes caused by third-party plugins that are erroneously installed in this legacy directory, as opposed to properly installed using the repo list. This directory has been deprecated for a long time, and is overdue for removal.

This removes support for the legacy devPlugins directory, requiring dev plugins to instead be loaded through the specified directories in settings.