### PR TITLE
Make FuzzyMatcher more convenient to use

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -1093,7 +1093,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             return;
         }
 
-        IEnumerable<IChangelogEntry> changelogs = null;
+        IEnumerable<IChangelogEntry>? changelogs = null;
         if (displayDalamud && displayPlugins && this.dalamudChangelogManager.Changelogs != null)
         {
             changelogs = this.dalamudChangelogManager.Changelogs;
@@ -1107,10 +1107,15 @@ internal class PluginInstallerWindow : Window, IDisposable
             changelogs = this.dalamudChangelogManager.Changelogs.OfType<PluginChangelogEntry>();
         }
 
-        var sortedChangelogs = changelogs?.Where(x => this.searchText.IsNullOrWhitespace() || new FuzzyMatcher(this.searchText.ToLowerInvariant(), MatchMode.FuzzyParts).Matches(x.Title.ToLowerInvariant()) > 0)
-                                                            .OrderByDescending(x => x.Date).ToList();
+        changelogs ??= Array.Empty<IChangelogEntry>();
+        var sortedChangelogs =
+            this.searchText.IsNullOrWhitespace()
+                ? changelogs.ToList()
+                : changelogs.Where(x => x.Title.FuzzyMatchesParts(this.searchText))
+                            .OrderByDescending(x => x.Date)
+                            .ToList();
 
