### PR TITLE
Fix num array size to add flytext native

### DIFF
--- a/Dalamud/Game/Gui/FlyText/FlyTextGui.cs
+++ b/Dalamud/Game/Gui/FlyText/FlyTextGui.cs
@@ -132,7 +132,7 @@ internal sealed class FlyTextGui : IDisposable, IServiceType, IFlyTextGui
                     1,
                     (IntPtr)numArray,
                     numOffset,
-                    9,
+                    10,
                     (IntPtr)strArray,
                     strOffset,
                     2,


### PR DESCRIPTION
After [adding the damage type icon](https://github.com/goatcorp/Dalamud/commit/4a74c19b6f9c4f5c5f27773aa61b63867acf28ec), the number array size should be 10 instead of 9.

@lmcintyre @Aireil 

fix: change the num array size to 10