### PR TITLE
fix: Make auto-update work again, the lazy way

### DIFF
--- a/Dalamud/Game/ChatHandlers.cs
+++ b/Dalamud/Game/ChatHandlers.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 
 using CheapLoc;
 using Dalamud.Configuration.Internal;
-using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.Gui;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
@@ -15,12 +14,9 @@ using Dalamud.Interface.Internal;
 using Dalamud.Interface.Internal.Notifications;
 using Dalamud.Interface.Internal.Windows;
 using Dalamud.Interface.Internal.Windows.PluginInstaller;
-using Dalamud.Logging;
 using Dalamud.Logging.Internal;
 using Dalamud.Plugin.Internal;
-using Dalamud.Plugin.Internal.Loader;
 using Dalamud.Utility;
-using Serilog;
 
 namespace Dalamud.Game;
 
@@ -176,15 +172,9 @@ internal class ChatHandlers : IServiceType
             if (!this.hasSeenLoadingMsg)
                 this.PrintWelcomeMessage();
             
-            // FIXME (kazwolfe): This will only run on the first Notice received, meaning auto-updates won't happen
-            // until the character is logged in. Ideally, this should move earlier into the process (after all repos
-            // are loaded) with just the update summary posted here. 
             if (!this.startedAutoUpdatingPlugins)
                 this.AutoUpdatePlugins();
         }
-
-        if (type == XivChatType.Notice && !this.hasSeenLoadingMsg)
-            this.PrintWelcomeMessage();
 
         // For injections while logged in
         if (clientState.LocalPlayer != null && clientState.TerritoryType == 0 && !this.hasSeenLoadingMsg)

--- a/Dalamud/Interface/Utility/ImGuiHelpers.cs
+++ b/Dalamud/Interface/Utility/ImGuiHelpers.cs
@@ -31,7 +31,8 @@ public static class ImGuiHelpers
     /// This does not necessarily mean you can call drawing functions.
     /// </summary>
     public static unsafe bool IsImGuiInitialized =>
-        ImGui.GetCurrentContext() is not 0 && ImGui.GetIO().NativePtr is not null;
+        ImGui.GetCurrentContext() is not (nint)0  // KW: IDEs get mad without the cast, despite being unnecessary
+        && ImGui.GetIO().NativePtr is not null; 
 
     /// <summary>
     /// Gets the global Dalamud scale; even available before drawing is ready.<br />

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -958,7 +958,7 @@ internal partial class PluginManager : IDisposable, IServiceType
             autoUpdate ? PluginListInvalidationKind.AutoUpdate : PluginListInvalidationKind.Update,
             updatedList.Select(x => x.InternalName));
 
-        Log.Information("Plugin update OK.");
+        Log.Information("Plugin update OK. {updateCount} plugins updated.", updatedList.Length);
 
         return updatedList;
     }
@@ -1581,6 +1581,8 @@ internal partial class PluginManager : IDisposable, IServiceType
 
     private void DetectAvailablePluginUpdates()
     {
+        Log.Debug("Starting plugin update check...");
+        
         lock (this.pluginListLock)
         {
             this.updatablePluginsList.Clear();
@@ -1615,10 +1617,12 @@ internal partial class PluginManager : IDisposable, IServiceType
                 }
             }
         }
+        
+        Log.Debug("Update check found {updateCount} available updates.", this.updatablePluginsList.Count);
     }
 
     private void NotifyAvailablePluginsChanged()
-    {
+    { 
         this.DetectAvailablePluginUpdates();
 
         this.OnAvailablePluginsChanged?.InvokeSafely();


### PR DESCRIPTION
This pull request aims to at least get auto update working again.

Auto updates were recently broken per some PM rewrites. This (alongside a case where a certain custom-repo plugin was triggering a chat message on the login screen) caused Dalamud to attempt to auto update before the update list was properly calculated, thereby not doing anything but marking the auto-update phase as complete. 

While it is possible to (and we probably *should*) fix the underlying problem with PluginManager such that an auto update triggers after all repos are loaded, this is somewhat more work and probably won't be clean. Per goat, this may be a good opportunity to also handle some cases such as informing plugins that there may be an update present.