### PR TITLE
Config change event

### DIFF
--- a/Dalamud/Game/Config/ConfigChangeEvent.cs
+++ b/Dalamud/Game/Config/ConfigChangeEvent.cs
@@ -1,0 +1,7 @@
+﻿using System;
+
+namespace Dalamud.Game.Config;
+
+public abstract record ConfigChangeEvent(Enum GenericOption);
+
+public record ConfigChangeEvent<T>(T ConfigOption) : ConfigChangeEvent(ConfigOption) where T : Enum;

--- a/Dalamud/Game/Config/ConfigChangeEvent.cs
+++ b/Dalamud/Game/Config/ConfigChangeEvent.cs
@@ -2,6 +2,6 @@
 
 namespace Dalamud.Game.Config;
 
-public abstract record ConfigChangeEvent(Enum GenericOption);
+public abstract record ConfigChangeEvent(Enum Option);
 
 public record ConfigChangeEvent<T>(T ConfigOption) : ConfigChangeEvent(ConfigOption) where T : Enum;

--- a/Dalamud/Game/Config/GameConfig.cs
+++ b/Dalamud/Game/Config/GameConfig.cs
@@ -44,7 +44,7 @@ public sealed class GameConfig : IServiceType, IGameConfig, IDisposable
     private unsafe delegate nint ConfigChangeDelegate(ConfigBase* configBase, ConfigEntry* configEntry);
     
     /// <inheritdoc/>
-    public event EventHandler<ConfigChangeEvent> ConfigChange;
+    public event EventHandler<ConfigChangeEvent> Changed;
     
     /// <inheritdoc/>
     public GameConfigSection System { get; private set; }
@@ -156,7 +156,7 @@ public sealed class GameConfig : IServiceType, IGameConfig, IDisposable
 
             if (eventArgs == null) return returnValue;
 
-            this.ConfigChange?.InvokeSafely(this, eventArgs);
+            this.Changed?.InvokeSafely(this, eventArgs);
         }
         catch (Exception ex)
         {

--- a/Dalamud/Game/Config/GameConfigAddressResolver.cs
+++ b/Dalamud/Game/Config/GameConfigAddressResolver.cs
@@ -1,0 +1,18 @@
+﻿namespace Dalamud.Game.Config;
+
+/// <summary>
+/// Game config system address resolver.
+/// </summary>
+public sealed class GameConfigAddressResolver : BaseAddressResolver
+{
+    /// <summary>
+    /// Gets the address of the method called when any config option is changed.
+    /// </summary>
+    public nint ConfigChangeAddress { get; private set; }
+    
+    /// <inheritdoc/>
+    protected override void Setup64Bit(SigScanner scanner)
+    {
+        this.ConfigChangeAddress = scanner.ScanText("E8 ?? ?? ?? ?? 48 8B 3F 49 3B 3E");
+    }
+}

--- a/Dalamud/Game/Config/GameConfigSection.cs
+++ b/Dalamud/Game/Config/GameConfigSection.cs
@@ -22,7 +22,7 @@ public class GameConfigSection
     /// <summary>
     /// Event which is fired when a game config option is changed within the section.
     /// </summary>
-    public event EventHandler<ConfigChangeEvent> Change; 
+    public event EventHandler<ConfigChangeEvent> Changed; 
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GameConfigSection"/> class.
@@ -415,7 +415,7 @@ public class GameConfigSection
 
         if (enumObject == null) return null;
         var eventArgs = new ConfigChangeEvent<TEnum>((TEnum)enumObject);
-        this.Change?.InvokeSafely(this, eventArgs);
+        this.Changed?.InvokeSafely(this, eventArgs);
         return eventArgs;
     }
     

--- a/Dalamud/Game/Config/GameConfigSection.cs
+++ b/Dalamud/Game/Config/GameConfigSection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 
 using Dalamud.Memory;
+using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Common.Configuration;
 using Serilog;
 
