### PR TITLE
Expose `CharacterData.ShieldValue` to Dalamud's Character wrapper.

### DIFF
--- a/Dalamud/Game/ClientState/Objects/Types/Character.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/Character.cs
@@ -62,6 +62,11 @@ public unsafe class Character : GameObject
     public uint MaxCp => this.Struct->CharacterData.MaxCraftingPoints;
 
     /// <summary>
+    /// Gets the shield percentage of this Chara.
+    /// </summary>
+    public byte ShieldPercentage => this.Struct->CharacterData.ShieldValue;
+
+    /// <summary>
     /// Gets the ClassJob of this Chara.
     /// </summary>
     public ExcelResolver<ClassJob> ClassJob => new(this.Struct->CharacterData.ClassJob);


### PR DESCRIPTION
I found it weird that this specific field wasn't exposed when I needed to see if shield changes would affect my plugin, so I thought I should rectify that. I was thinking of also offering an approximation of the actual shield value, but since that's not actually known to the client, and anyone could do the math themselves, I opted against it.