### PR TITLE
[v9] Make DataManager.IsDataReady internal

### DIFF
--- a/Dalamud/Data/DataManager.cs
+++ b/Dalamud/Data/DataManager.cs
@@ -131,6 +131,11 @@ public sealed class DataManager : IDisposable, IServiceType, IDataManager
         }
     }
 
+    /// <summary>
+    /// Gets a value indicating whether Game Data is ready to be read.
+    /// </summary>
+    internal bool IsDataReady { get; private set; }
+
     /// <inheritdoc/>
     public ClientLanguage Language { get; private set; }
 
@@ -146,9 +151,6 @@ public sealed class DataManager : IDisposable, IServiceType, IDataManager
 
     /// <inheritdoc/>
     public ExcelModule Excel => this.GameData.Excel;
-
-    /// <inheritdoc/>
-    public bool IsDataReady { get; private set; }
 
     /// <inheritdoc/>
     public bool HasModifiedGameDataFiles { get; private set; }

--- a/Dalamud/Plugin/Services/IDataManager.cs
+++ b/Dalamud/Plugin/Services/IDataManager.cs
@@ -39,11 +39,6 @@ public interface IDataManager
     public ExcelModule Excel { get; }
 
     /// <summary>
-    /// Gets a value indicating whether Game Data is ready to be read.
-    /// </summary>
-    public bool IsDataReady { get; }
-
-    /// <summary>
     /// Gets a value indicating whether the game data files have been modified by another third-party tool.
     /// </summary>
     public bool HasModifiedGameDataFiles { get; }


### PR DESCRIPTION
This change makes `DataManager.IsDataReady` an internal method.

There is no need for `IsDataReady` to be in the public API, since `DataManager` is a blocking service and its data is ready by the time plugins are loaded.

As per micro-discussion in [#dalamud-dev](https://discord.com/channels/581875019861328007/860813266468732938/1134898545498001468).