### PR TITLE
Fix incorrect ImGui code

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
@@ -44,7 +44,8 @@ internal class PluginStatWindow : Window
     {
         var pluginManager = Service<PluginManager>.Get();
 
-        ImGui.BeginTabBar("Stat Tabs");
+        if (!ImGui.BeginTabBar("Stat Tabs"))
+            return;
 
         if (ImGui.BeginTabItem("Draw times"))
         {

--- a/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs
@@ -155,6 +155,8 @@ internal class SettingsWindow : Window
                     ImGui.EndTabItem();
                 }
             }
+
+            ImGui.EndTabBar();
         }
 
         ImGui.SetCursorPos(windowSize - ImGuiHelpers.ScaledVector2(70));

--- a/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
@@ -211,120 +211,121 @@ public class StyleEditorWindow : Window
 
             if (ImGui.BeginTabItem(Loc.Localize("StyleEditorVariables", "Variables")))
             {
-                ImGui.BeginChild($"ScrollingVars", ImGuiHelpers.ScaledVector2(0, -32), true, ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.NoBackground);
+                if (ImGui.BeginChild($"ScrollingVars", ImGuiHelpers.ScaledVector2(0, -32), true, ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.NoBackground))
+                {
+                    ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 5);
 
-                ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 5);
+                    ImGui.SliderFloat2("WindowPadding", ref style.WindowPadding, 0.0f, 20.0f, "%.0f");
+                    ImGui.SliderFloat2("FramePadding", ref style.FramePadding, 0.0f, 20.0f, "%.0f");
+                    ImGui.SliderFloat2("CellPadding", ref style.CellPadding, 0.0f, 20.0f, "%.0f");
+                    ImGui.SliderFloat2("ItemSpacing", ref style.ItemSpacing, 0.0f, 20.0f, "%.0f");
+                    ImGui.SliderFloat2("ItemInnerSpacing", ref style.ItemInnerSpacing, 0.0f, 20.0f, "%.0f");
+                    ImGui.SliderFloat2("TouchExtraPadding", ref style.TouchExtraPadding, 0.0f, 10.0f, "%.0f");
+                    ImGui.SliderFloat("IndentSpacing", ref style.IndentSpacing, 0.0f, 30.0f, "%.0f");
+                    ImGui.SliderFloat("ScrollbarSize", ref style.ScrollbarSize, 1.0f, 20.0f, "%.0f");
+                    ImGui.SliderFloat("GrabMinSize", ref style.GrabMinSize, 1.0f, 20.0f, "%.0f");
+                    ImGui.Text("Borders");
+                    ImGui.SliderFloat("WindowBorderSize", ref style.WindowBorderSize, 0.0f, 1.0f, "%.0f");
+                    ImGui.SliderFloat("ChildBorderSize", ref style.ChildBorderSize, 0.0f, 1.0f, "%.0f");
+                    ImGui.SliderFloat("PopupBorderSize", ref style.PopupBorderSize, 0.0f, 1.0f, "%.0f");
+                    ImGui.SliderFloat("FrameBorderSize", ref style.FrameBorderSize, 0.0f, 1.0f, "%.0f");
+                    ImGui.SliderFloat("TabBorderSize", ref style.TabBorderSize, 0.0f, 1.0f, "%.0f");
+                    ImGui.Text("Rounding");
+                    ImGui.SliderFloat("WindowRounding", ref style.WindowRounding, 0.0f, 12.0f, "%.0f");
+                    ImGui.SliderFloat("ChildRounding", ref style.ChildRounding, 0.0f, 12.0f, "%.0f");
+                    ImGui.SliderFloat("FrameRounding", ref style.FrameRounding, 0.0f, 12.0f, "%.0f");
+                    ImGui.SliderFloat("PopupRounding", ref style.PopupRounding, 0.0f, 12.0f, "%.0f");
+                    ImGui.SliderFloat("ScrollbarRounding", ref style.ScrollbarRounding, 0.0f, 12.0f, "%.0f");
+                    ImGui.SliderFloat("GrabRounding", ref style.GrabRounding, 0.0f, 12.0f, "%.0f");
+                    ImGui.SliderFloat("LogSliderDeadzone", ref style.LogSliderDeadzone, 0.0f, 12.0f, "%.0f");
+                    ImGui.SliderFloat("TabRounding", ref style.TabRounding, 0.0f, 12.0f, "%.0f");
+                    ImGui.Text("Alignment");
+                    ImGui.SliderFloat2("WindowTitleAlign", ref style.WindowTitleAlign, 0.0f, 1.0f, "%.2f");
+                    var windowMenuButtonPosition = (int)style.WindowMenuButtonPosition + 1;
+                    if (ImGui.Combo("WindowMenuButtonPosition", ref windowMenuButtonPosition, "None\0Left\0Right\0"))
+                        style.WindowMenuButtonPosition = (ImGuiDir)(windowMenuButtonPosition - 1);
+                    ImGui.SliderFloat2("ButtonTextAlign", ref style.ButtonTextAlign, 0.0f, 1.0f, "%.2f");
+                    ImGui.SameLine();
+                    ImGuiComponents.HelpMarker("Alignment applies when a button is larger than its text content.");
+                    ImGui.SliderFloat2("SelectableTextAlign", ref style.SelectableTextAlign, 0.0f, 1.0f, "%.2f");
+                    ImGui.SameLine();
+                    ImGuiComponents.HelpMarker("Alignment applies when a selectable is larger than its text content.");
+                    ImGui.SliderFloat2("DisplaySafeAreaPadding", ref style.DisplaySafeAreaPadding, 0.0f, 30.0f, "%.0f");
+                    ImGui.SameLine();
+                    ImGuiComponents.HelpMarker(
+                        "Adjust if you cannot see the edges of your screen (e.g. on a TV where scaling has not been configured).");
 
