### PR TITLE
Use WorkingPluginId to identify plugins in profiles

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/ProfileManagerWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/ProfileManagerWidget.cs
@@ -406,7 +406,7 @@ internal class ProfileManagerWidget
             foreach (var plugin in profile.Plugins.ToArray())
             {
                 didAny = true;
-                var pmPlugin = pm.InstalledPlugins.FirstOrDefault(x => x.Manifest.InternalName == plugin.InternalName);
+                var pmPlugin = pm.InstalledPlugins.FirstOrDefault(x => x.Manifest.WorkingPluginId == plugin.WorkingPluginId);
                 var btnOffset = 2;
 
                 if (pmPlugin != null)
@@ -437,26 +437,33 @@ internal class ProfileManagerWidget
 
                     ImGui.SetCursorPosY(ImGui.GetCursorPosY() + (pluginLineHeight / 2) - (textHeight.Y / 2));
                     ImGui.TextUnformatted(text);
-
-                    var available =
+                    
+                    var firstAvailableInstalled = pm.InstalledPlugins.FirstOrDefault(x => x.InternalName == plugin.InternalName);
+                    var installable =
                         pm.AvailablePlugins.FirstOrDefault(
                             x => x.InternalName == plugin.InternalName && !x.SourceRepo.IsThirdParty);
-                    if (available != null)
+                    
+                    if (firstAvailableInstalled != null)
+                    {
+                        // TODO
+                        ImGui.Text("GOAT WAS TOO LAZY TO IMPLEMENT THIS");
+                    }
+                    else if (installable != null)
                     {
                         ImGui.SameLine();
                         ImGui.SetCursorPosX(windowSize.X - (ImGuiHelpers.GlobalScale * 30 * 2) - 2);
                         ImGui.SetCursorPosY(ImGui.GetCursorPosY() + (pluginLineHeight / 2) - (ImGui.GetFrameHeight() / 2));
                         btnOffset = 3;
 
-                        if (ImGuiComponents.IconButton($"###installMissingPlugin{available.InternalName}", FontAwesomeIcon.Download))
+                        if (ImGuiComponents.IconButton($"###installMissingPlugin{installable.InternalName}", FontAwesomeIcon.Download))
                         {
-                            this.installer.StartInstall(available, false);
+                            this.installer.StartInstall(installable, false);
                         }
 
                         if (ImGui.IsItemHovered())
                             ImGui.SetTooltip(Locs.InstallPlugin);
                     }
-
+                    
                     ImGui.SetCursorPos(before);
                 }
 

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/ProfileManagerWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/ProfileManagerWidget.cs
@@ -229,7 +229,7 @@ internal class ProfileManagerWidget
 
                 if (ImGuiComponents.IconButton($"###exportButton{profile.Guid}", FontAwesomeIcon.FileExport))
                 {
-                    ImGui.SetClipboardText(profile.Model.Serialize());
+                    ImGui.SetClipboardText(profile.Model.SerializeForShare());
                     Service<NotificationManager>.Get().AddNotification(Locs.CopyToClipboardNotification, type: NotificationType.Success);
                 }
 
@@ -300,7 +300,7 @@ internal class ProfileManagerWidget
 
                         if (ImGui.Selectable($"{plugin.Manifest.Name}###selector{plugin.Manifest.InternalName}"))
                         {
-                            Task.Run(() => profile.AddOrUpdateAsync(plugin.Manifest.InternalName, true, false))
+                            Task.Run(() => profile.AddOrUpdateAsync(plugin.Manifest.WorkingPluginId, true, false))
                                 .ContinueWith(this.installer.DisplayErrorContinuation, Locs.ErrorCouldNotChangeState);
                         }
                     }
@@ -327,7 +327,7 @@ internal class ProfileManagerWidget
 
         if (ImGuiComponents.IconButton(FontAwesomeIcon.FileExport))
         {
-            ImGui.SetClipboardText(profile.Model.Serialize());
+            ImGui.SetClipboardText(profile.Model.SerializeForShare());
             Service<NotificationManager>.Get().AddNotification(Locs.CopyToClipboardNotification, type: NotificationType.Success);
         }
 
