### PR TITLE
AddonLifecycle ReceiveEvent Fix

### DIFF
--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -173,7 +173,7 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
             var receiveEventHook = Hook<AddonReceiveEventDelegate>.FromAddress((nint)addon->VTable->ReceiveEvent, this.OnReceiveEvent);
             this.receiveEventHooks.TryAdd(addonName, receiveEventHook);
 
-            if (this.eventListeners.Any(listener => listener.EventType is AddonEvent.PostReceiveEvent or AddonEvent.PreReceiveEvent))
+            if (this.eventListeners.Any(listener => (listener.EventType is AddonEvent.PostReceiveEvent or AddonEvent.PreReceiveEvent) && listener.AddonName == addonName))
             {
                 receiveEventHook.Enable();
             }


### PR DESCRIPTION
Fixes accidentally activating **all** ReceiveEvent hooks if **any** listener is active.

This will now only activate the hook if the name matches.