### PR TITLE
GameConfig - Cache reflective name lookup

### DIFF
--- a/Dalamud/Game/Config/GameConfigEnumExtensions.cs
+++ b/Dalamud/Game/Config/GameConfigEnumExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
 
 using Dalamud.Utility;
 
@@ -9,9 +9,9 @@ namespace Dalamud.Game.Config;
 /// </summary>
 internal static class GameConfigEnumExtensions
 {
-    private static readonly Dictionary<SystemConfigOption, string> SystemNameCache = new();
-    private static readonly Dictionary<UiConfigOption, string> UIConfigNameCache = new();
-    private static readonly Dictionary<UiControlOption, string> UIControlNameCache = new();
+    private static readonly ConcurrentDictionary<SystemConfigOption, string> SystemNameCache = new();
+    private static readonly ConcurrentDictionary<UiConfigOption, string> UIConfigNameCache = new();
+    private static readonly ConcurrentDictionary<UiControlOption, string> UIControlNameCache = new();
 
     /// <summary>
     /// Gets the name of a SystemConfigOption from it's attribute.

--- a/Dalamud/Game/Config/GameConfigEnumExtensions.cs
+++ b/Dalamud/Game/Config/GameConfigEnumExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Dalamud.Utility;
+﻿using System.Collections.Generic;
+
+using Dalamud.Utility;
 
 namespace Dalamud.Game.Config;
 
@@ -7,6 +9,10 @@ namespace Dalamud.Game.Config;
 /// </summary>
 internal static class GameConfigEnumExtensions
 {
+    private static readonly Dictionary<SystemConfigOption, string> SystemNameCache = new();
+    private static readonly Dictionary<UiConfigOption, string> UIConfigNameCache = new();
+    private static readonly Dictionary<UiControlOption, string> UIControlNameCache = new();
+
     /// <summary>
     /// Gets the name of a SystemConfigOption from it's attribute.
     /// </summary>
@@ -14,7 +20,10 @@ internal static class GameConfigEnumExtensions
     /// <returns>Name of the option.</returns>
     public static string GetName(this SystemConfigOption systemConfigOption)
     {
-        return systemConfigOption.GetAttribute<GameConfigOptionAttribute>()?.Name ?? $"{systemConfigOption}";
+        if (SystemNameCache.TryGetValue(systemConfigOption, out var name)) return name;
+        name = systemConfigOption.GetAttribute<GameConfigOptionAttribute>()?.Name ?? $"{systemConfigOption}";
+        SystemNameCache.TryAdd(systemConfigOption, name);
+        return name;
     }
 
     /// <summary>
@@ -24,7 +33,10 @@ internal static class GameConfigEnumExtensions
     /// <returns>Name of the option.</returns>
     public static string GetName(this UiConfigOption uiConfigOption)
     {
-        return uiConfigOption.GetAttribute<GameConfigOptionAttribute>()?.Name ?? $"{uiConfigOption}";
+        if (UIConfigNameCache.TryGetValue(uiConfigOption, out var name)) return name;
+        name = uiConfigOption.GetAttribute<GameConfigOptionAttribute>()?.Name ?? $"{uiConfigOption}";
+        UIConfigNameCache.TryAdd(uiConfigOption, name);
+        return name;
     }
 
     /// <summary>
@@ -34,6 +46,9 @@ internal static class GameConfigEnumExtensions
     /// <returns>Name of the option.</returns>
     public static string GetName(this UiControlOption uiControlOption)
     {
-        return uiControlOption.GetAttribute<GameConfigOptionAttribute>()?.Name ?? $"{uiControlOption}";
+        if (UIControlNameCache.TryGetValue(uiControlOption, out var name)) return name;
+        name = uiControlOption.GetAttribute<GameConfigOptionAttribute>()?.Name ?? $"{uiControlOption}";
+        UIControlNameCache.TryAdd(uiControlOption, name);
+        return name;
     }
 }


### PR DESCRIPTION
Cache the results of the reflective name lookup, improving the performance of  `GameConfig.TryGet` functions by ~100x