### PR TITLE
Reduce heap allocation every frame in AddonLifecycle

### DIFF
--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonArgs.cs
@@ -14,17 +14,29 @@ public abstract unsafe class AddonArgs
     public const string InvalidAddon = "NullAddon";
     
     private string? addonName;
+    private IntPtr addon;
 
     /// <summary>
     /// Gets the name of the addon this args referrers to.
     /// </summary>
     public string AddonName => this.GetAddonName();
-    
+
     /// <summary>
     /// Gets the pointer to the addons AtkUnitBase.
     /// </summary>
-    public nint Addon { get; init; }
-    
+    public nint Addon
+    {
+        get => this.addon;
+        internal set
+        {
+            if (this.addon == value)
+                return;
+
+            this.addon = value;
+            this.addonName = null;
+        }
+    }
+
     /// <summary>
     /// Gets the type of these args.
     /// </summary>

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonArgs.cs
@@ -43,6 +43,23 @@ public abstract unsafe class AddonArgs
     public abstract AddonArgsType Type { get; }
 
     /// <summary>
+    /// Checks if addon name matches the given span of char.
+    /// </summary>
+    /// <param name="name">The name to check.</param>
+    /// <returns>Whether it is the case.</returns>
+    internal bool IsAddon(ReadOnlySpan<char> name)
+    {
+        if (this.Addon == nint.Zero) return false;
+        if (name.Length is 0 or > 0x20)
+            return false;
+
+        var addonPointer = (AtkUnitBase*)this.Addon;
+        if (addonPointer->Name is null) return false;
+        
+        return MemoryHelper.EqualsZeroTerminatedString(name, (nint)addonPointer->Name, null, 0x20);
+    }
+
+    /// <summary>
     /// Helper method for ensuring the name of the addon is valid.
     /// </summary>
     /// <returns>The name of the addon for this object. <see cref="InvalidAddon"/> when invalid.</returns>

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonDrawArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonDrawArgs.cs
@@ -3,8 +3,14 @@
 /// <summary>
 /// Addon argument data for Draw events.
 /// </summary>
-public class AddonDrawArgs : AddonArgs
+public class AddonDrawArgs : AddonArgs, ICloneable
 {
     /// <inheritdoc/>
     public override AddonArgsType Type => AddonArgsType.Draw;
+
+    /// <inheritdoc cref="ICloneable.Clone"/>
+    public AddonDrawArgs Clone() => (AddonDrawArgs)this.MemberwiseClone();
+    
+    /// <inheritdoc cref="Clone"/>
+    object ICloneable.Clone() => this.Clone();
 }

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonFinalizeArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonFinalizeArgs.cs
@@ -3,8 +3,14 @@ namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 /// <summary>
 /// Addon argument data for ReceiveEvent events.
 /// </summary>
-public class AddonFinalizeArgs : AddonArgs
+public class AddonFinalizeArgs : AddonArgs, ICloneable
 {
     /// <inheritdoc/>
     public override AddonArgsType Type => AddonArgsType.Finalize;
+
+    /// <inheritdoc cref="ICloneable.Clone"/>
+    public AddonFinalizeArgs Clone() => (AddonFinalizeArgs)this.MemberwiseClone();
+    
+    /// <inheritdoc cref="Clone"/>
+    object ICloneable.Clone() => this.Clone();
 }

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonReceiveEventArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonReceiveEventArgs.cs
@@ -3,28 +3,34 @@ namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 /// <summary>
 /// Addon argument data for ReceiveEvent events.
 /// </summary>
-public class AddonReceiveEventArgs : AddonArgs
+public class AddonReceiveEventArgs : AddonArgs, ICloneable
 {
     /// <inheritdoc/>
     public override AddonArgsType Type => AddonArgsType.ReceiveEvent;
     
     /// <summary>
-    /// Gets the AtkEventType for this event message.
+    /// Gets or sets the AtkEventType for this event message.
     /// </summary>
-    public byte AtkEventType { get; init; }
+    public byte AtkEventType { get; set; }
     
     /// <summary>
-    /// Gets the event id for this event message.
+    /// Gets or sets the event id for this event message.
     /// </summary>
-    public int EventParam { get; init; }
+    public int EventParam { get; set; }
     
     /// <summary>
-    /// Gets the pointer to an AtkEvent for this event message.
+    /// Gets or sets the pointer to an AtkEvent for this event message.
     /// </summary>
-    public nint AtkEvent { get; init; }
+    public nint AtkEvent { get; set; }
     
     /// <summary>
-    /// Gets the pointer to a block of data for this event message.
+    /// Gets or sets the pointer to a block of data for this event message.
     /// </summary>
-    public nint Data { get; init; }
+    public nint Data { get; set; }
+
+    /// <inheritdoc cref="ICloneable.Clone"/>
+    public AddonReceiveEventArgs Clone() => (AddonReceiveEventArgs)this.MemberwiseClone();
+    
+    /// <inheritdoc cref="Clone"/>
+    object ICloneable.Clone() => this.Clone();
 }

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonRefreshArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonRefreshArgs.cs
@@ -5,23 +5,29 @@ namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 /// <summary>
 /// Addon argument data for Refresh events.
 /// </summary>
