### PR TITLE
Show warning before deleting plugin data

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -842,7 +842,6 @@ internal class PluginInstallerWindow : Window, IDisposable
     private void DrawDeletePluginConfigWarningModal()
     {
         var modalTitle = Locs.DeletePluginConfigWarningModal_Title;
-        var pluginManager = Service<PluginManager>.Get();
 
         if (ImGui.BeginPopupModal(modalTitle, ref this.deletePluginConfigWarningModalDrawing, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar))
         {

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -90,6 +90,11 @@ internal class PluginInstallerWindow : Window, IDisposable
     private bool testingWarningModalDrawing = true;
     private bool testingWarningModalOnNextFrame = false;
 
+    private bool deletePluginConfigWarningModalDrawing = true;
+    private bool deletePluginConfigWarningModalOnNextFrame = false;
+    private string deletePluginConfigWarningModalPluginName = string.Empty;
+    private TaskCompletionSource<bool>? deletePluginConfigWarningModalTaskCompletionSource;
+
     private bool feedbackModalDrawing = true;
     private bool feedbackModalOnNextFrame = false;
     private bool feedbackModalOnNextFrameDontClear = false;
@@ -259,6 +264,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             this.DrawErrorModal();
             this.DrawUpdateModal();
             this.DrawTestingWarningModal();
+            this.DrawDeletePluginConfigWarningModal();
             this.DrawFeedbackModal();
             this.DrawProgressOverlay();
         }
@@ -822,6 +828,56 @@ internal class PluginInstallerWindow : Window, IDisposable
             ImGui.OpenPopup(modalTitle);
             this.testingWarningModalOnNextFrame = false;
             this.testingWarningModalDrawing = true;
+        }
+    }
+
+    private Task<bool> ShowDeletePluginConfigWarningModal(string pluginName)
+    {
+        this.deletePluginConfigWarningModalOnNextFrame = true;
+        this.deletePluginConfigWarningModalPluginName = pluginName;
+        this.deletePluginConfigWarningModalTaskCompletionSource = new TaskCompletionSource<bool>();
+        return this.deletePluginConfigWarningModalTaskCompletionSource.Task;
+    }
+    
+    private void DrawDeletePluginConfigWarningModal()
+    {
+        var modalTitle = Locs.DeletePluginConfigWarningModal_Title;
+        var pluginManager = Service<PluginManager>.Get();
+
+        if (ImGui.BeginPopupModal(modalTitle, ref this.deletePluginConfigWarningModalDrawing, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar))
+        {
+            ImGui.Text(Locs.DeletePluginConfigWarningModal_Body(this.deletePluginConfigWarningModalPluginName));
+            ImGui.Spacing();
+
+            var buttonWidth = 120f;
+            ImGui.SetCursorPosX((ImGui.GetWindowWidth() - ((buttonWidth * 2) - (ImGui.GetStyle().ItemSpacing.Y * 2))) / 2);
+
+            if (ImGui.Button(Locs.DeletePluginConfirmWarningModal_Yes, new Vector2(buttonWidth, 40)))
+            {
+                ImGui.CloseCurrentPopup();
+                this.deletePluginConfigWarningModalTaskCompletionSource?.SetResult(true);
+            }
+
+            ImGui.SameLine();
+
+            if (ImGui.Button(Locs.DeletePluginConfirmWarningModal_No, new Vector2(buttonWidth, 40)))
+            {
+                ImGui.CloseCurrentPopup();
+                this.deletePluginConfigWarningModalTaskCompletionSource?.SetResult(false);
+            }
+            
+            ImGui.EndPopup();
+        }
+
+        if (this.deletePluginConfigWarningModalOnNextFrame)
+        {
+            // NOTE(goat): ImGui cannot open a modal if no window is focused, at the moment.
+            // If people click out of the installer into the game while a plugin is installing, we won't be able to show a modal if we don't grab focus.
+            ImGui.SetWindowFocus(this.WindowName);
+
+            ImGui.OpenPopup(modalTitle);
+            this.deletePluginConfigWarningModalOnNextFrame = false;
+            this.deletePluginConfigWarningModalDrawing = true;
         }
     }
 
