### PR TITLE
Disable signing on non-Goatcorp repos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Test Dalamud
         run: .\build.ps1 test
       - name: Sign Dalamud
+        if: ${{ github.repository_owner == 'goatcorp' }}
         env:
           CODESIGN_CERT_PFX: ${{ secrets.CODESIGN_CERT_PFX }}
           CODESIGN_CERT_PASSWORD: ${{ secrets.CODESIGN_CERT_PASSWORD }}


### PR DESCRIPTION
Prevents workflows running elsewhere from failing.