@@ -16,6 +17,12 @@ public class GameConfigSection
     private readonly Framework framework;
     private readonly Dictionary<string, uint> indexMap = new();
     private readonly Dictionary<uint, string> nameMap = new();
+    private readonly Dictionary<uint, object> enumMap = new();
+
+    /// <summary>
+    /// Event which is fired when a game config option is changed within the section.
+    /// </summary>
+    public event EventHandler<ConfigChangeEvent> Change; 
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GameConfigSection"/> class.
@@ -59,7 +66,10 @@ public class GameConfigSection
     /// </summary>
     public string SectionName { get; }
 
-    private GetConfigBaseDelegate GetConfigBase { get; }
+    /// <summary>
+    /// Gets the pointer to the config section container.
+    /// </summary>
+    internal GetConfigBaseDelegate GetConfigBase { get; }
 
     /// <summary>
     /// Attempts to get a boolean config option.
@@ -380,6 +390,35 @@ public class GameConfigSection
         });
     }
 
+    /// <summary>
+    /// Invokes a change event within the config section.
+    /// </summary>
+    /// <param name="entry">The config entry that was changed.</param>
+    /// <typeparam name="TEnum">SystemConfigOption, UiConfigOption, or UiControlOption.</typeparam>
+    /// <returns>The ConfigChangeEvent record.</returns>
+    internal unsafe ConfigChangeEvent? InvokeChange<TEnum>(ConfigEntry* entry) where TEnum : Enum
+    {
+        if (!this.enumMap.TryGetValue(entry->Index, out var enumObject))
+        {
+            if (entry->Name == null) return null;
+            var name = MemoryHelper.ReadStringNullTerminated(new IntPtr(entry->Name));
+            if (Enum.TryParse(typeof(TEnum), name, out enumObject))
+            {
+                this.enumMap.Add(entry->Index, enumObject);
+            }
+            else
+            {
+                enumObject = null;
+                this.enumMap.Add(entry->Index, null);
+            }
+        }
+
+        if (enumObject == null) return null;
+        var eventArgs = new ConfigChangeEvent<TEnum>((TEnum)enumObject);
+        this.Change?.InvokeSafely(this, eventArgs);
+        return eventArgs;
+    }
+    
     private unsafe bool TryGetIndex(string name, out uint index)
     {
         if (this.indexMap.TryGetValue(name, out index))

--- a/Dalamud/Plugin/Services/IGameConfig.cs
+++ b/Dalamud/Plugin/Services/IGameConfig.cs
@@ -1,6 +1,8 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 
 using Dalamud.Game.Config;
+using FFXIVClientStructs.FFXIV.Common.Configuration;
 
 namespace Dalamud.Plugin.Services;
 
@@ -9,6 +11,11 @@ namespace Dalamud.Plugin.Services;
 /// </summary>
 public interface IGameConfig
 {
+    /// <summary>
+    /// Event which is fired when a game config option is changed.
+    /// </summary>
+    public event EventHandler<ConfigChangeEvent> ConfigChange;
+
     /// <summary>
     /// Gets the collection of config options that persist between characters.
     /// </summary>

--- a/Dalamud/Plugin/Services/IGameConfig.cs
+++ b/Dalamud/Plugin/Services/IGameConfig.cs
@@ -14,7 +14,7 @@ public interface IGameConfig
     /// <summary>
     /// Event which is fired when a game config option is changed.
     /// </summary>
-    public event EventHandler<ConfigChangeEvent> ConfigChange;
+    public event EventHandler<ConfigChangeEvent> Changed;
 
     /// <summary>
     /// Gets the collection of config options that persist between characters.


### PR DESCRIPTION
Emits events when a game config option is changed

```csharp
Service.GameConfig.Changed += (sender, change) => {
    if (change.Option is UiControlOption.MoveMode) {
        PluginLog.Log($"MoveMode was changed.");
    }
};

Service.GameConfig.System.Changed += (sender, change) => {
    PluginLog.Log($"System Config Option was Changed: {change.Option}");
};
```