### PR TITLE
fix: changelog crashes on improper LastUpdate timestamp

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginChangelogEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginChangelogEntry.cs
@@ -40,9 +40,10 @@ internal class PluginChangelogEntry : IChangelogEntry
         {
             this.Date = DateTimeOffset.FromUnixTimeSeconds(this.Plugin.Manifest.LastUpdate).DateTime;
         }
-        catch (ArgumentOutOfRangeException)
+        catch (ArgumentOutOfRangeException ex)
         {
-            Log.Verbose("Manifest included improper timestamp, e.g. wrong unit: {PluginName}", plugin.Manifest.Name);
+            Log.Warning(ex, "Manifest included improper timestamp, e.g. wrong unit: {PluginName}",
+                        plugin.Manifest.Name);
             // Create a Date from 0 as with a manifest that does not include a LastUpdate field
             this.Date = DateTimeOffset.FromUnixTimeSeconds(0).DateTime;
         }

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginChangelogEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginChangelogEntry.cs
@@ -1,7 +1,6 @@
-﻿using System;
-
-using CheapLoc;
+﻿using CheapLoc;
 using Dalamud.Plugin.Internal.Types;
+using Serilog;
 
 namespace Dalamud.Interface.Internal.Windows.PluginInstaller;
 
@@ -36,7 +35,17 @@ internal class PluginChangelogEntry : IChangelogEntry
         this.Version = plugin.EffectiveVersion.ToString();
         this.Text = plugin.Manifest.Changelog ?? Loc.Localize("ChangelogNoText", "No changelog for this version.");
         this.Author = plugin.Manifest.Author;
-        this.Date = DateTimeOffset.FromUnixTimeSeconds(this.Plugin.Manifest.LastUpdate).DateTime;
+
+        try
+        {
+            this.Date = DateTimeOffset.FromUnixTimeSeconds(this.Plugin.Manifest.LastUpdate).DateTime;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            Log.Verbose("Manifest included improper timestamp, e.g. wrong unit: {PluginName}", plugin.Manifest.Name);
+            // Create a Date from 0 as with a manifest that does not include a LastUpdate field
+            this.Date = DateTimeOffset.FromUnixTimeSeconds(0).DateTime;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
The changelog fails to load and appears to crash if a plugin reports its LastUpdate timestamp in something other than seconds.
It's stuck in "Loading plugins...", the error message only ever appears for the first opening of the changelog.

While I assume this is only a problem for (some, misconfigured) CRPs I would argue that we should stop a crash from happening nonetheless.

In my tests there was no need to assign `this.Date` anything, but i figured doing so is a better practice in case its ever needed again. I chose 0 since my own little plugins that don't implement a update timestamp have a value of 0 instead.

The [same error](https://discord.com/channels/581875019861328007/860813266468732938/1161454977017970758) was posted in Discord a few days ago.
The error:
```
19:54:32.381 ERR | [PLUGINW] Failed to load changelogs.
19:54:32.381 ERR | System.AggregateException: One or more errors occurred. (Valid values are between -62135596800 and 253402300799, inclusive. (Parameter 'seconds'))
19:54:32.381 ERR |  ---> System.ArgumentOutOfRangeException: Valid values are between -62135596800 and 253402300799, inclusive. (Parameter 'seconds')
19:54:32.381 ERR |    at System.DateTimeOffset.FromUnixTimeSeconds(Int64 seconds)
19:54:32.381 ERR |    at Dalamud.Interface.Internal.Windows.PluginInstaller.PluginChangelogEntry..ctor(LocalPlugin plugin) in C:\goatsoft\companysecrets\dalamud\Interface\Internal\Windows\PluginInstaller\PluginChangelogEntry.cs:line 39
19:54:32.381 ERR |    at Dalamud.Interface.Internal.Windows.PluginInstaller.DalamudChangelogManager.ReloadChangelogAsync() in C:\goatsoft\companysecrets\dalamud\Interface\Internal\Windows\PluginInstaller\DalamudChangelogManager.cs:line 76
19:54:32.381 ERR |    --- End of inner exception stack trace ---
```

Initially I searched for where `LastUpdate` is given its value but couldn't find it.

This commit honestly feels a bit like a bandage. But I'm not yet understanding the structure good enough to tell where the timestamp is first read from the (remote) manifest and saved. Or if its actually using the local timestamp or always trying to get a more current one from remote anyway etc. So this is my current fix.
