### PR TITLE
add workflow to rollup changes from master -> v9

### DIFF
--- a/.github/workflows/rollup.yml
+++ b/.github/workflows/rollup.yml
@@ -1,0 +1,48 @@
+﻿name: Rollup changes to next version
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branches:
+          - v9
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          ref: ${{ matrix.branches }}
+          token: ${{ secrets.UPDATE_PAT }}
+      - name: Create update branch
+        run: git checkout -b ${{ matrix.branches }}/rollup
+      - name: Initialize mandatory git config
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email noreply@github.com
+          git config --global pull.rebase false
+      - name: Update submodule
+        run: |
+          git fetch
+          git merge -s recursive -X ours origin/master
+          git push origin ${{ matrix.branches }}/rollup --force
+      - name: Create PR
+        run: |
+          echo ${{ secrets.UPDATE_PAT }} | gh auth login --with-token
+          prNumber=$(gh pr list --base ${{ matrix.branches }} --head ${{ matrix.branches }}/rollup --state open --json number --template "{{range .}}{{.number}}{{end}}")
+          if [ -z "$prNumber" ]; then
+            echo "No PR found, creating one"
+            gh pr create --head ${{ matrix.branches }}/rollup --title "[${{ matrix.branches }}] Rollup changes from master" --body "" --base ${{ matrix.branches }}
+          else
+            echo "PR already exists, ignoring"
+          fi


### PR DESCRIPTION
Untested (because it's a bit hard to test workflows), but this is mostly copypasta from the CS update workflow, so it should be ok.

This will automatically create a rollup PR (or update an existing rollup PR) to merge `master` changes into `v9` every time `master` is updated. We use the "ours" conflict resolution strategy for the merge, since it's presumed that changes in the next major version should supersede changes in the current release.