### PR TITLE
fix: Use SetValue for FlyText string arrays

### DIFF
--- a/Dalamud/Game/Gui/FlyText/FlyTextGui.cs
+++ b/Dalamud/Game/Gui/FlyText/FlyTextGui.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
@@ -113,32 +112,26 @@ internal sealed class FlyTextGui : IDisposable, IServiceType, IFlyTextGui
         numArray->IntArray[numOffset + 2] = unchecked((int)val1);
         numArray->IntArray[numOffset + 3] = unchecked((int)val2);
         numArray->IntArray[numOffset + 4] = unchecked((int)damageTypeIcon); // Icons for damage type
-        numArray->IntArray[numOffset + 5] = 5; // Unknown
+        numArray->IntArray[numOffset + 5] = 5;                              // Unknown
         numArray->IntArray[numOffset + 6] = unchecked((int)color);
         numArray->IntArray[numOffset + 7] = unchecked((int)icon);
         numArray->IntArray[numOffset + 8] = 0; // Unknown
         numArray->IntArray[numOffset + 9] = 0; // Unknown, has something to do with yOffset
 
-        fixed (byte* pText1 = text1.Encode())
-        {
-            fixed (byte* pText2 = text2.Encode())
-            {
-                strArray->StringArray[strOffset + 0] = pText1;
-                strArray->StringArray[strOffset + 1] = pText2;
+        strArray->SetValue((int)strOffset + 0, text1.Encode(), false, true, false);
+        strArray->SetValue((int)strOffset + 1, text2.Encode(), false, true, false);
 
-                this.addFlyTextNative(
-                    flytext,
-                    actorIndex,
-                    1,
-                    (IntPtr)numArray,
-                    numOffset,
-                    10,
-                    (IntPtr)strArray,
-                    strOffset,
-                    2,
-                    0);
-            }
-        }
+        this.addFlyTextNative(
+            flytext,
+            actorIndex,
+            1,
+            (IntPtr)numArray,
+            numOffset,
+            10,
+            (IntPtr)strArray,
+            strOffset,
+            2,
+            0);
     }
 
     private static byte[] Terminate(byte[] source)
@@ -230,7 +223,8 @@ internal sealed class FlyTextGui : IDisposable, IServiceType, IFlyTextGui
             if (!dirty)
             {
                 Log.Verbose("[FlyText] Calling flytext with original args.");
-                return this.createFlyTextHook.Original(addonFlyText, kind, val1, val2, text2, color, icon, damageTypeIcon, text1, yOffset);
+                return this.createFlyTextHook.Original(addonFlyText, kind, val1, val2, text2, color, icon,
+                                                       damageTypeIcon, text1, yOffset);
             }
 
             var terminated1 = Terminate(tmpText1.Encode());
@@ -299,10 +293,10 @@ internal class FlyTextGuiPluginScoped : IDisposable, IServiceType, IFlyTextGui
     {
         this.flyTextGuiService.FlyTextCreated += this.FlyTextCreatedForward;
     }
-        
+
     /// <inheritdoc/>
     public event IFlyTextGui.OnFlyTextCreatedDelegate? FlyTextCreated;
-    
+
     /// <inheritdoc/>
     public void Dispose()
     {

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "7.0.0",
-    "rollForward": "latestMinor",
+    "rollForward": "latestMajor",
     "allowPrerelease": true
   }
-}
+} 


### PR DESCRIPTION
This pull request aims to attempt to fix a bug that might be causing crashes with FlyText for certain users. 

At present Dalamud will directly assign a pointer to the StringArray, which may become invalid later due to GC or just normal managed shenanigans. To get around this, we instruct the game to copy the data to the array instead so that we can freely dispose of it on our end. See the docs for [`StringArray#SetValue`](https://github.com/aers/FFXIVClientStructs/blob/main/FFXIVClientStructs/FFXIV/Component/GUI/StringArrayData.cs#L28) for more information.

Also sneaks in a fix to allow building Dalamud for those of us that already upgraded to .NET 8.