### PR TITLE
Add IsTargetable to GameObject

### DIFF
--- a/Dalamud/Game/ClientState/Objects/Types/GameObject.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/GameObject.cs
@@ -147,7 +147,7 @@ public unsafe partial class GameObject
     /// <summary>
     /// Gets a value indicating whether the object is targetable.
     /// </summary>
-    public bool IsTargetable => Struct->GetIsTargetable();
+    public bool IsTargetable => this.Struct->GetIsTargetable();
 
     /// <summary>
     /// Gets the position of this <see cref="GameObject" />.

--- a/Dalamud/Game/ClientState/Objects/Types/GameObject.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/GameObject.cs
@@ -145,6 +145,11 @@ public unsafe partial class GameObject
     public bool IsDead => this.Struct->IsDead();
 
     /// <summary>
+    /// Gets a value indicating whether the object is targetable.
+    /// </summary>
+    public bool IsTargetable => Struct->GetIsTargetable();
+
+    /// <summary>
     /// Gets the position of this <see cref="GameObject" />.
     /// </summary>
     public Vector3 Position => new(this.Struct->Position.X, this.Struct->Position.Y, this.Struct->Position.Z);


### PR DESCRIPTION
I very often end up having to cast a Dalamud GameObject to a ClientStructs GameObject just to check if it is targetable.

This should fix that.