### PR TITLE
Use GameObject Method

### DIFF
--- a/Dalamud/Game/ClientState/Objects/Types/GameObject.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/GameObject.cs
@@ -101,7 +101,7 @@ public unsafe partial class GameObject
     /// <summary>
     /// Gets the object ID of this <see cref="GameObject" />.
     /// </summary>
-    public uint ObjectId => this.Struct->ObjectID;
+    public uint ObjectId => this.Struct->GetObjectID().ObjectID;
 
     /// <summary>
     /// Gets the data ID for linking to other respective game data.


### PR DESCRIPTION
Uses the GetObjectId method instead, which correctly looks up the ObjectId for objects that would otherwise have an id of 0xE0000000 in the ObjectTable.

Easy example, without this change all gathering nodes in the island sanctuary show an objectId of 0xE0000000

With this change they show meaningful objectId's as seen below:
![image](https://github.com/goatcorp/Dalamud/assets/9083275/01ab0e1a-68ab-4816-95b1-6c68f65ec641)
