### PR TITLE
IChatGui Add Readonly RegisteredLinkHandlers

### DIFF
--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -79,6 +79,9 @@ internal sealed class ChatGui : IDisposable, IServiceType, IChatGui
     /// <inheritdoc/>
     public byte LastLinkedItemFlags { get; private set; }
 
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<(string PluginName, uint CommandId), Action<uint, SeString>> RegisteredLinkHandlers => this.dalamudLinkHandlers;
+
     /// <summary>
     /// Dispose of managed and unmanaged resources.
     /// </summary>
@@ -452,6 +455,9 @@ internal class ChatGuiPluginScoped : IDisposable, IServiceType, IChatGui
 
     /// <inheritdoc/>
     public byte LastLinkedItemFlags => this.chatGuiService.LastLinkedItemFlags;
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<(string PluginName, uint CommandId), Action<uint, SeString>> RegisteredLinkHandlers => this.chatGuiService.RegisteredLinkHandlers;
 
     /// <inheritdoc/>
     public void Dispose()

--- a/Dalamud/Plugin/Services/IChatGui.cs
+++ b/Dalamud/Plugin/Services/IChatGui.cs
@@ -1,4 +1,6 @@
-﻿using Dalamud.Game.Gui;
+﻿using System.Collections.Generic;
+
+using Dalamud.Game.Gui;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 
@@ -76,6 +78,11 @@ public interface IChatGui
     /// Gets the flags of the last linked item.
     /// </summary>
     public byte LastLinkedItemFlags { get; }
+    
+    /// <summary>
+    /// Gets the dictionary of Dalamud Link Handlers.
+    /// </summary>
+    public IReadOnlyDictionary<(string PluginName, uint CommandId), Action<uint, SeString>> RegisteredLinkHandlers { get; }
 
     /// <summary>
     /// Queue a chat message. Dalamud will send queued messages on the next framework event.


### PR DESCRIPTION
Plugins such as Chat2 used to access this property via reflection, however due to plugin scoping it can no longer be accessed this way.

Providing the handlers through a readonly property seems like a safe and acceptable approach.