-        if (sortedChangelogs == null || !sortedChangelogs.Any())
+        if (!sortedChangelogs.Any())
         {
             ImGui.TextColored(
                 ImGuiColors.DalamudGrey2,
@@ -3124,21 +3129,25 @@ internal class PluginInstallerWindow : Window, IDisposable
 
     private bool IsManifestFiltered(IPluginManifest manifest)
     {
-        var searchString = this.searchText.ToLowerInvariant();
-        var matcher = new FuzzyMatcher(searchString, MatchMode.FuzzyParts);
         var hasSearchString = !string.IsNullOrWhiteSpace(this.searchText);
         var oldApi = manifest.DalamudApiLevel < PluginManager.DalamudApiLevel;
         var installed = this.IsManifestInstalled(manifest).IsInstalled;
 
-        if (oldApi && !hasSearchString && !installed)
-            return true;
+        // Are we not searching at all? Hide plugins of older API levels that aren't installed. 
+        if (!hasSearchString)
+            return oldApi && !installed;
 
-        return hasSearchString && !(
-                                       (!manifest.Name.IsNullOrEmpty() && matcher.Matches(manifest.Name.ToLowerInvariant()) > 0) ||
-                                       (!manifest.InternalName.IsNullOrEmpty() && matcher.Matches(manifest.InternalName.ToLowerInvariant()) > 0) ||
-                                       (!manifest.Author.IsNullOrEmpty() && matcher.Matches(manifest.Author.ToLowerInvariant()) > 0) ||
-                                       (!manifest.Punchline.IsNullOrEmpty() && manifest.Punchline.ToLowerInvariant().Contains(searchString)) ||
-                                       (manifest.Tags != null && matcher.MatchesAny(manifest.Tags.Select(term => term.ToLowerInvariant()).ToArray()) > 0));
+        if (manifest.Name.FuzzyMatchesParts(this.searchText))
+            return false;
+        if (manifest.InternalName.FuzzyMatchesParts(this.searchText))
+            return false;
+        if (manifest.Author.FuzzyMatchesParts(this.searchText))
+            return false;
+        if (manifest.Punchline?.Contains(this.searchText, StringComparison.InvariantCultureIgnoreCase) is true)
+            return false;
+        if (manifest.Tags?.Any(x => x.FuzzyMatchesParts(this.searchText)) is true)
+            return false;
+        return true;
     }
 
     private (bool IsInstalled, LocalPlugin Plugin) IsManifestInstalled(IPluginManifest? manifest)

--- a/Dalamud/Utility/FuzzyMatcher.cs
+++ b/Dalamud/Utility/FuzzyMatcher.cs
@@ -1,162 +1,122 @@
 ﻿#define BORDER_MATCHING
 
+using System.Globalization;
+
 namespace Dalamud.Utility;
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
-#pragma warning disable SA1600
-#pragma warning disable SA1602
-
-internal readonly ref struct FuzzyMatcher
+/// <summary>
+/// Matches a string in a fuzzy way.
+/// </summary>
+internal static class FuzzyMatcher
 {
-    private static readonly (int, int)[] EmptySegArray = Array.Empty<(int, int)>();
-
-    private readonly string needleString = string.Empty;
-    private readonly ReadOnlySpan<char> needleSpan = ReadOnlySpan<char>.Empty;
-    private readonly int needleFinalPosition = -1;
-    private readonly (int Start, int End)[] needleSegments = EmptySegArray;
-    private readonly MatchMode mode = MatchMode.Simple;
-
-    public FuzzyMatcher(string term, MatchMode matchMode)
+    /// <summary>
+    /// Specify fuzzy match mode.
+    /// </summary>
+    internal enum Mode
     {
-        this.needleString = term;
-        this.needleSpan = this.needleString.AsSpan();
-        this.needleFinalPosition = this.needleSpan.Length - 1;
-        this.mode = matchMode;
+        /// <summary>
+        /// The string is considered for fuzzy matching as a whole.
+        /// </summary>
+        Fuzzy,
 
-        switch (matchMode)
+        /// <summary>
+        /// Each part of the string, separated by whitespace, is considered for fuzzy matching; each part must match in a fuzzy way.
+        /// </summary>
+        FuzzyParts,
+    }
+
+    /// <summary>
+    /// Determines if <paramref name="needle"/> can be found in <paramref name="haystack"/> in a fuzzy way.
+    /// </summary>
+    /// <param name="haystack">The string to search from.</param>
+    /// <param name="needle">The substring to search for.</param>
+    /// <param name="mode">Fuzzy match mode.</param>
+    /// <param name="cultureInfo">Culture info for case insensitive matching.</param>
+    /// <param name="score">The score. 0 means that the string did not match. The scores are meaningful only across matches using the same <paramref name="needle"/> value.</param>
+    /// <returns><c>true</c> if matches.</returns>
+    public static bool FuzzyMatches(
+        this ReadOnlySpan<char> haystack,
+        ReadOnlySpan<char> needle,
+        Mode mode,
+        CultureInfo cultureInfo,
+        out int score)
+    {
+        score = 0;
+        switch (mode)
         {
-            case MatchMode.FuzzyParts:
-                this.needleSegments = FindNeedleSegments(this.needleSpan);
+            case var _ when needle.Length == 0:
+                score = 0;
                 break;
-            case MatchMode.Fuzzy:
-            case MatchMode.Simple:
-                this.needleSegments = EmptySegArray;
+
+            case Mode.Fuzzy:
+                score = GetRawScore(haystack, needle, cultureInfo);
                 break;
+
+            case Mode.FuzzyParts:
+                foreach (var needleSegment in new WordEnumerator(needle))
+                {
+                    var cur = GetRawScore(haystack, needleSegment, cultureInfo);
+                    if (cur == 0)
+                    {
+                        score = 0;
+                        break;
+                    }
+
+                    score += cur;
+                }
+
+                break;
+
             default:
-                throw new ArgumentOutOfRangeException(nameof(matchMode), matchMode, null);
+                throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
         }
+
+        return score > 0;
     }
 
-    private static (int Start, int End)[] FindNeedleSegments(ReadOnlySpan<char> span)
+    /// <inheritdoc cref="FuzzyMatches(ReadOnlySpan{char},ReadOnlySpan{char},Mode,CultureInfo,out int)"/>
+    public static bool FuzzyMatches(
+        this string haystack,
+        ReadOnlySpan<char> needle,
+        Mode mode,
+        CultureInfo cultureInfo,
+        out int score) => haystack.AsSpan().FuzzyMatches(needle, mode, cultureInfo, out score);
+
+    /// <summary>
+    /// Determines if <paramref name="needle"/> can be found in <paramref name="haystack"/> using the mode
+    /// <see cref="Mode.FuzzyParts"/>.
+    /// </summary>
+    /// <param name="haystack">The string to search from.</param>
+    /// <param name="needle">The substring to search for.</param>
+    /// <returns><c>true</c> if matches.</returns>
+    public static bool FuzzyMatchesParts(this string haystack, ReadOnlySpan<char> needle) =>
+        haystack.FuzzyMatches(needle, Mode.FuzzyParts, CultureInfo.InvariantCulture, out _);
+
+    private static int GetRawScore(ReadOnlySpan<char> haystack, ReadOnlySpan<char> needle, CultureInfo cultureInfo)
     {
-        var segments = new List<(int, int)>();
-        var wordStart = -1;
-
-        for (var i = 0; i < span.Length; i++)
-        {
-            if (span[i] is not ' ' and not '\u3000')
-            {
-                if (wordStart < 0)
-                {
-                    wordStart = i;
-                }
-            }
-            else if (wordStart >= 0)
-            {
-                segments.Add((wordStart, i - 1));
-                wordStart = -1;
-            }
-        }
-
-        if (wordStart >= 0)
-        {
-            segments.Add((wordStart, span.Length - 1));
-        }
-
-        return segments.ToArray();
-    }
-
-#pragma warning disable SA1202
-    public int Matches(string value)
-#pragma warning restore SA1202
-    {
-        if (this.needleFinalPosition < 0)
-        {
-            return 0;
-        }
-
-        if (this.mode == MatchMode.Simple)
-        {
-            return value.Contains(this.needleString) ? 1 : 0;
-        }
-
-        var haystack = value.AsSpan();
-
-        if (this.mode == MatchMode.Fuzzy)
-        {
-            return this.GetRawScore(haystack, 0, this.needleFinalPosition);
-        }
-
-        if (this.mode == MatchMode.FuzzyParts)
-        {
-            if (this.needleSegments.Length < 2)
-            {
-                return this.GetRawScore(haystack, 0, this.needleFinalPosition);
-            }
-
-            var total = 0;
-            for (var i = 0; i < this.needleSegments.Length; i++)
-            {
-                var (start, end) = this.needleSegments[i];
-                var cur = this.GetRawScore(haystack, start, end);
-                if (cur == 0)
-                {
-                    return 0;
-                }
-
-                total += cur;
-            }
-
-            return total;
-        }
-
-        return 8;
-    }
-
-    public int MatchesAny(params string[] values)
-    {
-        var max = 0;
-        for (var i = 0; i < values.Length; i++)
-        {
-            var cur = this.Matches(values[i]);
-            if (cur > max)
-            {
-                max = cur;
-            }
-        }
-
-        return max;
-    }
-
-    private int GetRawScore(ReadOnlySpan<char> haystack, int needleStart, int needleEnd)
-    {
-        var (startPos, gaps, consecutive, borderMatches, endPos) = this.FindForward(haystack, needleStart, needleEnd);
+        var (startPos, gaps, consecutive, borderMatches, endPos) = FindForward(haystack, needle, cultureInfo);
         if (startPos < 0)
         {
             return 0;
         }
 
-        var needleSize = needleEnd - needleStart + 1;
-
-        var score = CalculateRawScore(needleSize, startPos, gaps, consecutive, borderMatches);
+        var score = CalculateRawScore(needle.Length, startPos, gaps, consecutive, borderMatches);
         // PluginLog.Debug(
-        //     $"['{needleString.Substring(needleStart, needleEnd - needleStart + 1)}' in '{haystack}'] fwd: needleSize={needleSize} startPos={startPos} gaps={gaps} consecutive={consecutive} borderMatches={borderMatches} score={score}");
+        //     $"['{needle.Substring(needleStart, needleEnd - needleStart + 1)}' in '{haystack}'] fwd: needleSize={needleSize} startPos={startPos} gaps={gaps} consecutive={consecutive} borderMatches={borderMatches} score={score}");
 
-        (startPos, gaps, consecutive, borderMatches) = this.FindReverse(haystack, endPos, needleStart, needleEnd);
-        var revScore = CalculateRawScore(needleSize, startPos, gaps, consecutive, borderMatches);
+        (startPos, gaps, consecutive, borderMatches) = FindReverse(haystack[..(endPos + 1)], needle, cultureInfo);
+        var revScore = CalculateRawScore(needle.Length, startPos, gaps, consecutive, borderMatches);
         // PluginLog.Debug(
-        //     $"['{needleString.Substring(needleStart, needleEnd - needleStart + 1)}' in '{haystack}'] rev: needleSize={needleSize} startPos={startPos} gaps={gaps} consecutive={consecutive} borderMatches={borderMatches} score={revScore}");
+        //     $"['{needle.Substring(needleStart, needleEnd - needleStart + 1)}' in '{haystack}'] rev: needleSize={needleSize} startPos={startPos} gaps={gaps} consecutive={consecutive} borderMatches={borderMatches} score={revScore}");
 
         return int.Max(score, revScore);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#pragma warning disable SA1204
     private static int CalculateRawScore(int needleSize, int startPos, int gaps, int consecutive, int borderMatches)
-#pragma warning restore SA1204
     {
         var score = 100
                     + needleSize * 3
@@ -169,10 +129,12 @@ internal readonly ref struct FuzzyMatcher
         return score < 1 ? 1 : score;
     }
 
-    private (int StartPos, int Gaps, int Consecutive, int BorderMatches, int HaystackIndex) FindForward(
-        ReadOnlySpan<char> haystack, int needleStart, int needleEnd)
+    private static (int StartPos, int Gaps, int Consecutive, int BorderMatches, int HaystackIndex) FindForward(
+        ReadOnlySpan<char> haystack,
+        ReadOnlySpan<char> needle,
+        CultureInfo cultureInfo)
     {
-        var needleIndex = needleStart;
+        var needleIndex = 0;
         var lastMatchIndex = -10;
 
         var startPos = 0;
@@ -182,7 +144,7 @@ internal readonly ref struct FuzzyMatcher
 
         for (var haystackIndex = 0; haystackIndex < haystack.Length; haystackIndex++)
         {
-            if (haystack[haystackIndex] == this.needleSpan[needleIndex])
+            if (char.ToLower(haystack[haystackIndex], cultureInfo) == char.ToLower(needle[needleIndex], cultureInfo))
             {
 #if BORDER_MATCHING
                 if (haystackIndex > 0)
@@ -201,7 +163,7 @@ internal readonly ref struct FuzzyMatcher
                     consecutive++;
                 }
 
-                if (needleIndex > needleEnd)
+                if (needleIndex >= needle.Length)
                 {
                     return (startPos, gaps, consecutive, borderMatches, haystackIndex);
                 }
@@ -210,7 +172,7 @@ internal readonly ref struct FuzzyMatcher
             }
             else
             {
-                if (needleIndex > needleStart)
+                if (needleIndex > 0)
                 {
                     gaps++;
                 }
@@ -224,19 +186,21 @@ internal readonly ref struct FuzzyMatcher
         return (-1, 0, 0, 0, 0);
     }
 
-    private (int StartPos, int Gaps, int Consecutive, int BorderMatches) FindReverse(
-        ReadOnlySpan<char> haystack, int haystackLastMatchIndex, int needleStart, int needleEnd)
+    private static (int StartPos, int Gaps, int Consecutive, int BorderMatches) FindReverse(
+        ReadOnlySpan<char> haystack,
+        ReadOnlySpan<char> needle,
+        CultureInfo cultureInfo)
     {
-        var needleIndex = needleEnd;
+        var needleIndex = needle.Length - 1;
         var revLastMatchIndex = haystack.Length + 10;
 
         var gaps = 0;
         var consecutive = 0;
         var borderMatches = 0;
 
-        for (var haystackIndex = haystackLastMatchIndex; haystackIndex >= 0; haystackIndex--)
+        for (var haystackIndex = haystack.Length - 1; haystackIndex >= 0; haystackIndex--)
         {
-            if (haystack[haystackIndex] == this.needleSpan[needleIndex])
+            if (char.ToLower(haystack[haystackIndex], cultureInfo) == char.ToLower(needle[needleIndex], cultureInfo))
             {
 #if BORDER_MATCHING
                 if (haystackIndex > 0)
@@ -255,7 +219,7 @@ internal readonly ref struct FuzzyMatcher
                     consecutive++;
                 }
 
-                if (needleIndex < needleStart)
+                if (needleIndex < 0)
                 {
                     return (haystackIndex, gaps, consecutive, borderMatches);
                 }
@@ -270,14 +234,44 @@ internal readonly ref struct FuzzyMatcher
 
         return (-1, 0, 0, 0);
     }
-}
 
-internal enum MatchMode
-{
-    Simple,
-    Fuzzy,
-    FuzzyParts,
-}
+    private ref struct WordEnumerator
+    {
+        private readonly ReadOnlySpan<char> fullNeedle;
+        private int start = -1;
+        private int end = 0;
 
-#pragma warning restore SA1600
-#pragma warning restore SA1602
+        public WordEnumerator(ReadOnlySpan<char> fullNeedle)
+        {
+            this.fullNeedle = fullNeedle;
+        }
+
+        public ReadOnlySpan<char> Current
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => this.fullNeedle[this.start..this.end];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MoveNext()
+        {
+            if (this.start >= this.fullNeedle.Length - 1)
+                return false;
+
+            this.start = this.end;
+
+            // Skip the spaces
+            while (this.start < this.fullNeedle.Length && char.IsWhiteSpace(this.fullNeedle[this.start]))
+                this.start++;
+
+            this.end = this.start;
+            while (this.end < this.fullNeedle.Length && !char.IsWhiteSpace(this.fullNeedle[this.end]))
+                this.end++;
+
+            return this.start != this.end;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public WordEnumerator GetEnumerator() => this;
+    }
+}


### PR DESCRIPTION
Removed the requirements to accommodate `ref struct` from the invoker code. Can be used as an extension method, with the shortest form of `haystack.FuzzyMatchesParts(needle)`.