### PR TITLE
Improve unhooking of hooked functions

### DIFF
--- a/Dalamud/Hooking/AsmHook.cs
+++ b/Dalamud/Hooking/AsmHook.cs
@@ -35,12 +35,8 @@ public sealed class AsmHook : IDisposable, IDalamudHook
     {
         address = HookManager.FollowJmp(address);
 
-        var hasOtherHooks = HookManager.Originals.ContainsKey(address);
-        if (!hasOtherHooks)
-        {
-            MemoryHelper.ReadRaw(address, 0x32, out var original);
-            HookManager.Originals[address] = original;
-        }
+        // We cannot call TrimAfterHook here because the hook is activated by the caller.
+        HookManager.RegisterUnhooker(address);
 
         this.address = address;
         this.hookImpl = ReloadedHooks.Instance.CreateAsmHook(assembly, address.ToInt64(), (Reloaded.Hooks.Definitions.Enums.AsmHookBehaviour)asmHookBehaviour);
@@ -65,12 +61,8 @@ public sealed class AsmHook : IDisposable, IDalamudHook
     {
         address = HookManager.FollowJmp(address);
 
-        var hasOtherHooks = HookManager.Originals.ContainsKey(address);
-        if (!hasOtherHooks)
-        {
-            MemoryHelper.ReadRaw(address, 0x32, out var original);
-            HookManager.Originals[address] = original;
-        }
+        // We cannot call TrimAfterHook here because the hook is activated by the caller.
+        HookManager.RegisterUnhooker(address);
 
         this.address = address;
         this.hookImpl = ReloadedHooks.Instance.CreateAsmHook(assembly, address.ToInt64(), (Reloaded.Hooks.Definitions.Enums.AsmHookBehaviour)asmHookBehaviour);

--- a/Dalamud/Hooking/Internal/FunctionPointerVariableHook.cs
+++ b/Dalamud/Hooking/Internal/FunctionPointerVariableHook.cs
@@ -41,12 +41,7 @@ internal class FunctionPointerVariableHook<T> : Hook<T>
     {
         lock (HookManager.HookEnableSyncRoot)
         {
-            var hasOtherHooks = HookManager.Originals.ContainsKey(this.Address);
-            if (!hasOtherHooks)
-            {
-                MemoryHelper.ReadRaw(this.Address, 0x32, out var original);
-                HookManager.Originals[this.Address] = original;
-            }
+            var unhooker = HookManager.RegisterUnhooker(this.Address);
 
             if (!HookManager.MultiHookTracker.TryGetValue(this.Address, out var indexList))
             {
@@ -103,6 +98,8 @@ internal class FunctionPointerVariableHook<T> : Hook<T>
 
             // Add afterwards, so the hookIdent starts at 0.
             indexList.Add(this);
+
+            unhooker.TrimAfterHook();
 
             HookManager.TrackedHooks.TryAdd(Guid.NewGuid(), new HookInfo(this, detour, callingAssembly));
         }

--- a/Dalamud/Hooking/Internal/FunctionPointerVariableHook.cs
+++ b/Dalamud/Hooking/Internal/FunctionPointerVariableHook.cs
@@ -41,7 +41,7 @@ internal class FunctionPointerVariableHook<T> : Hook<T>
     {
         lock (HookManager.HookEnableSyncRoot)
         {
-            var unhooker = HookManager.RegisterUnhooker(this.Address);
+            var unhooker = HookManager.RegisterUnhooker(this.Address, 8, 8);
 
             if (!HookManager.MultiHookTracker.TryGetValue(this.Address, out var indexList))
             {

--- a/Dalamud/Hooking/Internal/HookManager.cs
+++ b/Dalamud/Hooking/Internal/HookManager.cs
@@ -43,13 +43,26 @@ internal class HookManager : IDisposable, IServiceType
 
     /// <summary>
     /// Creates a new Unhooker instance for the provided address if no such unhooker was already registered, or returns
-    /// an existing instance if the address registered previously.
+    /// an existing instance if the address was registered previously. By default, the unhooker will restore between 0
+    /// and 0x32 bytes depending on the detected size of the hook. To specify the minimum and maximum bytes restored
+    /// manually, use <see cref="RegisterUnhooker(System.IntPtr, int, int)"/>.
     /// </summary>
     /// <param name="address">The address of the instruction.</param>
-    /// <param name="minBytes">The minimum amount of bytes to restore when unhooking. Defaults to 0.</param>
-    /// <param name="maxBytes">The maximum amount of bytes to restore when unhooking. Defaults to 0x32.</param>
     /// <returns>A new Unhooker instance.</returns>
-    public static Unhooker RegisterUnhooker(IntPtr address, int minBytes = 0, int maxBytes = 0x32)
+    public static Unhooker RegisterUnhooker(IntPtr address)
+    {
+        return RegisterUnhooker(address, 0, 0x32);
+    }
+
+    /// <summary>
+    /// Creates a new Unhooker instance for the provided address if no such unhooker was already registered, or returns
+    /// an existing instance if the address was registered previously.
+    /// </summary>
+    /// <param name="address">The address of the instruction.</param>
+    /// <param name="minBytes">The minimum amount of bytes to restore when unhooking.</param>
+    /// <param name="maxBytes">The maximum amount of bytes to restore when unhooking.</param>
+    /// <returns>A new Unhooker instance.</returns>
+    public static Unhooker RegisterUnhooker(IntPtr address, int minBytes, int maxBytes)
     {
         Log.Verbose($"Registering hook at 0x{address.ToInt64():X} (minBytes=0x{minBytes:X}, maxBytes=0x{maxBytes:X})");
         return Unhookers.GetOrAdd(address, _ => new Unhooker(address, minBytes, maxBytes));

--- a/Dalamud/Hooking/Internal/HookManager.cs
+++ b/Dalamud/Hooking/Internal/HookManager.cs
@@ -16,7 +16,10 @@ namespace Dalamud.Hooking.Internal;
 [ServiceManager.EarlyLoadedService]
 internal class HookManager : IDisposable, IServiceType
 {
-    private static readonly ModuleLog Log = new("HM");
+    /// <summary>
+    /// Logger shared with <see cref="Unhooker"/>
+    /// </summary>
+    internal static readonly ModuleLog Log = new("HM");
 
     [ServiceManager.ServiceConstructor]
     private HookManager()
@@ -34,9 +37,21 @@ internal class HookManager : IDisposable, IServiceType
     internal static ConcurrentDictionary<Guid, HookInfo> TrackedHooks { get; } = new();
 
     /// <summary>
-    /// Gets a static dictionary of original code for a hooked address.
+    /// Gets a static dictionary of unhookers for a hooked address.
     /// </summary>
-    internal static ConcurrentDictionary<IntPtr, byte[]> Originals { get; } = new();
+    internal static ConcurrentDictionary<IntPtr, Unhooker> Unhookers { get; } = new();
+
+    /// <summary>
+    /// Creates a new Unhooker instance for the provided address if no such unhooker was already registered, or returns
+    /// an existing instance if the address registered previously.
+    /// </summary>
+    /// <param name="address">The address of the instruction.</param>
+    /// <returns>A new Unhooker instance.</returns>
+    public static Unhooker RegisterUnhooker(IntPtr address)
+    {
+        Log.Verbose($"Registering hook at 0x{address.ToInt64():X}");
+        return Unhookers.GetOrAdd(address, adr => new Unhooker(adr));
+    }
 
     /// <summary>
     /// Gets a static dictionary of the number of hooks on a given address.
@@ -48,7 +63,7 @@ internal class HookManager : IDisposable, IServiceType
     {
         RevertHooks();
         TrackedHooks.Clear();
-        Originals.Clear();
+        Unhookers.Clear();
     }
 
     /// <summary>
@@ -60,7 +75,7 @@ internal class HookManager : IDisposable, IServiceType
     {
         while (true)
         {
-            var hasOtherHooks = HookManager.Originals.ContainsKey(address);
+            var hasOtherHooks = HookManager.Unhookers.ContainsKey(address);
             if (hasOtherHooks)
             {
                 // This address has been hooked already. Do not follow a jmp into a trampoline of our own making.
@@ -124,28 +139,11 @@ internal class HookManager : IDisposable, IServiceType
         return address;
     }
 
-    private static unsafe void RevertHooks()
+    private static void RevertHooks()
     {
-        foreach (var (address, originalBytes) in Originals)
+        foreach (var unhooker in Unhookers.Values)
         {
-            var i = 0;
-            var current = (byte*)address;
-            // Find how many bytes have been modified by comparing to the saved original
-            for (; i < originalBytes.Length; i++)
-            {
-                if (current[i] == originalBytes[i])
-                    break;
-            }
-
-            var snippet = originalBytes[0..i];
-
-            if (i > 0)
-            {
-                Log.Verbose($"Reverting hook at 0x{address.ToInt64():X} ({snippet.Length} bytes)");
-                MemoryHelper.ChangePermission(address, i, MemoryProtection.ExecuteReadWrite, out var oldPermissions);
-                MemoryHelper.WriteRaw(address, snippet);
-                MemoryHelper.ChangePermission(address, i, oldPermissions);
-            }
+            unhooker.Unhook();
         }
     }
 }

--- a/Dalamud/Hooking/Internal/HookManager.cs
+++ b/Dalamud/Hooking/Internal/HookManager.cs
@@ -46,11 +46,13 @@ internal class HookManager : IDisposable, IServiceType
     /// an existing instance if the address registered previously.
     /// </summary>
     /// <param name="address">The address of the instruction.</param>
+    /// <param name="minBytes">The minimum amount of bytes to restore when unhooking. Defaults to 0.</param>
+    /// <param name="maxBytes">The maximum amount of bytes to restore when unhooking. Defaults to 0x32.</param>
     /// <returns>A new Unhooker instance.</returns>
-    public static Unhooker RegisterUnhooker(IntPtr address)
+    public static Unhooker RegisterUnhooker(IntPtr address, int minBytes = 0, int maxBytes = 0x32)
     {
-        Log.Verbose($"Registering hook at 0x{address.ToInt64():X}");
-        return Unhookers.GetOrAdd(address, adr => new Unhooker(adr));
+        Log.Verbose($"Registering hook at 0x{address.ToInt64():X} (minBytes=0x{minBytes:X}, maxBytes=0x{maxBytes:X})");
+        return Unhookers.GetOrAdd(address, _ => new Unhooker(address, minBytes, maxBytes));
     }
 
     /// <summary>

--- a/Dalamud/Hooking/Internal/Unhooker.cs
+++ b/Dalamud/Hooking/Internal/Unhooker.cs
@@ -1,0 +1,91 @@
+﻿using System;
+
+using Dalamud.Memory;
+
+namespace Dalamud.Hooking.Internal;
+
+/// <summary>
+/// A class which stores a copy of the bytes at a location which will be hooked in the future, such that those bytes can
+/// be restored later to "unhook" the function.
+/// </summary>
+public class Unhooker
+{
+    private readonly IntPtr address;
+    private byte[] originalBytes;
+    private bool trimmed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Unhooker"/> class. Upon creation, the Unhooker stores a copy of
+    /// the bytes stored at the provided address, and can be used to restore these bytes when the hook should be
+    /// removed. As such this class should be instantiated before the function is actually hooked.
+    /// </summary>
+    /// <param name="address">The address which will be hooked.</param>
+    public Unhooker(IntPtr address)
+    {
+        this.address = address;
+        MemoryHelper.ReadRaw(address, 0x32, out this.originalBytes);
+    }
+
+    /// <summary>
+    /// When called after a hook is created, checks the pre-hook original bytes and post-hook modified bytes, trimming
+    /// the original bytes stored and removing unmodified bytes from the end of the byte sequence. Assuming no
+    /// concurrent actions modified the same address space, this should result in storing only the minimum bytes
+    /// required to unhook the function.
+    /// </summary>
+    public void TrimAfterHook()
+    {
+        if (this.trimmed)
+        {
+            return;
+        }
+
+        this.originalBytes = this.originalBytes[..this.GetFullHookLength()];
+        this.trimmed = true;
+    }
+
+    /// <summary>
+    /// Attempts to unhook the function by replacing the hooked bytes with the original bytes. If
+    /// <see cref="TrimAfterHook"/> was called, the trimmed original bytes stored at that time will be used for
+    /// unhooking. Otherwise, a naive algorithm which only restores bytes until the first unchanged byte will be used in
+    /// order to avoid overwriting adjacent data.
+    /// </summary>
+    public void Unhook()
+    {
+        var len = this.trimmed ? this.originalBytes.Length : this.GetNaiveHookLength();
+        if (len > 0)
+        {
+            HookManager.Log.Verbose($"Reverting hook at 0x{this.address.ToInt64():X} ({len} bytes, trimmed={this.trimmed})");
+            MemoryHelper.ChangePermission(this.address, len, MemoryProtection.ExecuteReadWrite, out var oldPermissions);
+            MemoryHelper.WriteRaw(this.address, this.originalBytes[..len]);
+            MemoryHelper.ChangePermission(this.address, len, oldPermissions);
+        }
+    }
+
+    private unsafe int GetNaiveHookLength()
+    {
+        var current = (byte*)this.address;
+        for (var i = 0; i < this.originalBytes.Length; i++)
+        {
+            if (current[i] == this.originalBytes[i])
+            {
+                return i;
+            }
+        }
+
+        return 0;
+    }
+
+    private unsafe int GetFullHookLength()
+    {
+        var current = (byte*)this.address;
+        for (var i = this.originalBytes.Length - 1; i >= 0; i--)
+        {
+            if (current[i] != this.originalBytes[i])
+            {
+                return i + 1;
+            }
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
This PR is presented as an attempted solution to issue #1236 reported by me.

In most aspects of these changes I've tried to take a cautious approach. `Unhooker.TrimAfterHook` is called immediately after hooking (rather than at unhook time) with the idea that accidentally capturing additional hooks in adjacent data are less likely if we grab the snapshot as soon as possible.

However, there are a couple things which I can certainly see changing:

1. Currently the pre-trimmed original byte snapshot stores 50 bytes, just as it did before. However this may be excessive, as the longest hook I've seen in practice is 14 bytes. Trimming to 30 or even 20 may be reasonable, but I don't know how long the "longest hook" may actually be in theory. Any ideas?
2. The "naive" unhook logic is kept around for hooks which cannot be trimmed. Right now this only applies to `AsmHook`, of which there is only one in Dalamud itself. However this might be being too cautious, and it may be reasonable just to restore the entire original byte snapshot for untrimmed hooks (especially if we were to reduce this snapshot size as mentioned above).

Please let me know if you have an opinions on the above.

There are certainly a number of different approaches we might take here, and others ways to structure the code itself. I just went with a way that seemed to make sense to me, but I'm happy to hear feedback on any aspect of this PR in addition to the points above.

Thanks.

P.S. The **unhooker-dbg** branch in my repo (https://github.com/nebel/Dalamud/tree/unhooker-dbg) contains essentially the same changes as this PR but with additional debug logging, which was what I used to log the "Mismatch analysis" information presented in the linked issue. Feel free to use this branch for local testing if you're interested in seeing this information for yourself.