### PR TITLE
Add filter to plugin stats window draw and framework times

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
@@ -23,6 +23,8 @@ namespace Dalamud.Interface.Internal.Windows;
 internal class PluginStatWindow : Window
 {
     private bool showDalamudHooks;
+    private string drawSearchText = string.Empty;
+    private string frameworkSearchText = string.Empty;
     private string hookSearchText = string.Empty;
 
     /// <summary>
@@ -79,6 +81,12 @@ internal class PluginStatWindow : Window
                 ImGui.SameLine();
                 ImGuiComponents.TextWithLabel("Collective Average", $"{(loadedPlugins.Any() ? totalAverage / loadedPlugins.Count() / 10000f : 0):F4}ms", "Average of all average draw times");
 
+                ImGui.InputTextWithHint(
+                    "###PluginStatWindow_DrawSearch",
+                    "Search",
+                    ref this.drawSearchText,
+                    500);
+
                 if (ImGui.BeginTable(
                         "##PluginStatsDrawTimes",
                         4,
@@ -114,6 +122,12 @@ internal class PluginStatWindow : Window
 
                     foreach (var plugin in loadedPlugins)
                     {
+                        if (!this.drawSearchText.IsNullOrEmpty()
+                            && !plugin.Manifest.Name.Contains(this.drawSearchText, StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
                         ImGui.TableNextRow();
 
                         ImGui.TableNextColumn();
@@ -168,6 +182,12 @@ internal class PluginStatWindow : Window
                 ImGui.SameLine();
                 ImGuiComponents.TextWithLabel("Collective Average", $"{(statsHistory.Any() ? totalAverage / statsHistory.Length : 0):F4}ms", "Average of all average update times");
 
+                ImGui.InputTextWithHint(
+                    "###PluginStatWindow_FrameworkSearch",
+                    "Search",
+                    ref this.frameworkSearchText,
+                    500);
+
                 if (ImGui.BeginTable(
                         "##PluginStatsFrameworkTimes",
                         4,
@@ -204,6 +224,13 @@ internal class PluginStatWindow : Window
                     foreach (var handlerHistory in statsHistory)
                     {
                         if (!handlerHistory.Value.Any())
+                        {
+                            continue;
+                        }
+
+                        if (!this.frameworkSearchText.IsNullOrEmpty()
+                            && handlerHistory.Key != null
+                            && !handlerHistory.Key.Contains(this.frameworkSearchText, StringComparison.OrdinalIgnoreCase))
                         {
                             continue;
                         }


### PR DESCRIPTION
In the Plugin Statistics window, adds filters to "Draw times" and "Framework times" tabs, similar to the existing filter in the "Hooks" tab. I found this useful when looking for bottlenecks in plugin code, as the entries I'm interested in would otherwise be scrolled offscreen or jump around a lot after a reset (depending on the sorting).