### PR TITLE
`GameConfig` Improvements

### DIFF
--- a/Dalamud/Game/Config/GameConfig.cs
+++ b/Dalamud/Game/Config/GameConfig.cs
@@ -77,7 +77,7 @@ public sealed class GameConfig : IServiceType, IGameConfig, IDisposable
     public bool TryGet(UiConfigOption option, out float value) => this.UiConfig.TryGet(option.GetName(), out value);
 
     /// <inheritdoc/>
-    public bool TryGet(UiConfigOption option, out string value) => this.UiControl.TryGet(option.GetName(), out value);
+    public bool TryGet(UiConfigOption option, out string value) => this.UiConfig.TryGet(option.GetName(), out value);
 
     /// <inheritdoc/>
     public bool TryGet(UiControlOption option, out bool value) => this.UiControl.TryGet(option.GetName(), out value);
@@ -89,7 +89,7 @@ public sealed class GameConfig : IServiceType, IGameConfig, IDisposable
     public bool TryGet(UiControlOption option, out float value) => this.UiControl.TryGet(option.GetName(), out value);
 
     /// <inheritdoc/>
-    public bool TryGet(UiControlOption option, out string value) => this.System.TryGet(option.GetName(), out value);
+    public bool TryGet(UiControlOption option, out string value) => this.UiControl.TryGet(option.GetName(), out value);
     
     /// <inheritdoc/>
     public void Set(SystemConfigOption option, bool value) => this.System.Set(option.GetName(), value);

--- a/Dalamud/Game/Config/GameConfig.cs
+++ b/Dalamud/Game/Config/GameConfig.cs
@@ -68,6 +68,15 @@ public sealed class GameConfig : IServiceType, IGameConfig, IDisposable
     public bool TryGet(SystemConfigOption option, out string value) => this.System.TryGet(option.GetName(), out value);
 
     /// <inheritdoc/>
+    public bool TryGet(SystemConfigOption option, out UIntConfigProperties? properties) => this.System.TryGetProperties(option.GetName(), out properties);
+    
+    /// <inheritdoc/>
+    public bool TryGet(SystemConfigOption option, out FloatConfigProperties? properties) => this.System.TryGetProperties(option.GetName(), out properties);
+    
+    /// <inheritdoc/>
+    public bool TryGet(SystemConfigOption option, out StringConfigProperties? properties) => this.System.TryGetProperties(option.GetName(), out properties);
+    
+    /// <inheritdoc/>
     public bool TryGet(UiConfigOption option, out bool value) => this.UiConfig.TryGet(option.GetName(), out value);
 
     /// <inheritdoc/>
@@ -78,6 +87,15 @@ public sealed class GameConfig : IServiceType, IGameConfig, IDisposable
 
     /// <inheritdoc/>
     public bool TryGet(UiConfigOption option, out string value) => this.UiConfig.TryGet(option.GetName(), out value);
+    
+    /// <inheritdoc/>
+    public bool TryGet(UiConfigOption option, out UIntConfigProperties properties) => this.UiConfig.TryGetProperties(option.GetName(), out properties);
+    
+    /// <inheritdoc/>
+    public bool TryGet(UiConfigOption option, out FloatConfigProperties properties) => this.UiConfig.TryGetProperties(option.GetName(), out properties);
+    
+    /// <inheritdoc/>
+    public bool TryGet(UiConfigOption option, out StringConfigProperties properties) => this.UiConfig.TryGetProperties(option.GetName(), out properties);
 
     /// <inheritdoc/>
     public bool TryGet(UiControlOption option, out bool value) => this.UiControl.TryGet(option.GetName(), out value);
@@ -90,7 +108,16 @@ public sealed class GameConfig : IServiceType, IGameConfig, IDisposable
 
     /// <inheritdoc/>
     public bool TryGet(UiControlOption option, out string value) => this.UiControl.TryGet(option.GetName(), out value);
+
+    /// <inheritdoc/>
+    public bool TryGet(UiControlOption option, out UIntConfigProperties properties) => this.UiControl.TryGetProperties(option.GetName(), out properties);
     
+    /// <inheritdoc/>
+    public bool TryGet(UiControlOption option, out FloatConfigProperties properties) => this.UiControl.TryGetProperties(option.GetName(), out properties);
+    
+    /// <inheritdoc/>
+    public bool TryGet(UiControlOption option, out StringConfigProperties properties) => this.UiControl.TryGetProperties(option.GetName(), out properties);
+
     /// <inheritdoc/>
     public void Set(SystemConfigOption option, bool value) => this.System.Set(option.GetName(), value);
 