-                ImGui.SliderFloat2("WindowPadding", ref style.WindowPadding, 0.0f, 20.0f, "%.0f");
-                ImGui.SliderFloat2("FramePadding", ref style.FramePadding, 0.0f, 20.0f, "%.0f");
-                ImGui.SliderFloat2("CellPadding", ref style.CellPadding, 0.0f, 20.0f, "%.0f");
-                ImGui.SliderFloat2("ItemSpacing", ref style.ItemSpacing, 0.0f, 20.0f, "%.0f");
-                ImGui.SliderFloat2("ItemInnerSpacing", ref style.ItemInnerSpacing, 0.0f, 20.0f, "%.0f");
-                ImGui.SliderFloat2("TouchExtraPadding", ref style.TouchExtraPadding, 0.0f, 10.0f, "%.0f");
-                ImGui.SliderFloat("IndentSpacing", ref style.IndentSpacing, 0.0f, 30.0f, "%.0f");
-                ImGui.SliderFloat("ScrollbarSize", ref style.ScrollbarSize, 1.0f, 20.0f, "%.0f");
-                ImGui.SliderFloat("GrabMinSize", ref style.GrabMinSize, 1.0f, 20.0f, "%.0f");
-                ImGui.Text("Borders");
-                ImGui.SliderFloat("WindowBorderSize", ref style.WindowBorderSize, 0.0f, 1.0f, "%.0f");
-                ImGui.SliderFloat("ChildBorderSize", ref style.ChildBorderSize, 0.0f, 1.0f, "%.0f");
-                ImGui.SliderFloat("PopupBorderSize", ref style.PopupBorderSize, 0.0f, 1.0f, "%.0f");
-                ImGui.SliderFloat("FrameBorderSize", ref style.FrameBorderSize, 0.0f, 1.0f, "%.0f");
-                ImGui.SliderFloat("TabBorderSize", ref style.TabBorderSize, 0.0f, 1.0f, "%.0f");
-                ImGui.Text("Rounding");
-                ImGui.SliderFloat("WindowRounding", ref style.WindowRounding, 0.0f, 12.0f, "%.0f");
-                ImGui.SliderFloat("ChildRounding", ref style.ChildRounding, 0.0f, 12.0f, "%.0f");
-                ImGui.SliderFloat("FrameRounding", ref style.FrameRounding, 0.0f, 12.0f, "%.0f");
-                ImGui.SliderFloat("PopupRounding", ref style.PopupRounding, 0.0f, 12.0f, "%.0f");
-                ImGui.SliderFloat("ScrollbarRounding", ref style.ScrollbarRounding, 0.0f, 12.0f, "%.0f");
-                ImGui.SliderFloat("GrabRounding", ref style.GrabRounding, 0.0f, 12.0f, "%.0f");
-                ImGui.SliderFloat("LogSliderDeadzone", ref style.LogSliderDeadzone, 0.0f, 12.0f, "%.0f");
-                ImGui.SliderFloat("TabRounding", ref style.TabRounding, 0.0f, 12.0f, "%.0f");
-                ImGui.Text("Alignment");
-                ImGui.SliderFloat2("WindowTitleAlign", ref style.WindowTitleAlign, 0.0f, 1.0f, "%.2f");
-                var windowMenuButtonPosition = (int)style.WindowMenuButtonPosition + 1;
-                if (ImGui.Combo("WindowMenuButtonPosition", ref windowMenuButtonPosition, "None\0Left\0Right\0"))
-                    style.WindowMenuButtonPosition = (ImGuiDir)(windowMenuButtonPosition - 1);
-                ImGui.SliderFloat2("ButtonTextAlign", ref style.ButtonTextAlign, 0.0f, 1.0f, "%.2f");
-                ImGui.SameLine();
-                ImGuiComponents.HelpMarker("Alignment applies when a button is larger than its text content.");
-                ImGui.SliderFloat2("SelectableTextAlign", ref style.SelectableTextAlign, 0.0f, 1.0f, "%.2f");
-                ImGui.SameLine();
-                ImGuiComponents.HelpMarker("Alignment applies when a selectable is larger than its text content.");
-                ImGui.SliderFloat2("DisplaySafeAreaPadding", ref style.DisplaySafeAreaPadding, 0.0f, 30.0f, "%.0f");
-                ImGui.SameLine();
-                ImGuiComponents.HelpMarker(
-                    "Adjust if you cannot see the edges of your screen (e.g. on a TV where scaling has not been configured).");
-                ImGui.EndTabItem();
-
-                ImGui.EndChild();
+                    ImGui.EndChild();
+                }
 
                 ImGui.EndTabItem();
             }
 
             if (ImGui.BeginTabItem(Loc.Localize("StyleEditorColors", "Colors")))
             {
-                ImGui.BeginChild("ScrollingColors", ImGuiHelpers.ScaledVector2(0, -30), true, ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.NoBackground);
-
-                ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 5);
-
-                if (ImGui.RadioButton("Opaque", this.alphaFlags == ImGuiColorEditFlags.None))
-                    this.alphaFlags = ImGuiColorEditFlags.None;
-                ImGui.SameLine();
-                if (ImGui.RadioButton("Alpha", this.alphaFlags == ImGuiColorEditFlags.AlphaPreview))
-                    this.alphaFlags = ImGuiColorEditFlags.AlphaPreview;
-                ImGui.SameLine();
-                if (ImGui.RadioButton("Both", this.alphaFlags == ImGuiColorEditFlags.AlphaPreviewHalf))
-                    this.alphaFlags = ImGuiColorEditFlags.AlphaPreviewHalf;
-                ImGui.SameLine();
-
-                ImGuiComponents.HelpMarker(
-                    "In the color list:\n" +
-                    "Left-click on color square to open color picker,\n" +
-                    "Right-click to open edit options menu.");
-
-                foreach (var imGuiCol in Enum.GetValues<ImGuiCol>())
+                if (ImGui.BeginChild("ScrollingColors", ImGuiHelpers.ScaledVector2(0, -30), true, ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.NoBackground))
                 {
-                    if (imGuiCol == ImGuiCol.COUNT)
-                        continue;
+                    ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 5);
 
