### PR TITLE
Fix ChatGui race condition

### DIFF
--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.InteropServices;
 
@@ -40,6 +40,7 @@ internal sealed class ChatGui : IDisposable, IServiceType, IChatGui
     private readonly LibcFunction libcFunction = Service<LibcFunction>.Get();
 
     private IntPtr baseAddress = IntPtr.Zero;
+    private ImmutableDictionary<(string PluginName, uint CommandId), Action<uint, SeString>>? dalamudLinkHandlersCopy;
 
     [ServiceManager.ServiceConstructor]
     private ChatGui(TargetSigScanner sigScanner)
@@ -80,7 +81,21 @@ internal sealed class ChatGui : IDisposable, IServiceType, IChatGui
     public byte LastLinkedItemFlags { get; private set; }
 
     /// <inheritdoc/>
-    public IReadOnlyDictionary<(string PluginName, uint CommandId), Action<uint, SeString>> RegisteredLinkHandlers => this.dalamudLinkHandlers;
+    public IReadOnlyDictionary<(string PluginName, uint CommandId), Action<uint, SeString>> RegisteredLinkHandlers
+    {
+        get
+        {
+            var copy = this.dalamudLinkHandlersCopy;
+            if (copy is not null)
+                return copy;
+
+            lock (this.dalamudLinkHandlers)
+            {
+                return this.dalamudLinkHandlersCopy ??=
+                           this.dalamudLinkHandlers.ToImmutableDictionary(x => x.Key, x => x.Value);
+            }
+        }
+    }
 
     /// <summary>
     /// Dispose of managed and unmanaged resources.
@@ -156,7 +171,12 @@ internal sealed class ChatGui : IDisposable, IServiceType, IChatGui
     internal DalamudLinkPayload AddChatLinkHandler(string pluginName, uint commandId, Action<uint, SeString> commandAction)
     {
         var payload = new DalamudLinkPayload { Plugin = pluginName, CommandId = commandId };
-        this.dalamudLinkHandlers.Add((pluginName, commandId), commandAction);
+        lock (this.dalamudLinkHandlers)
+        {
+            this.dalamudLinkHandlers.Add((pluginName, commandId), commandAction);
+            this.dalamudLinkHandlersCopy = null;
+        }
+
         return payload;
     }
 
@@ -166,9 +186,14 @@ internal sealed class ChatGui : IDisposable, IServiceType, IChatGui
     /// <param name="pluginName">The name of the plugin handling the links.</param>
     internal void RemoveChatLinkHandler(string pluginName)
     {
-        foreach (var handler in this.dalamudLinkHandlers.Keys.ToList().Where(k => k.PluginName == pluginName))
+        lock (this.dalamudLinkHandlers)
         {
-            this.dalamudLinkHandlers.Remove(handler);
+            var changed = false;
+            
+            foreach (var handler in this.RegisteredLinkHandlers.Keys.Where(k => k.PluginName == pluginName))
+                changed |= this.dalamudLinkHandlers.Remove(handler);
+            if (changed)
+                this.dalamudLinkHandlersCopy = null;
         }
     }
 
@@ -179,7 +204,11 @@ internal sealed class ChatGui : IDisposable, IServiceType, IChatGui
     /// <param name="commandId">The ID of the command to be removed.</param>
     internal void RemoveChatLinkHandler(string pluginName, uint commandId)
     {
-        this.dalamudLinkHandlers.Remove((pluginName, commandId));
+        lock (this.dalamudLinkHandlers)
+        {
+            if (this.dalamudLinkHandlers.Remove((pluginName, commandId)))
+                this.dalamudLinkHandlersCopy = null;
+        }
     }
 
     [ServiceManager.CallWhenServicesReady]
@@ -395,7 +424,7 @@ internal sealed class ChatGui : IDisposable, IServiceType, IChatGui
             var linkPayload = payloads[0];
             if (linkPayload is DalamudLinkPayload link)
             {
-                if (this.dalamudLinkHandlers.TryGetValue((link.Plugin, link.CommandId), out var value))
+                if (this.RegisteredLinkHandlers.TryGetValue((link.Plugin, link.CommandId), out var value))
                 {
                     Log.Verbose($"Sending DalamudLink to {link.Plugin}: {link.CommandId}");
                     value.Invoke(link.CommandId, new SeString(payloads));


### PR DESCRIPTION
Made `RegisteredLinkHandlers` an immutable copy of the underlying `dalamudLinkHandlers`, so that underlying dictionary can be modified under a lock, while the copy of it can be accessed without any consideration of thread safety.

```
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at Dalamud.Game.Gui.ChatGui.AddChatLinkHandler(String pluginName, UInt32 commandId, Action`2 commandAction) in Z:\GitWorks\Soreepeong\Dalamud\Dalamud\Game\Gui\ChatGui.cs:line 163
   at Dalamud.Game.ChatHandlers..ctor(ChatGui chatGui) in Z:\GitWorks\Soreepeong\Dalamud\Dalamud\Game\ChatHandlers.cs:line 120
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.ConstructorInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
```