### PR TITLE
Add ImRaii.ContextPopupItem

### DIFF
--- a/Dalamud.Interface/Raii/EndObjects.cs
+++ b/Dalamud.Interface/Raii/EndObjects.cs
@@ -51,6 +51,12 @@ public static partial class ImRaii
     public static IEndObject ContextPopup(string id, ImGuiPopupFlags flags)
         => new EndConditionally(ImGui.EndPopup, ImGui.BeginPopupContextWindow(id, flags));
 
+    public static IEndObject ContextPopupItem(string id)
+        => new EndConditionally(ImGui.EndPopup, ImGui.BeginPopupContextItem(id));
+
+    public static IEndObject ContextPopupItem(string id, ImGuiPopupFlags flags)
+        => new EndConditionally(ImGui.EndPopup, ImGui.BeginPopupContextItem(id, flags));
+
     public static IEndObject Combo(string label, string previewValue)
         => new EndConditionally(ImGui.EndCombo, ImGui.BeginCombo(label, previewValue));
 


### PR DESCRIPTION
I often want to add a context menu on the last item, but for some reason the existing `ContextPopup` uses `BeginPopupContextWindow`, which is not my use case.

So here I am with a PR to add a `ContextPopupItem`, that uses `BeginPopupContextItem`. 🙂

Perhaps `ContextPopup` should be renamed to `ContextPopupWindow` to better match the [ImGui API](https://github.com/ocornut/imgui/blob/1109de3/imgui.h#L720-L721)?