-                    ImGui.PushID(imGuiCol.ToString());
+                    if (ImGui.RadioButton("Opaque", this.alphaFlags == ImGuiColorEditFlags.None))
+                        this.alphaFlags = ImGuiColorEditFlags.None;
+                    ImGui.SameLine();
+                    if (ImGui.RadioButton("Alpha", this.alphaFlags == ImGuiColorEditFlags.AlphaPreview))
+                        this.alphaFlags = ImGuiColorEditFlags.AlphaPreview;
+                    ImGui.SameLine();
+                    if (ImGui.RadioButton("Both", this.alphaFlags == ImGuiColorEditFlags.AlphaPreviewHalf))
+                        this.alphaFlags = ImGuiColorEditFlags.AlphaPreviewHalf;
+                    ImGui.SameLine();
 
-                    ImGui.ColorEdit4("##color", ref style.Colors[(int)imGuiCol], ImGuiColorEditFlags.AlphaBar | this.alphaFlags);
+                    ImGuiComponents.HelpMarker(
+                        "In the color list:\n" +
+                        "Left-click on color square to open color picker,\n" +
+                        "Right-click to open edit options menu.");
 
-                    ImGui.SameLine(0.0f, style.ItemInnerSpacing.X);
-                    ImGui.TextUnformatted(imGuiCol.ToString());
-
-                    ImGui.PopID();
-                }
-
-                ImGui.Separator();
-
-                foreach (var property in typeof(DalamudColors).GetProperties(BindingFlags.Public | BindingFlags.Instance))
-                {
-                    ImGui.PushID(property.Name);
-
-                    var colorVal = property.GetValue(workStyle.BuiltInColors);
-                    if (colorVal == null)
+                    foreach (var imGuiCol in Enum.GetValues<ImGuiCol>())
                     {
-                        colorVal = property.GetValue(StyleModelV1.DalamudStandard.BuiltInColors);
-                        property.SetValue(workStyle.BuiltInColors, colorVal);
+                        if (imGuiCol == ImGuiCol.COUNT)
+                            continue;
+
+                        ImGui.PushID(imGuiCol.ToString());
+
+                        ImGui.ColorEdit4("##color", ref style.Colors[(int)imGuiCol], ImGuiColorEditFlags.AlphaBar | this.alphaFlags);
+
+                        ImGui.SameLine(0.0f, style.ItemInnerSpacing.X);
+                        ImGui.TextUnformatted(imGuiCol.ToString());
+
+                        ImGui.PopID();
                     }
 
-                    var color = (Vector4)colorVal;
+                    ImGui.Separator();
 
-                    if (ImGui.ColorEdit4("##color", ref color, ImGuiColorEditFlags.AlphaBar | this.alphaFlags))
+                    foreach (var property in typeof(DalamudColors).GetProperties(BindingFlags.Public | BindingFlags.Instance))
                     {
-                        property.SetValue(workStyle.BuiltInColors, color);
-                        workStyle.BuiltInColors?.Apply();
+                        ImGui.PushID(property.Name);
+
+                        var colorVal = property.GetValue(workStyle.BuiltInColors);
+                        if (colorVal == null)
+                        {
+                            colorVal = property.GetValue(StyleModelV1.DalamudStandard.BuiltInColors);
+                            property.SetValue(workStyle.BuiltInColors, colorVal);
+                        }
+
+                        var color = (Vector4)colorVal;
+
+                        if (ImGui.ColorEdit4("##color", ref color, ImGuiColorEditFlags.AlphaBar | this.alphaFlags))
+                        {
+                            property.SetValue(workStyle.BuiltInColors, color);
+                            workStyle.BuiltInColors?.Apply();
+                        }
+
+                        ImGui.SameLine(0.0f, style.ItemInnerSpacing.X);
+                        ImGui.TextUnformatted(property.Name);
+
+                        ImGui.PopID();
                     }
 
-                    ImGui.SameLine(0.0f, style.ItemInnerSpacing.X);
-                    ImGui.TextUnformatted(property.Name);
-
-                    ImGui.PopID();
+                    ImGui.EndChild();
                 }
-
-                ImGui.EndChild();
 
                 ImGui.EndTabItem();
             }


### PR DESCRIPTION
Adds a missing `ImGui.EndTabBar()` call to end the tab bar here. https://github.com/goatcorp/Dalamud/blob/40e90a39c8250528eeb94191a026a821c8a1493c/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs#L94

Note: I also just upstreamed some fixes for incorrect ImGui code that will crash without clear stacks with 42af3c80f2a259becb214754d67b5452b97d35cf.