### PR TITLE
Add support for HTTP2 connections

### DIFF
--- a/Dalamud/Networking/Http/HappyHttpClient.cs
+++ b/Dalamud/Networking/Http/HappyHttpClient.cs
@@ -27,8 +27,8 @@ internal class HappyHttpClient : IDisposable, IServiceType
             ConnectCallback = this.SharedHappyEyeballsCallback.ConnectCallback,
         })
         {
-            DefaultRequestVersion = HttpVersion.Version11,
-            DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher,
+            DefaultRequestVersion = HttpVersion.Version20,
+            DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower,
         };
     }
 

--- a/Dalamud/Networking/Http/HappyHttpClient.cs
+++ b/Dalamud/Networking/Http/HappyHttpClient.cs
@@ -25,7 +25,11 @@ internal class HappyHttpClient : IDisposable, IServiceType
         {
             AutomaticDecompression = DecompressionMethods.All,
             ConnectCallback = this.SharedHappyEyeballsCallback.ConnectCallback,
-        });
+        })
+        {
+            DefaultRequestVersion = HttpVersion.Version11,
+            DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher,
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request aims to allow the shared HTTP client to upgrade connections to HTTP2, depending on the remote server (and the system the code is running on). This is basically a direct port of what MS docs [tell us to do](https://learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-http3#httpclient-settings).

n.b. this appears to work at a surface level and the very quick tests I threw at it, but given .NET HTTP's fragility, we might want this to stay in staging for a while.