### PR TITLE
AddonLifecycle ReceiveEvent improvements

### DIFF
--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -206,19 +206,13 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
             {
                 if (!existingListener.AddonNames.Contains(addonName))
                 {
-                    Log.Verbose($"[{addonName}] Duplicate address found, adding to addon list: [{string.Join(",", existingListener.AddonNames)}]");
                     existingListener.AddonNames.Add(addonName);
-                }
-                else
-                {
-                    Log.Verbose($"[{addonName}] Listener already contains addon. Skipping.");
                 }
             }
 
             // Else, we have an addon that we don't have the ReceiveEvent for yet, make it.
             else
             {
-                Log.Verbose($"[{addonName}] Adding new ReceiveEventListener");
                 this.ReceiveEventListeners.Add(new AddonLifecycleReceiveEventListener(this, addonName, receiveEventAddress));
             }
 
@@ -227,14 +221,9 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
             {
                 if (this.ReceiveEventListeners.FirstOrDefault(listener => listener.AddonNames.Contains(addonName)) is { } receiveEventListener)
                 {
-                    Log.Verbose($"[{addonName}] Enabling Hook, Plugin has requested events.");
                     receiveEventListener.Hook?.Enable();
                 }
             }
-        }
-        else
-        {
-            Log.Verbose($"[{addonName}] Tried to register global event handler. Disallowed safely.");
         }
     }
 
@@ -243,13 +232,11 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
         // Remove this addons ReceiveEvent Registration
         if (this.ReceiveEventListeners.FirstOrDefault(listener => listener.AddonNames.Contains(addonName)) is { } eventListener)
         {
-            Log.Verbose($"[{addonName}] Removing from ReceiveEvent list.");
             eventListener.AddonNames.Remove(addonName);
 
             // If there are no more listeners let's remove and dispose.
             if (eventListener.AddonNames.Count is 0)
             {
-                Log.Verbose($"[{addonName}] No listeners remain, disabling hook. Disposing Listener object.");
                 this.ReceiveEventListeners.Remove(eventListener);
                 eventListener.Dispose();
             }

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycleReceiveEventListener.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycleReceiveEventListener.cs
@@ -1,0 +1,110 @@
+﻿using System.Collections.Generic;
+
+using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
+using Dalamud.Hooking;
+using Dalamud.Logging.Internal;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+
+namespace Dalamud.Game.Addon.Lifecycle;
+
+/// <summary>
+/// This class is a helper for tracking and invoking listener delegates for Addon_OnReceiveEvent.
+/// Multiple addons may use the same ReceiveEvent function, this helper makes sure that those addon events are handled properly.
+/// </summary>
+internal unsafe class AddonLifecycleReceiveEventListener : IDisposable
+{
+    private static readonly ModuleLog Log = new("AddonLifecycle");
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AddonLifecycleReceiveEventListener"/> class.
+    /// </summary>
+    /// <param name="service">AddonLifecycle service instance.</param>
+    /// <param name="addonName">Initial Addon Requesting this listener.</param>
+    /// <param name="receiveEventAddress">Address of Addon's ReceiveEvent function.</param>
+    internal AddonLifecycleReceiveEventListener(AddonLifecycle service, string addonName, nint receiveEventAddress)
+    {
+        this.AddonLifecycle = service;
+        this.AddonNames = new List<string> { addonName };
+        this.Hook = Hook<AddonReceiveEventDelegate>.FromAddress(receiveEventAddress, this.OnReceiveEvent);
+    }
+
+    /// <summary>
+    /// Addon Receive Event Function delegate.
+    /// </summary>
+    /// <param name="addon">Addon Pointer.</param>
+    /// <param name="eventType">Event Type.</param>
+    /// <param name="eventParam">Unique Event ID.</param>
+    /// <param name="atkEvent">Event Data.</param>
+    /// <param name="a5">Unknown.</param>
+    public delegate void AddonReceiveEventDelegate(AtkUnitBase* addon, AtkEventType eventType, int eventParam, AtkEvent* atkEvent, nint a5);
+
+    /// <summary>
+    /// Gets the list of addons that use this receive event hook.
+    /// </summary>
+    public List<string> AddonNames { get; init; }
+    
+    /// <summary>
+    /// Gets the address of the registered hook.
+    /// </summary>
+    public nint HookAddress => this.Hook.Address;
+    
+    /// <summary>
+    /// Gets the contained hook for these addons.
+    /// </summary>
+    public Hook<AddonReceiveEventDelegate> Hook { get; init; }
+    
+    /// <summary>
+    /// Gets or sets the Reference to AddonLifecycle service instance.
+    /// </summary>
+    private AddonLifecycle AddonLifecycle { get; set; }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        this.Hook.Dispose();
+    }
+
+    private void OnReceiveEvent(AtkUnitBase* addon, AtkEventType eventType, int eventParam, AtkEvent* atkEvent, nint data)
+    {
+        try
+        {
+            this.AddonLifecycle.InvokeListeners(AddonEvent.PreReceiveEvent, new AddonReceiveEventArgs
+            {
+                Addon = (nint)addon, 
+                AtkEventType = (byte)eventType,
+                EventParam = eventParam,
+                AtkEvent = (nint)atkEvent,
+                Data = data,
+            });
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Exception in OnReceiveEvent pre-receiveEvent invoke.");
+        }
+        
+        try
+        {
+            this.Hook.Original(addon, eventType, eventParam, atkEvent, data);
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Caught exception when calling original AddonReceiveEvent. This may be a bug in the game or another plugin hooking this method.");
+        }
+
+        try
+        {
+            this.AddonLifecycle.InvokeListeners(AddonEvent.PostReceiveEvent, new AddonReceiveEventArgs
+            {
+                Addon = (nint)addon, 
+                AtkEventType = (byte)eventType,
+                EventParam = eventParam,
+                AtkEvent = (nint)atkEvent,
+                Data = data,
+            });
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Exception in OnAddonRefresh post-receiveEvent invoke.");
+        }
+    }
+}

