### PR TITLE
Catch exceptions in Window.Draw

### DIFF
--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Numerics;
 
 using Dalamud.Configuration.Internal;
 using Dalamud.Game.ClientState.Keys;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using ImGuiNET;
+using Serilog;
 
 namespace Dalamud.Interface.Windowing;
 
@@ -284,7 +286,14 @@ public abstract class Window
         if (this.ShowCloseButton ? ImGui.Begin(this.WindowName, ref this.internalIsOpen, this.Flags) : ImGui.Begin(this.WindowName, this.Flags))
         {
             // Draw the actual window contents
-            this.Draw();
+            try
+            {
+                this.Draw();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, $"Error during Draw(): {this.WindowName}");
+            }
         }
 
         if (wasFocused)

--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -3,9 +3,9 @@ using System.Numerics;
 
 using Dalamud.Configuration.Internal;
 using Dalamud.Game.ClientState.Keys;
+using Dalamud.Logging.Internal;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using ImGuiNET;
-using Serilog;
 
 namespace Dalamud.Interface.Windowing;
 
@@ -14,6 +14,8 @@ namespace Dalamud.Interface.Windowing;
 /// </summary>
 public abstract class Window
 {
+    private static readonly ModuleLog Log = new("WindowSystem");
+
     private static bool wasEscPressedLastFrame = false;
 
     private bool internalLastIsOpen = false;


### PR DESCRIPTION
When an Exception is thrown inside the `Draw()` method of a plugins window, it would prevent the execution of the remaining code in `Window.DrawInternal()`. I added a try/catch block around the `Draw()` call to prevent this.

The most important reason for this is to ensure that the `PostDraw()` method is always called, even if the `Draw()` method fails.
The `PostDraw()` method might be important for popping styles and colors that were pushed in the `PreDraw()` method to change the windows appearance.