### PR TITLE
[v9] Use IEnumerable when appending payloads to SeString

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -421,7 +421,7 @@ public class SeString
     /// </summary>
     /// <param name="payloads">The Payloads to append.</param>
     /// <returns>This object.</returns>
-    public SeString Append(List<Payload> payloads)
+    public SeString Append(IEnumerable<Payload> payloads)
     {
         this.Payloads.AddRange(payloads);
         return this;

--- a/Dalamud/Game/Text/SeStringHandling/SeStringBuilder.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeStringBuilder.cs
@@ -38,7 +38,11 @@ public class SeStringBuilder
     /// </summary>
     /// <param name="payloads">A list of payloads.</param>
     /// <returns>The current builder.</returns>
-    public SeStringBuilder Append(IEnumerable<Payload> payloads) => this.Append(new SeString(payloads.ToList()));
+    public SeStringBuilder Append(IEnumerable<Payload> payloads)
+    {
+        this.BuiltString.Payloads.AddRange(payloads);
+        return this;
+    }
 
     /// <summary>
     /// Append raw text to the builder.


### PR DESCRIPTION
Followup for https://github.com/goatcorp/Dalamud/pull/1334:

- **Changed:** `SeString.Append` now accepts `IEnumerable<Payload>` instead of `List<Payload>` (a6ed6dabe4206b445cad9b0f16d53633287c3bdf)
- **Internally changed:** `SeStringBuilder.Append` now directly appends the payloads, without calling `new SeString()` and `.ToList()` (54790711ddcd6604f108f31fbd93fd4c3ec15240)