### PR TITLE
Allow plugins to load Dalamud dependency assemblies

### DIFF
--- a/Dalamud/Plugin/Internal/Loader/PluginLoader.cs
+++ b/Dalamud/Plugin/Internal/Loader/PluginLoader.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Nate McMaster, Dalamud team.
 // Licensed under the Apache License, Version 2.0. See License.txt in the Loader root for license information.
 
-using System;
+using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
 
@@ -150,6 +150,14 @@ internal class PluginLoader : IDisposable
         {
             builder.PreferDefaultLoadContextAssembly(assemblyName);
         }
+
+        // This allows plugins to search for dependencies in the Dalamud directory when their assembly
+        // load would otherwise fail, allowing them to resolve assemblies not already loaded by Dalamud
+        // itself yet.
+        builder.AddProbingPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+
+        // Also make sure that plugins do not load their own Dalamud assembly.
+        builder.PreferDefaultLoadContextAssembly(Assembly.GetExecutingAssembly().GetName());
 
         return builder;
     }


### PR DESCRIPTION
This allows plugins to probe the directory of Dalamud when resolving assemblies as fallback, allowing them to load dependencies which are not loaded into Dalamud proper yet.
For managed assemblies additional probing paths are resolved last, just before failure, so this should be a fairly safe change (and would only take effect when resolution would fail anyways).
Also this disallows plugins loading their own `Dalamud.dll`.