### PR TITLE
chore: specify csproj files directly in docfx config

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -4,8 +4,14 @@
       "src": [
         {
           "files": [
-            "Dalamud.sln"
-          ],
+            "Dalamud.Interface/Dalamud.Interface.csproj",
+            "Dalamud/Dalamud.csproj",
+            "lib/FFXIVClientStructs/FFXIVClientStructs.InteropSourceGenerators/FFXIVClientStructs.InteropSourceGenerators.csproj",
+            "lib/FFXIVClientStructs/FFXIVClientStructs/FFXIVClientStructs.csproj",
+            "lib/ImGuiScene/ImGuiScene/ImGuiScene.csproj",
+            "lib/ImGuiScene/deps/ImGui.NET/src/ImGui.NET-472/ImGui.NET-472.csproj",
+            "lib/ImGuiScene/deps/SDL2-CS/SDL2-CS.csproj"
+          ]
         }
       ],
       "dest": "api",


### PR DESCRIPTION
Solves this issue with newer MSBuild/docfx versions:

```
Error: Cannot open project 'D:\a\_temp\Dalamud-master\Dalamud.Boot\Dalamud.Boot.vcxproj' because the file extension '.vcxproj' is not associated with a language.
```

I've avoided using wildcards here intentionally, so as to only capture the csproj files that are referenced by Dalamud.sln currently, as opposed to recursively capturing every csproj file (including irrelevant ones, like Dalamud.Injector.Boot, FFXIVClientStructs.CExporter, etc).