### PR TITLE
chore: Suppress expected load errors

### DIFF
--- a/Dalamud/Plugin/Internal/Exceptions/BannedPluginException.cs
+++ b/Dalamud/Plugin/Internal/Exceptions/BannedPluginException.cs
@@ -3,19 +3,14 @@ namespace Dalamud.Plugin.Internal.Exceptions;
 /// <summary>
 /// This represents a banned plugin that attempted an operation.
 /// </summary>
-internal class BannedPluginException : PluginException
+internal class BannedPluginException : PluginPreconditionFailedException
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BannedPluginException"/> class.
     /// </summary>
     /// <param name="message">The message describing the invalid operation.</param>
     public BannedPluginException(string message)
+        : base(message)
     {
-        this.Message = message;
     }
-
-    /// <summary>
-    /// Gets the message describing the invalid operation.
-    /// </summary>
-    public override string Message { get; }
 }

--- a/Dalamud/Plugin/Internal/Exceptions/PluginPreconditionFailedException.cs
+++ b/Dalamud/Plugin/Internal/Exceptions/PluginPreconditionFailedException.cs
@@ -1,0 +1,16 @@
+﻿namespace Dalamud.Plugin.Internal.Exceptions;
+
+/// <summary>
+/// An exception to be thrown when policy blocks a plugin from loading.
+/// </summary>
+internal class PluginPreconditionFailedException : InvalidPluginOperationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PluginPreconditionFailedException"/> class.
+    /// </summary>
+    /// <param name="message">The message to associate with this exception.</param>
+    public PluginPreconditionFailedException(string message)
+        : base(message)
+    {
+    }
+}

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -315,23 +315,23 @@ internal class LocalPlugin : IDisposable
             }
 
             if (pluginManager.IsManifestBanned(this.manifest) && !this.IsDev)
-                throw new BannedPluginException($"Unable to load {this.Name}, banned");
+                throw new BannedPluginException($"Unable to load {this.Name} as it was banned");
 
             if (this.manifest.ApplicableVersion < dalamud.StartInfo.GameVersion)
-                throw new InvalidPluginOperationException($"Unable to load {this.Name}, no applicable version");
+                throw new PluginPreconditionFailedException($"Unable to load {this.Name}, game is newer than applicable version {this.manifest.ApplicableVersion}");
 
             if (this.manifest.DalamudApiLevel < PluginManager.DalamudApiLevel && !pluginManager.LoadAllApiLevels)
-                throw new InvalidPluginOperationException($"Unable to load {this.Name}, incompatible API level");
+                throw new PluginPreconditionFailedException($"Unable to load {this.Name}, incompatible API level {this.manifest.DalamudApiLevel}");
 
             // We might want to throw here?
             if (!this.IsWantedByAnyProfile)
                 Log.Warning("{Name} is loading, but isn't wanted by any profile", this.Name);
 
             if (this.IsOrphaned)
-                throw new InvalidPluginOperationException($"Plugin {this.Name} had no associated repo.");
+                throw new PluginPreconditionFailedException($"Plugin {this.Name} had no associated repo");
 
             if (!this.CheckPolicy())
-                throw new InvalidPluginOperationException("Plugin was not loaded as per policy");
+                throw new PluginPreconditionFailedException($"Unable to load {this.Name} as a load policy forbids it");
 
             this.State = PluginState.Loading;
             Log.Information($"Loading {this.DllFile.Name}");
@@ -439,7 +439,10 @@ internal class LocalPlugin : IDisposable
         {
             this.State = PluginState.LoadError;
 
-            if (ex is not BannedPluginException)
+            // If a precondition fails, don't record it as an error, as it isn't really. 
+            if (ex is PluginPreconditionFailedException)
+                Log.Warning(ex.Message);
+            else
                 Log.Error(ex, $"Error while loading {this.Name}");
 
             throw;


### PR DESCRIPTION
- Add new `PluginPreconditionFailedException` to track cases where a plugin could not be loaded due to a precondition not being met.
  - Make `BannedPluginException` inherit from this
- Make `PluginPreconditionFailedException`s show as warnings in the log.