### PR TITLE
[v9] Improvements to SeString

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/Payloads/MapLinkPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/MapLinkPayload.cs
@@ -130,7 +130,13 @@ public class MapLinkPayload : Payload
             var y = Math.Truncate((this.YCoord + fudge) * 10.0f) / 10.0f;
 
             // the formatting and spacing the game uses
-            return $"( {x:0.0}  , {y:0.0} )";
+            var clientState = Service<ClientState.ClientState>.Get();
+            return clientState.ClientLanguage switch
+            {
+                ClientLanguage.German => $"( {x:0.0}, {y:0.0} )",
+                ClientLanguage.Japanese => $"({x:0.0}, {y:0.0})",
+                _ => $"( {x:0.0}  , {y:0.0} )",
+            };
         }
     }
 

--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -211,8 +211,8 @@ public class SeString
             // arrow goes here
             new TextPayload(displayName),
             RawPayload.LinkTerminator,
-            // sometimes there is another set of uiglow/foreground off payloads here
-            // might be necessary when including additional text after the item name
+            UIGlowPayload.UIGlowOff,
+            UIForegroundPayload.UIForegroundOff,
         });
         payloads.InsertRange(3, TextArrowPayloads);
 

--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -194,7 +194,7 @@ public class SeString
                 case ItemPayload.ItemKind.Hq:
                     var item = data.GetExcelSheet<Item>()?.GetRow(itemId);
                     displayName = item?.Name;
-                    rarity = item.Rarity;
+                    rarity = item?.Rarity ?? 1;
                     break;
                 case ItemPayload.ItemKind.EventItem:
                     displayName = data.GetExcelSheet<EventItem>()?.GetRow(itemId)?.Name;

--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -210,10 +210,10 @@ public class SeString
 
         // Note: `SeStringBuilder.AddItemLink` uses this function, so don't call it here!
         return new SeStringBuilder()
-            .Add(new ItemPayload(itemId, kind))
-            .Append(TextArrowPayloads)
             .AddUiForeground(textColor)
             .AddUiGlow(textGlowColor)
+            .Add(new ItemPayload(itemId, kind))
+            .Append(TextArrowPayloads)
             .AddText(displayName)
             .AddUiGlowOff()
             .AddUiForegroundOff()

--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -52,14 +52,27 @@ public class SeString
     /// with the appropriate glow and coloring.
     /// </summary>
     /// <returns>A list of all the payloads required to insert the link marker.</returns>
-    public static IEnumerable<Payload> TextArrowPayloads => new List<Payload>(new Payload[]
+    public static IEnumerable<Payload> TextArrowPayloads
     {
-        new UIForegroundPayload(0x01F4),
-        new UIGlowPayload(0x01F5),
-        new TextPayload($"{(char)SeIconChar.LinkMarker}"),
-        UIGlowPayload.UIGlowOff,
-        UIForegroundPayload.UIForegroundOff,
-    });
+        get
+        {
+            var clientState = Service<ClientState.ClientState>.Get();
+            var markerSpace = clientState.ClientLanguage switch
+            {
+                ClientLanguage.German => " ",
+                ClientLanguage.French => " ",
+                _ => string.Empty,
+            };
+            return new List<Payload>
+            {
+                new UIForegroundPayload(500),
+                new UIGlowPayload(501),
+                new TextPayload($"{(char)SeIconChar.LinkMarker}{markerSpace}"),
+                UIGlowPayload.UIGlowOff,
+                UIForegroundPayload.UIForegroundOff,
+            };
+        }
+    }
 
     /// <summary>
     /// Gets an empty SeString.

--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -208,6 +208,7 @@ public class SeString
         var textColor = (ushort)(549 + ((rarity - 1) * 2));
         var textGlowColor = (ushort)(textColor + 1);
 
+        // Note: `SeStringBuilder.AddItemLink` uses this function, so don't call it here!
         return new SeStringBuilder()
             .Add(new ItemPayload(itemId, kind))
             .Append(TextArrowPayloads)

--- a/Dalamud/Game/Text/SeStringHandling/SeStringBuilder.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeStringBuilder.cs
@@ -114,7 +114,7 @@ public class SeStringBuilder
     /// <param name="itemNameOverride">Override for the item's name.</param>
     /// <returns>The current builder.</returns>
     public SeStringBuilder AddItemLink(uint itemId, bool isHq, string? itemNameOverride = null) =>
