### PR TITLE
AddonEventManager Add Safety Check

### DIFF
--- a/Dalamud/Game/Addon/Events/PluginEventController.cs
+++ b/Dalamud/Game/Addon/Events/PluginEventController.cs
@@ -52,7 +52,7 @@ internal unsafe class PluginEventController : IDisposable
 
         if ((int)node->Type >= 1000)
         {
-            Log.Error("Wrong node type. Attempted to attach an event to a component node. No event was attached.");
+            Log.Error($"Wrong node type. Attempted to attach an event to a component node. No event was attached.\nAtkUnitBase: {atkUnitBase:X}, AtkResNode: {atkResNode:X}, EventType: {atkEventType}");
             return null;
         }
         

--- a/Dalamud/Game/Addon/Events/PluginEventController.cs
+++ b/Dalamud/Game/Addon/Events/PluginEventController.cs
@@ -44,7 +44,7 @@ internal unsafe class PluginEventController : IDisposable
     /// <param name="atkEventType">The Event Type.</param>
     /// <param name="handler">The delegate to call when invoking this event.</param>
     /// <returns>IAddonEventHandle used to remove the event.</returns>
-    public IAddonEventHandle? AddEvent(nint atkUnitBase, nint atkResNode, AddonEventType atkEventType, IAddonEventManager.AddonEventHandler handler)
+    public IAddonEventHandle AddEvent(nint atkUnitBase, nint atkResNode, AddonEventType atkEventType, IAddonEventManager.AddonEventHandler handler)
     {
         var node = (AtkResNode*)atkResNode;
         var addon = (AtkUnitBase*)atkUnitBase;
@@ -52,8 +52,8 @@ internal unsafe class PluginEventController : IDisposable
 
         if ((int)node->Type >= 1000)
         {
-            Log.Error($"Wrong node type. Attempted to attach an event to a component node. No event was attached.\nAtkUnitBase: {atkUnitBase:X}, AtkResNode: {atkResNode:X}, EventType: {atkEventType}");
-            return null;
+            throw new Exception("Attempted to attach an event to a node of the wrong type.\n" +
+                                "Unable to attach to ComponentNodes, attach to an AtkResNode.");
         }
         
         var eventId = this.GetNextParamKey();

--- a/Dalamud/Game/Addon/Events/PluginEventController.cs
+++ b/Dalamud/Game/Addon/Events/PluginEventController.cs
@@ -44,11 +44,18 @@ internal unsafe class PluginEventController : IDisposable
     /// <param name="atkEventType">The Event Type.</param>
     /// <param name="handler">The delegate to call when invoking this event.</param>
     /// <returns>IAddonEventHandle used to remove the event.</returns>
-    public IAddonEventHandle AddEvent(nint atkUnitBase, nint atkResNode, AddonEventType atkEventType, IAddonEventManager.AddonEventHandler handler)
+    public IAddonEventHandle? AddEvent(nint atkUnitBase, nint atkResNode, AddonEventType atkEventType, IAddonEventManager.AddonEventHandler handler)
     {
         var node = (AtkResNode*)atkResNode;
         var addon = (AtkUnitBase*)atkUnitBase;
         var eventType = (AtkEventType)atkEventType;
+
+        if ((int)node->Type >= 1000)
+        {
+            Log.Error("Wrong node type. Attempted to attach an event to a component node. No event was attached.");
+            return null;
+        }
+        
         var eventId = this.GetNextParamKey();
         var eventGuid = Guid.NewGuid();
         


### PR DESCRIPTION
I realized a common pitfall with attaching events is trying to attach to a component node, these nodes do not allow events to be attached directly, you have to attach the events to the contained AtkResNode itself.

Without this safety check, adding an event to a component node causes an immediate crash to desktop.

![image](https://github.com/goatcorp/Dalamud/assets/9083275/4ff7e636-2d68-4c01-93b7-1dd89ae2c821)
