### PR TITLE
Add ImDrawList UserCallback support

### DIFF
--- a/Dalamud.CorePlugin/Dalamud.CorePlugin.csproj
+++ b/Dalamud.CorePlugin/Dalamud.CorePlugin.csproj
@@ -50,4 +50,10 @@
             <Private>false</Private>
         </ProjectReference>
     </ItemGroup>
+
+    <ItemGroup>
+        <None Update="Dalamud.CorePlugin.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 </Project>

--- a/Dalamud.CorePlugin/Dalamud.CorePlugin.json
+++ b/Dalamud.CorePlugin/Dalamud.CorePlugin.json
@@ -1,0 +1,9 @@
+﻿{
+    "Author": "Dalamud Maintainers",
+    "Name": "CorePlugin",
+    "Punchline": "Testbed for developing Dalamud features.",
+    "Description": "Develop and debug internal Dalamud features using CorePlugin. You have full access to all types in Dalamud assembly.",
+    "InternalName": "CorePlugin",
+    "ApplicableVersion": "any",
+    "Tags": []
+}

--- a/Dalamud.CorePlugin/PluginImpl.cs
+++ b/Dalamud.CorePlugin/PluginImpl.cs
@@ -56,7 +56,7 @@ namespace Dalamud.CorePlugin
         /// </summary>
         /// <param name="pluginInterface">Dalamud plugin interface.</param>
         /// <param name="log">Logging service.</param>