--- a/Dalamud/Game/Config/GameConfigSection.cs
+++ b/Dalamud/Game/Config/GameConfigSection.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 
 using Dalamud.Memory;
@@ -15,9 +15,8 @@ namespace Dalamud.Game.Config;
 public class GameConfigSection
 {
     private readonly Framework framework;
-    private readonly Dictionary<string, uint> indexMap = new();
-    private readonly Dictionary<uint, string> nameMap = new();
-    private readonly Dictionary<uint, object> enumMap = new();
+    private readonly ConcurrentDictionary<string, uint> indexMap = new();
+    private readonly ConcurrentDictionary<uint, object> enumMap = new();
 
     /// <summary>
     /// Event which is fired when a game config option is changed within the section.
@@ -404,12 +403,12 @@ public class GameConfigSection
             var name = MemoryHelper.ReadStringNullTerminated(new IntPtr(entry->Name));
             if (Enum.TryParse(typeof(TEnum), name, out enumObject))
             {
-                this.enumMap.Add(entry->Index, enumObject);
+                this.enumMap.TryAdd(entry->Index, enumObject);
             }
             else
             {
                 enumObject = null;
-                this.enumMap.Add(entry->Index, null);
+                this.enumMap.TryAdd(entry->Index, null);
             }
         }
 
@@ -439,7 +438,6 @@ public class GameConfigSection
             if (eName.Equals(name))
             {
                 this.indexMap.TryAdd(name, i);
-                this.nameMap.TryAdd(i, name);
                 index = i;
                 return true;
             }

--- a/Dalamud/Game/Config/GameConfigSection.cs
+++ b/Dalamud/Game/Config/GameConfigSection.cs
@@ -390,6 +390,99 @@ public class GameConfigSection
     }
 
     /// <summary>
