### PR TITLE
Allow filtering plugin logs from IPluginLog

### DIFF
--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -504,14 +504,16 @@ internal class ConsoleWindow : Window, IDisposable
             HasException = logEvent.Exception != null,
         };
         
+        // TODO (v9): Remove SourceContext property check.
         if (logEvent.Properties.ContainsKey("Dalamud.ModuleName"))
         {
             entry.Source = "DalamudInternal";
         }
-        else if (logEvent.Properties.TryGetValue("Dalamud.PluginName", out var sourceProp) &&
-                 sourceProp is ScalarValue { Value: string value })
+        else if ((logEvent.Properties.TryGetValue("Dalamud.PluginName", out var sourceProp) ||
+                  logEvent.Properties.TryGetValue("SourceContext", out sourceProp)) &&
+                 sourceProp is ScalarValue { Value: string sourceValue })
         {
-            entry.Source = value;
+            entry.Source = sourceValue;
         }
 
         this.logText.Add(entry);

--- a/Dalamud/Logging/Internal/ModuleLog.cs
+++ b/Dalamud/Logging/Internal/ModuleLog.cs
@@ -12,6 +12,10 @@ public class ModuleLog
 {
     private readonly string moduleName;
     private readonly ILogger moduleLogger;
+    
+    // FIXME (v9): Deprecate this class in favor of using contextualized ILoggers with proper formatting.
+    //             We can keep this class around as a Serilog helper, but ModuleLog should no longer be a returned
+    //             type, instead returning a (prepared) ILogger appropriately.
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ModuleLog"/> class.
@@ -20,10 +24,8 @@ public class ModuleLog
     /// <param name="moduleName">The module name.</param>
     public ModuleLog(string? moduleName)
     {
-        // FIXME: Should be namespaced better, e.g. `Dalamud.PluginLoader`, but that becomes a relatively large
-        //        change.
         this.moduleName = moduleName ?? "DalamudInternal";
-        this.moduleLogger = Log.ForContext("SourceContext", this.moduleName);
+        this.moduleLogger = Log.ForContext("Dalamud.ModuleName", this.moduleName);
     }
 
     /// <summary>
@@ -128,7 +130,8 @@ public class ModuleLog
     public void Fatal(Exception exception, string messageTemplate, params object[] values)
         => this.WriteLog(LogEventLevel.Fatal, messageTemplate, exception, values);
 
-    private void WriteLog(LogEventLevel level, string messageTemplate, Exception? exception = null, params object[] values)
+    private void WriteLog(
+        LogEventLevel level, string messageTemplate, Exception? exception = null, params object[] values)
     {
         // FIXME: Eventually, the `pluginName` tag should be removed from here and moved over to the actual log
         //        formatter.

--- a/Dalamud/Logging/PluginLog.cs
+++ b/Dalamud/Logging/PluginLog.cs
@@ -256,7 +256,7 @@ public static class PluginLog
 
     private static ILogger GetPluginLogger(string? pluginName)
     {
-        return Serilog.Log.ForContext("SourceContext", pluginName ?? string.Empty);
+        return Serilog.Log.ForContext("Dalamud.PluginName", pluginName ?? string.Empty);
     }
 
     private static void WriteLog(string? pluginName, LogEventLevel level, string messageTemplate, Exception? exception = null, params object[] values)


### PR DESCRIPTION
This pull request restores the ability to filter log messages from plugins using `IPluginLog`, as well as cleans up some unnecessary confusion.

- `PluginLog` will now use `Dalamud.PluginName` as its context property.
- `ModuleLog` will now use `Dalamud.ModuleName` as its context property.
- The console window will now filter on `Dalamud.PluginName` and `SourceContext` (with the first taking precedence)
  - A new source `DalamudInternal` has been added to filter only Dalamud-level messages.
  - The "plugin" filter dropdown has been renamed to the "source" filter.
  - `SourceContext` filtering will be removed in API 9.