### PR TITLE
Default Minimum/Maximum WindowSizeConstraints

### DIFF
--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -71,7 +71,6 @@ internal class ConsoleWindow : Window, IDisposable
         this.SizeConstraints = new WindowSizeConstraints
         {
             MinimumSize = new Vector2(600.0f, 200.0f),
-            MaximumSize = new Vector2(9999.0f, 9999.0f),
         };
 
         this.RespectCloseHotkey = false;

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -148,7 +148,6 @@ internal class PluginInstallerWindow : Window, IDisposable
         this.SizeConstraints = new WindowSizeConstraints
         {
             MinimumSize = this.Size.Value,
-            MaximumSize = new Vector2(5000, 5000),
         };
 
         Service<PluginManager>.GetAsync().ContinueWith(pluginManagerTask =>

--- a/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
@@ -43,7 +43,6 @@ public class StyleEditorWindow : Window
         this.SizeConstraints = new WindowSizeConstraints
         {
             MinimumSize = new Vector2(890, 560),
-            MaximumSize = new Vector2(10000, 10000),
         };
     }
 

--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -624,14 +624,21 @@ public abstract class Window
     public struct WindowSizeConstraints
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="WindowSizeConstraints"/> struct.
+        /// </summary>
+        public WindowSizeConstraints()
+        {
+        }
+
+        /// <summary>
         /// Gets or sets the minimum size of the window.
         /// </summary>
-        public Vector2 MinimumSize { get; set; }
+        public Vector2 MinimumSize { get; set; } = new(0);
 
         /// <summary>
         /// Gets or sets the maximum size of the window.
         /// </summary>
-        public Vector2 MaximumSize { get; set; }
+        public Vector2 MaximumSize { get; set; } = new(float.PositiveInfinity);
     }
 
     /// <summary>

--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -623,6 +623,8 @@ public abstract class Window
     /// </summary>
     public struct WindowSizeConstraints
     {
+        private Vector2 internalMaxSize = new(float.MaxValue);
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="WindowSizeConstraints"/> struct.
         /// </summary>
@@ -634,11 +636,25 @@ public abstract class Window
         /// Gets or sets the minimum size of the window.
         /// </summary>
         public Vector2 MinimumSize { get; set; } = new(0);
-
+        
         /// <summary>
         /// Gets or sets the maximum size of the window.
         /// </summary>
-        public Vector2 MaximumSize { get; set; } = new(float.PositiveInfinity);
+        public Vector2 MaximumSize
+        {
+            get => this.GetSafeMaxSize();
+            set => this.internalMaxSize = value;
+        }
+        
+        private Vector2 GetSafeMaxSize()
+        {
+            var currentMin = this.MinimumSize;
+
+            if (this.internalMaxSize.X < currentMin.X || this.internalMaxSize.Y < currentMin.Y) 
+                return new Vector2(float.MaxValue);
+
+            return this.internalMaxSize;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
When creating a new `WindowSizeConstraints` struct for use in a window, allow omitting either `MinimumSize` or `MaximumSize`. If this value is omitted, that constraint will be treated as unbounded.

This is a behavioral change to the API, but no consumer should currently have `MaximumSize` unset as it leads to unusable Windows. This does not change API or ABI, to my knowledge.