### PR TITLE
Obsolete (static) PluginLog for future removal

### DIFF
--- a/Dalamud.CorePlugin/PluginImpl.cs
+++ b/Dalamud.CorePlugin/PluginImpl.cs
@@ -1,10 +1,8 @@
 using System;
 using System.IO;
-
 using Dalamud.Configuration.Internal;
 using Dalamud.Game.Command;
 using Dalamud.Interface.Windowing;
-using Dalamud.Logging;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 using Dalamud.Utility;
@@ -52,6 +50,8 @@ namespace Dalamud.CorePlugin
         private readonly WindowSystem windowSystem = new("Dalamud.CorePlugin");
         private Localization localization;
 
+        private IPluginLog pluginLog;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PluginImpl"/> class.
         /// </summary>
@@ -63,6 +63,7 @@ namespace Dalamud.CorePlugin
             {
                 // this.InitLoc();
                 this.Interface = pluginInterface;
+                this.pluginLog = log;
 
                 this.windowSystem.AddWindow(new PluginWindow());
 
@@ -76,7 +77,7 @@ namespace Dalamud.CorePlugin
             }
             catch (Exception ex)
             {
-                PluginLog.Error(ex, "kaboom");
+                log.Error(ex, "kaboom");
             }
         }
 
@@ -130,13 +131,13 @@ namespace Dalamud.CorePlugin
             }
             catch (Exception ex)
             {
-                PluginLog.Error(ex, "Boom");
+                this.pluginLog.Error(ex, "Boom");
             }
         }
 
         private void OnCommand(string command, string args)
         {
-            PluginLog.Information("Command called!");
+            this.pluginLog.Information("Command called!");
 
             // this.window.IsOpen = true;
         }

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/ThirdRepoSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/ThirdRepoSettingsEntry.cs
@@ -1,10 +1,8 @@
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
-
 using CheapLoc;
 using Dalamud.Configuration;
 using Dalamud.Configuration.Internal;
@@ -80,25 +78,28 @@ public class ThirdRepoSettingsEntry : SettingsEntry
         var disclaimerDismissed = config.ThirdRepoSpeedbumpDismissed.Value;
         
         ImGui.PushFont(InterfaceManager.IconFont);
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, FontAwesomeIcon.ExclamationTriangle.ToIconString());
+        ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudOrange);
+        ImGuiHelpers.SafeTextWrapped(FontAwesomeIcon.ExclamationTriangle.ToIconString());
         ImGui.PopFont();
         ImGui.SameLine();
         ImGuiHelpers.ScaledDummy(2);
         ImGui.SameLine();
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, Loc.Localize("DalamudSettingCustomRepoWarningReadThis", "READ THIS FIRST!"));
+        ImGuiHelpers.SafeTextWrapped(Loc.Localize("DalamudSettingCustomRepoWarningReadThis", "READ THIS FIRST!"));
         ImGui.SameLine();
         ImGuiHelpers.ScaledDummy(2);
         ImGui.SameLine();
         ImGui.PushFont(InterfaceManager.IconFont);
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, FontAwesomeIcon.ExclamationTriangle.ToIconString());
+        ImGuiHelpers.SafeTextWrapped(FontAwesomeIcon.ExclamationTriangle.ToIconString());
         ImGui.PopFont();
 
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, Loc.Localize("DalamudSettingCustomRepoWarning", "We cannot take any responsibility for custom plugins and repositories."));
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, Loc.Localize("DalamudSettingCustomRepoWarning5", "If someone told you to copy/paste something here, it's very possible that you are being scammed or taken advantage of."));
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, Loc.Localize("DalamudSettingCustomRepoWarning2", "Plugins have full control over your PC, like any other program, and may cause harm or crashes."));
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, Loc.Localize("DalamudSettingCustomRepoWarning4", "They can delete your character, steal your FC or Discord account, and burn down your house."));
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, Loc.Localize("DalamudSettingCustomRepoWarning3", "Please make absolutely sure that you only install plugins from developers you trust."));
+        ImGuiHelpers.SafeTextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning", "We cannot take any responsibility for custom plugins and repositories."));
+        ImGuiHelpers.SafeTextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning5", "If someone told you to copy/paste something here, it's very possible that you are being scammed or taken advantage of."));
+        ImGuiHelpers.SafeTextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning2", "Plugins have full control over your PC, like any other program, and may cause harm or crashes."));
+        ImGuiHelpers.SafeTextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning4", "They can delete your character, steal your FC or Discord account, and burn down your house."));
+        ImGuiHelpers.SafeTextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning3", "Please make absolutely sure that you only install plugins from developers you trust."));
 
