### PR TITLE
Fade to black during credits animation

### DIFF
--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -524,7 +524,8 @@ internal class DalamudInterface : IDisposable, IServiceType
 
     private void DrawCreditsDarkeningAnimation()
     {
-        using var style = ImRaii.PushStyle(ImGuiStyleVar.WindowRounding, 0f);
+        using var style = ImRaii.PushStyle(ImGuiStyleVar.WindowRounding | ImGuiStyleVar.WindowBorderSize, 0f);
+        using var color = ImRaii.PushColor(ImGuiCol.WindowBg, new Vector4(0, 0, 0, 0));
 
         ImGui.SetNextWindowPos(new Vector2(0, 0));
         ImGui.SetNextWindowSize(ImGuiHelpers.MainViewport.Size);


### PR DESCRIPTION
Instead of using the color from the current style's window background, fade to black. Not sure if the original behaviour was intended, but it produced some weird results that didn't seem fitting. Also changed the border size to 0, so you don't actually see the border on custom color schemes.