### PR TITLE
Auto-update plugins on startup

### DIFF
--- a/Dalamud/Interface/Internal/Notifications/NotificationManager.cs
+++ b/Dalamud/Interface/Internal/Notifications/NotificationManager.cs
@@ -323,7 +323,7 @@ internal class NotificationManager : IServiceType
         internal TimeSpan ElapsedTime => DateTime.Now - this.CreationTime;
 
         /// <inheritdoc/>
-        void IDisposable.Dispose() => this.Dismiss(TimeSpan.FromMilliseconds(this.DurationMs));
+        public void Dispose() => this.Dismiss(TimeSpan.FromMilliseconds(this.DurationMs));
 
         /// <summary>
         /// Dismisses this notification.

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabGeneral.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabGeneral.cs
@@ -64,7 +64,7 @@ public class SettingsTabGeneral : SettingsTab
 
         new SettingsEntry<bool>(
             Loc.Localize("DalamudSettingsAutoUpdatePlugins", "Auto-update plugins"),
-            Loc.Localize("DalamudSettingsAutoUpdatePluginsMsgHint", "Automatically update plugins when logging in with a character."),
+            Loc.Localize("DalamudSettingsAutoUpdatePluginsMsgHint", "Automatically update plugins on startup."),
             c => c.AutoUpdatePlugins,
             (v, c) => c.AutoUpdatePlugins = v),
 

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -112,7 +112,7 @@ public sealed class DalamudPluginInterface : IDisposable
     /// <summary>
     /// Gets a value indicating whether or not auto-updates have already completed this session.
     /// </summary>
-    public bool IsAutoUpdateComplete => Service<ChatHandlers>.Get().IsAutoUpdateComplete;
+    public bool IsAutoUpdateComplete => Service<PluginManager>.Get().AutoUpdateTask?.IsCompleted ?? false;
 
     /// <summary>
     /// Gets the repository from which this plugin was installed.


### PR DESCRIPTION
![image](https://github.com/goatcorp/Dalamud/assets/3614868/f50c7a14-1daa-4665-a89f-0ac278a78867)
![image](https://github.com/goatcorp/Dalamud/assets/3614868/d11b1108-8bcc-42bf-8d68-181e19fc7221)

### Changes
* Auto-update initiator has been moved from `ChatHandlers` to `PluginManager.LoadAndStartLoadSyncPlugins`.
* Auto-update will happen on startup instead of logging in.
* `NotificationManager.Notification` now has the following:
    * `Persistent`:  if `true`, the notification will stay until `.Dispose()` or `.Dismiss(waitTimeSpan)` is called.
    * `Interactible`: if `true`, the notification will respond to inputs.
    * `Draw`: an event that gets called upon drawing the notification entry.