### PR TITLE
AddonEventManager return IAddonEventHandle

### DIFF
--- a/Dalamud/Game/AddonEventManager/AddonEventEntry.cs
+++ b/Dalamud/Game/AddonEventManager/AddonEventEntry.cs
@@ -1,4 +1,6 @@
-﻿using Dalamud.Memory;
+﻿using System;
+
+using Dalamud.Memory;
 using Dalamud.Plugin.Services;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
@@ -46,9 +48,14 @@ internal unsafe class AddonEventEntry
     /// Gets the event type for this event.
     /// </summary>
     required public AddonEventType EventType { get; init; }
+    
+    /// <summary>
+    /// Gets the event handle for this event.
+    /// </summary>
+    required internal IAddonEventHandle Handle { get; init; }
 
     /// <summary>
     /// Gets the formatted log string for this AddonEventEntry.
     /// </summary>
-    internal string LogString => $"ParamKey: {this.ParamKey}, Addon: {this.AddonName}, Event: {this.EventType}";
+    internal string LogString => $"ParamKey: {this.ParamKey}, Addon: {this.AddonName}, Event: {this.EventType}, GUID: {this.Handle.EventGuid}";
 }

--- a/Dalamud/Game/AddonEventManager/AddonEventHandle.cs
+++ b/Dalamud/Game/AddonEventManager/AddonEventHandle.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Dalamud.Game.Addon;
+
+/// <summary>
+/// Class that represents a addon event handle.
+/// </summary>
+public class AddonEventHandle : IAddonEventHandle
+{
+    /// <inheritdoc/>
+    public uint ParamKey { get; init; }
+
+    /// <inheritdoc/>
+    public string AddonName { get; init; } = "NullAddon";
+    
+    /// <inheritdoc/>
+    public AddonEventType EventType { get; init; }
+
+    /// <inheritdoc/>
+    public Guid EventGuid { get; init; }
+}

--- a/Dalamud/Game/AddonEventManager/AddonEventManager.cs
+++ b/Dalamud/Game/AddonEventManager/AddonEventManager.cs
@@ -77,33 +77,32 @@ internal unsafe class AddonEventManager : IDisposable, IServiceType
     /// Registers an event handler for the specified addon, node, and type.
     /// </summary>
     /// <param name="pluginId">Unique ID for this plugin.</param>
-    /// <param name="eventId">Unique Id for this event, maximum 0x10000.</param>
     /// <param name="atkUnitBase">The parent addon for this event.</param>
     /// <param name="atkResNode">The node that will trigger this event.</param>
     /// <param name="eventType">The event type for this event.</param>
     /// <param name="eventHandler">The handler to call when event is triggered.</param>
-    internal void AddEvent(string pluginId, uint eventId, IntPtr atkUnitBase, IntPtr atkResNode, AddonEventType eventType, IAddonEventManager.AddonEventHandler eventHandler)
+    /// <returns>IAddonEventHandle used to remove the event.</returns>
+    internal IAddonEventHandle? AddEvent(string pluginId, IntPtr atkUnitBase, IntPtr atkResNode, AddonEventType eventType, IAddonEventManager.AddonEventHandler eventHandler)
     {
         if (this.pluginEventControllers.FirstOrDefault(entry => entry.PluginId == pluginId) is { } eventController)
         {
-            eventController.AddEvent(eventId, atkUnitBase, atkResNode, eventType, eventHandler);
+            return eventController.AddEvent(atkUnitBase, atkResNode, eventType, eventHandler);
         }
-        else
-        {
-            Log.Verbose($"Unable to locate controller for {pluginId}. No event was added.");
-        }
+        
+        Log.Verbose($"Unable to locate controller for {pluginId}. No event was added.");
+        return null;
     }
 
     /// <summary>
     /// Unregisters an event handler with the specified event id and event type.
     /// </summary>
     /// <param name="pluginId">Unique ID for this plugin.</param>
