### PR TITLE
Use EarlyLoadedService for anything that is not mandatory for kicking off plugin loader

### DIFF
--- a/Dalamud/Data/DataManager.cs
+++ b/Dalamud/Data/DataManager.cs
@@ -20,7 +20,7 @@ namespace Dalamud.Data;
 /// </summary>
 [PluginInterface]
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<IDataManager>]
 #pragma warning restore SA1015

--- a/Dalamud/Game/ChatHandlers.cs
+++ b/Dalamud/Game/ChatHandlers.cs
@@ -25,7 +25,7 @@ namespace Dalamud.Game;
 /// <summary>
 /// Chat events and public helper functions.
 /// </summary>
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal class ChatHandlers : IServiceType
 {
     // private static readonly Dictionary<string, string> UnicodeToDiscordEmojiDict = new()

--- a/Dalamud/Game/ClientState/Aetherytes/AetheryteList.cs
+++ b/Dalamud/Game/ClientState/Aetherytes/AetheryteList.cs
@@ -14,7 +14,7 @@ namespace Dalamud.Game.ClientState.Aetherytes;
 /// </summary>
 [PluginInterface]
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<IAetheryteList>]
 #pragma warning restore SA1015

--- a/Dalamud/Game/ClientState/Buddy/BuddyList.cs
+++ b/Dalamud/Game/ClientState/Buddy/BuddyList.cs
@@ -16,7 +16,7 @@ namespace Dalamud.Game.ClientState.Buddy;
 /// </summary>
 [PluginInterface]
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<IBuddyList>]
 #pragma warning restore SA1015

--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -22,7 +22,7 @@ namespace Dalamud.Game.ClientState;
 /// This class represents the state of the game client at the time of access.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal sealed class ClientState : IInternalDisposableService, IClientState
 {
     private static readonly ModuleLog Log = new("ClientState");

--- a/Dalamud/Game/ClientState/Conditions/Condition.cs
+++ b/Dalamud/Game/ClientState/Conditions/Condition.cs
@@ -9,8 +9,8 @@ namespace Dalamud.Game.ClientState.Conditions;
 /// Provides access to conditions (generally player state). You can check whether a player is in combat, mounted, etc.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
-internal sealed partial class Condition : IInternalDisposableService, ICondition
+[ServiceManager.EarlyLoadedService]
+internal sealed class Condition : IInternalDisposableService, ICondition
 {
     /// <summary>
     /// Gets the current max number of conditions. You can get this just by looking at the condition sheet and how many rows it has.

--- a/Dalamud/Game/ClientState/Fates/FateTable.cs
+++ b/Dalamud/Game/ClientState/Fates/FateTable.cs
@@ -14,7 +14,7 @@ namespace Dalamud.Game.ClientState.Fates;
 /// </summary>
 [PluginInterface]
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<IFateTable>]
 #pragma warning restore SA1015

--- a/Dalamud/Game/ClientState/GamePad/GamepadState.cs
+++ b/Dalamud/Game/ClientState/GamePad/GamepadState.cs
@@ -17,7 +17,7 @@ namespace Dalamud.Game.ClientState.GamePad;
 /// </summary>
 [PluginInterface]
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<IGamepadState>]
 #pragma warning restore SA1015

--- a/Dalamud/Game/ClientState/JobGauge/JobGauges.cs
+++ b/Dalamud/Game/ClientState/JobGauge/JobGauges.cs
@@ -15,7 +15,7 @@ namespace Dalamud.Game.ClientState.JobGauge;
 /// </summary>
 [PluginInterface]
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<IJobGauges>]
 #pragma warning restore SA1015

--- a/Dalamud/Game/ClientState/Keys/KeyState.cs
+++ b/Dalamud/Game/ClientState/Keys/KeyState.cs
@@ -24,7 +24,7 @@ namespace Dalamud.Game.ClientState.Keys;
 /// </remarks>
 [PluginInterface]
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<IKeyState>]
 #pragma warning restore SA1015

