### PR TITLE
Write configs asynchronously, first part of async API rewrite

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -368,17 +368,6 @@ public class SeString
         return null;
     }
 
-    private static string GetMapLinkNameString(string placeName, int? instance, string coordinateString)
-    {
-        var instanceString = string.Empty;
-        if (instance is > 0 and < 10)
-        {
-            instanceString = (SeIconChar.Instance1 + instance.Value - 1).ToIconString();
-        }
-        
-        return $"{placeName}{instanceString} {coordinateString}";
-    }
-
     /// <summary>
     /// Creates an SeString representing an entire payload chain that can be used to link party finder listings in the chat log.
     /// </summary>
@@ -511,5 +500,16 @@ public class SeString
     public override string ToString()
     {
         return this.TextValue;
+    }
+    
+    private static string GetMapLinkNameString(string placeName, int? instance, string coordinateString)
+    {
+        var instanceString = string.Empty;
+        if (instance is > 0 and < 10)
+        {
+            instanceString = (SeIconChar.Instance1 + instance.Value - 1).ToIconString();
+        }
+        
+        return $"{placeName}{instanceString} {coordinateString}";
     }
 }

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -249,7 +249,6 @@ internal class DalamudInterface : IDisposable, IServiceType
     /// <summary>
     /// Opens the <see cref="PluginInstallerWindow"/> on the plugin installed.
     /// </summary>
-    /// <param name="kind">The page of the installer to open.</param>
     public void OpenPluginInstaller()
     {
         this.pluginWindow.OpenTo(this.configuration.PluginInstallerOpen);
@@ -394,6 +393,7 @@ internal class DalamudInterface : IDisposable, IServiceType
     /// <summary>
     /// Toggles the <see cref="PluginInstallerWindow"/>.
     /// </summary>
+    /// <param name="kind">The page of the installer to open.</param>
     public void TogglePluginInstallerWindowTo(PluginInstallerWindow.PluginInstallerOpenKind kind) => this.pluginWindow.ToggleTo(kind);
 
     /// <summary>

--- a/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
@@ -50,6 +50,7 @@ internal class DataWindow : Window
         new DataShareWidget(),
         new NetworkMonitorWidget(),
         new IconBrowserWidget(),
+        new VfsWidget(),
     };
 
     private readonly IOrderedEnumerable<IDataWindowWidget> orderedModules;

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/VfsWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/VfsWidget.cs
@@ -1,0 +1,102 @@
+﻿using System.Diagnostics;
+using System.IO;
+
+using Dalamud.Configuration.Internal;
+using Dalamud.Storage;
+using ImGuiNET;
+using Serilog;
+
+namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
+
+/// <summary>
+/// Widget for displaying configuration info.
+/// </summary>
+internal class VfsWidget : IDataWindowWidget
+{
+    private int numBytes = 1024;
+    private int reps = 1;
+    
+    /// <inheritdoc/>
+    public string[]? CommandShortcuts { get; init; } = { "vfs" };
+    
+    /// <inheritdoc/>
+    public string DisplayName { get; init; } = "VFS"; 
+
+    /// <inheritdoc/>
+    public bool Ready { get; set; }
+
+    /// <inheritdoc/>
+    public void Load()
+    {
+        this.Ready = true;
+    }
+
+    /// <inheritdoc/>
+    public void Draw()
+    {
+        var service = Service<ReliableFileStorage>.Get();
+        var dalamud = Service<Dalamud>.Get();
+
+        ImGui.InputInt("Num bytes", ref this.numBytes);
+        ImGui.InputInt("Reps", ref this.reps);
+
+        var path = Path.Combine(dalamud.StartInfo.WorkingDirectory!, "test.bin");
+
+        if (ImGui.Button("Write"))
+        {
+            Log.Information("=== WRITING ===");
+            var data = new byte[this.numBytes];
+            var stopwatch = new Stopwatch();
+            var acc = 0L;
+            
+            for (var i = 0; i < this.reps; i++)
+            {
+                stopwatch.Restart();
+                service.WriteAllBytesAsync(path, data).GetAwaiter().GetResult();
+                stopwatch.Stop();
+                acc += stopwatch.ElapsedMilliseconds;
+                Log.Information("Turn {Turn} took {Ms}ms", i, stopwatch.ElapsedMilliseconds);
+            }
+            
+            Log.Information("Took {Ms}ms in total", acc);
+        }
+
+        if (ImGui.Button("Read"))
+        {
+            Log.Information("=== READING ===");
+            var stopwatch = new Stopwatch();
+            var acc = 0L;
+            
+            for (var i = 0; i < this.reps; i++)
+            {
+                stopwatch.Restart();
+                service.ReadAllBytes(path);
+                stopwatch.Stop();
+                acc += stopwatch.ElapsedMilliseconds;
+                Log.Information("Turn {Turn} took {Ms}ms", i, stopwatch.ElapsedMilliseconds);
+            }
+            
+            Log.Information("Took {Ms}ms in total", acc);
+        }
+
+        if (ImGui.Button("Test Config"))
+        {
+            var config = Service<DalamudConfiguration>.Get();
+            
+            Log.Information("=== READING ===");
+            var stopwatch = new Stopwatch();
+            var acc = 0L;
+            
+            for (var i = 0; i < this.reps; i++)
+            {
+                stopwatch.Restart();
+                config.ForceSave();
+                stopwatch.Stop();
+                acc += stopwatch.ElapsedMilliseconds;
+                Log.Information("Turn {Turn} took {Ms}ms", i, stopwatch.ElapsedMilliseconds);
+            }
+            
+            Log.Information("Took {Ms}ms in total", acc);
+        }
+    }
+}

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -6,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 
 using Dalamud.Configuration;
 using Dalamud.Configuration.Internal;
@@ -338,12 +338,30 @@ public sealed class DalamudPluginInterface : IDisposable
     /// Save a plugin configuration(inheriting IPluginConfiguration).
     /// </summary>
     /// <param name="currentConfig">The current configuration.</param>
+    [Obsolete("Prefer SavePluginConfigAsync() to avoid blocking the main thread.")]
     public void SavePluginConfig(IPluginConfiguration? currentConfig)
     {
         if (currentConfig == null)
             return;
 
+#pragma warning disable CS0618 // Type or member is obsolete
         this.configs.Save(currentConfig, this.plugin.InternalName, this.plugin.Manifest.WorkingPluginId);
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+
+    /// <summary>
+    /// Save a plugin configuration(inheriting IPluginConfiguration).
+    /// </summary>
+    /// <param name="currentConfig">The current configuration.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public async Task SavePluginConfigAsync(IPluginConfiguration? currentConfig)
+    {
+        if (currentConfig == null)
+            return;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        await this.configs.SaveAsync(currentConfig, this.plugin.InternalName, this.plugin.Manifest.WorkingPluginId);
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     /// <summary>


### PR DESCRIPTION
Should fix some microstuttering complaints we have been getting. Reads aren't async yet, they definitely should be, but they should take the same code path as before the VFS in 99.9% of cases so it doesn't matter at the moment.