### PR TITLE
Add SpecialPluginSource to public API

### DIFF
--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -56,7 +56,7 @@ public sealed class DalamudPluginInterface : IDisposable
 
         this.configs = Service<PluginManager>.Get().PluginConfigs;
         this.Reason = reason;
-        this.SourceRepository = this.IsDev ? LocalPluginManifest.FlagDevPlugin : plugin.Manifest.InstalledFromUrl;
+        this.SourceRepository = this.IsDev ? SpecialPluginSource.DevPlugin : plugin.Manifest.InstalledFromUrl;
         this.IsTesting = plugin.IsTesting;
 
         this.LoadTime = DateTime.Now;
@@ -118,8 +118,8 @@ public sealed class DalamudPluginInterface : IDisposable
     /// Gets the repository from which this plugin was installed.
     ///
     /// If a plugin was installed from the official/main repository, this will return the value of
-    /// <see cref="LocalPluginManifest.FlagMainRepo"/>. Developer plugins will return the value of
-    /// <see cref="LocalPluginManifest.FlagDevPlugin"/>.
+    /// <see cref="SpecialPluginSource.MainRepo"/>. Developer plugins will return the value of
+    /// <see cref="SpecialPluginSource.DevPlugin"/>.
     /// </summary>
     public string SourceRepository { get; }
 

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -873,7 +873,7 @@ internal partial class PluginManager : IDisposable, IServiceType
         }
 
         // Document the url the plugin was installed from
-        manifest.InstalledFromUrl = repoManifest.SourceRepo.IsThirdParty ? repoManifest.SourceRepo.PluginMasterUrl : LocalPluginManifest.FlagMainRepo;
+        manifest.InstalledFromUrl = repoManifest.SourceRepo.IsThirdParty ? repoManifest.SourceRepo.PluginMasterUrl : SpecialPluginSource.MainRepo;
 
         manifest.Save(manifestFile, "installation");
 

--- a/Dalamud/Plugin/Internal/Types/Manifest/LocalPluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/Manifest/LocalPluginManifest.cs
@@ -14,18 +14,6 @@ namespace Dalamud.Plugin.Internal.Types.Manifest;
 internal record LocalPluginManifest : PluginManifest, ILocalPluginManifest
 {
     /// <summary>
-    /// Flag indicating that a plugin was installed from the official repo.
-    /// </summary>
-    [JsonIgnore]
-    public const string FlagMainRepo = "OFFICIAL";
-
-    /// <summary>
-    /// Flag indicating that a plugin is a dev plugin..
-    /// </summary>
-    [JsonIgnore]
-    public const string FlagDevPlugin = "DEVPLUGIN";
-
-    /// <summary>
     /// Gets or sets a value indicating whether the plugin is disabled and should not be loaded.
     /// This value supersedes the ".disabled" file functionality and should not be included in the plugin master.
     /// </summary>
@@ -51,7 +39,7 @@ internal record LocalPluginManifest : PluginManifest, ILocalPluginManifest
     /// Gets a value indicating whether this manifest is associated with a plugin that was installed from a third party
     /// repo. Unless the manifest has been manually modified, this is determined by the InstalledFromUrl being null.
     /// </summary>
-    public bool IsThirdParty => !this.InstalledFromUrl.IsNullOrEmpty() && this.InstalledFromUrl != FlagMainRepo;
+    public bool IsThirdParty => !this.InstalledFromUrl.IsNullOrEmpty() && this.InstalledFromUrl != SpecialPluginSource.MainRepo;
 
     /// <summary>
     /// Gets the effective version of this plugin.

--- a/Dalamud/Plugin/Internal/Types/Manifest/SpecialPluginSource.cs
+++ b/Dalamud/Plugin/Internal/Types/Manifest/SpecialPluginSource.cs
@@ -1,0 +1,17 @@
+﻿namespace Dalamud.Plugin.Internal.Types.Manifest;
+
+/// <summary>
+/// A fake enum representing "special" sources for plugins.
+/// </summary>
+public static class SpecialPluginSource 
+{
+    /// <summary>
+    /// Indication that this plugin came from the official Dalamud repository. 
+    /// </summary>
+    public const string MainRepo = "OFFICIAL";
+
+    /// <summary>
+    /// Indication that this plugin is loaded as a dev plugin. See also <see cref="DalamudPluginInterface.IsDev"/>.
+    /// </summary>
+    public const string DevPlugin = "DEVPLUGIN";
+}


### PR DESCRIPTION
Per a discussion in Discord, it was discovered that our "special" source declarations were kept internal-only despite the resulting values being exposed to plugins via their APIs.

This pull request aims to formally expose these special plugin sources for comparison and testing purposes. 