### PR TITLE
Only Attempt Signing on Pushes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Test Dalamud
         run: .\build.ps1 test
       - name: Sign Dalamud
-        if: ${{ github.repository_owner == 'goatcorp' }}
+        if: ${{ github.repository_owner == 'goatcorp' && github.event_name == 'push' }}
         env:
           CODESIGN_CERT_PFX: ${{ secrets.CODESIGN_CERT_PFX }}
           CODESIGN_CERT_PASSWORD: ${{ secrets.CODESIGN_CERT_PASSWORD }}


### PR DESCRIPTION
This PR should hopefully fix a bug that causes pull request builds to fail due to signing errors.

As only deploys need to be signed (which are always push actions), it's probably simplest to only run signing appropriately. Ideally, the signing step would be moved to the release step, but I'm hesitant to also have to move the hashlist generation step(s).