-public class AddonRefreshArgs : AddonArgs
+public class AddonRefreshArgs : AddonArgs, ICloneable
 {
     /// <inheritdoc/>
     public override AddonArgsType Type => AddonArgsType.Refresh;
     
     /// <summary>
-    /// Gets the number of AtkValues.
+    /// Gets or sets the number of AtkValues.
     /// </summary>
-    public uint AtkValueCount { get; init; }
+    public uint AtkValueCount { get; set; }
     
     /// <summary>
-    /// Gets the address of the AtkValue array.
+    /// Gets or sets the address of the AtkValue array.
     /// </summary>
-    public nint AtkValues { get; init; }
+    public nint AtkValues { get; set; }
         
     /// <summary>
     /// Gets the AtkValues in the form of a span.
     /// </summary>
     public unsafe Span<AtkValue> AtkValueSpan => new(this.AtkValues.ToPointer(), (int)this.AtkValueCount);
+
+    /// <inheritdoc cref="ICloneable.Clone"/>
+    public AddonRefreshArgs Clone() => (AddonRefreshArgs)this.MemberwiseClone();
+    
+    /// <inheritdoc cref="Clone"/>
+    object ICloneable.Clone() => this.Clone();
 }

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonRequestedUpdateArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonRequestedUpdateArgs.cs
@@ -3,18 +3,24 @@
 /// <summary>
 /// Addon argument data for OnRequestedUpdate events.
 /// </summary>
-public class AddonRequestedUpdateArgs : AddonArgs
+public class AddonRequestedUpdateArgs : AddonArgs, ICloneable
 {
     /// <inheritdoc/>
     public override AddonArgsType Type => AddonArgsType.RequestedUpdate;
     
     /// <summary>
-    /// Gets the NumberArrayData** for this event.
+    /// Gets or sets the NumberArrayData** for this event.
     /// </summary>
-    public nint NumberArrayData { get; init; }
+    public nint NumberArrayData { get; set; }
     
     /// <summary>
-    /// Gets the StringArrayData** for this event.
+    /// Gets or sets the StringArrayData** for this event.
     /// </summary>
-    public nint StringArrayData { get; init; }
+    public nint StringArrayData { get; set; }
+
+    /// <inheritdoc cref="ICloneable.Clone"/>
+    public AddonRequestedUpdateArgs Clone() => (AddonRequestedUpdateArgs)this.MemberwiseClone();
+    
+    /// <inheritdoc cref="Clone"/>
+    object ICloneable.Clone() => this.Clone();
 }

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonSetupArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonSetupArgs.cs
@@ -5,23 +5,29 @@ namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 /// <summary>
 /// Addon argument data for Setup events.
 /// </summary>
-public class AddonSetupArgs : AddonArgs
+public class AddonSetupArgs : AddonArgs, ICloneable
 {
     /// <inheritdoc/>
     public override AddonArgsType Type => AddonArgsType.Setup;
     
     /// <summary>
-    /// Gets the number of AtkValues.
+    /// Gets or sets the number of AtkValues.
     /// </summary>
-    public uint AtkValueCount { get; init; }
+    public uint AtkValueCount { get; set; }
     
     /// <summary>
-    /// Gets the address of the AtkValue array.
+    /// Gets or sets the address of the AtkValue array.
     /// </summary>
-    public nint AtkValues { get; init; }
+    public nint AtkValues { get; set; }
     
     /// <summary>
     /// Gets the AtkValues in the form of a span.
     /// </summary>
     public unsafe Span<AtkValue> AtkValueSpan => new(this.AtkValues.ToPointer(), (int)this.AtkValueCount);
+
+    /// <inheritdoc cref="ICloneable.Clone"/>
+    public AddonSetupArgs Clone() => (AddonSetupArgs)this.MemberwiseClone();
+    
+    /// <inheritdoc cref="Clone"/>
+    object ICloneable.Clone() => this.Clone();
 }

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonUpdateArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonUpdateArgs.cs
@@ -3,7 +3,7 @@ namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 /// <summary>
 /// Addon argument data for Update events.
 /// </summary>
-public class AddonUpdateArgs : AddonArgs
+public class AddonUpdateArgs : AddonArgs, ICloneable
 {
     /// <inheritdoc/>
     public override AddonArgsType Type => AddonArgsType.Update;
@@ -11,5 +11,11 @@ public class AddonUpdateArgs : AddonArgs
     /// <summary>
     /// Gets the time since the last update.
     /// </summary>
-    public float TimeDelta { get; init; }
+    public float TimeDelta { get; internal set; }
+
+    /// <inheritdoc cref="ICloneable.Clone"/>
+    public AddonUpdateArgs Clone() => (AddonUpdateArgs)this.MemberwiseClone();
+    
+    /// <inheritdoc cref="Clone"/>
+    object ICloneable.Clone() => this.Clone();
 }

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -144,7 +144,7 @@ internal unsafe class AddonLifecycle : IDisposable, IServiceType
                 continue;
 
             // Match on string.empty for listeners that want events for all addons.
-            if (!string.IsNullOrWhiteSpace(listener.AddonName) && listener.AddonName != args.AddonName)
+            if (!string.IsNullOrWhiteSpace(listener.AddonName) && !args.IsAddon(listener.AddonName))
                 continue;
 
             try


### PR DESCRIPTION
A few events, such as update and draw, are fired every frame per addon when the condition is right. This change tries to reduce heap allocation during that process.