@@ -400,7 +400,7 @@ internal class ProfileManagerWidget
         if (pluginListChild)
         {
             var pluginLineHeight = 32 * ImGuiHelpers.GlobalScale;
-            string? wantRemovePluginInternalName = null;
+            Guid? wantRemovePluginGuid = null;
 
             using var syncScope = profile.GetSyncScope();
             foreach (var plugin in profile.Plugins.ToArray())
@@ -467,7 +467,7 @@ internal class ProfileManagerWidget
                 var enabled = plugin.IsEnabled;
                 if (ImGui.Checkbox($"###{this.editingProfileGuid}-{plugin.InternalName}", ref enabled))
                 {
-                    Task.Run(() => profile.AddOrUpdateAsync(plugin.InternalName, enabled))
+                    Task.Run(() => profile.AddOrUpdateAsync(plugin.WorkingPluginId, enabled))
                         .ContinueWith(this.installer.DisplayErrorContinuation, Locs.ErrorCouldNotChangeState);
                 }
 
@@ -477,17 +477,17 @@ internal class ProfileManagerWidget
 
                 if (ImGuiComponents.IconButton($"###removePlugin{plugin.InternalName}", FontAwesomeIcon.Trash))
                 {
-                    wantRemovePluginInternalName = plugin.InternalName;
+                    wantRemovePluginGuid = plugin.WorkingPluginId;
                 }
 
                 if (ImGui.IsItemHovered())
                     ImGui.SetTooltip(Locs.RemovePlugin);
             }
 
-            if (wantRemovePluginInternalName != null)
+            if (wantRemovePluginGuid != null)
             {
                 // TODO: handle error
-                Task.Run(() => profile.RemoveAsync(wantRemovePluginInternalName, false))
+                Task.Run(() => profile.RemoveAsync(wantRemovePluginGuid.Value, false))
                                 .ContinueWith(this.installer.DisplayErrorContinuation, Locs.ErrorCouldNotRemove);
             }
 

--- a/Dalamud/Logging/Internal/ModuleLog.cs
+++ b/Dalamud/Logging/Internal/ModuleLog.cs
@@ -33,7 +33,7 @@ public class ModuleLog
     /// </summary>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public void Verbose(string messageTemplate, params object[] values)
+    public void Verbose(string messageTemplate, params object?[] values)
         => this.WriteLog(LogEventLevel.Verbose, messageTemplate, null, values);
 
     /// <summary>
@@ -42,7 +42,7 @@ public class ModuleLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public void Verbose(Exception exception, string messageTemplate, params object[] values)
+    public void Verbose(Exception exception, string messageTemplate, params object?[] values)
         => this.WriteLog(LogEventLevel.Verbose, messageTemplate, exception, values);
 
     /// <summary>
@@ -50,7 +50,7 @@ public class ModuleLog
     /// </summary>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public void Debug(string messageTemplate, params object[] values)
+    public void Debug(string messageTemplate, params object?[] values)
         => this.WriteLog(LogEventLevel.Debug, messageTemplate, null, values);
 
     /// <summary>
@@ -59,7 +59,7 @@ public class ModuleLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public void Debug(Exception exception, string messageTemplate, params object[] values)
+    public void Debug(Exception exception, string messageTemplate, params object?[] values)
         => this.WriteLog(LogEventLevel.Debug, messageTemplate, exception, values);
 
     /// <summary>
@@ -67,7 +67,7 @@ public class ModuleLog
     /// </summary>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public void Information(string messageTemplate, params object[] values)
+    public void Information(string messageTemplate, params object?[] values)
         => this.WriteLog(LogEventLevel.Information, messageTemplate, null, values);
 
     /// <summary>
@@ -76,7 +76,7 @@ public class ModuleLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public void Information(Exception exception, string messageTemplate, params object[] values)
+    public void Information(Exception exception, string messageTemplate, params object?[] values)
         => this.WriteLog(LogEventLevel.Information, messageTemplate, exception, values);
 
     /// <summary>
@@ -84,7 +84,7 @@ public class ModuleLog
     /// </summary>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public void Warning(string messageTemplate, params object[] values)
+    public void Warning(string messageTemplate, params object?[] values)
         => this.WriteLog(LogEventLevel.Warning, messageTemplate, null, values);
 
     /// <summary>
@@ -93,7 +93,7 @@ public class ModuleLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public void Warning(Exception exception, string messageTemplate, params object[] values)
+    public void Warning(Exception exception, string messageTemplate, params object?[] values)
         => this.WriteLog(LogEventLevel.Warning, messageTemplate, exception, values);
 
     /// <summary>
@@ -101,7 +101,7 @@ public class ModuleLog
     /// </summary>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public void Error(string messageTemplate, params object[] values)
+    public void Error(string messageTemplate, params object?[] values)
         => this.WriteLog(LogEventLevel.Error, messageTemplate, null, values);
 
     /// <summary>
@@ -110,7 +110,7 @@ public class ModuleLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public void Error(Exception? exception, string messageTemplate, params object[] values)
+    public void Error(Exception? exception, string messageTemplate, params object?[] values)
         => this.WriteLog(LogEventLevel.Error, messageTemplate, exception, values);
 
     /// <summary>
@@ -118,7 +118,7 @@ public class ModuleLog
     /// </summary>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public void Fatal(string messageTemplate, params object[] values)
+    public void Fatal(string messageTemplate, params object?[] values)
         => this.WriteLog(LogEventLevel.Fatal, messageTemplate, null, values);
 
     /// <summary>
