### PR TITLE
chore: set EnableWindowsTargeting when building on non-Windows hosts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -58,5 +58,5 @@ fi
 
 echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
 
-"$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
-"$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"
+"$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false /p:EnableWindowsTargeting=true -nologo -clp:NoSummary --verbosity quiet
+"$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- /p:EnableWindowsTargeting=true "$@"


### PR DESCRIPTION
This doesn't necessarily guarantee builds on non-Windows hosts will work for the entirety of Dalamud, but it should enable building at least parts of Dalamud (i.e. the core itself, not including injector) on Linux runners.