### PR TITLE
Addon lifecycle exception safety

### DIFF
--- a/Dalamud/Game/AddonLifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/AddonLifecycle/AddonLifecycle.cs
@@ -88,7 +88,7 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType, IAddonLifecycl
 
     private void OnAddonFinalize(AtkUnitManager* unitManager, AtkUnitBase** atkUnitBase)
     {
-        if (atkUnitBase is null)
+        if (atkUnitBase is null || atkUnitBase[0] is null)
         {
             this.onAddonFinalizeHook.Original(unitManager, atkUnitBase);
             return;

--- a/Dalamud/Plugin/Services/IAddonLifecycle.cs
+++ b/Dalamud/Plugin/Services/IAddonLifecycle.cs
@@ -26,11 +26,6 @@ public interface IAddonLifecycle
     public event Action<AddonArgs> AddonPreFinalize;
     
     /// <summary>
-    /// Event that fires after an addon is done being finalized.
-    /// </summary>
-    public event Action<AddonArgs> AddonPostFinalize;
-    
-    /// <summary>
     /// Addon argument data for use in event subscribers.
     /// </summary>
     public unsafe class AddonArgs
@@ -40,7 +35,7 @@ public interface IAddonLifecycle
         /// <summary>
         /// Gets the name of the addon this args referrers to.
         /// </summary>
-        public string AddonName => this.addonName ??= MemoryHelper.ReadString((nint)((AtkUnitBase*)this.Addon)->Name, 0x20);
+        public string AddonName => this.Addon == nint.Zero ? "NullAddon" : this.addonName ??= MemoryHelper.ReadString((nint)((AtkUnitBase*)this.Addon)->Name, 0x20);
 
         /// <summary>
         /// Gets the pointer to the addons AtkUnitBase.


### PR DESCRIPTION
Fixed copy-paste error, finalize will now actually trigger on finalize.

Removed AddonPostFinalize, I never used AddonPostFinalize in DailyDuty, but thought I should include it here for completeness... but then after some testing today I realized, AddonPostFinalize is always null... because its after it's finalized... Yeah, smol brain on that one oops.

Also added default name to AddonArgs in case Addon is null.