@@ -127,11 +127,11 @@ public class ModuleLog
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="messageTemplate">The message template.</param>
     /// <param name="values">Values to log.</param>
-    public void Fatal(Exception exception, string messageTemplate, params object[] values)
+    public void Fatal(Exception exception, string messageTemplate, params object?[] values)
         => this.WriteLog(LogEventLevel.Fatal, messageTemplate, exception, values);
 
     private void WriteLog(
-        LogEventLevel level, string messageTemplate, Exception? exception = null, params object[] values)
+        LogEventLevel level, string messageTemplate, Exception? exception = null, params object?[] values)
     {
         // FIXME: Eventually, the `pluginName` tag should be removed from here and moved over to the actual log
         //        formatter.

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1299,6 +1299,9 @@ internal partial class PluginManager : IDisposable, IServiceType
         }
         
         // Perform a migration from InternalName to GUIDs. The plugin should definitely have a GUID here.
+        // This will also happen if you are installing a plugin with the installer, and that's intended!
+        // It means that, if you have a profile which has unsatisfied plugins, installing a matching plugin will
+        // enter it into the profiles it can match.
         if (plugin.Manifest.WorkingPluginId == Guid.Empty)
             throw new Exception("Plugin should have a WorkingPluginId at this point");
         this.profileManager.MigrateProfilesToGuidsForPlugin(plugin.Manifest.InternalName, plugin.Manifest.WorkingPluginId);

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1290,13 +1290,27 @@ internal partial class PluginManager : IDisposable, IServiceType
         if (isDev)
         {
             Log.Information($"Loading dev plugin {name}");
-            var devPlugin = new LocalDevPlugin(dllFile, manifest);
+            plugin = new LocalDevPlugin(dllFile, manifest);
+        }
+        else
+        {
+            Log.Information($"Loading plugin {name}");
+            plugin = new LocalPlugin(dllFile, manifest);
+        }
+        
+        // Perform a migration from InternalName to GUIDs. The plugin should definitely have a GUID here.
+        if (plugin.Manifest.WorkingPluginId == Guid.Empty)
+            throw new Exception("Plugin should have a WorkingPluginId at this point");
+        this.profileManager.MigrateProfilesToGuidsForPlugin(plugin.Manifest.InternalName, plugin.Manifest.WorkingPluginId);
+
+        // Now, if this is a devPlugin, figure out if we want to load it
+        if (isDev)
+        {
+            var devPlugin = (LocalDevPlugin)plugin;
             loadPlugin &= !isBoot;
 
-            var probablyInternalNameForThisPurpose = manifest?.InternalName ?? dllFile.Name;
-
             var wantsInDefaultProfile =
-                this.profileManager.DefaultProfile.WantsPlugin(probablyInternalNameForThisPurpose);
+                this.profileManager.DefaultProfile.WantsPlugin(plugin.Manifest.WorkingPluginId);
             if (wantsInDefaultProfile == null)
             {
                 // We don't know about this plugin, so we don't want to do anything here.
@@ -1305,46 +1319,41 @@ internal partial class PluginManager : IDisposable, IServiceType
             else if (wantsInDefaultProfile == false && devPlugin.StartOnBoot)
             {
                 // We didn't want this plugin, and StartOnBoot is on. That means we don't want it and it should stay off until manually enabled.
-                Log.Verbose("DevPlugin {Name} disabled and StartOnBoot => disable", probablyInternalNameForThisPurpose);
-                await this.profileManager.DefaultProfile.AddOrUpdateAsync(probablyInternalNameForThisPurpose, false, false);
+                Log.Verbose("DevPlugin {Name} disabled and StartOnBoot => disable", plugin.Manifest.InternalName);
+                await this.profileManager.DefaultProfile.AddOrUpdateAsync(plugin.Manifest.WorkingPluginId, false, false);
                 loadPlugin = false;
             }
             else if (wantsInDefaultProfile == true && devPlugin.StartOnBoot)
             {
                 // We wanted this plugin, and StartOnBoot is on. That means we actually do want it.
-                Log.Verbose("DevPlugin {Name} enabled and StartOnBoot => enable", probablyInternalNameForThisPurpose);
-                await this.profileManager.DefaultProfile.AddOrUpdateAsync(probablyInternalNameForThisPurpose, true, false);
+                Log.Verbose("DevPlugin {Name} enabled and StartOnBoot => enable", plugin.Manifest.InternalName);
+                await this.profileManager.DefaultProfile.AddOrUpdateAsync(plugin.Manifest.WorkingPluginId, true, false);
                 loadPlugin = !doNotLoad;
             }
             else if (wantsInDefaultProfile == true && !devPlugin.StartOnBoot)
             {
                 // We wanted this plugin, but StartOnBoot is off. This means we don't want it anymore.
-                Log.Verbose("DevPlugin {Name} enabled and !StartOnBoot => disable", probablyInternalNameForThisPurpose);
-                await this.profileManager.DefaultProfile.AddOrUpdateAsync(probablyInternalNameForThisPurpose, false, false);
+                Log.Verbose("DevPlugin {Name} enabled and !StartOnBoot => disable", plugin.Manifest.InternalName);
+                await this.profileManager.DefaultProfile.AddOrUpdateAsync(plugin.Manifest.WorkingPluginId, false, false);
                 loadPlugin = false;
             }
             else if (wantsInDefaultProfile == false && !devPlugin.StartOnBoot)
             {
                 // We didn't want this plugin, and StartOnBoot is off. We don't want it.
-                Log.Verbose("DevPlugin {Name} disabled and !StartOnBoot => disable", probablyInternalNameForThisPurpose);
-                await this.profileManager.DefaultProfile.AddOrUpdateAsync(probablyInternalNameForThisPurpose, false, false);
+                Log.Verbose("DevPlugin {Name} disabled and !StartOnBoot => disable", plugin.Manifest.InternalName);
+                await this.profileManager.DefaultProfile.AddOrUpdateAsync(plugin.Manifest.WorkingPluginId, false, false);
                 loadPlugin = false;
             }
 
             plugin = devPlugin;
         }
-        else
-        {
-            Log.Information($"Loading plugin {name}");
-            plugin = new LocalPlugin(dllFile, manifest);
-        }
 
 #pragma warning disable CS0618
         var defaultState = manifest?.Disabled != true && loadPlugin;
 #pragma warning restore CS0618
-
+        
         // Need to do this here, so plugins that don't load are still added to the default profile
-        var wantToLoad = await this.profileManager.GetWantStateAsync(plugin.Manifest.InternalName, defaultState);
+        var wantToLoad = await this.profileManager.GetWantStateAsync(plugin.Manifest.WorkingPluginId, defaultState);
 
         if (loadPlugin)
         {

--- a/Dalamud/Plugin/Internal/Profiles/Profile.cs
+++ b/Dalamud/Plugin/Internal/Profiles/Profile.cs
@@ -142,7 +142,7 @@ internal class Profile
     /// <summary>
     /// Check if this profile contains a specific plugin, and if it is enabled.
     /// </summary>
-    /// <param name="internalName">The internal name of the plugin.</param>
+    /// <param name="workingPluginId">The ID of the plugin.</param>
     /// <returns>Null if this profile does not declare the plugin, true if the profile declares the plugin and wants it enabled, false if the profile declares the plugin and does not want it enabled.</returns>
     public bool? WantsPlugin(Guid workingPluginId)
     {
@@ -157,7 +157,7 @@ internal class Profile
     /// Add a plugin to this profile with the desired state, or change the state of a plugin in this profile.
     /// This will block until all states have been applied.
     /// </summary>
-    /// <param name="internalName">The internal name of the plugin.</param>
+    /// <param name="workingPluginId">The ID of the plugin.</param>
     /// <param name="state">Whether or not the plugin should be enabled.</param>
     /// <param name="apply">Whether or not the current state should immediately be applied.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
@@ -198,7 +198,7 @@ internal class Profile
     /// Remove a plugin from this profile.
     /// This will block until all states have been applied.
     /// </summary>
-    /// <param name="internalName">The internal name of the plugin.</param>
+    /// <param name="workingPluginId">The ID of the plugin.</param>
     /// <param name="apply">Whether or not the current state should immediately be applied.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public async Task RemoveAsync(Guid workingPluginId, bool apply = true)

--- a/Dalamud/Plugin/Internal/Profiles/Profile.cs
+++ b/Dalamud/Plugin/Internal/Profiles/Profile.cs
@@ -246,6 +246,10 @@ internal class Profile
         {
             foreach (var plugin in this.modelV1.Plugins)
             {
+                // TODO: What should happen if a profile has a GUID locked in, but the plugin
+                // is not installed anymore? That probably means that the user uninstalled the plugin
+                // and is now reinstalling it. We should still satisfy that and update the ID.
+                
                 if (plugin.InternalName == internalName && plugin.WorkingPluginId == Guid.Empty)
                 {
                     plugin.WorkingPluginId = newGuid;

--- a/Dalamud/Plugin/Internal/Profiles/Profile.cs
+++ b/Dalamud/Plugin/Internal/Profiles/Profile.cs
@@ -102,7 +102,7 @@ internal class Profile
     /// Gets all plugins declared in this profile.
     /// </summary>
     public IEnumerable<ProfilePluginEntry> Plugins =>
-        this.modelV1.Plugins.Select(x => new ProfilePluginEntry(x.InternalName, x.IsEnabled));
+        this.modelV1.Plugins.Select(x => new ProfilePluginEntry(x.InternalName, x.WorkingPluginId, x.IsEnabled));
 
     /// <summary>
     /// Gets this profile's underlying model.
@@ -144,11 +144,11 @@ internal class Profile
     /// </summary>
     /// <param name="internalName">The internal name of the plugin.</param>
     /// <returns>Null if this profile does not declare the plugin, true if the profile declares the plugin and wants it enabled, false if the profile declares the plugin and does not want it enabled.</returns>
-    public bool? WantsPlugin(string internalName)
+    public bool? WantsPlugin(Guid workingPluginId)
     {
         lock (this)
         {
-            var entry = this.modelV1.Plugins.FirstOrDefault(x => x.InternalName == internalName);
+            var entry = this.modelV1.Plugins.FirstOrDefault(x => x.WorkingPluginId == workingPluginId);
             return entry?.IsEnabled;
         }
     }
@@ -161,13 +161,13 @@ internal class Profile
     /// <param name="state">Whether or not the plugin should be enabled.</param>
     /// <param name="apply">Whether or not the current state should immediately be applied.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public async Task AddOrUpdateAsync(string internalName, bool state, bool apply = true)
+    public async Task AddOrUpdateAsync(Guid workingPluginId, bool state, bool apply = true)
     {
-        Debug.Assert(!internalName.IsNullOrEmpty(), "!internalName.IsNullOrEmpty()");
-
+        Debug.Assert(workingPluginId != Guid.Empty, "Trying to add plugin with empty guid");
+        
         lock (this)
         {
-            var existing = this.modelV1.Plugins.FirstOrDefault(x => x.InternalName == internalName);
+            var existing = this.modelV1.Plugins.FirstOrDefault(x => x.WorkingPluginId == workingPluginId);
             if (existing != null)
             {
                 existing.IsEnabled = state;
@@ -176,16 +176,16 @@ internal class Profile
             {
                 this.modelV1.Plugins.Add(new ProfileModelV1.ProfileModelV1Plugin
                 {
-                    InternalName = internalName,
+                    WorkingPluginId = workingPluginId,
                     IsEnabled = state,
                 });
             }
         }
 
         // We need to remove this plugin from the default profile, if it declares it.
-        if (!this.IsDefaultProfile && this.manager.DefaultProfile.WantsPlugin(internalName) != null)
+        if (!this.IsDefaultProfile && this.manager.DefaultProfile.WantsPlugin(workingPluginId) != null)
         {
-            await this.manager.DefaultProfile.RemoveAsync(internalName, false);
+            await this.manager.DefaultProfile.RemoveAsync(workingPluginId, false);
         }
 
         Service<DalamudConfiguration>.Get().QueueSave();
@@ -201,25 +201,25 @@ internal class Profile
     /// <param name="internalName">The internal name of the plugin.</param>
     /// <param name="apply">Whether or not the current state should immediately be applied.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public async Task RemoveAsync(string internalName, bool apply = true)
+    public async Task RemoveAsync(Guid workingPluginId, bool apply = true)
     {
         ProfileModelV1.ProfileModelV1Plugin entry;
         lock (this)
         {
-            entry = this.modelV1.Plugins.FirstOrDefault(x => x.InternalName == internalName);
+            entry = this.modelV1.Plugins.FirstOrDefault(x => x.WorkingPluginId == workingPluginId);
             if (entry == null)
-                throw new ArgumentException($"No plugin \"{internalName}\" in profile \"{this.Guid}\"");
+                throw new ArgumentException($"No plugin \"{workingPluginId}\" in profile \"{this.Guid}\"");
 
             if (!this.modelV1.Plugins.Remove(entry))
                 throw new Exception("Couldn't remove plugin from model collection");
         }
 
         // We need to add this plugin back to the default profile, if we were the last profile to have it.
-        if (!this.manager.IsInAnyProfile(internalName))
+        if (!this.manager.IsInAnyProfile(workingPluginId))
         {
             if (!this.IsDefaultProfile)
             {
-                await this.manager.DefaultProfile.AddOrUpdateAsync(internalName, this.IsEnabled && entry.IsEnabled, false);
+                await this.manager.DefaultProfile.AddOrUpdateAsync(workingPluginId, this.IsEnabled && entry.IsEnabled, false);
             }
             else
             {
@@ -231,6 +231,30 @@ internal class Profile
 
         if (apply)
             await this.manager.ApplyAllWantStatesAsync();
+    }
+
+    /// <summary>
+    /// This function tries to migrate all plugins with this internalName which do not have
+    /// a GUID to the specified GUID.
+    /// This is best-effort and will probably work well for anyone that only uses regular plugins.
+    /// </summary>
+    /// <param name="internalName">InternalName of the plugin to migrate.</param>
+    /// <param name="newGuid">Guid to use.</param>
+    public void MigrateProfilesToGuidsForPlugin(string internalName, Guid newGuid)
+    {
+        lock (this)
+        {
+            foreach (var plugin in this.modelV1.Plugins)
+            {
+                if (plugin.InternalName == internalName && plugin.WorkingPluginId == Guid.Empty)
+                {
+                    plugin.WorkingPluginId = newGuid;
+                    Log.Information("Migrated profile {Profile} plugin {Name} to guid {Guid}", this, internalName, newGuid);
+                }
+            }
+        }
+        
+        Service<DalamudConfiguration>.Get().QueueSave();
     }
 
     /// <inheritdoc/>

--- a/Dalamud/Plugin/Internal/Profiles/ProfileManager.cs
+++ b/Dalamud/Plugin/Internal/Profiles/ProfileManager.cs
@@ -73,7 +73,7 @@ internal class ProfileManager : IServiceType
     /// <param name="defaultState">The state the plugin shall be in, if it needs to be added.</param>
     /// <param name="addIfNotDeclared">Whether or not the plugin should be added to the default preset, if it's not present in any preset.</param>
     /// <returns>Whether or not the plugin shall be enabled.</returns>
-    public async Task<bool> GetWantStateAsync(string internalName, bool defaultState, bool addIfNotDeclared = true)
+    public async Task<bool> GetWantStateAsync(Guid workingPluginId, bool defaultState, bool addIfNotDeclared = true)
     {
         var want = false;
         var wasInAnyProfile = false;
@@ -82,7 +82,7 @@ internal class ProfileManager : IServiceType
         {
             foreach (var profile in this.profiles)
             {
-                var state = profile.WantsPlugin(internalName);
+                var state = profile.WantsPlugin(workingPluginId);
                 if (state.HasValue)
                 {
                     want = want || (profile.IsEnabled && state.Value);
@@ -93,8 +93,8 @@ internal class ProfileManager : IServiceType
 
         if (!wasInAnyProfile && addIfNotDeclared)
         {
-            Log.Warning("{Name} was not in any profile, adding to default with {Default}", internalName, defaultState);
-            await this.DefaultProfile.AddOrUpdateAsync(internalName, defaultState, false);
+            Log.Warning("{Guid} was not in any profile, adding to default with {Default}", workingPluginId, defaultState);
+            await this.DefaultProfile.AddOrUpdateAsync(workingPluginId, defaultState, false);
 
             return defaultState;
         }
@@ -107,10 +107,10 @@ internal class ProfileManager : IServiceType
     /// </summary>
     /// <param name="internalName">The internal name of the plugin.</param>
     /// <returns>Whether or not the plugin is in any profile.</returns>
-    public bool IsInAnyProfile(string internalName)
+    public bool IsInAnyProfile(Guid workingPluginId)
     {
         lock (this.profiles)
-            return this.profiles.Any(x => x.WantsPlugin(internalName) != null);
+            return this.profiles.Any(x => x.WantsPlugin(workingPluginId) != null);
     }
 
     /// <summary>
@@ -119,8 +119,8 @@ internal class ProfileManager : IServiceType
     /// </summary>
     /// <param name="internalName">The internal name of the plugin.</param>
     /// <returns>Whether or not the plugin is in the default profile.</returns>
-    public bool IsInDefaultProfile(string internalName)
-        => this.DefaultProfile.WantsPlugin(internalName) != null;
+    public bool IsInDefaultProfile(Guid workingPluginId)
+        => this.DefaultProfile.WantsPlugin(workingPluginId) != null;
 
     /// <summary>
     /// Add a new profile.
@@ -151,7 +151,7 @@ internal class ProfileManager : IServiceType
     /// <returns>The newly cloned profile.</returns>
     public Profile CloneProfile(Profile toClone)
     {
-        var newProfile = this.ImportProfile(toClone.Model.Serialize());
+        var newProfile = this.ImportProfile(toClone.Model.SerializeForShare());
         if (newProfile == null)
             throw new Exception("New profile was null while cloning");
 
@@ -196,13 +196,13 @@ internal class ProfileManager : IServiceType
         this.isBusy = true;
         Log.Information("Getting want states...");
 
-        List<string> wantActive;
+        List<Guid> wantActive;
         lock (this.profiles)
         {
             wantActive = this.profiles
                              .Where(x => x.IsEnabled)
                              .SelectMany(profile => profile.Plugins.Where(plugin => plugin.IsEnabled)
-                                                           .Select(plugin => plugin.InternalName))
+                                                           .Select(plugin => plugin.WorkingPluginId))
                              .Distinct().ToList();
         }
 
@@ -218,7 +218,7 @@ internal class ProfileManager : IServiceType
         var pm = Service<PluginManager>.Get();
         foreach (var installedPlugin in pm.InstalledPlugins)
         {
-            var wantThis = wantActive.Contains(installedPlugin.Manifest.InternalName);
+            var wantThis = wantActive.Contains(installedPlugin.Manifest.WorkingPluginId);
             switch (wantThis)
             {
                 case true when !installedPlugin.IsLoaded:
@@ -267,7 +267,7 @@ internal class ProfileManager : IServiceType
         // We need to remove all plugins from the profile first, so that they are re-added to the default profile if needed
         foreach (var plugin in profile.Plugins.ToArray())
         {
-            await profile.RemoveAsync(plugin.InternalName, false);
+            await profile.RemoveAsync(plugin.WorkingPluginId, false);
         }
 
         if (!this.config.SavedProfiles!.Remove(profile.Model))
@@ -277,6 +277,22 @@ internal class ProfileManager : IServiceType
             throw new Exception("Couldn't remove runtime profile");
 
         this.config.QueueSave();
+    }
+
+    /// <summary>
+    /// This function tries to migrate all plugins with this internalName which do not have
+    /// a GUID to the specified GUID.
+    /// This is best-effort and will probably work well for anyone that only uses regular plugins.
+    /// </summary>
+    /// <param name="internalName">InternalName of the plugin to migrate.</param>
+    /// <param name="newGuid">Guid to use.</param>
+    public void MigrateProfilesToGuidsForPlugin(string internalName, Guid newGuid)
+    {
+        lock (this.profiles)
+        {
+            foreach (var profile in this.profiles)
+                profile.MigrateProfilesToGuidsForPlugin(internalName, newGuid);
+        }
     }
 
     private string GenerateUniqueProfileName(string startingWith)

--- a/Dalamud/Plugin/Internal/Profiles/ProfileManager.cs
+++ b/Dalamud/Plugin/Internal/Profiles/ProfileManager.cs
@@ -69,7 +69,7 @@ internal class ProfileManager : IServiceType
     /// <summary>
     /// Check if any enabled profile wants a specific plugin enabled.
     /// </summary>
-    /// <param name="internalName">The internal name of the plugin.</param>
+    /// <param name="workingPluginId">The ID of the plugin.</param>
     /// <param name="defaultState">The state the plugin shall be in, if it needs to be added.</param>
     /// <param name="addIfNotDeclared">Whether or not the plugin should be added to the default preset, if it's not present in any preset.</param>
     /// <returns>Whether or not the plugin shall be enabled.</returns>
@@ -105,7 +105,7 @@ internal class ProfileManager : IServiceType
     /// <summary>
     /// Check whether a plugin is declared in any profile.
     /// </summary>
-    /// <param name="internalName">The internal name of the plugin.</param>
+    /// <param name="workingPluginId">The ID of the plugin.</param>
     /// <returns>Whether or not the plugin is in any profile.</returns>
     public bool IsInAnyProfile(Guid workingPluginId)
     {
@@ -117,7 +117,7 @@ internal class ProfileManager : IServiceType
     /// Check whether a plugin is only in the default profile.
     /// A plugin can never be in the default profile if it is in any other profile.
     /// </summary>
-    /// <param name="internalName">The internal name of the plugin.</param>
+    /// <param name="workingPluginId">The ID of the plugin.</param>
     /// <returns>Whether or not the plugin is in the default profile.</returns>
     public bool IsInDefaultProfile(Guid workingPluginId)
         => this.DefaultProfile.WantsPlugin(workingPluginId) != null;

--- a/Dalamud/Plugin/Internal/Profiles/ProfileModel.cs
+++ b/Dalamud/Plugin/Internal/Profiles/ProfileModel.cs
@@ -1,7 +1,9 @@
 ﻿using System;
-
+using System.Collections.Generic;
+using System.Reflection;
 using Dalamud.Utility;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Dalamud.Plugin.Internal.Profiles;
 
@@ -39,11 +41,11 @@ public abstract class ProfileModel
     }
 
     /// <summary>
-    /// Serialize this model into a string usable for sharing.
+    /// Serialize this model into a string usable for sharing, without including GUIDs.
     /// </summary>
     /// <returns>The serialized representation of the model.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when an unsupported model is serialized.</exception>
-    public string Serialize()
+    public string SerializeForShare()
     {
         string prefix;
         switch (this)
@@ -55,6 +57,32 @@ public abstract class ProfileModel
                 throw new ArgumentOutOfRangeException();
         }
 
-        return prefix + Convert.ToBase64String(Util.CompressString(JsonConvert.SerializeObject(this)));
+        // HACK: Just filter the ID for now, we should split the sharing + saving model
+        var serialized = JsonConvert.SerializeObject(this, new JsonSerializerSettings()
+                                                         { ContractResolver = new IgnorePropertiesResolver(new[] { "WorkingPluginId" }) });
+
+        return prefix + Convert.ToBase64String(Util.CompressString(serialized));
+    }
+    
+    // Short helper class to ignore some properties from serialization
+    private class IgnorePropertiesResolver : DefaultContractResolver
+    {
+        private readonly HashSet<string> ignoreProps;
+
+        public IgnorePropertiesResolver(IEnumerable<string> propNamesToIgnore)
+        {
+            this.ignoreProps = new HashSet<string>(propNamesToIgnore);
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var property = base.CreateProperty(member, memberSerialization);
+            if (this.ignoreProps.Contains(property.PropertyName))
+            {
+                property.ShouldSerialize = _ => false;
+            }
+            
+            return property;
+        }
     }
 }

--- a/Dalamud/Plugin/Internal/Profiles/ProfileModel.cs
+++ b/Dalamud/Plugin/Internal/Profiles/ProfileModel.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
+
 using Dalamud.Utility;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;

--- a/Dalamud/Plugin/Internal/Profiles/ProfileModelV1.cs
+++ b/Dalamud/Plugin/Internal/Profiles/ProfileModelV1.cs
@@ -46,6 +46,8 @@ public class ProfileModelV1 : ProfileModel
         /// Gets or sets the internal name of the plugin.
         /// </summary>
         public string? InternalName { get; set; }
+        
+        public Guid WorkingPluginId { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether or not this entry is enabled.

--- a/Dalamud/Plugin/Internal/Profiles/ProfileModelV1.cs
+++ b/Dalamud/Plugin/Internal/Profiles/ProfileModelV1.cs
@@ -47,6 +47,9 @@ public class ProfileModelV1 : ProfileModel
         /// </summary>
         public string? InternalName { get; set; }
         
+        /// <summary>
+        /// Gets or sets an ID uniquely identifying this specific instance of a plugin.
+        /// </summary>
         public Guid WorkingPluginId { get; set; }
 
         /// <summary>

--- a/Dalamud/Plugin/Internal/Profiles/ProfilePluginEntry.cs
+++ b/Dalamud/Plugin/Internal/Profiles/ProfilePluginEntry.cs
@@ -9,6 +9,7 @@ internal class ProfilePluginEntry
     /// Initializes a new instance of the <see cref="ProfilePluginEntry"/> class.
     /// </summary>
     /// <param name="internalName">The internal name of the plugin.</param>
+    /// <param name="workingPluginId">The ID of the plugin.</param>
     /// <param name="state">A value indicating whether or not this entry is enabled.</param>
     public ProfilePluginEntry(string internalName, Guid workingPluginId, bool state)
     {
@@ -22,6 +23,9 @@ internal class ProfilePluginEntry
     /// </summary>
     public string InternalName { get; }
     
+    /// <summary>
+    /// Gets or sets an ID uniquely identifying this specific instance of a plugin.
+    /// </summary>
     public Guid WorkingPluginId { get; set; }
 
     /// <summary>

--- a/Dalamud/Plugin/Internal/Profiles/ProfilePluginEntry.cs
+++ b/Dalamud/Plugin/Internal/Profiles/ProfilePluginEntry.cs
@@ -10,9 +10,10 @@ internal class ProfilePluginEntry
     /// </summary>
     /// <param name="internalName">The internal name of the plugin.</param>
     /// <param name="state">A value indicating whether or not this entry is enabled.</param>
-    public ProfilePluginEntry(string internalName, bool state)
+    public ProfilePluginEntry(string internalName, Guid workingPluginId, bool state)
     {
         this.InternalName = internalName;
+        this.WorkingPluginId = workingPluginId;
         this.IsEnabled = state;
     }
 
@@ -20,6 +21,8 @@ internal class ProfilePluginEntry
     /// Gets the internal name of the plugin.
     /// </summary>
     public string InternalName { get; }
+    
+    public Guid WorkingPluginId { get; set; }
 
     /// <summary>
     /// Gets a value indicating whether or not this entry is enabled.

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -235,7 +235,7 @@ internal class LocalPlugin : IDisposable
     /// INCLUDES the default profile.
     /// </summary>
     public bool IsWantedByAnyProfile =>
-        Service<ProfileManager>.Get().GetWantStateAsync(this.manifest.InternalName, false, false).GetAwaiter().GetResult();
+        Service<ProfileManager>.Get().GetWantStateAsync(this.manifest.WorkingPluginId, false, false).GetAwaiter().GetResult();
 
     /// <summary>
     /// Gets a value indicating whether this plugin's API level is out of date.


### PR DESCRIPTION
Solves a lot of weirdness regarding devPlugins in profiles and in general, since the introduction of plugins.
Makes profile management more maintainable in general, as we can now for real uniquely identify installs of plugins, even if there are two with the same InternalName.

We should never use InternalName to uniquely identify plugins anymore, and the code that has to deal with installing plugins should be able to handle multiple plugins with the same InternalName at some point(TODO).
There are also some blank spots UX-wise that I will try to sort out at some point, noted by TODOs.
Probably best to leave for after v9.