-        this.Add(new ItemPayload(itemId, isHq, itemNameOverride));
+        this.Append(SeString.CreateItemLink(itemId, isHq, itemNameOverride));
 
     /// <summary>
     /// Add an item link to the builder.
@@ -124,7 +124,7 @@ public class SeStringBuilder
     /// <param name="itemNameOverride">Override for the item's name.</param>
     /// <returns>The current builder.</returns>
     public SeStringBuilder AddItemLink(uint itemId, ItemPayload.ItemKind kind, string? itemNameOverride = null) =>
-        this.Add(new ItemPayload(itemId, kind, itemNameOverride));
+        this.Append(SeString.CreateItemLink(itemId, kind, itemNameOverride));
 
     /// <summary>
     /// Add an item link to the builder.

--- a/Dalamud/Game/Text/SeStringHandling/SeStringBuilder.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeStringBuilder.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 
 namespace Dalamud.Game.Text.SeStringHandling;
@@ -29,6 +32,13 @@ public class SeStringBuilder
     /// <param name="text">The raw text.</param>
     /// <returns>The current builder.</returns>
     public SeStringBuilder Append(string text) => this.AddText(text);
+
+    /// <summary>
+    /// Append payloads to the builder.
+    /// </summary>
+    /// <param name="payloads">A list of payloads.</param>
+    /// <returns>The current builder.</returns>
+    public SeStringBuilder Append(IEnumerable<Payload> payloads) => this.Append(new SeString(payloads.ToList()));
 
     /// <summary>
     /// Append raw text to the builder.

--- a/Dalamud/Game/Text/SeStringHandling/SeStringBuilder.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeStringBuilder.cs
@@ -123,7 +123,7 @@ public class SeStringBuilder
     /// <param name="kind">Kind of item to encode.</param>
     /// <param name="itemNameOverride">Override for the item's name.</param>
     /// <returns>The current builder.</returns>
-    public SeStringBuilder AddItemLink(uint itemId, ItemPayload.ItemKind kind, string? itemNameOverride = null) =>
+    public SeStringBuilder AddItemLink(uint itemId, ItemPayload.ItemKind kind = ItemPayload.ItemKind.Normal, string? itemNameOverride = null) =>
         this.Append(SeString.CreateItemLink(itemId, kind, itemNameOverride));
 
     /// <summary>

--- a/Dalamud/Game/Text/SeStringHandling/SeStringBuilder.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeStringBuilder.cs
@@ -131,6 +131,7 @@ public class SeStringBuilder
     /// </summary>
     /// <param name="rawItemId">The raw item ID.</param>
     /// <returns>The current builder.</returns>
+    /// <remarks>To terminate this item link, add a <see cref="RawPayload.LinkTerminator"/>.</remarks>
     public SeStringBuilder AddItemLinkRaw(uint rawItemId) =>
         this.Add(ItemPayload.FromRaw(rawItemId));
 


### PR DESCRIPTION
This PR brings the following fixes/additions:

- **Behaviour Change**: `SeStringBuilder.AddItemLink` now correctly adds a full item link using `SeString.CreateItemLink`, instead of only adding an `ItemPayload`. (08100ef572c46d148e5bd60f43fbaf2f0a531f89)
- **Added:** New function `SeStringBuilder.Append(IEnumerable<Payload>)` to add payloads directly. (0f30b8240c2cd3ba80e83c66b4b30180674c81e1)
-  **Fixed:** `SeString.CreateItemLink` now correctly resets the text color after the item link. (982755c4a2858e9abbf662e0789884acfa050a8e)
- **Fixed:** `SeString.CreateItemLink` now respects the items rarity color. (3f78df23e3a96f2118ac0801c2748c2641135f49)
- **Fixed:** `SeString.TextArrowPayloads` now correctly includes a space after the marker in the German and French clients (see Addon sheet, row 371). (d6555007ce16745b538a5f960a3771c497168e14)
- **Fixed:** `MapLinkPayload.CoordinateString` now correctly formats the coordinates in the German and Japanese clients (spacing adjustments). (038de41592cb2e3cd0b43f664fb2289a227cc80d)
- **Changed:** The `ItemKind` parameter on `SeStringBuilder.AddItemLink` now defaults to `ItemPayload.ItemKind.Normal`, like the `SeString.CreateItemLink` counterpart, allowing it to be called with just the item id. (5b6c90f122da0cf3b7bf3f20d103a2752fbf3e3b)