--- a/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
@@ -50,6 +50,7 @@ internal class DataWindow : Window
         new DataShareWidget(),
         new NetworkMonitorWidget(),
         new IconBrowserWidget(),
+        new AddonLifecycleWidget(),
     };
 
     private readonly IOrderedEnumerable<IDataWindowWidget> orderedModules;

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonLifecycleWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonLifecycleWidget.cs
@@ -1,0 +1,135 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+using System.Linq;
+using Dalamud.Game.Addon.Lifecycle;
+using Dalamud.Interface.Utility;
+using ImGuiNET;
+
+namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
+
+/// <summary>
+/// Debug widget for displaying AddonLifecycle data.
+/// </summary>
+public class AddonLifecycleWidget : IDataWindowWidget
+{
+    /// <inheritdoc/>
+    public string[]? CommandShortcuts { get; init; } = { "AddonLifecycle" };
+
+    /// <inheritdoc/>
+    public string DisplayName { get; init; } = "Addon Lifecycle";
+    
+    /// <inheritdoc/>
+    [MemberNotNullWhen(true, "AddonLifecycle")]
+    public bool Ready { get; set; }
+    
+    private AddonLifecycle? AddonLifecycle { get; set; }
+
+    /// <inheritdoc/>
+    public void Load()
+    {
+        this.AddonLifecycle = Service<AddonLifecycle>.GetNullable();
+        if (this.AddonLifecycle is not null) this.Ready = true;
+    }
+    
+    /// <inheritdoc/>
+    public void Draw()
+    {
+        if (!this.Ready)
+        {
+            ImGui.Text("AddonLifecycle Reference is null, reload module.");
+            return;
+        }
+
+        if (ImGui.CollapsingHeader("Listeners"))
+        {
+            ImGui.Indent();
+            this.DrawEventListeners();
+            ImGui.Unindent();
+        }
+
+        if (ImGui.CollapsingHeader("ReceiveEvent Hooks"))
+        {
+            ImGui.Indent();
+            this.DrawReceiveEventHooks();
+            ImGui.Unindent();
+        }
+    }
+    
+    private void DrawEventListeners()
+    {
+        if (!this.Ready) return;
+        
+        foreach (var eventType in Enum.GetValues<AddonEvent>())
+        {
+            if (ImGui.CollapsingHeader(eventType.ToString()))
+            {
+                ImGui.Indent();
+                var listeners = this.AddonLifecycle.EventListeners.Where(listener => listener.EventType == eventType).ToList();
+
+                if (!listeners.Any())
+                {
+                    ImGui.Text("No Listeners Registered for Event");
+                }
+                
+                if (ImGui.BeginTable("AddonLifecycleListenersTable", 2))
+                {
+                    ImGui.TableSetupColumn("##AddonName", ImGuiTableColumnFlags.WidthFixed, 100.0f * ImGuiHelpers.GlobalScale);
+                    ImGui.TableSetupColumn("##MethodInvoke", ImGuiTableColumnFlags.WidthStretch);
+
+                    foreach (var listener in listeners)
+                    {
+                        ImGui.TableNextColumn();
+                        ImGui.Text(listener.AddonName is "" ? "GLOBAL" : listener.AddonName);
+
+                        ImGui.TableNextColumn();
+                        ImGui.Text($"{listener.FunctionDelegate.Target}::{listener.FunctionDelegate.Method.Name}");
+                    }
+                    
+                    ImGui.EndTable();
+                }
+                
+                ImGui.Unindent();
+            }
+        }
+    }
+
+    private void DrawReceiveEventHooks()
+    {
+        if (!this.Ready) return;
+
+        var listeners = this.AddonLifecycle.ReceiveEventListeners;
+
+        if (!listeners.Any())
+        {
+            ImGui.Text("No ReceiveEvent Hooks are Registered");
+        }
+        
+        foreach (var receiveEventListener in this.AddonLifecycle.ReceiveEventListeners)
+        {
+            if (ImGui.CollapsingHeader(string.Join(", ", receiveEventListener.AddonNames)))
+            {
+                ImGui.Columns(2);
+
+                ImGui.Text("Hook Address");
+                ImGui.NextColumn();
+                ImGui.Text(receiveEventListener.HookAddress.ToString("X"));
+
+                ImGui.NextColumn();
+                ImGui.Text("Hook Status");
+                ImGui.NextColumn();
+                if (receiveEventListener.Hook is null)
+                {
+                    ImGui.Text("Hook is null");
+                }
+                else
+                {
+                    var color = receiveEventListener.Hook.IsEnabled ? KnownColor.Green.Vector() : KnownColor.OrangeRed.Vector();
+                    var text = receiveEventListener.Hook.IsEnabled ? "Enabled" : "Disabled";
+                    ImGui.TextColored(color, text);
+                }
+                
+                ImGui.Columns(1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This new subsystem groups together the ReceiveEvent hooks for multiple addons when they share the same ReceiveEvent handler.

This addresses the issue that occurs when you try to hook addons that share handlers causing them to invoke each-others handlers recursively resulting in a stack overflow crash.

Also adds `AddonLifecycle` Data Window Widget for viewing the current status of all listeners and receive event handlers

Closes #1508 