### PR TITLE
Fix Dalamud trying to unload IServiceType and crashing

### DIFF
--- a/Dalamud/ServiceManager.cs
+++ b/Dalamud/ServiceManager.cs
@@ -336,7 +336,7 @@ internal static class ServiceManager
         
         foreach (var serviceType in Assembly.GetExecutingAssembly().GetTypes())
         {
-            if (!serviceType.IsAssignableTo(typeof(IServiceType)))
+            if (serviceType.IsAbstract || !serviceType.IsAssignableTo(typeof(IServiceType)))
                 continue;
             
             // Scoped services shall never be unloaded here.

--- a/Dalamud/Service{T}.cs
+++ b/Dalamud/Service{T}.cs
@@ -176,7 +176,7 @@ internal static class Service<T> where T : IServiceType
         {
             foreach (var serviceType in Assembly.GetExecutingAssembly().GetTypes())
             {
-                if (!serviceType.IsAssignableTo(typeof(IServiceType)))
+                if (serviceType.IsAbstract || !serviceType.IsAssignableTo(typeof(IServiceType)))
                     continue;
                 
                 if (serviceType == typeof(PluginManager))


### PR DESCRIPTION
Dalamud currently iterates over all types to determine which services to unload, attempting to unload `IServiceType` which crashes since it's not a concrete type. Instead, we shouldn't attempt to unload and by extension call methods with reflection on abstract types.