### PR TITLE
Better Service dependency handling

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -20,7 +20,7 @@ namespace Dalamud.Configuration.Internal;
 /// Class containing Dalamud settings.
 /// </summary>
 [Serializable]
-[ServiceManager.Service]
+[ServiceManager.ProvidedService]
 #pragma warning disable SA1015
 [InherentDependency<ReliableFileStorage>] // We must still have this when unloading
 #pragma warning restore SA1015

--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -30,7 +30,7 @@ namespace Dalamud;
 /// <summary>
 /// The main Dalamud class containing all subsystems.
 /// </summary>
-[ServiceManager.Service]
+[ServiceManager.ProvidedService]
 internal sealed class Dalamud : IServiceType
 {
     #region Internals

--- a/Dalamud/Game/Addon/Events/AddonEventManager.cs
+++ b/Dalamud/Game/Addon/Events/AddonEventManager.cs
@@ -18,7 +18,7 @@ namespace Dalamud.Game.Addon.Events;
 /// Service provider for addon event management.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.EarlyLoadedService]
+[ServiceManager.BlockingEarlyLoadedService]
 internal unsafe class AddonEventManager : IDisposable, IServiceType
 {
     /// <summary>

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -18,7 +18,7 @@ namespace Dalamud.Game.Addon.Lifecycle;
 /// This class provides events for in-game addon lifecycles.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.EarlyLoadedService]
+[ServiceManager.BlockingEarlyLoadedService]
 internal unsafe class AddonLifecycle : IDisposable, IServiceType
 {
     private static readonly ModuleLog Log = new("AddonLifecycle");

--- a/Dalamud/Game/Config/GameConfig.cs
+++ b/Dalamud/Game/Config/GameConfig.cs
@@ -12,7 +12,7 @@ namespace Dalamud.Game.Config;
 /// This class represents the game's configuration.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.EarlyLoadedService]
+[ServiceManager.BlockingEarlyLoadedService]
 internal sealed class GameConfig : IServiceType, IGameConfig, IDisposable
 {
     private readonly GameConfigAddressResolver address = new();

--- a/Dalamud/Game/DutyState/DutyState.cs
+++ b/Dalamud/Game/DutyState/DutyState.cs
@@ -12,7 +12,7 @@ namespace Dalamud.Game.DutyState;
 /// This class represents the state of the currently occupied duty.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.EarlyLoadedService]
+[ServiceManager.BlockingEarlyLoadedService]
 internal unsafe class DutyState : IDisposable, IServiceType, IDutyState
 {
     private readonly DutyStateAddressResolver address;

--- a/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
+++ b/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
@@ -22,14 +21,14 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
 
     private const string ApiKey = "GGD6RdSfGyRiHM5WDnAo0Nj9Nv7aC5NDhMj3BebT";
 
-    private readonly HttpClient httpClient = Service<HappyHttpClient>.Get().SharedHttpClient;
+    private readonly HttpClient httpClient;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UniversalisMarketBoardUploader"/> class.
     /// </summary>
-    public UniversalisMarketBoardUploader()
-    {
-    }
+    /// <param name="happyHttpClient">An instance of <see cref="HappyHttpClient"/>.</param>
+    public UniversalisMarketBoardUploader(HappyHttpClient happyHttpClient) =>
+        this.httpClient = happyHttpClient.SharedHttpClient;
 
     /// <inheritdoc/>
     public async Task Upload(MarketBoardItemRequest request)

--- a/Dalamud/Game/Network/Internal/NetworkHandlers.cs
+++ b/Dalamud/Game/Network/Internal/NetworkHandlers.cs
@@ -13,6 +13,7 @@ using Dalamud.Game.Network.Internal.MarketBoardUploaders;
 using Dalamud.Game.Network.Internal.MarketBoardUploaders.Universalis;
 using Dalamud.Game.Network.Structures;
 using Dalamud.Hooking;
+using Dalamud.Networking.Http;
 using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Client.UI.Info;
 using Lumina.Excel.GeneratedSheets;
@@ -23,7 +24,7 @@ namespace Dalamud.Game.Network.Internal;
 /// <summary>
 /// This class handles network notifications and uploading market board data.
 /// </summary>
-[ServiceManager.EarlyLoadedService]
+[ServiceManager.BlockingEarlyLoadedService]
 internal unsafe class NetworkHandlers : IDisposable, IServiceType
 {
     private readonly IMarketBoardUploader uploader;
@@ -55,9 +56,12 @@ internal unsafe class NetworkHandlers : IDisposable, IServiceType
     private bool disposing;
 
     [ServiceManager.ServiceConstructor]
-    private NetworkHandlers(GameNetwork gameNetwork, TargetSigScanner sigScanner)
+    private NetworkHandlers(
+        GameNetwork gameNetwork,
+        TargetSigScanner sigScanner,
+        HappyHttpClient happyHttpClient)
     {
-        this.uploader = new UniversalisMarketBoardUploader();
+        this.uploader = new UniversalisMarketBoardUploader(happyHttpClient);
 
         this.addressResolver = new NetworkHandlersAddressResolver();
         this.addressResolver.Setup(sigScanner);

--- a/Dalamud/Game/TargetSigScanner.cs
+++ b/Dalamud/Game/TargetSigScanner.cs
@@ -11,7 +11,7 @@ namespace Dalamud.Game;
 /// </summary>
 [PluginInterface]
 [InterfaceVersion("1.0")]
-[ServiceManager.Service]
+[ServiceManager.ProvidedService]
 #pragma warning disable SA1015
 [ResolveVia<ISigScanner>]
 #pragma warning restore SA1015

--- a/Dalamud/Interface/DragDrop/DragDropManager.cs
+++ b/Dalamud/Interface/DragDrop/DragDropManager.cs
@@ -15,7 +15,7 @@ namespace Dalamud.Interface.DragDrop;
 /// and can be used to create ImGui drag and drop sources and targets for those external events.
 /// </summary>
 [PluginInterface]
-[ServiceManager.EarlyLoadedService]
+[ServiceManager.BlockingEarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<IDragDropManager>]
 #pragma warning restore SA1015

--- a/Dalamud/Interface/GameFonts/GameFontManager.cs
+++ b/Dalamud/Interface/GameFonts/GameFontManager.cs
@@ -22,7 +22,7 @@ namespace Dalamud.Interface.GameFonts;
 /// <summary>
 /// Loads game font for use in ImGui.
 /// </summary>
-[ServiceManager.EarlyLoadedService]
+[ServiceManager.BlockingEarlyLoadedService]
 internal class GameFontManager : IServiceType
 {
     private static readonly string?[] FontNames =

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Reflection;
@@ -9,6 +7,7 @@ using System.Runtime.InteropServices;
 
 using CheapLoc;
 using Dalamud.Configuration.Internal;
+using Dalamud.Game.ClientState;
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.Gui;
 using Dalamud.Game.Internal;
@@ -25,14 +24,14 @@ using Dalamud.Interface.Style;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
-using Dalamud.Logging;
 using Dalamud.Logging.Internal;
 using Dalamud.Plugin.Internal;
 using Dalamud.Utility;
+
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using ImGuiNET;
-using ImGuiScene;
+
 using ImPlotNET;
 using PInvoke;
 using Serilog.Events;
@@ -48,9 +47,11 @@ internal class DalamudInterface : IDisposable, IServiceType
     private const float CreditsDarkeningMaxAlpha = 0.8f;
 
     private static readonly ModuleLog Log = new("DUI");
-    
+
+    private readonly Dalamud dalamud;
     private readonly DalamudConfiguration configuration;
-    
+    private readonly InterfaceManager interfaceManager;
+
     private readonly ChangelogWindow changelogWindow;
     private readonly ColorDemoWindow colorDemoWindow;
     private readonly ComponentDemoWindow componentDemoWindow;
@@ -92,11 +93,16 @@ internal class DalamudInterface : IDisposable, IServiceType
         DalamudConfiguration configuration,
         InterfaceManager.InterfaceManagerWithScene interfaceManagerWithScene,
         PluginImageCache pluginImageCache,
-        Branding branding)
+        Branding branding,
+        Game.Framework framework,
+        ClientState clientState,
+        TitleScreenMenu titleScreenMenu,
+        GameGui gameGui)
     {
+        this.dalamud = dalamud;
         this.configuration = configuration;
+        this.interfaceManager = interfaceManagerWithScene.Manager;
 
-        var interfaceManager = interfaceManagerWithScene.Manager;
         this.WindowSystem = new WindowSystem("DalamudCore");
         
         this.colorDemoWindow = new ColorDemoWindow() { IsOpen = false };
@@ -104,13 +110,20 @@ internal class DalamudInterface : IDisposable, IServiceType
         this.dataWindow = new DataWindow() { IsOpen = false };
         this.gamepadModeNotifierWindow = new GamepadModeNotifierWindow() { IsOpen = false };
         this.imeWindow = new ImeWindow() { IsOpen = false };
-        this.consoleWindow = new ConsoleWindow() { IsOpen = configuration.LogOpenAtStartup };
+        this.consoleWindow = new ConsoleWindow(configuration) { IsOpen = configuration.LogOpenAtStartup };
         this.pluginStatWindow = new PluginStatWindow() { IsOpen = false };
-        this.pluginWindow = new PluginInstallerWindow(pluginImageCache) { IsOpen = false };
+        this.pluginWindow = new PluginInstallerWindow(pluginImageCache, configuration) { IsOpen = false };
         this.settingsWindow = new SettingsWindow() { IsOpen = false };
         this.selfTestWindow = new SelfTestWindow() { IsOpen = false };
         this.styleEditorWindow = new StyleEditorWindow() { IsOpen = false };
-        this.titleScreenMenuWindow = new TitleScreenMenuWindow() { IsOpen = false };
+        this.titleScreenMenuWindow = new TitleScreenMenuWindow(
+            clientState,
+            dalamud,
+            configuration,
+            framework,
+            gameGui,
+            this.interfaceManager,
+            titleScreenMenu) { IsOpen = false };
         this.changelogWindow = new ChangelogWindow(this.titleScreenMenuWindow) { IsOpen = false };
         this.profilerWindow = new ProfilerWindow() { IsOpen = false };
         this.branchSwitcherWindow = new BranchSwitcherWindow() { IsOpen = false };
@@ -136,7 +149,7 @@ internal class DalamudInterface : IDisposable, IServiceType
         ImGuiManagedAsserts.AssertsEnabled = configuration.AssertsEnabledAtStartup;
         this.isImGuiDrawDevMenu = this.isImGuiDrawDevMenu || configuration.DevBarOpenAtStartup;
 
-        interfaceManager.Draw += this.OnDraw;
+        this.interfaceManager.Draw += this.OnDraw;
 
         var tsm = Service<TitleScreenMenu>.Get();
         tsm.AddEntryCore(Loc.Localize("TSMDalamudPlugins", "Plugin Installer"), branding.LogoSmall, () => this.OpenPluginInstaller());
@@ -173,7 +186,7 @@ internal class DalamudInterface : IDisposable, IServiceType
     /// <inheritdoc/>
     public void Dispose()
     {
-        Service<InterfaceManager>.Get().Draw -= this.OnDraw;
+        this.interfaceManager.Draw -= this.OnDraw;
 
         this.WindowSystem.RemoveAllWindows();
 
@@ -356,7 +369,7 @@ internal class DalamudInterface : IDisposable, IServiceType
     /// Toggles the <see cref="DataWindow"/>.
     /// </summary>
     /// <param name="dataKind">The data kind to switch to after opening.</param>
-    public void ToggleDataWindow(string dataKind = null)
+    public void ToggleDataWindow(string? dataKind = null)
     {
         this.dataWindow.Toggle();
         if (dataKind != null && this.dataWindow.IsOpen)
@@ -378,7 +391,7 @@ internal class DalamudInterface : IDisposable, IServiceType
     /// <summary>
     /// Toggles the <see cref="ImeWindow"/>.
     /// </summary>
-    public void ToggleIMEWindow() => this.imeWindow.Toggle();
+    public void ToggleImeWindow() => this.imeWindow.Toggle();
 
     /// <summary>
     /// Toggles the <see cref="ConsoleWindow"/>.
@@ -504,7 +517,8 @@ internal class DalamudInterface : IDisposable, IServiceType
 
     private void DrawCreditsDarkeningAnimation()
     {
-        using var style = ImRaii.PushStyle(ImGuiStyleVar.WindowRounding | ImGuiStyleVar.WindowBorderSize, 0f);
+        using var style1 = ImRaii.PushStyle(ImGuiStyleVar.WindowRounding, 0f);
+        using var style2 = ImRaii.PushStyle(ImGuiStyleVar.WindowBorderSize, 0f);
         using var color = ImRaii.PushColor(ImGuiCol.WindowBg, new Vector4(0, 0, 0, 0));
 
         ImGui.SetNextWindowPos(new Vector2(0, 0));
@@ -579,18 +593,16 @@ internal class DalamudInterface : IDisposable, IServiceType
         {
             if (ImGui.BeginMainMenuBar())
             {
-                var dalamud = Service<Dalamud>.Get();
-                var configuration = Service<DalamudConfiguration>.Get();
                 var pluginManager = Service<PluginManager>.Get();
 
                 if (ImGui.BeginMenu("Dalamud"))
                 {
                     ImGui.MenuItem("Draw dev menu", string.Empty, ref this.isImGuiDrawDevMenu);
-                    var devBarAtStartup = configuration.DevBarOpenAtStartup;
+                    var devBarAtStartup = this.configuration.DevBarOpenAtStartup;
                     if (ImGui.MenuItem("Draw dev menu at startup", string.Empty, ref devBarAtStartup))
                     {
-                        configuration.DevBarOpenAtStartup ^= true;
-                        configuration.QueueSave();
+                        this.configuration.DevBarOpenAtStartup ^= true;
+                        this.configuration.QueueSave();
                     }
 
                     ImGui.Separator();
@@ -607,25 +619,25 @@ internal class DalamudInterface : IDisposable, IServiceType
                             if (ImGui.MenuItem(logLevel + "##logLevelSwitch", string.Empty, EntryPoint.LogLevelSwitch.MinimumLevel == logLevel))
                             {
                                 EntryPoint.LogLevelSwitch.MinimumLevel = logLevel;
-                                configuration.LogLevel = logLevel;
-                                configuration.QueueSave();
+                                this.configuration.LogLevel = logLevel;
+                                this.configuration.QueueSave();
                             }
                         }
 
                         ImGui.EndMenu();
                     }
                     
-                    var logSynchronously = configuration.LogSynchronously;
+                    var logSynchronously = this.configuration.LogSynchronously;
                     if (ImGui.MenuItem("Log Synchronously", null, ref logSynchronously))
                     {
-                        configuration.LogSynchronously = logSynchronously;
-                        configuration.QueueSave();
+                        this.configuration.LogSynchronously = logSynchronously;
+                        this.configuration.QueueSave();
 
                         EntryPoint.InitLogging(
-                            dalamud.StartInfo.LogPath!,
-                            dalamud.StartInfo.BootShowConsole,
-                            configuration.LogSynchronously,
-                            dalamud.StartInfo.LogName);
+                            this.dalamud.StartInfo.LogPath!,
+                            this.dalamud.StartInfo.BootShowConsole,
+                            this.configuration.LogSynchronously,
+                            this.dalamud.StartInfo.LogName);
                     }
 
                     var antiDebug = Service<AntiDebug>.Get();
@@ -637,8 +649,8 @@ internal class DalamudInterface : IDisposable, IServiceType
                         else
                             antiDebug.Disable();
 
-                        configuration.IsAntiAntiDebugEnabled = newEnabled;
-                        configuration.QueueSave();
+                        this.configuration.IsAntiAntiDebugEnabled = newEnabled;
+                        this.configuration.QueueSave();
                     }
 
                     ImGui.Separator();
@@ -730,10 +742,10 @@ internal class DalamudInterface : IDisposable, IServiceType
                         }
                     }
 
-                    if (ImGui.MenuItem("Report crashes at shutdown", null, configuration.ReportShutdownCrashes))
+                    if (ImGui.MenuItem("Report crashes at shutdown", null, this.configuration.ReportShutdownCrashes))
                     {
-                        configuration.ReportShutdownCrashes = !configuration.ReportShutdownCrashes;
-                        configuration.QueueSave();
+                        this.configuration.ReportShutdownCrashes = !this.configuration.ReportShutdownCrashes;
+                        this.configuration.QueueSave();
                     }
 
                     ImGui.Separator();
@@ -744,7 +756,7 @@ internal class DalamudInterface : IDisposable, IServiceType
                     }
 
                     ImGui.MenuItem(Util.AssemblyVersion, false);
-                    ImGui.MenuItem(dalamud.StartInfo.GameVersion?.ToString() ?? "Unknown version", false);
+                    ImGui.MenuItem(this.dalamud.StartInfo.GameVersion?.ToString() ?? "Unknown version", false);
                     ImGui.MenuItem($"D: {Util.GetGitHash()}[{Util.GetGitCommitCount()}] CS: {Util.GetGitHashClientStructs()}[{FFXIVClientStructs.Interop.Resolver.Version}]", false);
                     ImGui.MenuItem($"CLR: {Environment.Version}", false);
 
@@ -766,10 +778,10 @@ internal class DalamudInterface : IDisposable, IServiceType
                         ImGuiManagedAsserts.AssertsEnabled = val;
                     }
 
-                    if (ImGui.MenuItem("Enable asserts at startup", null, configuration.AssertsEnabledAtStartup))
+                    if (ImGui.MenuItem("Enable asserts at startup", null, this.configuration.AssertsEnabledAtStartup))
                     {
-                        configuration.AssertsEnabledAtStartup = !configuration.AssertsEnabledAtStartup;
-                        configuration.QueueSave();
+                        this.configuration.AssertsEnabledAtStartup = !this.configuration.AssertsEnabledAtStartup;
+                        this.configuration.QueueSave();
                     }
 
                     if (ImGui.MenuItem("Clear focus"))
@@ -779,7 +791,7 @@ internal class DalamudInterface : IDisposable, IServiceType
 
                     if (ImGui.MenuItem("Clear stacks"))
                     {
-                        Service<InterfaceManager>.Get().ClearStacks();
+                        this.interfaceManager.ClearStacks();
                     }
 
                     if (ImGui.MenuItem("Dump style"))
@@ -792,7 +804,7 @@ internal class DalamudInterface : IDisposable, IServiceType
                         {
                             if (propertyInfo.PropertyType == typeof(Vector2))
                             {
-                                var vec2 = (Vector2)propertyInfo.GetValue(style);
+                                var vec2 = (Vector2)propertyInfo.GetValue(style)!;
                                 info += $"{propertyInfo.Name} = new Vector2({vec2.X.ToString(enCulture)}f, {vec2.Y.ToString(enCulture)}f),\n";
                             }
                             else
@@ -815,9 +827,9 @@ internal class DalamudInterface : IDisposable, IServiceType
                         Log.Information(info);
                     }
 
-                    if (ImGui.MenuItem("Show dev bar info", null, configuration.ShowDevBarInfo))
+                    if (ImGui.MenuItem("Show dev bar info", null, this.configuration.ShowDevBarInfo))
                     {
-                        configuration.ShowDevBarInfo = !configuration.ShowDevBarInfo;
+                        this.configuration.ShowDevBarInfo = !this.configuration.ShowDevBarInfo;
                     }
 
                     ImGui.EndMenu();
@@ -827,7 +839,7 @@ internal class DalamudInterface : IDisposable, IServiceType
                 {
                     if (ImGui.MenuItem("Replace ExceptionHandler"))
                     {
-                        dalamud.ReplaceExceptionHandler();
+                        this.dalamud.ReplaceExceptionHandler();
                     }
 
                     ImGui.EndMenu();
@@ -922,7 +934,7 @@ internal class DalamudInterface : IDisposable, IServiceType
                 if (Service<GameGui>.Get().GameUiHidden)
                     ImGui.BeginMenu("UI is hidden...", false);
 
-                if (configuration.ShowDevBarInfo)
+                if (this.configuration.ShowDevBarInfo)
                 {
                     ImGui.PushFont(InterfaceManager.MonoFont);
 
@@ -931,9 +943,9 @@ internal class DalamudInterface : IDisposable, IServiceType
                     ImGui.BeginMenu(ImGui.GetIO().Framerate.ToString("000"), false);
                     ImGui.BeginMenu($"W:{Util.FormatBytes(GC.GetTotalMemory(false))}", false);
 
-                    var videoMem = Service<InterfaceManager>.Get().GetD3dMemoryInfo();
+                    var videoMem = this.interfaceManager.GetD3dMemoryInfo();
                     ImGui.BeginMenu(
-                        !videoMem.HasValue ? $"V:???" : $"V:{Util.FormatBytes(videoMem.Value.Used)}",
+                        !videoMem.HasValue ? "V:???" : $"V:{Util.FormatBytes(videoMem.Value.Used)}",
                         false);
 
                     ImGui.PopFont();

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -1277,7 +1277,7 @@ internal class InterfaceManager : IDisposable, IServiceType
     /// <summary>
     /// Represents an instance of InstanceManager with scene ready for use.
     /// </summary>
-    [ServiceManager.Service]
+    [ServiceManager.ProvidedService]
     public class InterfaceManagerWithScene : IServiceType
     {
         /// <summary>

--- a/Dalamud/Interface/Internal/Windows/ChangelogWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ChangelogWindow.cs
@@ -67,7 +67,7 @@ internal sealed class ChangelogWindow : Window, IDisposable
         
         // If we are going to show a changelog, make sure we have the font ready, otherwise it will hitch
         if (WarrantsChangelog())
-            this.MakeFont();
+            Service<GameFontManager>.GetAsync().ContinueWith(t => this.MakeFont(t.Result));
     }
 
     private enum State
@@ -98,7 +98,7 @@ internal sealed class ChangelogWindow : Window, IDisposable
         Service<DalamudInterface>.Get().SetCreditsDarkeningAnimation(true);
         this.tsmWindow.AllowDrawing = false;
 
-        this.MakeFont();
+        this.MakeFont(Service<GameFontManager>.Get());
         
         this.state = State.WindowFadeIn;
         this.windowFade.Reset();
@@ -379,12 +379,6 @@ internal sealed class ChangelogWindow : Window, IDisposable
         this.logoTexture.Dispose();
     }
 
-    private void MakeFont()
-    {
-        if (this.bannerFont == null)
-        {
-            var gfm = Service<GameFontManager>.Get();
-            this.bannerFont = gfm.NewFontRef(new GameFontStyle(GameFontFamilyAndSize.MiedingerMid18));
-        }
-    }
+    private void MakeFont(GameFontManager gfm) =>
+        this.bannerFont ??= gfm.NewFontRef(new GameFontStyle(GameFontFamilyAndSize.MiedingerMid18));
 }

--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -56,11 +56,10 @@ internal class ConsoleWindow : Window, IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="ConsoleWindow"/> class.
     /// </summary>
-    public ConsoleWindow()
+    /// <param name="configuration">An instance of <see cref="DalamudConfiguration"/>.</param>
+    public ConsoleWindow(DalamudConfiguration configuration)
         : base("Dalamud Console", ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse)
     {
-        var configuration = Service<DalamudConfiguration>.Get();
-
         this.autoScroll = configuration.LogAutoScroll;
         this.autoOpen = configuration.LogOpenAtStartup;
         SerilogEventSink.Instance.LogLine += this.OnLogLine;

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -69,7 +69,7 @@ internal class PluginInstallerWindow : Window, IDisposable
     private string[] testerImagePaths = new string[5];
     private string testerIconPath = string.Empty;
 
-    private IDalamudTextureWrap?[] testerImages;
+    private IDalamudTextureWrap?[]? testerImages;
     private IDalamudTextureWrap? testerIcon;
 
     private bool testerError = false;
@@ -132,9 +132,10 @@ internal class PluginInstallerWindow : Window, IDisposable
     /// Initializes a new instance of the <see cref="PluginInstallerWindow"/> class.
     /// </summary>
     /// <param name="imageCache">An instance of <see cref="PluginImageCache"/> class.</param>
-    public PluginInstallerWindow(PluginImageCache imageCache)
+    /// <param name="configuration">An instance of <see cref="DalamudConfiguration"/>.</param>
+    public PluginInstallerWindow(PluginImageCache imageCache, DalamudConfiguration configuration)
         : base(
-            Locs.WindowTitle + (Service<DalamudConfiguration>.Get().DoPluginTest ? Locs.WindowTitleMod_Testing : string.Empty) + "###XlPluginInstaller",
+            Locs.WindowTitle + (configuration.DoPluginTest ? Locs.WindowTitleMod_Testing : string.Empty) + "###XlPluginInstaller",
             ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoScrollbar)
     {
         this.IsOpen = true;

--- a/Dalamud/Interface/Internal/Windows/TitleScreenMenuWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/TitleScreenMenuWindow.cs
@@ -12,8 +12,8 @@ using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
 using Dalamud.Plugin.Services;
+
 using ImGuiNET;
-using ImGuiScene;
 
 namespace Dalamud.Interface.Internal.Windows;
 
@@ -24,6 +24,12 @@ internal class TitleScreenMenuWindow : Window, IDisposable
 {
     private const float TargetFontSizePt = 18f;
     private const float TargetFontSizePx = TargetFontSizePt * 4 / 3;
+
+    private readonly ClientState clientState;
+    private readonly DalamudConfiguration configuration;
+    private readonly Framework framework;
+    private readonly GameGui gameGui;
+    private readonly TitleScreenMenu titleScreenMenu;
 
     private readonly IDalamudTextureWrap shadeTexture;
 
@@ -39,12 +45,32 @@ internal class TitleScreenMenuWindow : Window, IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="TitleScreenMenuWindow"/> class.
     /// </summary>
-    public TitleScreenMenuWindow()
+    /// <param name="clientState">An instance of <see cref="ClientState"/>.</param>
+    /// <param name="dalamud">An instance of <see cref="Dalamud"/>.</param>
+    /// <param name="configuration">An instance of <see cref="DalamudConfiguration"/>.</param>
+    /// <param name="framework">An instance of <see cref="Framework"/>.</param>
+    /// <param name="interfaceManager">An instance of <see cref="InterfaceManager"/>.</param>
+    /// <param name="titleScreenMenu">An instance of <see cref="TitleScreenMenu"/>.</param>
+    /// <param name="gameGui">An instance of <see cref="gameGui"/>.</param>
+    public TitleScreenMenuWindow(
+        ClientState clientState,
+        Dalamud dalamud,
+        DalamudConfiguration configuration,
+        Framework framework,
+        GameGui gameGui,
+        InterfaceManager interfaceManager,
+        TitleScreenMenu titleScreenMenu)
         : base(
             "TitleScreenMenuOverlay",
             ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar |
             ImGuiWindowFlags.NoBackground | ImGuiWindowFlags.NoFocusOnAppearing | ImGuiWindowFlags.NoNavFocus)
     {
+        this.clientState = clientState;
+        this.configuration = configuration;
+        this.framework = framework;
+        this.gameGui = gameGui;
+        this.titleScreenMenu = titleScreenMenu;
+
         this.IsOpen = true;
         this.DisableWindowSounds = true;
         this.ForceMainWindow = true;
@@ -53,17 +79,13 @@ internal class TitleScreenMenuWindow : Window, IDisposable
         this.PositionCondition = ImGuiCond.Always;
         this.RespectCloseHotkey = false;
 
-        var dalamud = Service<Dalamud>.Get();
-        var interfaceManager = Service<InterfaceManager>.Get();
-
         var shadeTex =
             interfaceManager.LoadImage(Path.Combine(dalamud.AssetDirectory.FullName, "UIRes", "tsmShade.png"));
         this.shadeTexture = shadeTex ?? throw new Exception("Could not load TSM background texture.");
 
-        var framework = Service<Framework>.Get();
         framework.Update += this.FrameworkOnUpdate;
     }
-    
+
     private enum State
     {
         Hide,
@@ -95,8 +117,7 @@ internal class TitleScreenMenuWindow : Window, IDisposable
     public void Dispose()
     {
         this.shadeTexture.Dispose();
-        var framework = Service<Framework>.Get();
-        framework.Update -= this.FrameworkOnUpdate;
+        this.framework.Update -= this.FrameworkOnUpdate;
     }
 
     /// <inheritdoc/>
@@ -106,9 +127,7 @@ internal class TitleScreenMenuWindow : Window, IDisposable
             return;
         
         var scale = ImGui.GetIO().FontGlobalScale;
-        var entries = Service<TitleScreenMenu>.Get().Entries
-                                              .OrderByDescending(x => x.IsInternal)
-                                              .ToList();
+        var entries = this.titleScreenMenu.Entries.OrderByDescending(x => x.IsInternal).ToList();
 
         switch (this.state)
         {
@@ -369,17 +388,14 @@ internal class TitleScreenMenuWindow : Window, IDisposable
 
     private void FrameworkOnUpdate(IFramework framework)
     {
-        var clientState = Service<ClientState>.Get();
-        this.IsOpen = !clientState.IsLoggedIn;
+        this.IsOpen = !this.clientState.IsLoggedIn;
 
-        var configuration = Service<DalamudConfiguration>.Get();
-        if (!configuration.ShowTsm)
+        if (!this.configuration.ShowTsm)
             this.IsOpen = false;
 
-        var gameGui = Service<GameGui>.Get();
-        var charaSelect = gameGui.GetAddonByName("CharaSelect", 1);
-        var charaMake = gameGui.GetAddonByName("CharaMake", 1);
-        var titleDcWorldMap = gameGui.GetAddonByName("TitleDCWorldMap", 1);
+        var charaSelect = this.gameGui.GetAddonByName("CharaSelect", 1);
+        var charaMake = this.gameGui.GetAddonByName("CharaMake", 1);
+        var titleDcWorldMap = this.gameGui.GetAddonByName("TitleDCWorldMap", 1);
         if (charaMake != IntPtr.Zero || charaSelect != IntPtr.Zero || titleDcWorldMap != IntPtr.Zero)
             this.IsOpen = false;
     }

--- a/Dalamud/IoC/Internal/ServiceContainer.cs
+++ b/Dalamud/IoC/Internal/ServiceContainer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -16,7 +15,7 @@ namespace Dalamud.IoC.Internal;
 /// This is only used to resolve dependencies for plugins.
 /// Dalamud services are constructed via Service{T}.ConstructObject at the moment.
 /// </summary>
-[ServiceManager.Service]
+[ServiceManager.ProvidedService]
 internal class ServiceContainer : IServiceProvider, IServiceType
 {
     private static readonly ModuleLog Log = new("SERVICECONTAINER");
@@ -228,7 +227,7 @@ internal class ServiceContainer : IServiceProvider, IServiceType
         if (this.interfaceToTypeMap.TryGetValue(serviceType, out var implementingType))
             serviceType = implementingType;
         
-        if (serviceType.GetCustomAttribute<ServiceManager.ScopedService>() != null)
+        if (serviceType.GetCustomAttribute<ServiceManager.ScopedServiceAttribute>() != null)
         {
             if (scope == null)
             {
@@ -299,7 +298,7 @@ internal class ServiceContainer : IServiceProvider, IServiceType
             var contains = types.Any(x => x.IsAssignableTo(type));
 
             // Scoped services are created on-demand
-            return contains || type.GetCustomAttribute<ServiceManager.ScopedService>() != null;
+            return contains || type.GetCustomAttribute<ServiceManager.ScopedServiceAttribute>() != null;
         }
         
         var parameters = ctor.GetParameters();

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -38,7 +37,7 @@ namespace Dalamud.Plugin.Internal;
 /// Class responsible for loading and unloading plugins.
 /// NOTE: ALL plugin exposed services are marked as dependencies for PluginManager in Service{T}.
 /// </summary>
-[ServiceManager.EarlyLoadedService]
+[ServiceManager.BlockingEarlyLoadedService]
 #pragma warning disable SA1015
 
 // DalamudTextureWrap registers textures to dispose with IM
@@ -82,6 +81,9 @@ internal partial class PluginManager : IDisposable, IServiceType
 
     [ServiceManager.ServiceDependency]
     private readonly HappyHttpClient happyHttpClient = Service<HappyHttpClient>.Get();
+
+    [ServiceManager.ServiceDependency]
+    private readonly ChatGui chatGui = Service<ChatGui>.Get();
 
     static PluginManager()
     {
@@ -129,12 +131,13 @@ internal partial class PluginManager : IDisposable, IServiceType
             throw new InvalidDataException("Couldn't deserialize banned plugins manifest.");
         }
 
-        this.openInstallerWindowPluginChangelogsLink = Service<ChatGui>.Get().AddChatLinkHandler("Dalamud", 1003, (_, _) =>
+        this.openInstallerWindowPluginChangelogsLink = this.chatGui.AddChatLinkHandler("Dalamud", 1003, (_, _) =>
         {
             Service<DalamudInterface>.GetNullable()?.OpenPluginInstallerTo(PluginInstallerWindow.PluginInstallerOpenKind.Changelogs);
         });
 
-        this.configuration.PluginTestingOptIns ??= new List<PluginTestingOptIn>();
+        this.configuration.PluginTestingOptIns ??= new();
+        this.MainRepo = PluginRepository.CreateMainRepo(this.happyHttpClient);
 
         this.ApplyPatches();
     }
@@ -196,6 +199,11 @@ internal partial class PluginManager : IDisposable, IServiceType
             }
         }
     }
+
+    /// <summary>
+    /// Gets the main repository.
+    /// </summary>
+    public PluginRepository MainRepo { get; }
 
     /// <summary>
     /// Gets a list of all plugin repositories. The main repo should always be first.
@@ -282,11 +290,9 @@ internal partial class PluginManager : IDisposable, IServiceType
     /// <param name="header">The header text to send to chat prior to any update info.</param>
     public void PrintUpdatedPlugins(List<PluginUpdateStatus>? updateMetadata, string header)
     {
-        var chatGui = Service<ChatGui>.Get();
-
         if (updateMetadata is { Count: > 0 })
         {
-            chatGui.Print(new XivChatEntry
+            this.chatGui.Print(new XivChatEntry
             {
                 Message = new SeString(new List<Payload>()
                 {
@@ -305,11 +311,11 @@ internal partial class PluginManager : IDisposable, IServiceType
             {
                 if (metadata.Status == PluginUpdateStatus.StatusKind.Success)
                 {
-                    chatGui.Print(Locs.DalamudPluginUpdateSuccessful(metadata.Name, metadata.Version));
+                    this.chatGui.Print(Locs.DalamudPluginUpdateSuccessful(metadata.Name, metadata.Version));
                 }
                 else
                 {
-                    chatGui.Print(new XivChatEntry
+                    this.chatGui.Print(new XivChatEntry
                     {
                         Message = Locs.DalamudPluginUpdateFailed(metadata.Name, metadata.Version, PluginUpdateStatus.LocalizeUpdateStatusKind(metadata.Status)),
                         Type = XivChatType.Urgent,
@@ -405,10 +411,10 @@ internal partial class PluginManager : IDisposable, IServiceType
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public async Task SetPluginReposFromConfigAsync(bool notify)
     {
-        var repos = new List<PluginRepository>() { PluginRepository.MainRepo };
+        var repos = new List<PluginRepository> { this.MainRepo };
         repos.AddRange(this.configuration.ThirdRepoList
                            .Where(repo => repo.IsEnabled)
-                           .Select(repo => new PluginRepository(repo.Url, repo.IsEnabled)));
+                           .Select(repo => new PluginRepository(this.happyHttpClient, repo.Url, repo.IsEnabled)));
 
         this.Repos = repos;
         await this.ReloadPluginMastersAsync(notify);

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -267,10 +267,6 @@ internal class LocalPlugin : IDisposable
         var pluginManager = await Service<PluginManager>.GetAsync();
         var dalamud = await Service<Dalamud>.GetAsync();
 
-        // UiBuilder constructor requires the following two.
-        await Service<InterfaceManager>.GetAsync();
-        await Service<GameFontManager>.GetAsync();
-
         if (this.manifest.LoadRequiredState == 0)
             _ = await Service<InterfaceManager.InterfaceManagerWithScene>.GetAsync();
 

--- a/Dalamud/Plugin/Ipc/Internal/DataShare.cs
+++ b/Dalamud/Plugin/Ipc/Internal/DataShare.cs
@@ -13,7 +13,7 @@ namespace Dalamud.Plugin.Ipc.Internal;
 /// <summary>
 /// This class facilitates sharing data-references of standard types between plugins without using more expensive IPC.
 /// </summary>
-[ServiceManager.EarlyLoadedService]
+[ServiceManager.BlockingEarlyLoadedService]
 internal class DataShare : IServiceType
 {
     private readonly Dictionary<string, DataCache> caches = new();

--- a/Dalamud/Storage/ReliableFileStorage.cs
+++ b/Dalamud/Storage/ReliableFileStorage.cs
@@ -21,7 +21,7 @@ namespace Dalamud.Storage;
 /// <remarks>
 /// This is not an early-loaded service, as it is needed before they are initialized.
 /// </remarks>
-[ServiceManager.Service]
+[ServiceManager.ProvidedService]
 public class ReliableFileStorage : IServiceType, IDisposable
 {
     private static readonly ModuleLog Log = new("VFS");


### PR DESCRIPTION
* Turned `ServiceManager.Service` into an abstract class.
* Renamed `ServiceManager.*Service` to have `Attribute` suffixes.
* Added `ProvidedServiceAttribute` category.
* Made all implicit dependencies for `PluginManager` (due to exposure to plugins) `BlockingEarlyLoadedService`.
* Forbid `Service<T>.Get()` calls from service constructors, if T is not marked as a dependency.