### PR TITLE
Chat Payload Remove Logspam

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/Payload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payload.cs
@@ -207,13 +207,8 @@ public abstract partial class Payload
                 payload = new IconPayload();
                 break;
             
-            // Known chunk types that are not implemented by dalamud. No reason to spam the log for these.
-            case SeStringChunkType.SeColor:
-            case SeStringChunkType.SeGlow:
-                break;
-
             default:
-                Log.Verbose("Unhandled SeStringChunkType: {0}", chunkType);
+                // Log.Verbose("Unhandled SeStringChunkType: {0}", chunkType);
                 break;
         }
 
@@ -322,16 +317,6 @@ public abstract partial class Payload
         /// </summary>
         Icon = 0x12,
 
-        /// <summary>
-        /// Known but not implemented type.
-        /// </summary>
-        SeColor = 0x13,
-
-        /// <summary>
-        /// Known but not implemented type.
-        /// </summary>
-        SeGlow = 0x14,
-        
         /// <summary>
         /// See the <see cref="EmphasisItalicPayload"/> class.
         /// </summary>

--- a/Dalamud/Game/Text/SeStringHandling/Payload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payload.cs
@@ -341,7 +341,7 @@ public abstract partial class Payload
         /// See the <see cref="SeHyphenPayload"/> class.
         /// </summary>
         SeHyphen = 0x1F,
-        
+
         /// <summary>
         /// See any of the link-type classes:
         /// <see cref="PlayerPayload"/>,

--- a/Dalamud/Game/Text/SeStringHandling/Payload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payload.cs
@@ -206,6 +206,11 @@ public abstract partial class Payload
             case SeStringChunkType.Icon:
                 payload = new IconPayload();
                 break;
+            
+            // Known chunk types that are not implemented by dalamud. No reason to spam the log for these.
+            case SeStringChunkType.SeColor:
+            case SeStringChunkType.SeGlow:
+                break;
 
             default:
                 Log.Verbose("Unhandled SeStringChunkType: {0}", chunkType);
@@ -308,25 +313,35 @@ public abstract partial class Payload
     protected enum SeStringChunkType
     {
         /// <summary>
+        /// See the <see cref="NewLinePayload"/>.
+        /// </summary>
+        NewLine = 0x10,
+        
+        /// <summary>
         /// See the <see cref="IconPayload"/> class.
         /// </summary>
         Icon = 0x12,
 
+        /// <summary>
+        /// Known but not implemented type.
+        /// </summary>
+        SeColor = 0x13,
+
+        /// <summary>
+        /// Known but not implemented type.
+        /// </summary>
+        SeGlow = 0x14,
+        
         /// <summary>
         /// See the <see cref="EmphasisItalicPayload"/> class.
         /// </summary>
         EmphasisItalic = 0x1A,
 
         /// <summary>
-        /// See the <see cref="NewLinePayload"/>.
-        /// </summary>
-        NewLine = 0x10,
-
-        /// <summary>
         /// See the <see cref="SeHyphenPayload"/> class.
         /// </summary>
         SeHyphen = 0x1F,
-
+        
         /// <summary>
         /// See any of the link-type classes:
         /// <see cref="PlayerPayload"/>,


### PR DESCRIPTION
Removes spamming verbose logging. This logging causes Honorific and PrefPro to spam the log due to implementation of custom payloads that dalamud does not recognize.

Also re-ordered SeStringChunkTypes to be in ascending numerical order.