### PR TITLE
Remove Sdk attribute from Dalamud.Plugin targets

### DIFF
--- a/targets/Dalamud.Plugin.Bootstrap.targets
+++ b/targets/Dalamud.Plugin.Bootstrap.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+<Project>
     <PropertyGroup>
         <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
     </PropertyGroup>

--- a/targets/Dalamud.Plugin.targets
+++ b/targets/Dalamud.Plugin.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+<Project>
     <PropertyGroup>
         <TargetFramework>net7.0-windows</TargetFramework>
         <Platforms>x64</Platforms>


### PR DESCRIPTION
Currently the .targets files specify the Sdk attribute on `<Project>`. The .csproj of a plugin should be the only one that specifies the Sdk attribute, otherwise it throws a bunch of warnings at us for importing the Sdk props multiple times:

> \SamplePlugin\Dalamud.Plugin.Bootstrap.targets : warning MSB4011: "C:\Program Files\dotnet\sdk\7.0.306\Sdks\Microsoft.NET.Sdk\Sdk\Sdk.props" cannot be imported again. It was already imported at "\SamplePlugin\SamplePlugin.csproj". This is most likely a build authoring error. This subsequent import will be ignored.

> \AppData\Roaming\XIVLauncher\addon\Hooks\dev\targets\Dalamud.Plugin.targets : warning MSB4011: "C:\Program Files\dotnet\sdk\7.0.306\Sdks\Microsoft.NET.Sdk\Sdk\Sdk.props" cannot be imported again. It was already imported at "\SamplePlugin\SamplePlugin.csproj". This is most likely a build authoring error. This subsequent import will be ignored.