### PR TITLE
Fix rollup action fetch depth

### DIFF
--- a/.github/workflows/rollup.yml
+++ b/.github/workflows/rollup.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+          fetch-depth: 0
           ref: ${{ matrix.branches }}
           token: ${{ secrets.UPDATE_PAT }}
       - name: Create update branch


### PR DESCRIPTION
The rollup GitHub action fails, because the default fetch depth is set to 1 causing it to only fetch 1 commit(?), which is not enough to merge master into the v9-rollup branch.

Defining a fetch-depth of 0 causes no --depth argument to be applied to the git fetch command (see [action code](https://github.com/actions/checkout/blob/d106d46/src/git-command-manager.ts#L256-L257)).

Bear in mind, I'm no expert in this, but *it worked on my machine*. 😊