--- a/Dalamud/Game/ClientState/Objects/ObjectTable.cs
+++ b/Dalamud/Game/ClientState/Objects/ObjectTable.cs
@@ -24,7 +24,7 @@ namespace Dalamud.Game.ClientState.Objects;
 /// </summary>
 [PluginInterface]
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<IObjectTable>]
 #pragma warning restore SA1015

--- a/Dalamud/Game/ClientState/Objects/TargetManager.cs
+++ b/Dalamud/Game/ClientState/Objects/TargetManager.cs
@@ -12,7 +12,7 @@ namespace Dalamud.Game.ClientState.Objects;
 /// </summary>
 [PluginInterface]
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<ITargetManager>]
 #pragma warning restore SA1015

--- a/Dalamud/Game/ClientState/Party/PartyList.cs
+++ b/Dalamud/Game/ClientState/Party/PartyList.cs
@@ -15,7 +15,7 @@ namespace Dalamud.Game.ClientState.Party;
 /// </summary>
 [PluginInterface]
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<IPartyList>]
 #pragma warning restore SA1015

--- a/Dalamud/Game/Command/CommandManager.cs
+++ b/Dalamud/Game/Command/CommandManager.cs
@@ -18,7 +18,7 @@ namespace Dalamud.Game.Command;
 /// This class manages registered in-game slash commands.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal sealed class CommandManager : IInternalDisposableService, ICommandManager
 {
     private static readonly ModuleLog Log = new("Command");

--- a/Dalamud/Game/Config/GameConfig.cs
+++ b/Dalamud/Game/Config/GameConfig.cs
@@ -14,7 +14,7 @@ namespace Dalamud.Game.Config;
 /// This class represents the game's configuration.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal sealed class GameConfig : IInternalDisposableService, IGameConfig
 {
     private readonly TaskCompletionSource tcsInitialization = new();

--- a/Dalamud/Game/DutyState/DutyState.cs
+++ b/Dalamud/Game/DutyState/DutyState.cs
@@ -12,7 +12,7 @@ namespace Dalamud.Game.DutyState;
 /// This class represents the state of the currently occupied duty.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal unsafe class DutyState : IInternalDisposableService, IDutyState
 {
     private readonly DutyStateAddressResolver address;

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -22,14 +22,12 @@ namespace Dalamud.Game;
 /// This class represents the Framework of the native game client and grants access to various subsystems.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal sealed class Framework : IInternalDisposableService, IFramework
 {
     private static readonly ModuleLog Log = new("Framework");
 
     private static readonly Stopwatch StatsStopwatch = new();
-
-    private readonly GameLifecycle lifecycle;
 
     private readonly Stopwatch updateStopwatch = new();
     private readonly HitchDetector hitchDetector;
@@ -38,6 +36,9 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     private readonly Hook<OnRealDestroyDelegate> destroyHook;
 
     private readonly FrameworkAddressResolver addressResolver;
+    
+    [ServiceManager.ServiceDependency]
+    private readonly GameLifecycle lifecycle = Service<GameLifecycle>.Get();
 
     [ServiceManager.ServiceDependency]
     private readonly DalamudConfiguration configuration = Service<DalamudConfiguration>.Get();
@@ -51,9 +52,8 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     private ulong tickCounter; 
 
     [ServiceManager.ServiceConstructor]
-    private Framework(TargetSigScanner sigScanner, GameLifecycle lifecycle)
+    private Framework(TargetSigScanner sigScanner)
     {
-        this.lifecycle = lifecycle;
         this.hitchDetector = new HitchDetector("FrameworkUpdate", this.configuration.FrameworkUpdateHitch);
 
         this.addressResolver = new FrameworkAddressResolver();
@@ -90,7 +90,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     /// <summary>
     /// Executes during FrameworkUpdate before all <see cref="Update"/> delegates.
     /// </summary>
-    internal event IFramework.OnUpdateDelegate BeforeUpdate;
+    internal event IFramework.OnUpdateDelegate? BeforeUpdate;
 
     /// <summary>
     /// Gets or sets a value indicating whether the collection of stats is enabled.

--- a/Dalamud/Game/GameLifecycle.cs
+++ b/Dalamud/Game/GameLifecycle.cs
@@ -11,7 +11,7 @@ namespace Dalamud.Game;
 /// </summary>
 [PluginInterface]
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<IGameLifecycle>]
 #pragma warning restore SA1015

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -29,9 +29,7 @@ namespace Dalamud.Game.Gui;
 /// This class handles interacting with the native chat UI.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService($"{nameof(PluginManager)} currently uses this.")]
-// ^ TODO: This seems unnecessary, remove the hard dependency at a later time.
-//         Otherwise, if PM eventually marks this class as required, note that in the comment above.
+[ServiceManager.EarlyLoadedService]
 internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
 {
     private static readonly ModuleLog Log = new("ChatGui");

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -12,6 +12,7 @@ using Dalamud.IoC;
 using Dalamud.IoC.Internal;
 using Dalamud.Logging.Internal;
 using Dalamud.Memory;
+using Dalamud.Plugin.Internal;
 using Dalamud.Plugin.Services;
 using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Client.System.String;
@@ -28,7 +29,9 @@ namespace Dalamud.Game.Gui;
 /// This class handles interacting with the native chat UI.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.BlockingEarlyLoadedService($"{nameof(PluginManager)} currently uses this.")]
+// ^ TODO: This seems unnecessary, remove the hard dependency at a later time.
+//         Otherwise, if PM eventually marks this class as required, note that in the comment above.
 internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
 {
     private static readonly ModuleLog Log = new("ChatGui");

--- a/Dalamud/Game/Gui/Dtr/DtrBar.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBar.cs
@@ -21,7 +21,7 @@ namespace Dalamud.Game.Gui.Dtr;
 /// Class used to interface with the server info bar.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal sealed unsafe class DtrBar : IInternalDisposableService, IDtrBar
 {
     private const uint BaseNodeId = 1000;

--- a/Dalamud/Game/Gui/FlyText/FlyTextGui.cs
+++ b/Dalamud/Game/Gui/FlyText/FlyTextGui.cs
@@ -15,7 +15,7 @@ namespace Dalamud.Game.Gui.FlyText;
 /// This class facilitates interacting with and creating native in-game "fly text".
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal sealed class FlyTextGui : IInternalDisposableService, IFlyTextGui
 {
     /// <summary>

--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -26,7 +26,7 @@ namespace Dalamud.Game.Gui;
 /// A class handling many aspects of the in-game UI.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal sealed unsafe class GameGui : IInternalDisposableService, IGameGui
 {
     private static readonly ModuleLog Log = new("GameGui");

--- a/Dalamud/Game/Gui/PartyFinder/PartyFinderGui.cs
+++ b/Dalamud/Game/Gui/PartyFinder/PartyFinderGui.cs
@@ -14,7 +14,7 @@ namespace Dalamud.Game.Gui.PartyFinder;
 /// This class handles interacting with the native PartyFinder window.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal sealed class PartyFinderGui : IInternalDisposableService, IPartyFinderGui
 {
     private readonly PartyFinderAddressResolver address;

--- a/Dalamud/Game/Gui/Toast/ToastGui.cs
+++ b/Dalamud/Game/Gui/Toast/ToastGui.cs
@@ -13,7 +13,7 @@ namespace Dalamud.Game.Gui.Toast;
 /// This class facilitates interacting with and creating native toast windows.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal sealed partial class ToastGui : IInternalDisposableService, IToastGui
 {
     private const uint QuestToastCheckmarkMagic = 60081;

--- a/Dalamud/Game/Inventory/GameInventory.cs
+++ b/Dalamud/Game/Inventory/GameInventory.cs
@@ -18,7 +18,7 @@ namespace Dalamud.Game.Inventory;
 /// This class provides events for the players in-game inventory.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal class GameInventory : IInternalDisposableService
 {
     private readonly List<GameInventoryPluginScoped> subscribersPendingChange = new();

--- a/Dalamud/Game/Libc/LibcFunction.cs
+++ b/Dalamud/Game/Libc/LibcFunction.cs
@@ -13,7 +13,7 @@ namespace Dalamud.Game.Libc;
 /// </summary>
 [PluginInterface]
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<ILibcFunction>]
 #pragma warning restore SA1015

--- a/Dalamud/Game/Network/GameNetwork.cs
+++ b/Dalamud/Game/Network/GameNetwork.cs
@@ -14,7 +14,7 @@ namespace Dalamud.Game.Network;
 /// This class handles interacting with game network events.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal sealed class GameNetwork : IInternalDisposableService, IGameNetwork
 {
     private readonly GameNetworkAddressResolver address;

--- a/Dalamud/Game/Network/Internal/NetworkHandlers.cs
+++ b/Dalamud/Game/Network/Internal/NetworkHandlers.cs
@@ -25,7 +25,7 @@ namespace Dalamud.Game.Network.Internal;
 /// <summary>
 /// This class handles network notifications and uploading market board data.
 /// </summary>
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal unsafe class NetworkHandlers : IInternalDisposableService
 {
     private readonly IMarketBoardUploader uploader;

--- a/Dalamud/Hooking/WndProcHook/WndProcHookManager.cs
+++ b/Dalamud/Hooking/WndProcHook/WndProcHookManager.cs
@@ -14,7 +14,7 @@ namespace Dalamud.Hooking.WndProcHook;
 /// <summary>
 /// Manages WndProc hooks for game main window and extra ImGui viewport windows.
 /// </summary>
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal sealed class WndProcHookManager : IInternalDisposableService
 {
     private static readonly ModuleLog Log = new(nameof(WndProcHookManager));

--- a/Dalamud/Interface/DragDrop/DragDropManager.cs
+++ b/Dalamud/Interface/DragDrop/DragDropManager.cs
@@ -15,7 +15,7 @@ namespace Dalamud.Interface.DragDrop;
 /// and can be used to create ImGui drag and drop sources and targets for those external events.
 /// </summary>
 [PluginInterface]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<IDragDropManager>]
 #pragma warning restore SA1015

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -51,7 +51,7 @@ namespace Dalamud.Interface.Internal;
 /// <summary>
 /// This class manages interaction with the ImGui interface.
 /// </summary>
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal class InterfaceManager : IInternalDisposableService
 {
     /// <summary>

--- a/Dalamud/Interface/Internal/TextureManager.cs
+++ b/Dalamud/Interface/Internal/TextureManager.cs
@@ -22,7 +22,7 @@ namespace Dalamud.Interface.Internal;
 /// </summary>
 [PluginInterface]
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 #pragma warning disable SA1015
 [ResolveVia<ITextureProvider>]
 [ResolveVia<ITextureSubstitutionProvider>]

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ServicesWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ServicesWidget.cs
@@ -304,7 +304,7 @@ internal class ServicesWidget : IDataWindowWidget
         public uint TypeSuffixColor { get; }
 
         public Vector2 DisplayedNameSize =>
-            ImGui.CalcTextSize(this.DisplayedName) + ImGui.CalcTextSize(this.TypeSuffix);
+            ImGui.CalcTextSize(this.DisplayedName) + ImGui.CalcTextSize(this.TypeSuffix) with { Y = 0 };
 
         public ServiceManager.ServiceKind Kind { get; }
 

--- a/Dalamud/Interface/Internal/Windows/ProfilerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ProfilerWindow.cs
@@ -25,7 +25,7 @@ public class ProfilerWindow : Window
     /// Initializes a new instance of the <see cref="ProfilerWindow"/> class.
     /// </summary>
     public ProfilerWindow()
-        : base("Profiler", forceMainWindow: true)
+        : base("Profiler")
     {
     }
 

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.cs
@@ -29,7 +29,7 @@ namespace Dalamud.Interface.ManagedFontAtlas.Internals;
 /// <summary>
 /// Factory for the implementation of <see cref="IFontAtlas"/>.
 /// </summary>
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal sealed partial class FontAtlasFactory
     : IInternalDisposableService, GamePrebakedFontHandle.IGameFontTextureProvider
 {

--- a/Dalamud/Interface/TitleScreenMenu/TitleScreenMenu.cs
+++ b/Dalamud/Interface/TitleScreenMenu/TitleScreenMenu.cs
@@ -15,7 +15,7 @@ namespace Dalamud.Interface;
 /// Class responsible for managing elements in the title screen menu.
 /// </summary>
 [InterfaceVersion("1.0")]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
 {
     /// <summary>

--- a/Dalamud/Networking/Http/HappyHttpClient.cs
+++ b/Dalamud/Networking/Http/HappyHttpClient.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 
+using Dalamud.Plugin.Internal;
 using Dalamud.Utility;
 
 namespace Dalamud.Networking.Http;
@@ -11,7 +12,9 @@ namespace Dalamud.Networking.Http;
 /// A service to help build and manage HttpClients with some semblance of Happy Eyeballs (RFC 8305 - IPv4 fallback)
 /// awareness.
 /// </summary>
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.BlockingEarlyLoadedService($"{nameof(PluginManager)} currently uses this.")]
+// ^ TODO: This seems unnecessary, remove the hard dependency at a later time.
+//         Otherwise, if PM eventually marks this class as required, note that in the comment above.
 internal class HappyHttpClient : IInternalDisposableService
 {
     /// <summary>

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -39,22 +39,10 @@ namespace Dalamud.Plugin.Internal;
 
 /// <summary>
 /// Class responsible for loading and unloading plugins.
-/// NOTE: ALL plugin exposed services are marked as dependencies for PluginManager in Service{T}.
+/// NOTE: ALL plugin exposed services are marked as dependencies for <see cref="PluginManager"/>
+/// from <see cref="ResolvePossiblePluginDependencyServices"/>.
 /// </summary>
-[ServiceManager.BlockingEarlyLoadedService]
-#pragma warning disable SA1015
-
-// DalamudTextureWrap registers textures to dispose with IM
-[InherentDependency<InterfaceManager>]
-
-// LocalPlugin uses ServiceContainer to create scopes
-[InherentDependency<ServiceContainer>]
-
-// DalamudPluginInterface hands out a reference to this, so we have to keep it around
-// TODO api9: make it a service 
-[InherentDependency<DataShare>]
-
-#pragma warning restore SA1015
+[ServiceManager.BlockingEarlyLoadedService("Accomodation of plugins that blocks the game startup.")]
 internal partial class PluginManager : IInternalDisposableService
 {
     /// <summary>
@@ -1257,6 +1245,16 @@ internal partial class PluginManager : IInternalDisposableService
     /// <returns>The dependency services.</returns>
     private static IEnumerable<Type> ResolvePossiblePluginDependencyServices()
     {
+        // DalamudPluginInterface hands out a reference to this, so we have to keep it around.
+        // TODO api9: make it a service
+        yield return typeof(DataShare);
+
+        // DalamudTextureWrap registers textures to dispose with IM.
+        yield return typeof(InterfaceManager);
+
+        // Note: LocalPlugin uses ServiceContainer to create scopes, but it is done outside PM ctor.
+        // This is not required: yield return typeof(ServiceContainer);
+
         foreach (var serviceType in ServiceManager.GetConcreteServiceTypes())
         {
             if (serviceType == typeof(PluginManager))

--- a/Dalamud/Plugin/Internal/Profiles/ProfileManager.cs
+++ b/Dalamud/Plugin/Internal/Profiles/ProfileManager.cs
@@ -15,7 +15,7 @@ namespace Dalamud.Plugin.Internal.Profiles;
 /// <summary>
 /// Class responsible for managing plugin profiles.
 /// </summary>
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.BlockingEarlyLoadedService($"Data provider for {nameof(PluginManager)}.")]
 internal class ProfileManager : IServiceType
 {
     private static readonly ModuleLog Log = new("PROFMAN");

--- a/Dalamud/Plugin/Ipc/Internal/DataShare.cs
+++ b/Dalamud/Plugin/Ipc/Internal/DataShare.cs
@@ -11,7 +11,7 @@ namespace Dalamud.Plugin.Ipc.Internal;
 /// <summary>
 /// This class facilitates sharing data-references of standard types between plugins without using more expensive IPC.
 /// </summary>
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.EarlyLoadedService]
 internal class DataShare : IServiceType
 {
     /// <summary>

--- a/Dalamud/ServiceManager.cs
+++ b/Dalamud/ServiceManager.cs
@@ -638,10 +638,15 @@ internal static class ServiceManager
         /// <summary>
         /// Initializes a new instance of the <see cref="BlockingEarlyLoadedServiceAttribute"/> class.
         /// </summary>
-        public BlockingEarlyLoadedServiceAttribute()
+        /// <param name="blockReason">Reason of blocking the game startup.</param>
+        public BlockingEarlyLoadedServiceAttribute(string blockReason)
             : base(ServiceKind.BlockingEarlyLoadedService)
         {
+            this.BlockReason = blockReason;
         }
+
+        /// <summary>Gets the reason of blocking the startup of the game.</summary>
+        public string BlockReason { get; }
     }
 
     /// <summary>

--- a/Dalamud/Service{T}.cs
+++ b/Dalamud/Service{T}.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
+using Dalamud.Utility;
 using Dalamud.Utility.Timing;
 using JetBrains.Annotations;
 
@@ -198,13 +199,16 @@ internal static class Service<T> where T : IServiceType
                                 .ToArray();
             if (offenders.Any())
             {
-                ServiceManager.Log.Error(
-                    "{me} is a {bels}; it can only depend on {bels} and {ps}.\nOffending dependencies:\n{offenders}",
-                    typeof(T),
-                    nameof(ServiceManager.BlockingEarlyLoadedServiceAttribute),
-                    nameof(ServiceManager.BlockingEarlyLoadedServiceAttribute),
-                    nameof(ServiceManager.ProvidedServiceAttribute),
-                    string.Join("\n", offenders.Select(x => $"\t* {x.Name}")));
+                const string bels = nameof(ServiceManager.BlockingEarlyLoadedServiceAttribute);
+                const string ps = nameof(ServiceManager.ProvidedServiceAttribute);
+                var errmsg =
+                    $"{typeof(T)} is a {bels}; it can only depend on {bels} and {ps}.\nOffending dependencies:\n" +
+                    string.Join("\n", offenders.Select(x => $"\t* {x.Name}"));
+#if DEBUG
+                Util.Fatal(errmsg, "Service Dependency Check");
+#else
+                ServiceManager.Log.Error(errmsg);
+#endif
             }
         }
 

--- a/Dalamud/Storage/Assets/DalamudAssetManager.cs
+++ b/Dalamud/Storage/Assets/DalamudAssetManager.cs
@@ -23,7 +23,8 @@ namespace Dalamud.Storage.Assets;
 /// A concrete class for <see cref="IDalamudAssetManager"/>.
 /// </summary>
 [PluginInterface]
-[ServiceManager.BlockingEarlyLoadedService]
+[ServiceManager.BlockingEarlyLoadedService(
+    "Ensuring that it is worth continuing loading Dalamud, by checking if all required assets are properly available.")]
 #pragma warning disable SA1015
 [ResolveVia<IDalamudAssetManager>]
 #pragma warning restore SA1015


### PR DESCRIPTION
* As many services as possible will be treated as nonblocker for game startup. Doing this will let us make a lot of fields of `InterfaceManager` readonly and remove the need for two-step initialization of IM.
* `PluginManager` will now not have `ChatGui` as a hard dependency, and changed to instead do additional work once it has been finished loading.

This will effectively reduce startup time by 300ms, as the constructor `PluginManager` would not have to wait for services that take some time to initialize.
![image](https://github.com/goatcorp/Dalamud/assets/3614868/b77448de-f1ab-4133-814e-e8772521aa21)

If a plugin blocks game startup and needs to use services not marked as nonblocker, the plugin will wait for that service to load, and Dalamud will block game load until that plugin loads, effectively making services optionally blocking.

As there is no service that is dependent on a plugin or the boot time plugin loader, this should not deadlock depending on set of plugins installed.

This is an alternate solution for
* #1579

This incorporates:
* #1580 

Side note: as MonoMod initialization takes a long time, for testing purposes when it's commented out, loading would become much more efficient. This is not included in this PR.

![image](https://github.com/goatcorp/Dalamud/assets/3614868/c7273b87-81ab-4134-af65-1fea6fa6d5e2)
