### PR TITLE
Fix multi-line copy/paste between ImGui and XIV

### DIFF
--- a/Dalamud/Interface/Internal/ImGuiClipboardConfig.cs
+++ b/Dalamud/Interface/Internal/ImGuiClipboardConfig.cs
@@ -1,0 +1,80 @@
+using System.Runtime.InteropServices;
+using ImGuiNET;
+
+namespace Dalamud.Interface.Internal;
+
+/// <summary>
+/// Configures the ImGui clipboard behaviour to work nicely with XIV.
+/// </summary>
+/// <remarks>
+/// <para>
+/// XIV uses '\r' for line endings and will truncate all text after a '\n' character.
+/// This means that copy/pasting multi-line text from ImGui to XIV will only copy the first line.
+/// </para>
+/// <para>
+/// ImGui uses '\n' for line endings and will ignore '\r' entirely.
+/// This means that copy/pasting multi-line text from XIV to ImGui will copy all the text
+/// without line breaks.
+/// </para>
+/// <para>
+/// To fix this we normalize all clipboard line endings entering/exiting ImGui to '\r\n' which
+/// works for both ImGui and XIV.
+/// </para>
+/// </remarks>
+internal static class ImGuiClipboardConfig
+{
+    private delegate void SetClipboardTextDelegate(IntPtr userData, string text);
+    private delegate string GetClipboardTextDelegate();
+
+    private static SetClipboardTextDelegate? _setTextOriginal = null;
+    private static GetClipboardTextDelegate? _getTextOriginal = null;
+
+    // These must exist as variables to prevent them from being GC'd
+    private static SetClipboardTextDelegate? _setText = null;
+    private static GetClipboardTextDelegate? _getText = null;
+
+    public static void Apply()
+    {
+        var io = ImGui.GetIO();
+        if (_setTextOriginal == null)
+        {
+            _setTextOriginal =
+                Marshal.GetDelegateForFunctionPointer<SetClipboardTextDelegate>(io.SetClipboardTextFn);
+        }
+
+        if (_getTextOriginal == null)
+        {
+            _getTextOriginal =
+                Marshal.GetDelegateForFunctionPointer<GetClipboardTextDelegate>(io.GetClipboardTextFn);
+        }
+
+        _setText = new SetClipboardTextDelegate(SetClipboardText);
+        _getText = new GetClipboardTextDelegate(GetClipboardText);
+
+        io.SetClipboardTextFn = Marshal.GetFunctionPointerForDelegate(_setText);
+        io.GetClipboardTextFn = Marshal.GetFunctionPointerForDelegate(_getText);
+    }
+
+    public static void Unapply()
+    {
+        var io = ImGui.GetIO();
+        if (_setTextOriginal != null)
+        {
+            io.SetClipboardTextFn = Marshal.GetFunctionPointerForDelegate(_setTextOriginal);
+        }
+        if (_getTextOriginal != null)
+        {
+            io.GetClipboardTextFn = Marshal.GetFunctionPointerForDelegate(_getTextOriginal);
+        }
+    }
+
+    private static void SetClipboardText(IntPtr userData, string text)
+    {
+        _setTextOriginal!(userData, text.ReplaceLineEndings("\r\n"));
+    }
+
+    private static string GetClipboardText()
+    {
+        return _getTextOriginal!().ReplaceLineEndings("\r\n");
+    }
+}

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -231,6 +231,7 @@ internal class InterfaceManager : IDisposable, IServiceType
             this.processMessageHook?.Dispose();
         }).Wait();
 
+        ImGuiClipboardConfig.Unapply();
         this.scene?.Dispose();
     }
 
@@ -619,6 +620,7 @@ internal class InterfaceManager : IDisposable, IServiceType
             ImGui.GetIO().FontGlobalScale = configuration.GlobalUiScale;
 
             this.SetupFonts();
+            ImGuiClipboardConfig.Apply();
 
             if (!configuration.IsDocking)
             {


### PR DESCRIPTION
# Problem

At the moment multi-line copy/paste between ImGui and XIV is broken:

- Going from ImGui -> XIV only copies the first line.
- Going from XIV -> ImGui loses all line breaks.

This happens because XIV uses `\r` line terminators and ImGui uses `\n`.

To fix this we normalize all line breaks that are copied in/out of ImGui to `\r\n`. This works bidirectionally because ImGui will ignore the `\r` and XIV will ignore the `\n`.

You can test this by using any addon with a `InputTextMutliline` (like QoLBar). Try copying/pasting text between the Macro window or the Chat Log to see the issue.

# Implementation

I'm not very familiar with the Dalamud codebase so I'm not sure if this is the best place / approach for encoding the change. Ultimately we need to set `io.SetClipboardTextFn` and `io.GetClipboardTextFn` but I'm happy to move things around to make it more cohesive with the rest of the code.

We also could also make this change in ImGuiScene [here](https://github.com/goatcorp/ImGuiScene/blob/2f37349ffd778561a1103a650683116c43edc86c/ImGuiScene/ImGui_Impl/Input/ImGui_Impl_SDL.cs#L74-L76). But I felt like this was a XIV-specific change which feels like it belongs in Dalamud.

# Alternatives

At the moment this can be worked around on specific `InputTextMutliline` by using a hack like this:

```c#
    private void InputTextXIVPasteHack() {
        if (ImGui.IsItemFocused()) {
            var clipboardText = ImGui.GetClipboardText();
            if ((clipboardText.Contains("\r") || clipboardText.Contains("\n")) && !clipboardText.Contains("\r\n")) {
                // We want to normalize all line endings to \r\n so ImGui and FFXIV can accept them when pasted.
                //
                // Line endings from XIV only have '\r'.
                ImGui.SetClipboardText(clipboardText.ReplaceLineEndings("\r\n"));
            }
        }
    }
```

Basically we overwrite the clipboard if we are focusing on multi-line text box, with the understanding that we must focus on the box before we can copy into/out of it. 