### PR TITLE
Fix SignatureHelper Hooks

### DIFF
--- a/Dalamud/Utility/Signatures/SignatureHelper.cs
+++ b/Dalamud/Utility/Signatures/SignatureHelper.cs
@@ -161,7 +161,7 @@ internal static class SignatureHelper
                         continue;
                     }
 
-                    var hook = creator.Invoke(null, new object?[] { ptr, detour, IGameInteropProvider.HookBackend.Automatic }) as IDalamudHook;
+                    var hook = creator.Invoke(null, new object?[] { ptr, detour, false }) as IDalamudHook;
                     info.SetValue(self, hook);
                     createdHooks.Add(hook);
 


### PR DESCRIPTION
This came up in Discord (#plugin-dev).

The parameters from [Hook<>.FromAddress()](https://github.com/goatcorp/Dalamud/blob/v9/Dalamud/Hooking/Hook.cs#L222) are different from [GameInteropProvider.HookFromAddress<>()](https://github.com/goatcorp/Dalamud/blob/v9/Dalamud/Hooking/Internal/GameInteropProviderPluginScoped.cs#L74).