### PR TITLE
AddonLifecycle Extra Safety

### DIFF
--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -49,7 +49,8 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
         this.address = new AddonLifecycleAddressResolver();
         this.address.Setup(sigScanner);
 
-        this.disallowedReceiveEventAddress = (nint)((AtkEventListener*)this.address.AtkEventListener)->vfunc[2];
+        // We want value of the function pointer at vFunc[2]
+        this.disallowedReceiveEventAddress = ((nint*)this.address.AtkEventListener)![2];
         
         this.framework.Update += this.OnFrameworkUpdate;
 
@@ -176,6 +177,7 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
             // Disallows hooking the core internal event handler.
             var addonName = MemoryHelper.ReadStringNullTerminated((nint)addon->Name);
             var receiveEventAddress = (nint)addon->VTable->ReceiveEvent;
+            Log.Debug($"{receiveEventAddress:X} - {this.disallowedReceiveEventAddress:X}");
             if (receiveEventAddress != this.disallowedReceiveEventAddress)
             {
                 var receiveEventHook = Hook<AddonReceiveEventDelegate>.FromAddress(receiveEventAddress, this.OnReceiveEvent);

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -177,7 +177,6 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
             // Disallows hooking the core internal event handler.
             var addonName = MemoryHelper.ReadStringNullTerminated((nint)addon->Name);
             var receiveEventAddress = (nint)addon->VTable->ReceiveEvent;
-            Log.Debug($"{receiveEventAddress:X} - {this.disallowedReceiveEventAddress:X}");
             if (receiveEventAddress != this.disallowedReceiveEventAddress)
             {
                 var receiveEventHook = Hook<AddonReceiveEventDelegate>.FromAddress(receiveEventAddress, this.OnReceiveEvent);

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -208,7 +208,14 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
             Log.Error(e, "Exception in OnAddonSetup pre-setup invoke.");
         }
 
-        addon->OnSetup(valueCount, values);
+        try
+        {
+            addon->OnSetup(valueCount, values);
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Caught exception when calling original AddonSetup. This may be a bug in the game or another plugin hooking this method.");
+        }
 
         try
         {
@@ -251,7 +258,14 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
             Log.Error(e, "Exception in OnAddonFinalize pre-finalize invoke.");
         }
 
-        this.onAddonFinalizeHook.Original(unitManager, atkUnitBase);
+        try
+        {
+            this.onAddonFinalizeHook.Original(unitManager, atkUnitBase);
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Caught exception when calling original AddonFinalize. This may be a bug in the game or another plugin hooking this method.");
+        }
     }
 
     private void OnAddonDraw(AtkUnitBase* addon)
@@ -265,7 +279,14 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
             Log.Error(e, "Exception in OnAddonDraw pre-draw invoke.");
         }
 
-        addon->Draw();
+        try
+        {
+            addon->Draw();
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Caught exception when calling original AddonDraw. This may be a bug in the game or another plugin hooking this method.");
+        }
 
         try
         {
@@ -288,7 +309,14 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
             Log.Error(e, "Exception in OnAddonUpdate pre-update invoke.");
         }
 
-        addon->Update(delta);
+        try
+        {
+            addon->Update(delta);
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Caught exception when calling original AddonUpdate. This may be a bug in the game or another plugin hooking this method.");
+        }
 
         try
         {
@@ -302,6 +330,8 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
 
     private byte OnAddonRefresh(AtkUnitManager* atkUnitManager, AtkUnitBase* addon, uint valueCount, AtkValue* values)
     {
+        byte result = 0;
+        
         try
         {
             this.InvokeListeners(AddonEvent.PreRefresh, new AddonRefreshArgs
@@ -316,7 +346,14 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
             Log.Error(e, "Exception in OnAddonRefresh pre-refresh invoke.");
         }
 
-        var result = this.onAddonRefreshHook.Original(atkUnitManager, addon, valueCount, values);
+        try
+        {
+            result = this.onAddonRefreshHook.Original(atkUnitManager, addon, valueCount, values);
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Caught exception when calling original AddonRefresh. This may be a bug in the game or another plugin hooking this method.");
+        }
 
         try
         {
@@ -351,7 +388,14 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
             Log.Error(e, "Exception in OnRequestedUpdate pre-requestedUpdate invoke.");
         }
 
-        addon->OnUpdate(numberArrayData, stringArrayData);
+        try
+        {
+            addon->OnUpdate(numberArrayData, stringArrayData);
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Caught exception when calling original AddonRequestedUpdate. This may be a bug in the game or another plugin hooking this method.");
+        }
 
         try
         {
@@ -386,8 +430,15 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
             Log.Error(e, "Exception in OnReceiveEvent pre-receiveEvent invoke.");
         }
 
-        var addonName = MemoryHelper.ReadStringNullTerminated((nint)addon->Name);
-        this.receiveEventHooks[addonName].Original(addon, eventType, eventParam, atkEvent, data);
+        try
+        {
+            var addonName = MemoryHelper.ReadStringNullTerminated((nint)addon->Name);
+            this.receiveEventHooks[addonName].Original(addon, eventType, eventParam, atkEvent, data);
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Caught exception when calling original AddonReceiveEvent. This may be a bug in the game or another plugin hooking this method.");
+        }
         
         try
         {

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycleAddressResolver.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycleAddressResolver.cs
@@ -43,6 +43,12 @@ internal class AddonLifecycleAddressResolver : BaseAddressResolver
     /// Gets the address of AtkUnitManager_vf10 which triggers addon onRefresh.
     /// </summary>
     public nint AddonOnRefresh { get; private set; }
+    
+    /// <summary>
+    /// Gets the address of AtkEventListener base vTable.
+    /// This is used to ensure that we do not hook ReceiveEvents that resolve back to the internal handler.
+    /// </summary>
+    public nint AtkEventListener { get; private set; }
 
     /// <summary>
     /// Scan for and setup any configured address pointers.
@@ -57,5 +63,6 @@ internal class AddonLifecycleAddressResolver : BaseAddressResolver
         this.AddonUpdate = sig.ScanText("FF 90 ?? ?? ?? ?? 40 88 AF");
         this.AddonOnRequestedUpdate = sig.ScanText("FF 90 98 01 00 00 48 8B 5C 24 30 48 83 C4 20");
         this.AddonOnRefresh = sig.ScanText("48 89 5C 24 08 57 48 83 EC 20 41 8B F8 48 8B DA");
+        this.AtkEventListener = sig.GetStaticAddressFromSig("4C 8D 3D ?? ?? ?? ?? 49 8D 8E");
     }
 }


### PR DESCRIPTION
This PR adds a sig for AtkEventListener, so that we can get the address of the base AtkEventListener.ReceiveEvent function.
This is used during the OnSetup of an addon to check to see if that addon implements their own ReceiveEvent function.
If they do not implement their own ReceiveEvent function, then we **should not** hook the AtkEventListener.ReceiveEvent base function.