### PR TITLE
chore: Consolidate on ImGuiColors

### DIFF
--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -150,7 +150,7 @@ internal class ConsoleWindow : Window, IDisposable
         {
             const string regexErrorString = "Regex Filter Error";
             ImGui.SetCursorPosX(ImGui.GetContentRegionMax().X / 2.0f - ImGui.CalcTextSize(regexErrorString).X / 2.0f);
-            ImGui.TextColored(KnownColor.OrangeRed.Vector(), regexErrorString);
+            ImGui.TextColored(ImGuiColors.DalamudRed, regexErrorString);
         }
         
         ImGui.BeginChild("scrolling", new Vector2(0, ImGui.GetFrameHeightWithSpacing() - 55 * ImGuiHelpers.GlobalScale), false, ImGuiWindowFlags.AlwaysHorizontalScrollbar | ImGuiWindowFlags.AlwaysVerticalScrollbar);
@@ -491,7 +491,7 @@ internal class ConsoleWindow : Window, IDisposable
             
             if (!sourceNames.Any())
             {
-                ImGui.TextColored(KnownColor.OrangeRed.Vector(), "No Results");
+                ImGui.TextColored(ImGuiColors.DalamudRed, "No Results");
             }
 
             foreach (var selectable in sourceNames)

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonLifecycleWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonLifecycleWidget.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Linq;
 
 using Dalamud.Game.Addon.Lifecycle;
+using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility;
 using ImGuiNET;
 
@@ -130,7 +131,7 @@ public class AddonLifecycleWidget : IDataWindowWidget
                 }
                 else
                 {
-                    var color = receiveEventListener.Hook.IsEnabled ? KnownColor.Green.Vector() : KnownColor.OrangeRed.Vector();
+                    var color = receiveEventListener.Hook.IsEnabled ? ImGuiColors.HealerGreen : ImGuiColors.DalamudRed;
                     var text = receiveEventListener.Hook.IsEnabled ? "Enabled" : "Disabled";
                     ImGui.TextColored(color, text);
                 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/IconBrowserWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/IconBrowserWidget.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 
 using Dalamud.Data;
+using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility;
 using Dalamud.Utility;
 using ImGuiNET;
@@ -154,7 +155,7 @@ public class IconBrowserWidget : IDataWindowWidget
                 this.nullValues.Add(iconId);
             }
 
-            ImGui.GetWindowDrawList().AddRect(cursor, cursor + this.iconSize, ImGui.GetColorU32(KnownColor.White.Vector()));
+            ImGui.GetWindowDrawList().AddRect(cursor, cursor + this.iconSize, ImGui.GetColorU32(ImGuiColors.DalamudWhite));
         }
         catch (Exception)
         {


### PR DESCRIPTION
Uses ImGuiColors over KnownColor in most places so that themes override things properly.

Note that I did not edit the verified checkmarks in `PluginInstallerWindow` as (a) these colors were chosen very specifically, and (b) we don't actually have a known color for `Black`. We can add the latter if necessary, I suppose.