### PR TITLE
[AddonEventManager] Actually Ensure Thread Safety

### DIFF
--- a/Dalamud/Game/Addon/Events/AddonEventListener.cs
+++ b/Dalamud/Game/Addon/Events/AddonEventListener.cs
@@ -67,7 +67,10 @@ internal unsafe class AddonEventListener : IDisposable
     {
         if (node is null) return;
 
-        node->AddEvent(eventType, param, this.eventListener, (AtkResNode*)addon, false);
+        Service<Framework>.Get().RunOnFrameworkThread(() =>
+        {
+            node->AddEvent(eventType, param, this.eventListener, (AtkResNode*)addon, false);
+        });
     }
 
     /// <summary>
@@ -80,7 +83,10 @@ internal unsafe class AddonEventListener : IDisposable
     {
         if (node is null) return;
 
-        node->RemoveEvent(eventType, param, this.eventListener, false);
+        Service<Framework>.Get().RunOnFrameworkThread(() =>
+        {
+            node->RemoveEvent(eventType, param, this.eventListener, false);
+        });
     }
     
     [UnmanagedCallersOnly]

--- a/Dalamud/Game/Addon/Events/AddonEventManager.cs
+++ b/Dalamud/Game/Addon/Events/AddonEventManager.cs
@@ -25,7 +25,7 @@ internal unsafe class AddonEventManager : IDisposable, IServiceType
     /// <summary>
     /// PluginName for Dalamud Internal use.
     /// </summary>
-    public static Guid DalamudInternalKey = new("Dalamud.Internal");
+    public static readonly Guid DalamudInternalKey = new("Dalamud.Internal");
     
     private static readonly ModuleLog Log = new("AddonEventManager");
     

--- a/Dalamud/Game/Addon/Events/AddonEventManager.cs
+++ b/Dalamud/Game/Addon/Events/AddonEventManager.cs
@@ -92,8 +92,6 @@ internal unsafe class AddonEventManager : IDisposable, IServiceType
     /// <returns>IAddonEventHandle used to remove the event.</returns>
     internal IAddonEventHandle? AddEvent(string pluginId, IntPtr atkUnitBase, IntPtr atkResNode, AddonEventType eventType, IAddonEventManager.AddonEventHandler eventHandler)
     {
-        if (!ThreadSafety.IsMainThread) throw new InvalidOperationException("This should be done only from the main thread. Modifying active native code on non-main thread is not supported.");
-        
         if (this.pluginEventControllers.FirstOrDefault(entry => entry.PluginId == pluginId) is { } eventController)
         {
             return eventController.AddEvent(atkUnitBase, atkResNode, eventType, eventHandler);
@@ -110,8 +108,6 @@ internal unsafe class AddonEventManager : IDisposable, IServiceType
     /// <param name="eventHandle">The Unique Id for this event.</param>
     internal void RemoveEvent(string pluginId, IAddonEventHandle eventHandle)
     {
-        if (!ThreadSafety.IsMainThread) throw new InvalidOperationException("This should be done only from the main thread. Modifying active native code on non-main thread is not supported.");
-        
         if (this.pluginEventControllers.FirstOrDefault(entry => entry.PluginId == pluginId) is { } eventController)
         {
             eventController.RemoveEvent(eventHandle);

--- a/Dalamud/Game/Addon/Events/PluginEventController.cs
+++ b/Dalamud/Game/Addon/Events/PluginEventController.cs
@@ -19,19 +19,11 @@ internal unsafe class PluginEventController : IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="PluginEventController"/> class.
     /// </summary>
-    /// <param name="pluginId">The Unique ID for this plugin.</param>
-    public PluginEventController(Guid pluginId)
+    public PluginEventController()
     {
-        this.PluginId = pluginId;
-
         this.EventListener = new AddonEventListener(this.PluginEventListHandler);
     }
 
-    /// <summary>
-    /// Gets the unique ID for this PluginEventList.
-    /// </summary>
-    public Guid PluginId { get; init; }
-    
     private AddonEventListener EventListener { get; init; }
     
     private List<AddonEventEntry> Events { get; } = new();
@@ -125,7 +117,7 @@ internal unsafe class PluginEventController : IDisposable
             if (this.Events.All(registeredEvent => registeredEvent.ParamKey != i)) return i;
         }
 
-        throw new OverflowException($"uint.MaxValue number of ParamKeys used for {this.PluginId}");
+        throw new OverflowException($"uint.MaxValue number of ParamKeys used for this event controller.");
     }
     
     /// <summary>

--- a/Dalamud/Game/Addon/Events/PluginEventController.cs
+++ b/Dalamud/Game/Addon/Events/PluginEventController.cs
@@ -20,7 +20,7 @@ internal unsafe class PluginEventController : IDisposable
     /// Initializes a new instance of the <see cref="PluginEventController"/> class.
     /// </summary>
     /// <param name="pluginId">The Unique ID for this plugin.</param>
-    public PluginEventController(string pluginId)
+    public PluginEventController(Guid pluginId)
     {
         this.PluginId = pluginId;
 
@@ -30,7 +30,7 @@ internal unsafe class PluginEventController : IDisposable
     /// <summary>
     /// Gets the unique ID for this PluginEventList.
     /// </summary>
-    public string PluginId { get; init; }
+    public Guid PluginId { get; init; }
     
     private AddonEventListener EventListener { get; init; }
     


### PR DESCRIPTION
Since plugins often load and unload async, this has been reporting exceptions due to events being registered and unregisterd from a non-main thread.

This PR will force the specific native calls that AddonEventManager uses, to be on the main game thread.

There is a **potential** but **probably impossible** race condition introduced here if someone tries to Register and event and then Unregister that event in the next call, as the Registration will return a handle to the event immediately, even if the event hasn't been registered yet.

It's probably impossible because the same way the Register gets queued in the Framework.RunOnFrameworkThread, the Unregister will most likely get queued after it regardless.