### PR TITLE
Add appropriate HTTP headers to repository requests

### DIFF
--- a/Dalamud/Plugin/Internal/Types/PluginRepository.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginRepository.cs
@@ -47,7 +47,7 @@ internal class PluginRepository
             },
             UserAgent =
             {
-                new ProductInfoHeaderValue("Dalamud", typeof(Dalamud).Assembly.GetName().Version?.ToString()),
+                new ProductInfoHeaderValue("Dalamud", Util.AssemblyVersion),
             },
         },
     };

--- a/Dalamud/Plugin/Internal/Types/PluginRepository.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginRepository.cs
@@ -47,7 +47,7 @@ internal class PluginRepository
             },
             UserAgent =
             {
-                new ProductInfoHeaderValue("Dalamud", $"{Util.GetGitHash()}[{Util.GetGitCommitCount()}]"),
+                new ProductInfoHeaderValue("Dalamud", typeof(Dalamud).Assembly.GetName().Version?.ToString()),
             },
         },
     };

--- a/Dalamud/Plugin/Internal/Types/PluginRepository.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginRepository.cs
@@ -37,9 +37,17 @@ internal class PluginRepository
         Timeout = TimeSpan.FromSeconds(20),
         DefaultRequestHeaders =
         {
+            Accept =
+            {
+                new MediaTypeWithQualityHeaderValue("application/json"),
+            },
             CacheControl = new CacheControlHeaderValue
             {
                 NoCache = true,
+            },
+            UserAgent =
+            {
+                new ProductInfoHeaderValue("Dalamud", $"{Util.GetGitHash()}[{Util.GetGitCommitCount()}]"),
             },
         },
     };


### PR DESCRIPTION
HTTP requests to repositories should specify they're looking for JSON and who's asking, so this just adds `Accept: application/json` and `User-Agent: Dalamud/<git hash shown in /xldev>` headers to the requests.