@@ -2044,24 +2100,32 @@ internal class PluginInstallerWindow : Window, IDisposable
 
             if (ImGui.Selectable(Locs.PluginContext_DeletePluginConfig))
             {
-                Log.Debug($"Deleting config for {manifest.InternalName}");
+                this.ShowDeletePluginConfigWarningModal(manifest.Name).ContinueWith(t =>
+                {
+                    var shouldDelete = t.Result;
 
-                this.installStatus = OperationStatus.InProgress;
-
-                Task.Run(() =>
+                    if (shouldDelete)
                     {
-                        pluginManager.PluginConfigs.Delete(manifest.InternalName);
-                        var dir = pluginManager.PluginConfigs.GetDirectory(manifest.InternalName);
+                        Log.Debug($"Deleting config for {manifest.InternalName}");
 
-                        if (Directory.Exists(dir))
-                            Directory.Delete(dir, true);
-                    })
-                    .ContinueWith(task =>
-                    {
-                        this.installStatus = OperationStatus.Idle;
+                        this.installStatus = OperationStatus.InProgress;
 
-                        this.DisplayErrorContinuation(task, Locs.ErrorModal_DeleteConfigFail(manifest.InternalName));
-                    });
+                        Task.Run(() =>
+                            {
+                                pluginManager.PluginConfigs.Delete(manifest.InternalName);
+                                var dir = pluginManager.PluginConfigs.GetDirectory(manifest.InternalName);
+
+                                if (Directory.Exists(dir))
+                                    Directory.Delete(dir, true);
+                            })
+                            .ContinueWith(task =>
+                            {
+                                this.installStatus = OperationStatus.Idle;
+
+                                this.DisplayErrorContinuation(task, Locs.ErrorModal_DeleteConfigFail(manifest.InternalName));
+                            });
+                    }
+                });
             }
 
             ImGui.EndPopup();
@@ -2384,17 +2448,25 @@ internal class PluginInstallerWindow : Window, IDisposable
 
             if (ImGui.MenuItem(Locs.PluginContext_DeletePluginConfigReload))
             {
-                Log.Debug($"Deleting config for {plugin.Manifest.InternalName}");
+                this.ShowDeletePluginConfigWarningModal(plugin.Name).ContinueWith(t =>
+                {
+                    var shouldDelete = t.Result;
 
-                this.installStatus = OperationStatus.InProgress;
-
-                Task.Run(() => pluginManager.DeleteConfigurationAsync(plugin))
-                    .ContinueWith(task =>
+                    if (shouldDelete)
                     {
-                        this.installStatus = OperationStatus.Idle;
+                        Log.Debug($"Deleting config for {plugin.Manifest.InternalName}");
 
-                        this.DisplayErrorContinuation(task, Locs.ErrorModal_DeleteConfigFail(plugin.Name));
-                    });
+                        this.installStatus = OperationStatus.InProgress;
+
+                        Task.Run(() => pluginManager.DeleteConfigurationAsync(plugin))
+                            .ContinueWith(task =>
+                            {
+                                this.installStatus = OperationStatus.Idle;
+
+                                this.DisplayErrorContinuation(task, Locs.ErrorModal_DeleteConfigFail(plugin.Name));
+                            });
+                    }
+                });
             }
 
             ImGui.EndPopup();
@@ -3578,6 +3650,18 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         #endregion
 
+        #region Delete Plugin Config Warning Modal
+
+        public static string DeletePluginConfigWarningModal_Title => Loc.Localize("InstallerDeletePluginConfigWarning", "Warning###InstallerDeletePluginConfigWarning");
+
+        public static string DeletePluginConfigWarningModal_Body(string pluginName) => Loc.Localize("InstallerDeletePluginConfigWarningBody", "Are you sure you want to delete all data and configuration for v{0}?").Format(pluginName);
+
+        public static string DeletePluginConfirmWarningModal_Yes => Loc.Localize("InstallerDeletePluginConfigWarningYes", "Yes");
+
+        public static string DeletePluginConfirmWarningModal_No => Loc.Localize("InstallerDeletePluginConfigWarningNo", "No");
+
+        #endregion
+        
         #region Plugin Update chatbox
 
         public static string PluginUpdateHeader_Chatbox => Loc.Localize("DalamudPluginUpdates", "Updates:");


### PR DESCRIPTION
These two buttons are fairly easy to click accidentally (especially the one right next to the "enable testing" button), so it would be good to show a confirmation modal before actually deleting the data.

Also, I hadn't realised that "reset plugin data" meant "delete plugin configuration", in the context of reloading the plugin I thought it meant resetting the in-memory data, so the button didn't do what I expected either, an additional reminder would've helped. Not sure how many would get confused by this, though.

This is my first time contributing here and also my first time writing any C# in a _long_ time, so I'm not 100% confident in this code, but I did test it locally and it seemed to work for me. I mostly just duplicated some of the code from the other modals.