### PR TITLE
Fix verbose log in TextureManager.Dispose

### DIFF
--- a/Dalamud/Interface/Internal/TextureManager.cs
+++ b/Dalamud/Interface/Internal/TextureManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Numerics;
@@ -273,7 +273,10 @@ internal class TextureManager : IDisposable, IServiceType, ITextureProvider, ITe
         this.fallbackTextureWrap?.Dispose();
         this.framework.Update -= this.FrameworkOnUpdate;
         
-        Log.Verbose("Disposing {Num} left behind textures.");
+        if (this.activeTextures.Count == 0)
+            return;
+
+        Log.Verbose("Disposing {Num} left behind textures.", this.activeTextures.Count);
         
         foreach (var activeTexture in this.activeTextures)
         {


### PR DESCRIPTION
The Log.Verbose call was missing the count of textures.
Also made it return early, so it doesn't log if there are no textures to dispose.