### PR TITLE
Fix crash from BuildLookupTable access violation

### DIFF
--- a/Dalamud/Interface/GameFonts/GameFontManager.cs
+++ b/Dalamud/Interface/GameFonts/GameFontManager.cs
@@ -169,7 +169,7 @@ internal class GameFontManager : IServiceType
         }
 
         if (rebuildLookupTable && fontPtr.Glyphs.Size > 0)
-            fontPtr.BuildLookupTable();
+            fontPtr.BuildLookupTableNonstandard();
     }
 
     /// <summary>

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -1028,7 +1028,7 @@ internal class InterfaceManager : IDisposable, IServiceType
                 if (font.FindGlyphNoFallback(Fallback1Codepoint).NativePtr != null)
                     font.FallbackChar = Fallback1Codepoint;
 
-                font.BuildLookupTable();
+                font.BuildLookupTableNonstandard();
             }
 
             Log.Verbose("[FONT] Invoke OnAfterBuildFonts");


### PR DESCRIPTION
ImGui resolves ` ` with `FindGlyph`, which uses `FallbackGlyph`, which is resolved after resolving ` `.
On the first call of `BuildLookupTable`, called from `BuildFonts`, `FallbackGlyph` is set to `null`, making `FindGlyph` return `null`.
On our secondary calls of `BuildLookupTable`, `FallbackGlyph` is set to some value that is not null, making ImGui attempt to treat whatever was there as a ` `.
This may have caused random glyphs to be sized randomly, if not an access violation exception.