### PR TITLE
Disable window sounds for TitleScreenMenuWindow

### DIFF
--- a/Dalamud/Interface/Internal/Windows/TitleScreenMenuWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/TitleScreenMenuWindow.cs
@@ -45,7 +45,7 @@ internal class TitleScreenMenuWindow : Window, IDisposable
             ImGuiWindowFlags.NoBackground | ImGuiWindowFlags.NoFocusOnAppearing | ImGuiWindowFlags.NoNavFocus)
     {
         this.IsOpen = true;
-
+        this.DisableWindowSounds = true;
         this.ForceMainWindow = true;
 
         this.Position = new Vector2(0, 200);


### PR DESCRIPTION
This PR disables the window open/close sound effects in `TitleScreenMenuWindow`, the little overlay-menu on the left.
They played several times during the login process due to changing `IsOpen` in the `FrameworkOnUpdate` method.