### PR TITLE
add support for area instance to SeString.CreateMapLink()

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -254,10 +254,10 @@ public class SeString
     /// <param name="rawX">The raw x-coordinate for this link.</param>
     /// <param name="rawY">The raw y-coordinate for this link..</param>
     /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
-    public static SeString CreateMapLink(uint territoryId, uint mapId, int rawX, int rawY)
+    public static SeString CreateMapLink(uint territoryId, uint mapId, int rawX, int rawY, int? instance = null)
     {
         var mapPayload = new MapLinkPayload(territoryId, mapId, rawX, rawY);
-        var nameString = $"{mapPayload.PlaceName} {mapPayload.CoordinateString}";
+        var nameString = GetMapLinkNameString(mapPayload.PlaceName, mapPayload.CoordinateString, instance);
 
         var payloads = new List<Payload>(new Payload[]
         {
@@ -280,10 +280,10 @@ public class SeString
     /// <param name="yCoord">The human-readable y-coordinate for this link.</param>
     /// <param name="fudgeFactor">An optional offset to account for rounding and truncation errors; it is best to leave this untouched in most cases.</param>
     /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
-    public static SeString CreateMapLink(uint territoryId, uint mapId, float xCoord, float yCoord, float fudgeFactor = 0.05f)
+    public static SeString CreateMapLink(uint territoryId, uint mapId, float xCoord, float yCoord, float fudgeFactor = 0.05f, int? instance = null)
     {
         var mapPayload = new MapLinkPayload(territoryId, mapId, xCoord, yCoord, fudgeFactor);
-        var nameString = $"{mapPayload.PlaceName} {mapPayload.CoordinateString}";
+        var nameString = GetMapLinkNameString(mapPayload.PlaceName, mapPayload.CoordinateString, instance);
 
         var payloads = new List<Payload>(new Payload[]
         {
@@ -306,7 +306,7 @@ public class SeString
     /// <param name="yCoord">The human-readable y-coordinate for this link.</param>
     /// <param name="fudgeFactor">An optional offset to account for rounding and truncation errors; it is best to leave this untouched in most cases.</param>
     /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
-    public static SeString? CreateMapLink(string placeName, float xCoord, float yCoord, float fudgeFactor = 0.05f)
+    public static SeString? CreateMapLink(string placeName, float xCoord, float yCoord, float fudgeFactor = 0.05f, int? instance = null)
     {
         var data = Service<DataManager>.Get();
 
@@ -321,12 +321,23 @@ public class SeString
             var map = mapSheet.FirstOrDefault(row => row.PlaceName.Row == place.RowId);
             if (map != null && map.TerritoryType.Row != 0)
             {
-                return CreateMapLink(map.TerritoryType.Row, map.RowId, xCoord, yCoord, fudgeFactor);
+                return CreateMapLink(map.TerritoryType.Row, map.RowId, xCoord, yCoord, fudgeFactor, instance);
             }
         }
 
         // TODO: empty? throw?
         return null;
+    }
+
+    private static string GetMapLinkNameString(string placeName, string coordinateString, int? instance = null)
+    {
+        var instanceString = string.Empty;
+        if (instance is > 0 and < 10)
+        {
+            instanceString = (SeIconChar.Instance1 + instance.Value - 1).ToIconString();
+        }
+        
+        return $"{placeName}{instanceString} {coordinateString}";
     }
 
     /// <summary>

--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -255,7 +255,7 @@ public class SeString
     /// <param name="rawY">The raw y-coordinate for this link..</param>
     /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
     public static SeString CreateMapLink(uint territoryId, uint mapId, int rawX, int rawY) =>
-        CreateMapLink(territoryId, mapId, null, rawX, rawY);
+        CreateMapLinkWithInstance(territoryId, mapId, null, rawX, rawY);
 
     /// <summary>
     /// Creates an SeString representing an entire Payload chain that can be used to link a map position in the chat log.
@@ -266,7 +266,7 @@ public class SeString
     /// <param name="rawX">The raw x-coordinate for this link.</param>
     /// <param name="rawY">The raw y-coordinate for this link..</param>
     /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
-    public static SeString CreateMapLink(uint territoryId, uint mapId, int? instance, int rawX, int rawY)
+    public static SeString CreateMapLinkWithInstance(uint territoryId, uint mapId, int? instance, int rawX, int rawY)
     {
         var mapPayload = new MapLinkPayload(territoryId, mapId, rawX, rawY);
         var nameString = GetMapLinkNameString(mapPayload.PlaceName, instance, mapPayload.CoordinateString);
@@ -294,7 +294,7 @@ public class SeString
     /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
     public static SeString CreateMapLink(
         uint territoryId, uint mapId, float xCoord, float yCoord, float fudgeFactor = 0.05f) =>
-        CreateMapLink(territoryId, mapId, null, xCoord, yCoord, fudgeFactor);
+        CreateMapLinkWithInstance(territoryId, mapId, null, xCoord, yCoord, fudgeFactor);
     
     /// <summary>
     /// Creates an SeString representing an entire Payload chain that can be used to link a map position in the chat log.
@@ -306,7 +306,7 @@ public class SeString
     /// <param name="yCoord">The human-readable y-coordinate for this link.</param>
     /// <param name="fudgeFactor">An optional offset to account for rounding and truncation errors; it is best to leave this untouched in most cases.</param>
     /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
-    public static SeString CreateMapLink(uint territoryId, uint mapId, int? instance, float xCoord, float yCoord, float fudgeFactor = 0.05f)
+    public static SeString CreateMapLinkWithInstance(uint territoryId, uint mapId, int? instance, float xCoord, float yCoord, float fudgeFactor = 0.05f)
     {
         var mapPayload = new MapLinkPayload(territoryId, mapId, xCoord, yCoord, fudgeFactor);
         var nameString = GetMapLinkNameString(mapPayload.PlaceName, instance, mapPayload.CoordinateString);
@@ -333,7 +333,7 @@ public class SeString
     /// <param name="fudgeFactor">An optional offset to account for rounding and truncation errors; it is best to leave this untouched in most cases.</param>
     /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
     public static SeString? CreateMapLink(string placeName, float xCoord, float yCoord, float fudgeFactor = 0.05f) =>
-        CreateMapLink(placeName, null, xCoord, yCoord, fudgeFactor);
+        CreateMapLinkWithInstance(placeName, null, xCoord, yCoord, fudgeFactor);
     
     /// <summary>
     /// Creates an SeString representing an entire Payload chain that can be used to link a map position in the chat log, matching a specified zone name.
@@ -345,7 +345,7 @@ public class SeString
     /// <param name="yCoord">The human-readable y-coordinate for this link.</param>
     /// <param name="fudgeFactor">An optional offset to account for rounding and truncation errors; it is best to leave this untouched in most cases.</param>
     /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
-    public static SeString? CreateMapLink(string placeName, int? instance, float xCoord, float yCoord, float fudgeFactor = 0.05f)
+    public static SeString? CreateMapLinkWithInstance(string placeName, int? instance, float xCoord, float yCoord, float fudgeFactor = 0.05f)
     {
         var data = Service<DataManager>.Get();
 
@@ -360,7 +360,7 @@ public class SeString
             var map = mapSheet.FirstOrDefault(row => row.PlaceName.Row == place.RowId);
             if (map != null && map.TerritoryType.Row != 0)
             {
-                return CreateMapLink(map.TerritoryType.Row, map.RowId, instance, xCoord, yCoord, fudgeFactor);
+                return CreateMapLinkWithInstance(map.TerritoryType.Row, map.RowId, instance, xCoord, yCoord, fudgeFactor);
             }
         }
 

--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -254,10 +254,22 @@ public class SeString
     /// <param name="rawX">The raw x-coordinate for this link.</param>
     /// <param name="rawY">The raw y-coordinate for this link..</param>
     /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
-    public static SeString CreateMapLink(uint territoryId, uint mapId, int rawX, int rawY, int? instance = null)
+    public static SeString CreateMapLink(uint territoryId, uint mapId, int rawX, int rawY) =>
+        CreateMapLink(territoryId, mapId, null, rawX, rawY);
+
+    /// <summary>
+    /// Creates an SeString representing an entire Payload chain that can be used to link a map position in the chat log.
+    /// </summary>
+    /// <param name="territoryId">The id of the TerritoryType for this map link.</param>
+    /// <param name="mapId">The id of the Map for this map link.</param>
+    /// <param name="instance">An optional area instance number to be included in this link.</param>
+    /// <param name="rawX">The raw x-coordinate for this link.</param>
+    /// <param name="rawY">The raw y-coordinate for this link..</param>
+    /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
+    public static SeString CreateMapLink(uint territoryId, uint mapId, int? instance, int rawX, int rawY)
     {
         var mapPayload = new MapLinkPayload(territoryId, mapId, rawX, rawY);
-        var nameString = GetMapLinkNameString(mapPayload.PlaceName, mapPayload.CoordinateString, instance);
+        var nameString = GetMapLinkNameString(mapPayload.PlaceName, instance, mapPayload.CoordinateString);
 
         var payloads = new List<Payload>(new Payload[]
         {
@@ -280,10 +292,24 @@ public class SeString
     /// <param name="yCoord">The human-readable y-coordinate for this link.</param>
     /// <param name="fudgeFactor">An optional offset to account for rounding and truncation errors; it is best to leave this untouched in most cases.</param>
     /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
-    public static SeString CreateMapLink(uint territoryId, uint mapId, float xCoord, float yCoord, float fudgeFactor = 0.05f, int? instance = null)
+    public static SeString CreateMapLink(
+        uint territoryId, uint mapId, float xCoord, float yCoord, float fudgeFactor = 0.05f) =>
+        CreateMapLink(territoryId, mapId, null, xCoord, yCoord, fudgeFactor);
+    
+    /// <summary>
+    /// Creates an SeString representing an entire Payload chain that can be used to link a map position in the chat log.
+    /// </summary>
+    /// <param name="territoryId">The id of the TerritoryType for this map link.</param>
+    /// <param name="mapId">The id of the Map for this map link.</param>
+    /// <param name="instance">An optional area instance number to be included in this link.</param>
+    /// <param name="xCoord">The human-readable x-coordinate for this link.</param>
+    /// <param name="yCoord">The human-readable y-coordinate for this link.</param>
+    /// <param name="fudgeFactor">An optional offset to account for rounding and truncation errors; it is best to leave this untouched in most cases.</param>
+    /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
+    public static SeString CreateMapLink(uint territoryId, uint mapId, int? instance, float xCoord, float yCoord, float fudgeFactor = 0.05f)
     {
         var mapPayload = new MapLinkPayload(territoryId, mapId, xCoord, yCoord, fudgeFactor);
-        var nameString = GetMapLinkNameString(mapPayload.PlaceName, mapPayload.CoordinateString, instance);
+        var nameString = GetMapLinkNameString(mapPayload.PlaceName, instance, mapPayload.CoordinateString);
 
         var payloads = new List<Payload>(new Payload[]
         {
@@ -306,7 +332,20 @@ public class SeString
     /// <param name="yCoord">The human-readable y-coordinate for this link.</param>
     /// <param name="fudgeFactor">An optional offset to account for rounding and truncation errors; it is best to leave this untouched in most cases.</param>
     /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
-    public static SeString? CreateMapLink(string placeName, float xCoord, float yCoord, float fudgeFactor = 0.05f, int? instance = null)
+    public static SeString? CreateMapLink(string placeName, float xCoord, float yCoord, float fudgeFactor = 0.05f) =>
+        CreateMapLink(placeName, null, xCoord, yCoord, fudgeFactor);
+    
+    /// <summary>
+    /// Creates an SeString representing an entire Payload chain that can be used to link a map position in the chat log, matching a specified zone name.
+    /// Returns null if no corresponding PlaceName was found.
+    /// </summary>
+    /// <param name="placeName">The name of the location for this link.  This should be exactly the name as seen in a displayed map link in-game for the same zone.</param>
+    /// <param name="instance">An optional area instance number to be included in this link.</param>
+    /// <param name="xCoord">The human-readable x-coordinate for this link.</param>
+    /// <param name="yCoord">The human-readable y-coordinate for this link.</param>
+    /// <param name="fudgeFactor">An optional offset to account for rounding and truncation errors; it is best to leave this untouched in most cases.</param>
+    /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
+    public static SeString? CreateMapLink(string placeName, int? instance, float xCoord, float yCoord, float fudgeFactor = 0.05f)
     {
         var data = Service<DataManager>.Get();
 
@@ -321,7 +360,7 @@ public class SeString
             var map = mapSheet.FirstOrDefault(row => row.PlaceName.Row == place.RowId);
             if (map != null && map.TerritoryType.Row != 0)
             {
-                return CreateMapLink(map.TerritoryType.Row, map.RowId, xCoord, yCoord, fudgeFactor, instance);
+                return CreateMapLink(map.TerritoryType.Row, map.RowId, instance, xCoord, yCoord, fudgeFactor);
             }
         }
 
@@ -329,7 +368,7 @@ public class SeString
         return null;
     }
 
-    private static string GetMapLinkNameString(string placeName, string coordinateString, int? instance = null)
+    private static string GetMapLinkNameString(string placeName, int? instance, string coordinateString)
     {
         var instanceString = string.Empty;
         if (instance is > 0 and < 10)


### PR DESCRIPTION
`SeString.CreateMapLink()` does not currently support area instance in the name of the link. this change adds support for `instance`, so that map link text can match what is shown in game with fields like `<flag>` and `<pos>` as follows:

![image](https://github.com/goatcorp/Dalamud/assets/1133653/7805e6a5-f55c-47e2-b5d1-794b00b74738)

this is only a change to the text of the link, as instance doesn't affect the link behavior itself (as far as i know).