-    /// <param name="eventId">The Unique Id for this event.</param>
-    internal void RemoveEvent(string pluginId, uint eventId)
+    /// <param name="eventHandle">The Unique Id for this event.</param>
+    internal void RemoveEvent(string pluginId, IAddonEventHandle eventHandle)
     {
         if (this.pluginEventControllers.FirstOrDefault(entry => entry.PluginId == pluginId) is { } eventController)
         {
-            eventController.RemoveEvent(eventId);
+            eventController.RemoveEvent(eventHandle);
         }
         else
         {
@@ -239,12 +238,12 @@ internal class AddonEventManagerPluginScoped : IDisposable, IServiceType, IAddon
     }
     
     /// <inheritdoc/>
-    public void AddEvent(uint eventId, IntPtr atkUnitBase, IntPtr atkResNode, AddonEventType eventType, IAddonEventManager.AddonEventHandler eventHandler) 
-        => this.eventManagerService.AddEvent(this.plugin.Manifest.WorkingPluginId.ToString(), eventId, atkUnitBase, atkResNode, eventType, eventHandler);
+    public IAddonEventHandle? AddEvent(IntPtr atkUnitBase, IntPtr atkResNode, AddonEventType eventType, IAddonEventManager.AddonEventHandler eventHandler) 
+        => this.eventManagerService.AddEvent(this.plugin.Manifest.WorkingPluginId.ToString(), atkUnitBase, atkResNode, eventType, eventHandler);
 
     /// <inheritdoc/>
-    public void RemoveEvent(uint eventId)
-        => this.eventManagerService.RemoveEvent(this.plugin.Manifest.WorkingPluginId.ToString(), eventId);
+    public void RemoveEvent(IAddonEventHandle eventHandle)
+        => this.eventManagerService.RemoveEvent(this.plugin.Manifest.WorkingPluginId.ToString(), eventHandle);
     
     /// <inheritdoc/>
     public void SetCursor(AddonCursorType cursor)

--- a/Dalamud/Game/AddonEventManager/IAddonEventHandle.cs
+++ b/Dalamud/Game/AddonEventManager/IAddonEventHandle.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Dalamud.Game.Addon;
+
+/// <summary>
+/// Interface representing the data used for managing AddonEvents.
+/// </summary>
+public interface IAddonEventHandle
+{
+    /// <summary>
+    /// Gets the param key associated with this event.
+    /// </summary>
+    public uint ParamKey { get; init; }
+    
+    /// <summary>
+    /// Gets the name of the addon that this event was attached to.
+    /// </summary>
+    public string AddonName { get; init; }
+    
+    /// <summary>
+    /// Gets the event type associated with this handle.
+    /// </summary>
+    public AddonEventType EventType { get; init; }
+    
+    /// <summary>
+    /// Gets the unique ID for this handle.
+    /// </summary>
+    public Guid EventGuid { get; init; }
+}

--- a/Dalamud/Game/Gui/Dtr/DtrBar.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBar.cs
@@ -25,9 +25,6 @@ namespace Dalamud.Game.Gui.Dtr;
 public sealed unsafe class DtrBar : IDisposable, IServiceType, IDtrBar
 {
     private const uint BaseNodeId = 1000;
-    private const uint MouseOverEventIdOffset = 10000;
-    private const uint MouseOutEventIdOffset = 20000;
-    private const uint MouseClickEventIdOffset = 30000;
 
     private static readonly ModuleLog Log = new("DtrBar");
     
@@ -51,6 +48,8 @@ public sealed unsafe class DtrBar : IDisposable, IServiceType, IDtrBar
     
     private readonly ConcurrentBag<DtrBarEntry> newEntries = new();
     private readonly List<DtrBarEntry> entries = new();
+
+    private readonly Dictionary<uint, List<IAddonEventHandle>> eventHandles = new();
     
     private uint runningNodeIds = BaseNodeId;
 
@@ -328,6 +327,11 @@ public sealed unsafe class DtrBar : IDisposable, IServiceType, IDtrBar
     private void RecreateNodes()
     {
         this.runningNodeIds = BaseNodeId;
+        if (this.entries.Any())
+        {
+            this.eventHandles.Clear();
+        }
+        
         foreach (var entry in this.entries)
         {
             entry.TextNode = this.MakeNode(++this.runningNodeIds);
@@ -362,10 +366,14 @@ public sealed unsafe class DtrBar : IDisposable, IServiceType, IDtrBar
         var dtr = this.GetDtr();
         if (dtr == null || dtr->RootNode == null || dtr->UldManager.NodeList == null || node == null) return false;
 
-        this.uiEventManager.AddEvent(AddonEventManager.DalamudInternalKey, node->AtkResNode.NodeID + MouseOverEventIdOffset, (nint)dtr, (nint)node, AddonEventType.MouseOver, this.DtrEventHandler);
-        this.uiEventManager.AddEvent(AddonEventManager.DalamudInternalKey, node->AtkResNode.NodeID + MouseOutEventIdOffset, (nint)dtr, (nint)node, AddonEventType.MouseOut, this.DtrEventHandler);
-        this.uiEventManager.AddEvent(AddonEventManager.DalamudInternalKey, node->AtkResNode.NodeID + MouseClickEventIdOffset, (nint)dtr, (nint)node, AddonEventType.MouseClick, this.DtrEventHandler);
-
+        this.eventHandles.TryAdd(node->AtkResNode.NodeID, new List<IAddonEventHandle>());
+        this.eventHandles[node->AtkResNode.NodeID].AddRange(new List<IAddonEventHandle>
+        {
+            this.uiEventManager.AddEvent(AddonEventManager.DalamudInternalKey, (nint)dtr, (nint)node, AddonEventType.MouseOver, this.DtrEventHandler),
+            this.uiEventManager.AddEvent(AddonEventManager.DalamudInternalKey, (nint)dtr, (nint)node, AddonEventType.MouseOut, this.DtrEventHandler),
+            this.uiEventManager.AddEvent(AddonEventManager.DalamudInternalKey, (nint)dtr, (nint)node, AddonEventType.MouseClick, this.DtrEventHandler),
+        });
+        
         var lastChild = dtr->RootNode->ChildNode;
         while (lastChild->PrevSiblingNode != null) lastChild = lastChild->PrevSiblingNode;
         Log.Debug($"Found last sibling: {(ulong)lastChild:X}");
@@ -387,9 +395,8 @@ public sealed unsafe class DtrBar : IDisposable, IServiceType, IDtrBar
         var dtr = this.GetDtr();
         if (dtr == null || dtr->RootNode == null || dtr->UldManager.NodeList == null || node == null) return;
 
-        this.uiEventManager.RemoveEvent(AddonEventManager.DalamudInternalKey, node->AtkResNode.NodeID + MouseOverEventIdOffset);
-        this.uiEventManager.RemoveEvent(AddonEventManager.DalamudInternalKey, node->AtkResNode.NodeID + MouseOutEventIdOffset);
-        this.uiEventManager.RemoveEvent(AddonEventManager.DalamudInternalKey, node->AtkResNode.NodeID + MouseClickEventIdOffset);
+        this.eventHandles[node->AtkResNode.NodeID].ForEach(handle => this.uiEventManager.RemoveEvent(AddonEventManager.DalamudInternalKey, handle));
+        this.eventHandles[node->AtkResNode.NodeID].Clear();
 
         var tmpPrevNode = node->AtkResNode.PrevSiblingNode;
         var tmpNextNode = node->AtkResNode.NextSiblingNode;

--- a/Dalamud/Game/Gui/Dtr/DtrBar.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBar.cs
@@ -172,7 +172,7 @@ public sealed unsafe class DtrBar : IDisposable, IServiceType, IDtrBar
         this.HandleAddedNodes();
 
         var dtr = this.GetDtr();
-        if (dtr == null) return;
+        if (dtr == null || dtr->RootNode == null || dtr->RootNode->ChildNode == null) return;
 
         // The collision node on the DTR element is always the width of its content
         if (dtr->UldManager.NodeList == null) return;

--- a/Dalamud/Plugin/Services/IAddonEventManager.cs
+++ b/Dalamud/Plugin/Services/IAddonEventManager.cs
@@ -18,18 +18,18 @@ public interface IAddonEventManager
     /// <summary>
     /// Registers an event handler for the specified addon, node, and type.
     /// </summary>
-    /// <param name="eventId">Unique Id for this event, maximum 0x10000.</param>
     /// <param name="atkUnitBase">The parent addon for this event.</param>
     /// <param name="atkResNode">The node that will trigger this event.</param>
     /// <param name="eventType">The event type for this event.</param>
     /// <param name="eventHandler">The handler to call when event is triggered.</param>
-    void AddEvent(uint eventId, nint atkUnitBase, nint atkResNode, AddonEventType eventType, AddonEventHandler eventHandler);
+    /// <returns>IAddonEventHandle used to remove the event. Null if no event was added.</returns>
+    IAddonEventHandle? AddEvent(nint atkUnitBase, nint atkResNode, AddonEventType eventType, AddonEventHandler eventHandler);
 
     /// <summary>
     /// Unregisters an event handler with the specified event id and event type.
     /// </summary>
-    /// <param name="eventId">The Unique Id for this event.</param>
-    void RemoveEvent(uint eventId);
+    /// <param name="eventHandle">Unique handle identifying this event.</param>
+    void RemoveEvent(IAddonEventHandle eventHandle);
 
     /// <summary>
     /// Force the game cursor to be the specified cursor.


### PR DESCRIPTION
I'm not too convinced that the way I am doing this is optimal or good, but it works.

Also fixes NullReference exception from DTR Bar, the cause was the Addon pointer being valid but the RootNode not being allocated yet.