-        public PluginImpl(DalamudPluginInterface pluginInterface, IPluginLog log)
+        public PluginImpl(DalamudPluginInterface pluginInterface, IDataManager dataManager, ITextureProvider textureProvider, IPluginLog log)
         {
             try
             {
@@ -64,7 +64,7 @@ namespace Dalamud.CorePlugin
                 this.Interface = pluginInterface;
                 this.pluginLog = log;
 
-                this.windowSystem.AddWindow(new PluginWindow());
+                this.windowSystem.AddWindow(new PluginWindow(pluginInterface.UiBuilder, dataManager, textureProvider));
 
                 this.Interface.UiBuilder.Draw += this.OnDraw;
                 this.Interface.UiBuilder.OpenConfigUi += this.OnOpenConfigUi;

--- a/Dalamud.CorePlugin/PluginWindow.cs
+++ b/Dalamud.CorePlugin/PluginWindow.cs
@@ -1,8 +1,14 @@
 using System;
-using System.Numerics;
-
+using System.IO;
+using Dalamud.Interface;
+using Dalamud.Interface.Internal;
 using Dalamud.Interface.Windowing;
+using Dalamud.Plugin.Services;
 using ImGuiNET;
+using Lumina.Data.Files;
+using SharpDX;
+using SharpDX.Direct3D11;
+using Vector2 = System.Numerics.Vector2;
 
 namespace Dalamud.CorePlugin
 {
@@ -11,21 +17,59 @@ namespace Dalamud.CorePlugin
     /// </summary>
     internal class PluginWindow : Window, IDisposable
     {
+        private readonly UiBuilder uiBuilder;
+        private readonly ITextureProvider textureProvider;
+        private readonly IDalamudTextureWrap tex;
+        private readonly IntPtr callbackId;
+        private readonly Device device;
+        private readonly DeviceContext deviceContext;
+        private readonly PixelShader pixelShader;
+        private readonly SamplerState fontSampler;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PluginWindow"/> class.
         /// </summary>
-        public PluginWindow()
+        public PluginWindow(UiBuilder uiBuilder, IDataManager dataManager, ITextureProvider textureProvider)
             : base("CorePlugin")
         {
+            this.uiBuilder = uiBuilder;
+            this.textureProvider = textureProvider;
             this.IsOpen = true;
 
             this.Size = new Vector2(810, 520);
             this.SizeCondition = ImGuiCond.FirstUseEver;
+
+            this.tex = this.textureProvider.GetTexture(dataManager.GetFile<TexFile>("chara/monster/m0361/obj/body/b0001/texture/v01_m0361b0001_n.tex")!);
+            this.callbackId = this.uiBuilder.AddImGuiDrawCmdUserCallback(this.DrawCmdUserCallback);
+            this.device = CppObject.FromPointer<Device>(uiBuilder.DeviceNativePointer);
+            this.deviceContext = CppObject.FromPointer<DeviceContext>(uiBuilder.DeviceContextNativePointer);
+            this.pixelShader = new PixelShader(this.device, File.ReadAllBytes(@"Z:\test.fxc"));
+            this.fontSampler = new SamplerState(this.device, new SamplerStateDescription
+            {
+                Filter = Filter.MinMagMipLinear,
+                AddressU = TextureAddressMode.Wrap,
+                AddressV = TextureAddressMode.Wrap,
+                AddressW = TextureAddressMode.Wrap,
+                MipLodBias = 0,
+                ComparisonFunction = Comparison.Always,
+                MinimumLod = 0,
+                MaximumLod = 0,
+            });
+        }
+
+        private void DrawCmdUserCallback(ImDrawDataPtr drawData, ImDrawCmdPtr drawCmd)
+        {
+            this.deviceContext.PixelShader.Set(this.pixelShader);
+            this.deviceContext.PixelShader.SetSampler(0, this.fontSampler);
         }
 
         /// <inheritdoc/>
         public void Dispose()
         {
+            this.uiBuilder.RemoveImGuiDrawCmdUserCallback(this.DrawCmdUserCallback);
+            this.tex.Dispose();
+            this.pixelShader.Dispose();
+            this.fontSampler.Dispose();
         }
 
         /// <inheritdoc/>
@@ -36,6 +80,15 @@ namespace Dalamud.CorePlugin
         /// <inheritdoc/>
         public override void Draw()
         {
+            var drawList = ImGui.GetWindowDrawList();
+            drawList.AddCallback(this.callbackId, nint.Zero);
+            ImGui.Image(this.tex.ImGuiHandle, new(512, 512), new(1, 0), new(2, 1));
+            ImGui.SameLine();
+            ImGui.Image(this.tex.ImGuiHandle, new(512, 512), new(2, 0), new(3, 1));
+            ImGui.Image(this.tex.ImGuiHandle, new(512, 512), new(3, 0), new(4, 1));
+            ImGui.SameLine();
+            ImGui.Image(this.tex.ImGuiHandle, new(512, 512), new(4, 0), new(5, 1));
+            drawList.AddCallback(this.uiBuilder.ImGuiResetDrawCmdUserCallback, nint.Zero);
         }
     }
 }

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -149,6 +149,11 @@ internal class InterfaceManager : IDisposable, IServiceType
     public ImGuiIOPtr LastImGuiIoPtr { get; set; }
 
     /// <summary>
+    /// Gets the ImGuiRenderer from ImGuiScene.
+    /// </summary>
+    public IImGuiRenderer? ImGuiRenderer => this.scene?.Renderer;
+
+    /// <summary>
     /// Gets the D3D11 device instance. Note that the reference count is not increased.
     /// </summary>
     public SharpDX.Direct3D11.Device? Device => this.scene?.Device;

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -149,9 +149,14 @@ internal class InterfaceManager : IDisposable, IServiceType
     public ImGuiIOPtr LastImGuiIoPtr { get; set; }
 
     /// <summary>
-    /// Gets the D3D11 device instance.
+    /// Gets the D3D11 device instance. Note that the reference count is not increased.
     /// </summary>
     public SharpDX.Direct3D11.Device? Device => this.scene?.Device;
+
+    /// <summary>
+    /// Gets the D3D11 device context. Note that the reference count is not increased.
+    /// </summary>
+    public DeviceContext? DeviceContext => this.scene?.DeviceContext;
 
     /// <summary>
     /// Gets the address handle to the main process window.

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -16,7 +16,6 @@ using Dalamud.Utility;
 using ImGuiNET;
 using ImGuiScene;
 using Serilog;
-using SharpDX.Direct3D11;
 
 namespace Dalamud.Interface;
 
@@ -122,9 +121,26 @@ public sealed class UiBuilder : IDisposable
     public static ImFontPtr MonoFont => InterfaceManager.MonoFont;
 
     /// <summary>
-    /// Gets the game's active Direct3D device.
+    /// Gets the game's active D3D11 device instance. Note that the reference count is not increased.
     /// </summary>
-    public Device Device => this.InterfaceManagerWithScene.Device!;
+    public SharpDX.Direct3D11.Device? Device => this.InterfaceManagerWithScene?.Device;
+
+    /// <summary>
+    /// Gets the game's active D3D11 device context. Note that the reference count is not increased.
+    /// </summary>
+    public SharpDX.Direct3D11.DeviceContext? DeviceContext => this.InterfaceManagerWithScene?.DeviceContext;
+
+    /// <summary>
+    /// Gets the native pointer of the game's active D3D11 device instance.
+    /// Note that the reference count is not increased.
+    /// </summary>
+    public nint DeviceNativePointer => this.Device?.NativePointer ?? nint.Zero;
+
+    /// <summary>
+    /// Gets the native pointer of the game's active D3D11 device context.
+    /// Note that the reference count is not increased.
+    /// </summary>
+    public nint DeviceContextNativePointer => this.DeviceContext?.NativePointer ?? nint.Zero;
 
     /// <summary>
     /// Gets the game's main window handle.


### PR DESCRIPTION
Commits need to be edited after merging [ImGuiScene#11](https://github.com/goatcorp/ImGuiScene/pull/11) first.

When reviewing, the relevant commit is the third commit. Four commit is for example purposes; it is to be removed before merging.

Also, did the following:
* Add Dalamud.CorePlugin.json.
* Expose `DeviceContext` from `UiBuilder`.
* Expose `DeviceNativePointer` and `DeviceContextNativePointer`, due to SharpDX dependency types in Dalamud assembly not being exposed correctly to plugins, resulting in incompatible types across assemblies. Or, that's what I think what's going on, at least.


![image](https://github.com/goatcorp/Dalamud/assets/3614868/32eb9575-830c-4fbd-905a-d8b627a1fa7b)

```hlsl
SamplerState Sampler : register(s0);
Texture2D Texture : register(t0);

struct PSInput {
    float4 position : SV_POSITION;
    float4 color : COLOR;
    float2 uv : TEXCOORD;
};

float4 main_ps(PSInput input) : SV_TARGET {
    const float4 color = Texture.Sample(Sampler, input.uv);
    switch (floor(input.uv.x)) {
        case 1: return float4(input.color.xyz, color.r);
        case 2: return float4(input.color.xyz, color.g);
        case 3: return float4(input.color.xyz, color.b);
        case 4: return float4(input.color.xyz, color.a);
        default: return input.color * color;
    }
}
```

[test.fxc.zip](https://github.com/goatcorp/Dalamud/files/13325068/test.fxc.zip)
