### PR TITLE
[v9] Make Wine Checks More Resilient

### DIFF
--- a/Dalamud.Boot/dllmain.cpp
+++ b/Dalamud.Boot/dllmain.cpp
@@ -133,8 +133,8 @@ DWORD WINAPI InitializeImpl(LPVOID lpParam, HANDLE hMainThreadContinue) {
     // ============================== VEH ======================================== //
 
     logging::I("Initializing VEH...");
-    if (utils::is_running_on_linux()) {
-        logging::I("=> VEH was disabled, running on linux");
+    if (utils::is_running_on_wine()) {
+        logging::I("=> VEH was disabled, running on wine");
     } else if (g_startInfo.BootVehEnabled) {
         if (veh::add_handler(g_startInfo.BootVehFull, g_startInfo.WorkingDirectory))
             logging::I("=> Done!");

--- a/Dalamud.Boot/utils.cpp
+++ b/Dalamud.Boot/utils.cpp
@@ -578,7 +578,7 @@ std::vector<std::string> utils::get_env_list(const wchar_t* pcszName) {
     return res;
 }
 
-bool utils::is_running_on_linux() {
+bool utils::is_running_on_wine() {
     if (get_env<bool>(L"XL_WINEONLINUX"))
         return true;
     HMODULE hntdll = GetModuleHandleW(L"ntdll.dll");
@@ -587,6 +587,10 @@ bool utils::is_running_on_linux() {
     if (GetProcAddress(hntdll, "wine_get_version"))
         return true;
     if (GetProcAddress(hntdll, "wine_get_host_version"))
+        return true;
+    if (GetProcAddress(hntdll, "wine_server_call"))
+        return true;
+    if (GetProcAddress(hntdll, "wine_unix_to_nt_file_name"))
         return true;
     return false;
 }

--- a/Dalamud.Boot/utils.h
+++ b/Dalamud.Boot/utils.h
@@ -264,7 +264,7 @@ namespace utils {
         return get_env_list<T>(unicode::convert<std::wstring>(pcszName).c_str());
     }
 
-    bool is_running_on_linux();
+    bool is_running_on_wine();
 
     std::filesystem::path get_module_path(HMODULE hModule);
 

--- a/Dalamud/EntryPoint.cs
+++ b/Dalamud/EntryPoint.cs
@@ -166,7 +166,7 @@ public sealed class EntryPoint
             // This is due to GitHub not supporting TLS 1.0, so we enable all TLS versions globally
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12 | SecurityProtocolType.Tls;
 
-            if (!Util.IsLinux())
+            if (!Util.IsWine())
                 InitSymbolHandler(info);
 
             var dalamud = new Dalamud(info, configuration, mainThreadContinueEvent);


### PR DESCRIPTION
This pull request aims to improve our wine check resilience to better handle some edge cases:

* Remove checks looking for `HKCU:\Software\Wine` and `HKLM:\Software\Wine`, as certain programs will create these registry paths (even on Windows!) to improve Linux compatibility.
* Add checks for the `wine_server_call` and `wine_unix_to_nt_file_name` exports, which are *not* hidden by the `HideWineExports` option.
    * The other listed Wine exports will all be hidden for licensing reasons for Linux users.
* Rename `Util.IsLinux()` to `Util.IsWine()` to prevent confusion with macOS detection.

Generally speaking, all *supported* users will already be covered by the `XL_WINEONLINUX` environment variable already. However, retaining export checks does allow us a bit more flexibility in the future.
