### PR TITLE
Fix window system scoping

### DIFF
--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -21,6 +21,7 @@ public abstract class Window
     private bool internalLastIsOpen = false;
     private bool internalIsOpen = false;
     private bool nextFrameBringToFront = false;
+    private string? internalNamespace = null;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Window"/> class.
@@ -41,7 +42,20 @@ public abstract class Window
     /// <summary>
     /// Gets or sets the namespace of the window.
     /// </summary>
-    public string? Namespace { get; set; }
+    public string? Namespace
+    {
+        get => this.internalNamespace;
+        set
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                this.internalNamespace = value;
+                return;
+            }
+
+            this.internalNamespace = value.TrimStart('#');
+        }
+    }
 
     /// <summary>
     /// Gets or sets the name of the window.
@@ -74,7 +88,7 @@ public abstract class Window
     /// Gets or sets a value representing the sound effect id to be played when the window is closed.
     /// </summary>
     public uint OnCloseSfxId { get; set; } = 24u;
-    
+
     /// <summary>
     /// Gets or sets the position of this window.
     /// </summary>
@@ -227,7 +241,7 @@ public abstract class Window
     /// <summary>
     /// Draw the window via ImGui.
     /// </summary>
-    internal void DrawInternal(DalamudConfiguration? configuration)
+    internal void DrawInternal(DalamudConfiguration? configuration, string pluginNamespace)
     {
         this.PreOpenCheck();
 
@@ -241,7 +255,7 @@ public abstract class Window
                 this.OnClose();
 
                 this.IsFocused = false;
-                
+
                 if (doSoundEffects && !this.DisableWindowSounds) UIModule.PlaySound(this.OnCloseSfxId, 0, 0, 0);
             }
 
@@ -252,10 +266,8 @@ public abstract class Window
         if (!this.DrawConditions())
             return;
 
-        var hasNamespace = !string.IsNullOrEmpty(this.Namespace);
-
-        if (hasNamespace)
-            ImGui.PushID(this.Namespace);
+        var windowNamespace = !string.IsNullOrEmpty(this.Namespace) ? $"##{this.Namespace}" : string.Empty;
+        var windowName = $"{this.WindowName}{pluginNamespace}{windowNamespace}";
 
         this.PreDraw();
         this.ApplyConditionals();
@@ -285,7 +297,7 @@ public abstract class Window
             this.nextFrameBringToFront = false;
         }
 
-        if (this.ShowCloseButton ? ImGui.Begin(this.WindowName, ref this.internalIsOpen, this.Flags) : ImGui.Begin(this.WindowName, this.Flags))
+        if (this.ShowCloseButton ? ImGui.Begin(windowName, ref this.internalIsOpen, this.Flags) : ImGui.Begin(windowName, this.Flags))
         {
             // Draw the actual window contents
             try
@@ -323,9 +335,6 @@ public abstract class Window
         ImGui.End();
 
         this.PostDraw();
-
-        if (hasNamespace)
-            ImGui.PopID();
     }
 
     // private void CheckState()

--- a/Dalamud/Interface/Windowing/WindowSystem.cs
+++ b/Dalamud/Interface/Windowing/WindowSystem.cs
@@ -19,6 +19,7 @@ public class WindowSystem
     private readonly List<Window> windows = new();
 
     private string lastFocusedWindowName = string.Empty;
+    private string? internalNamespace = null;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WindowSystem"/> class.
@@ -59,7 +60,20 @@ public class WindowSystem
     /// <summary>
     /// Gets or sets the name/ID-space of this <see cref="WindowSystem"/>.
     /// </summary>
-    public string? Namespace { get; set; }
+    public string? Namespace
+    {
+        get => this.internalNamespace;
+        set
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                this.internalNamespace = value;
+                return;
+            }
+
+            this.internalNamespace = value.TrimStart('#');
+        }
+    }
 
     /// <summary>
     /// Add a window to this <see cref="WindowSystem"/>.
@@ -107,10 +121,7 @@ public class WindowSystem
     /// </summary>
     public void Draw()
     {
-        var hasNamespace = !string.IsNullOrEmpty(this.Namespace);
-
-        if (hasNamespace)
-            ImGui.PushID(this.Namespace);
+        var pluginNamespace = !string.IsNullOrEmpty(this.Namespace) ? $"##{this.Namespace}" : string.Empty;
 
         var config = Service<DalamudConfiguration>.GetNullable();
 
@@ -122,7 +133,7 @@ public class WindowSystem
 #endif
             var snapshot = ImGuiManagedAsserts.GetSnapshot();
 
-            window.DrawInternal(config);
+            window.DrawInternal(config, pluginNamespace);
 
             var source = ($"{this.Namespace}::" ?? string.Empty) + window.WindowName;
             ImGuiManagedAsserts.ReportProblems(source, snapshot);
@@ -152,8 +163,5 @@ public class WindowSystem
                 this.lastFocusedWindowName = string.Empty;
             }
         }
-
-        if (hasNamespace)
-            ImGui.PopID();
     }
 }


### PR DESCRIPTION
Changes how the Namespace is applied to both WindowSystem and Window, changing it from PushID to a combined string which is used in `Begin()`

The resulting Window ID:  `WindowName##WindowSystem##Window`
Original: `PushID WindowSystem -> PushID Window -> Begin(WindowName)`

Any additional # will be removed from the start of both namespace strings to prevent "###", which would overwrite WindowName "###"