### PR TITLE
Allow plugins to bundle their own Lumina

### DIFF
--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -624,8 +624,6 @@ internal class LocalPlugin : IDisposable
         config.IsUnloadable = true;
         config.LoadInMemory = true;
         config.PreferSharedTypes = false;
-        config.SharedAssemblies.Add(typeof(Lumina.GameData).Assembly.GetName());
-        config.SharedAssemblies.Add(typeof(Lumina.Excel.ExcelSheetImpl).Assembly.GetName());
     }
 
     private void EnsureLoader()


### PR DESCRIPTION
Started from a discussion in `#dalamud-dev`: https://canary.discord.com/channels/581875019861328007/860813266468732938/1183117203093073940

- Plugins that bundle their own Lumina will have exceptions thrown trying to use Dalamud APIs that expose Lumina. I consider this a tradeoff.
- The only plugin that exposes a custom Lumina on the official repository (to my knowledge) is Distant Seas, which I have a fix prepared for.

I was able to load on the title screen and didn't see any exceptions or broken logic in the plugins I have installed.