### PR TITLE
fix: Don't generate dummy sale entries if no sales are present.

### DIFF
--- a/Dalamud/Game/Network/Structures/MarketBoardHistory.cs
+++ b/Dalamud/Game/Network/Structures/MarketBoardHistory.cs
@@ -42,10 +42,17 @@ public class MarketBoardHistory
         using var stream = new UnmanagedMemoryStream((byte*)dataPtr.ToPointer(), 1544);
         using var reader = new BinaryReader(stream);
 
-        var output = new MarketBoardHistory();
+        var output = new MarketBoardHistory
+        {
+            CatalogId = reader.ReadUInt32(),
+            CatalogId2 = reader.ReadUInt32(),
+        };
 
-        output.CatalogId = reader.ReadUInt32();
-        output.CatalogId2 = reader.ReadUInt32();
+        if (output.CatalogId2 == 0)
+        {
+            // No items found in the resulting packet - just return the empty history.
+            return output;
+        }
 
         for (var i = 0; i < 20; i++)
         {


### PR DESCRIPTION
- Fixes a bug that's apparently been around for a while that submitted invalid data to Universalis.