### PR TITLE
chore: export docfx metadata with build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Define VERSION
@@ -105,3 +105,32 @@ jobs:
         git commit -m "[CI] Update staging for ${DVER} on ${GH_BRANCH}" || true
         
         git push origin main || true
+
+  # docfx metadata generation can often take several minutes, so we run it in parallel to the main build
+  generate-docfx-metadata:
+    name: Generate docfx metadata
+    runs-on: windows-2022
+    steps:
+      - name: Checkout Dalamud
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 1
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Define VERSION
+        run: |
+          $env:COMMIT = $env:GITHUB_SHA.Substring(0, 7)
+          $env:REPO_NAME = $env:GITHUB_REPOSITORY -replace '.*/'
+          $env:BRANCH = $env:GITHUB_REF -replace '.*/'
+
+          ($env:REPO_NAME) >> VERSION
+          ($env:BRANCH) >> VERSION
+          ($env:COMMIT) >> VERSION
+      - name: Build Dalamud & generate metadata
+        run: .\build.ps1 ExportDocfxMetadata
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dalamud-docfx-metadata
+          path: api\

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -79,6 +79,7 @@
               "CompileDalamudCrashHandler",
               "CompileInjector",
               "CompileInjectorBoot",
+              "ExportDocfxMetadata",
               "Restore",
               "Test"
             ]
@@ -101,6 +102,7 @@
               "CompileDalamudCrashHandler",
               "CompileInjector",
               "CompileInjectorBoot",
+              "ExportDocfxMetadata",
               "Restore",
               "Test"
             ]

--- a/build/DalamudBuild.cs
+++ b/build/DalamudBuild.cs
@@ -5,6 +5,7 @@ using Nuke.Common.Execution;
 using Nuke.Common.Git;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
+using Nuke.Common.Tools.DocFX;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.MSBuild;
 
@@ -98,6 +99,13 @@ public class DalamudBuild : NukeBuild
             MSBuildTasks.MSBuild(s => s
                 .SetTargetPath(InjectorBootProjectFile)
                 .SetConfiguration(Configuration));
+        });
+
+    Target ExportDocfxMetadata => _ => _
+        .DependsOn(CompileDalamud)
+        .Executes(() =>
+        {
+            DocFXTasks.DocFXMetadata();
         });
 
     Target Compile => _ => _

--- a/build/build.csproj
+++ b/build/build.csproj
@@ -12,4 +12,7 @@
     <ItemGroup>
         <PackageReference Include="Nuke.Common" Version="6.2.1" />
     </ItemGroup>
+    <ItemGroup>
+        <PackageDownload Include="docfx.console" Version="[2.59.4]" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds a build step that runs in parallel with the main build process to export docfx metadata and upload it as a separate workflow artifact.
This will allow us to automatically generate API documentation for the new dev docs site (WIP, will push something up once @goaaats creates the repo for it).

Also changes `fetch-depth` from 0 to 1 to speed up the build process a little bit. The checkout action treats `0` as "fetch all history from every linked repo", which is the opposite of what we want in CI.