+    /// Attempts to get the properties of a UInt option from the config section.
+    /// </summary>
+    /// <param name="name">Name of the option to get the properties of.</param>
+    /// <param name="properties">Details of the option: Minimum, Maximum, and Default values.</param>
+    /// <returns>A value representing the success.</returns>
+    public unsafe bool TryGetProperties(string name, out UIntConfigProperties? properties)
+    {
+        if (!this.TryGetIndex(name, out var index))
+        {
+            properties = null;
+            return false;
+        }
+
+        if (!this.TryGetEntry(index, out var entry))
+        {
+            properties = null;
+            return false;
+        }
+
+        if ((ConfigType)entry->Type != ConfigType.UInt)
+        {
+            properties = null;
+            return false;
+        }
+
+        var prop = &entry->Properties.UInt;
+        properties = new UIntConfigProperties(prop->DefaultValue, prop->MinValue, prop->MaxValue);
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to get the properties of a Float option from the config section.
+    /// </summary>
+    /// <param name="name">Name of the option to get the properties of.</param>
+    /// <param name="properties">Details of the option: Minimum, Maximum, and Default values.</param>
+    /// <returns>A value representing the success.</returns>
+    public unsafe bool TryGetProperties(string name, out FloatConfigProperties? properties)
+    {
+        if (!this.TryGetIndex(name, out var index))
+        {
+            properties = null;
+            return false;
+        }
+
+        if (!this.TryGetEntry(index, out var entry))
+        {
+            properties = null;
+            return false;
+        }
+
+        if ((ConfigType)entry->Type != ConfigType.Float)
+        {
+            properties = null;
+            return false;
+        }
+
+        var prop = &entry->Properties.Float;
+        properties = new FloatConfigProperties(prop->DefaultValue, prop->MinValue, prop->MaxValue);
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to get the properties of a String option from the config section.
+    /// </summary>
+    /// <param name="name">Name of the option to get the properties of.</param>
+    /// <param name="properties">Details of the option: Minimum, Maximum, and Default values.</param>
+    /// <returns>A value representing the success.</returns>
+    public unsafe bool TryGetProperties(string name, out StringConfigProperties? properties)
+    {
+        if (!this.TryGetIndex(name, out var index))
+        {
+            properties = null;
+            return false;
+        }
+
+        if (!this.TryGetEntry(index, out var entry))
+        {
+            properties = null;
+            return false;
+        }
+
+        if ((ConfigType)entry->Type != ConfigType.String)
+        {
+            properties = null;
+            return false;
+        }
+
+        var prop = entry->Properties.String;
+        properties = new StringConfigProperties(prop.DefaultValue == null ? null : MemoryHelper.ReadSeString(prop.DefaultValue));
+        return true;
+    }
+
+    /// <summary>
     /// Invokes a change event within the config section.
     /// </summary>
     /// <param name="entry">The config entry that was changed.</param>

--- a/Dalamud/Game/Config/Properties.cs
+++ b/Dalamud/Game/Config/Properties.cs
@@ -1,0 +1,7 @@
+﻿using Dalamud.Game.Text.SeStringHandling;
+
+namespace Dalamud.Game.Config;
+
+public record StringConfigProperties(SeString? Default);
+public record UIntConfigProperties(uint Default, uint Minimum, uint Maximum);
+public record FloatConfigProperties(float Default, float Minimum, float Maximum);

--- a/Dalamud/Plugin/Services/IGameConfig.cs
+++ b/Dalamud/Plugin/Services/IGameConfig.cs
@@ -62,6 +62,30 @@ public interface IGameConfig
     /// <param name="value">The returned value of the config option.</param>
     /// <returns>A value representing the success.</returns>
     public bool TryGet(SystemConfigOption option, out string value);
+    
+    /// <summary>
+    /// Attempts to get the properties of a UInt option from the System section.
+    /// </summary>
+    /// <param name="option">Option to get the properties of.</param>
+    /// <param name="properties">Details of the option: Minimum, Maximum, and Default values.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(SystemConfigOption option, out UIntConfigProperties? properties);
+    
+    /// <summary>
+    /// Attempts to get the properties of a Float option from the System section.
+    /// </summary>
+    /// <param name="option">Option to get the properties of.</param>
+    /// <param name="properties">Details of the option: Minimum, Maximum, and Default values.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(SystemConfigOption option, out FloatConfigProperties? properties);
+    
+    /// <summary>
+    /// Attempts to get the properties of a String option from the System section.
+    /// </summary>
+    /// <param name="option">Option to get the properties of.</param>
+    /// <param name="properties">Details of the option: Default Value</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(SystemConfigOption option, out StringConfigProperties? properties);
 
     /// <summary>
     /// Attempts to get a boolean config value from the UiConfig section.
@@ -96,6 +120,30 @@ public interface IGameConfig
     public bool TryGet(UiConfigOption option, out string value);
 
     /// <summary>
+    /// Attempts to get the properties of a UInt option from the UiConfig section.
+    /// </summary>
+    /// <param name="option">Option to get the properties of.</param>
+    /// <param name="properties">Details of the option: Minimum, Maximum, and Default values.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(UiConfigOption option, out UIntConfigProperties? properties);
+    
+    /// <summary>
+    /// Attempts to get the properties of a Float option from the UiConfig section.
+    /// </summary>
+    /// <param name="option">Option to get the properties of.</param>
+    /// <param name="properties">Details of the option: Minimum, Maximum, and Default values.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(UiConfigOption option, out FloatConfigProperties? properties);
+    
+    /// <summary>
+    /// Attempts to get the properties of a String option from the UiConfig section.
+    /// </summary>
+    /// <param name="option">Option to get the properties of.</param>
+    /// <param name="properties">Details of the option: Default Value</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(UiConfigOption option, out StringConfigProperties? properties);
+    
+    /// <summary>
     /// Attempts to get a boolean config value from the UiControl section.
     /// </summary>
     /// <param name="option">Option to get the value of.</param>
@@ -126,6 +174,30 @@ public interface IGameConfig
     /// <param name="value">The returned value of the config option.</param>
     /// <returns>A value representing the success.</returns>
     public bool TryGet(UiControlOption option, out string value);
+
+    /// <summary>
+    /// Attempts to get the properties of a UInt option from the UiControl section.
+    /// </summary>
+    /// <param name="option">Option to get the properties of.</param>
+    /// <param name="properties">Details of the option: Minimum, Maximum, and Default values.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(UiControlOption option, out UIntConfigProperties? properties);
+    
+    /// <summary>
+    /// Attempts to get the properties of a Float option from the UiControl section.
+    /// </summary>
+    /// <param name="option">Option to get the properties of.</param>
+    /// <param name="properties">Details of the option: Minimum, Maximum, and Default values.</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(UiControlOption option, out FloatConfigProperties? properties);
+    
+    /// <summary>
+    /// Attempts to get the properties of a String option from the UiControl section.
+    /// </summary>
+    /// <param name="option">Option to get the properties of.</param>
+    /// <param name="properties">Details of the option: Default Value</param>
+    /// <returns>A value representing the success.</returns>
+    public bool TryGet(UiControlOption option, out StringConfigProperties? properties);
 
     /// <summary>
     /// Set a boolean config option in the System config section.


### PR DESCRIPTION
- Fixes 2 functions using the wrong section
- Use `ConcurrentDictionary` for extra safety
- Add methods to get the properties of a config entry
  - Default for all types
  - Min/Max for Float and UInt