+        ImGui.PopStyleColor();
+        
         if (!disclaimerDismissed)
         {
             const int speedbumpTime = 15;

--- a/Dalamud/Logging/PluginLog.cs
+++ b/Dalamud/Logging/PluginLog.cs
@@ -1,6 +1,5 @@
-using System;
 using System.Reflection;
-
+using Dalamud.Plugin.Services;
 using Serilog;
 using Serilog.Events;
 
@@ -9,6 +8,11 @@ namespace Dalamud.Logging;
 /// <summary>
 /// Class offering various static methods to allow for logging in plugins.
 /// </summary>
+/// <remarks>
+/// PluginLog has been obsoleted and replaced by the <see cref="IPluginLog"/> service. Developers are encouraged to
+/// move over as soon as reasonably possible for performance reasons.
+/// </remarks>
+[Obsolete("Static PluginLog will be removed in API 10. Developers should use IPluginLog.")]
 public static class PluginLog
 {
     #region "Log" prefixed Serilog style methods

--- a/Dalamud/Logging/ScopedPluginLogService.cs
+++ b/Dalamud/Logging/ScopedPluginLogService.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Dalamud.IoC;
+﻿using Dalamud.IoC;
 using Dalamud.IoC.Internal;
 using Dalamud.Plugin.Internal.Types;
 using Dalamud.Plugin.Services;
@@ -90,6 +88,14 @@ public class ScopedPluginLogService : IServiceType, IPluginLog, IDisposable
     /// <inheritdoc />
     public void Information(Exception? exception, string messageTemplate, params object[] values) =>
         this.Write(LogEventLevel.Information, exception, messageTemplate, values);
+    
+    /// <inheritdoc/>
+    public void Info(string messageTemplate, params object[] values) =>
+        this.Information(messageTemplate, values);
+    
+    /// <inheritdoc/>
+    public void Info(Exception? exception, string messageTemplate, params object[] values) =>
+        this.Information(exception, messageTemplate, values);
 
     /// <inheritdoc />
     public void Debug(string messageTemplate, params object[] values) =>

--- a/Dalamud/Plugin/Services/IPluginLog.cs
+++ b/Dalamud/Plugin/Services/IPluginLog.cs
@@ -76,6 +76,12 @@ public interface IPluginLog
     /// <inheritdoc cref="Information(string,object[])"/>
     /// <param name="exception">An (optional) exception that should be recorded alongside this event.</param>
     void Information(Exception? exception, string messageTemplate, params object[] values);
+
+    /// <inheritdoc cref="Information(string,object[])"/>
+    void Info(string messageTemplate, params object[] values);
+
+    /// <inheritdoc cref="Information(Exception?,string,object[])"/>
+    void Info(Exception? exception, string messageTemplate, params object[] values);
     
     /// <summary>
     /// Log a <see cref="LogEventLevel.Debug" /> message to the Dalamud log for this plugin. This log level should be

--- a/Dalamud/Utility/Signatures/SignatureHelper.cs
+++ b/Dalamud/Utility/Signatures/SignatureHelper.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-
 using Dalamud.Game;
 using Dalamud.Hooking;
-using Dalamud.Logging;
 using Dalamud.Utility.Signatures.Wrappers;
 using Serilog;
 
@@ -23,7 +20,7 @@ public static class SignatureHelper
     /// <see cref="SignatureAttribute"/>.
     /// </summary>
     /// <param name="self">The object to initialise.</param>
-    /// <param name="log">If warnings should be logged using <see cref="PluginLog"/>.</param>
+    /// <param name="log">If warnings should be logged.</param>
     public static void Initialise(object self, bool log = true)
     {
         var scanner = Service<SigScanner>.Get();
@@ -61,7 +58,7 @@ public static class SignatureHelper
                                    : message;
                 if (fallible)
                 {
-                    PluginLog.Warning(errorMsg);
+                    Log.Warning(errorMsg);
                 }
                 else
                 {


### PR DESCRIPTION
Honestly I was expecting we were going to remove the old PluginLog in v9 entirely, but *eh*. This pull requests marks it as obsolete and encourages developers to switch to using IPluginLog. Internal references to PluginLog were also removed.

For developers, I *highly* encourage you switch to `IPluginLog` as a service as part of your API 9 upgrades, as it represents a noticeable performance improvement thanks to the removal of `GetCallingAssembly()`. The static class will not get any features moving forward either.