### PR TITLE
Bump Luminas

### DIFF
--- a/Dalamud.CorePlugin/Dalamud.CorePlugin.csproj
+++ b/Dalamud.CorePlugin/Dalamud.CorePlugin.csproj
@@ -27,8 +27,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Lumina" Version="3.11.0" />
-        <PackageReference Include="Lumina.Excel" Version="6.5.0" />
+        <PackageReference Include="Lumina" Version="3.15.2" />
+        <PackageReference Include="Lumina.Excel" Version="6.5.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333">
             <PrivateAssets>all</PrivateAssets>

--- a/Dalamud.CorePlugin/Dalamud.CorePlugin.csproj
+++ b/Dalamud.CorePlugin/Dalamud.CorePlugin.csproj
@@ -28,7 +28,7 @@
 
     <ItemGroup>
         <PackageReference Include="Lumina" Version="3.15.2" />
-        <PackageReference Include="Lumina.Excel" Version="6.5.1" />
+        <PackageReference Include="Lumina.Excel" Version="6.5.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333">
             <PrivateAssets>all</PrivateAssets>

--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -68,8 +68,8 @@
         <PackageReference Include="goaaats.Reloaded.Hooks" Version="4.2.0-goat.4" />
         <PackageReference Include="goaaats.Reloaded.Assembler" Version="1.0.14-goat.2" />
         <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
-        <PackageReference Include="Lumina" Version="3.11.0" />
-        <PackageReference Include="Lumina.Excel" Version="6.5.0" />
+        <PackageReference Include="Lumina" Version="3.15.2" />
+        <PackageReference Include="Lumina.Excel" Version="6.5.1" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.46-beta">
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -69,7 +69,7 @@
         <PackageReference Include="goaaats.Reloaded.Assembler" Version="1.0.14-goat.2" />
         <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
         <PackageReference Include="Lumina" Version="3.15.2" />
-        <PackageReference Include="Lumina.Excel" Version="6.5.1" />
+        <PackageReference Include="Lumina.Excel" Version="6.5.2" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.46-beta">
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
Adds a completely new namespace for generated Lumina sheets, GeneratedSheets2. These are generated from the project https://github.com/xivdev/EXDSchema for the current game version, [2023.09.28.0000.0000](https://github.com/xivdev/EXDSchema/tree/main/2023.09.28.0000.0000).
Will write up some dev docs for the API soon.
This impl is non-breaking but non-final.

This utilizes Lumina 3.15.2 which fixes the previously breaking behavior upon attempting to get a row which does not exist.