### PR TITLE
AddonLifecycle Add AddonReceiveEvent

### DIFF
--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonDrawArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonDrawArgs.cs
@@ -1,7 +1,7 @@
 ﻿namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 
 /// <summary>
-/// Addon argument data for Finalize events.
+/// Addon argument data for Draw events.
 /// </summary>
 public class AddonDrawArgs : AddonArgs
 {

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonFinalizeArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonFinalizeArgs.cs
@@ -1,7 +1,7 @@
 namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 
 /// <summary>
-/// Addon argument data for Finalize events.
+/// Addon argument data for ReceiveEvent events.
 /// </summary>
 public class AddonFinalizeArgs : AddonArgs
 {

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonReceiveEventArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonReceiveEventArgs.cs
@@ -1,0 +1,30 @@
+namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
+
+/// <summary>
+/// Addon argument data for ReceiveEvent events.
+/// </summary>
+public class AddonReceiveEventArgs : AddonArgs
+{
+    /// <inheritdoc/>
+    public override AddonArgsType Type => AddonArgsType.ReceiveEvent;
+    
+    /// <summary>
+    /// Gets the AtkEventType for this event message.
+    /// </summary>
+    public byte AtkEventType { get; init; }
+    
+    /// <summary>
+    /// Gets the event id for this event message.
+    /// </summary>
+    public int EventParam { get; init; }
+    
+    /// <summary>
+    /// Gets the pointer to an AtkEvent for this event message.
+    /// </summary>
+    public nint AtkEvent { get; init; }
+    
+    /// <summary>
+    /// Gets the pointer to a block of data for this event message.
+    /// </summary>
+    public nint Data { get; init; }
+}

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonRefreshArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonRefreshArgs.cs
@@ -3,7 +3,7 @@ using FFXIVClientStructs.FFXIV.Component.GUI;
 namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 
 /// <summary>
-/// Addon argument data for Finalize events.
+/// Addon argument data for Refresh events.
 /// </summary>
 public class AddonRefreshArgs : AddonArgs
 {

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonRequestedUpdateArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonRequestedUpdateArgs.cs
@@ -1,7 +1,7 @@
 ﻿namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 
 /// <summary>
-/// Addon argument data for Finalize events.
+/// Addon argument data for OnRequestedUpdate events.
 /// </summary>
 public class AddonRequestedUpdateArgs : AddonArgs
 {

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonUpdateArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonUpdateArgs.cs
@@ -1,7 +1,7 @@
 namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 
 /// <summary>
-/// Addon argument data for Finalize events.
+/// Addon argument data for Update events.
 /// </summary>
 public class AddonUpdateArgs : AddonArgs
 {

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgsType.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgsType.cs
@@ -34,4 +34,9 @@ public enum AddonArgsType
     /// Contains argument data for Refresh.
     /// </summary>   
     Refresh,
+    
+    /// <summary>
+    /// Contains argument data for ReceiveEvent.
+    /// </summary>
+    ReceiveEvent,
 }

--- a/Dalamud/Game/Addon/Lifecycle/AddonEvent.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonEvent.cs
@@ -59,4 +59,14 @@ public enum AddonEvent
     /// Event that is fired after an addon has finished a refresh.
     /// </summary>
     PostRefresh,
+    
+    /// <summary>
+    /// Event that is fired before an addon begins processing an event.
+    /// </summary>
+    PreReceiveEvent,
+    
+    /// <summary>
+    /// Event that is fired after an addon has processed an event.
+    /// </summary>
+    PostReceiveEvent,
 }


### PR DESCRIPTION
Adds events for receiving addon events without users needing to hook them.

Also fixes a bunch of copy-paste errors in documentation.