### PR TITLE
Make `IFontHandle` lockable, and add font change event

### DIFF
--- a/Dalamud.CorePlugin/PluginImpl.cs
+++ b/Dalamud.CorePlugin/PluginImpl.cs
@@ -69,6 +69,10 @@ namespace Dalamud.CorePlugin
                 this.Interface.UiBuilder.Draw += this.OnDraw;
                 this.Interface.UiBuilder.OpenConfigUi += this.OnOpenConfigUi;
                 this.Interface.UiBuilder.OpenMainUi += this.OnOpenMainUi;
+                this.Interface.UiBuilder.DefaultFontHandle.ImFontChanged += fc =>
+                {
+                    Log.Information($"CorePlugin : DefaultFontHandle.ImFontChanged called {fc}");
+                };
 
                 Service<CommandManager>.Get().AddHandler("/coreplug", new(this.OnCommand) { HelpMessage = "Access the plugin." });
 

--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -70,6 +70,7 @@
         <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
         <PackageReference Include="Lumina" Version="3.15.2" />
         <PackageReference Include="Lumina.Excel" Version="6.5.2" />
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.1" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.46-beta">
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Dalamud/Interface/GameFonts/GameFontHandle.cs
+++ b/Dalamud/Interface/GameFonts/GameFontHandle.cs
@@ -72,8 +72,8 @@ public sealed class GameFontHandle : IFontHandle
     /// <returns>An <see cref="IDisposable"/> that can be used to pop the font on dispose.</returns>
     public IDisposable Push() => this.fontHandle.Push();
 
-    /// <inheritdoc/>
-    IFontHandle.FontPopper IFontHandle.Push() => this.fontHandle.Push();
+    /// <inheritdoc />
+    public void Pop() => this.fontHandle.Pop();
 
     /// <inheritdoc />
     public Task<IFontHandle> WaitAsync() => this.fontHandle.WaitAsync();

--- a/Dalamud/Interface/GameFonts/GameFontHandle.cs
+++ b/Dalamud/Interface/GameFonts/GameFontHandle.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using System.Threading.Tasks;
 
 using Dalamud.Interface.ManagedFontAtlas;
 using Dalamud.Interface.ManagedFontAtlas.Internals;
@@ -29,6 +30,13 @@ public sealed class GameFontHandle : IFontHandle
     }
 
     /// <inheritdoc />
+    public event Action<IFontHandle> ImFontChanged
+    {
+        add => this.fontHandle.ImFontChanged += value;
+        remove => this.fontHandle.ImFontChanged -= value;
+    }
+
+    /// <inheritdoc />
     public Exception? LoadException => this.fontHandle.LoadException;
 
     /// <inheritdoc />
@@ -55,14 +63,20 @@ public sealed class GameFontHandle : IFontHandle
     /// <inheritdoc />
     public void Dispose() => this.fontHandle.Dispose();
 
+    /// <inheritdoc />
+    public IFontHandle.ImFontLocked Lock() => this.fontHandle.Lock();
+
     /// <summary>
     /// Pushes the font.
     /// </summary>
     /// <returns>An <see cref="IDisposable"/> that can be used to pop the font on dispose.</returns>
     public IDisposable Push() => this.fontHandle.Push();
-    
+
     /// <inheritdoc/>
     IFontHandle.FontPopper IFontHandle.Push() => this.fontHandle.Push();
+
+    /// <inheritdoc />
+    public Task<IFontHandle> WaitAsync() => this.fontHandle.WaitAsync();
 
     /// <summary>
     /// Creates a new <see cref="GameFontLayoutPlan.Builder"/>.<br />

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -725,13 +725,16 @@ internal class InterfaceManager : IDisposable, IServiceType
                     // Do not use DefaultFont, IconFont, and MonoFont.
                     // Use font handles directly.
 
+                    using var defaultFont = this.DefaultFontHandle.Lock();
+                    using var monoFont = this.MonoFontHandle.Lock();
+
                     // Fill missing glyphs in MonoFont from DefaultFont
-                    tk.CopyGlyphsAcrossFonts(this.DefaultFontHandle.ImFont, this.MonoFontHandle.ImFont, true);
+                    tk.CopyGlyphsAcrossFonts(defaultFont, monoFont, true);
 
                     // Update default font
                     unsafe
                     {
-                        ImGui.GetIO().NativePtr->FontDefault = this.DefaultFontHandle.ImFont;
+                        ImGui.GetIO().NativePtr->FontDefault = defaultFont;
                     }
 
                     // Broadcast to auto-rebuilding instances

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -231,6 +231,11 @@ internal class InterfaceManager : IDisposable, IServiceType
     public Task FontBuildTask => WhenFontsReady().dalamudAtlas!.BuildTask;
 
     /// <summary>
+    /// Gets the number of calls to <see cref="PresentDetour"/> so far.
+    /// </summary>
+    public long CumulativePresentCalls { get; private set; }
+
+    /// <summary>
     /// Dispose of managed and unmanaged resources.
     /// </summary>
     public void Dispose()
@@ -647,6 +652,8 @@ internal class InterfaceManager : IDisposable, IServiceType
      */
     private IntPtr PresentDetour(IntPtr swapChain, uint syncInterval, uint presentFlags)
     {
+        this.CumulativePresentCalls++;
+
         Debug.Assert(this.presentHook is not null, "How did PresentDetour get called when presentHook is null?");
         Debug.Assert(this.dalamudAtlas is not null, "dalamudAtlas should have been set already");
 

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/GamePrebakedFontsTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/GamePrebakedFontsTestWidget.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using System.Text;
+using System.Threading.Tasks;
 
 using Dalamud.Interface.GameFonts;
 using Dalamud.Interface.ManagedFontAtlas;
@@ -10,6 +12,8 @@ using Dalamud.Interface.Utility;
 using Dalamud.Utility;
 
 using ImGuiNET;
+
+using Serilog;
 
 namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
 
@@ -102,6 +106,10 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
                 "(Game)-[Font] {Test}. 0123456789!! <氣気气きキ기>。"u8,
                 minCapacity: 1024);
         }
+
+        ImGui.SameLine();
+        if (ImGui.Button("Test Lock"))
+            Task.Run(this.TestLock);
 
         fixed (byte* labelPtr = "Test Input"u8)
         {
@@ -209,5 +217,50 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
         this.fontHandles = null;
         this.privateAtlas?.Dispose();
         this.privateAtlas = null;
+    }
+
+    private async void TestLock()
+    {
+        if (this.fontHandles is not { } fontHandlesCopy)
+            return;
+
+        Log.Information($"{nameof(GamePrebakedFontsTestWidget)}: {nameof(this.TestLock)} waiting for build");
+
+        await using var garbage = new DisposeSafety.ScopedFinalizer();
+        var fonts = new List<ImFontPtr>();
+        IFontHandle[] handles;
+        try
+        {
+            handles = fontHandlesCopy.Values.SelectMany(x => x).Select(x => x.Handle.Value).ToArray();
+            foreach (var handle in handles)
+            {
+                await handle.WaitAsync();
+                var locked = handle.Lock();
+                garbage.Add(locked);
+                fonts.Add(locked);
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            Log.Information($"{nameof(GamePrebakedFontsTestWidget)}: {nameof(this.TestLock)} cancelled");
+            return;
+        }
+
+        Log.Information($"{nameof(GamePrebakedFontsTestWidget)}: {nameof(this.TestLock)} waiting in lock");
+        await Task.Delay(5000);
+
+        foreach (var (font, handle) in fonts.Zip(handles))
+            TestSingle(font, handle);
+
+        return;
+
+        unsafe void TestSingle(ImFontPtr fontPtr, IFontHandle handle)
+        {
+            var dim = default(Vector2);
+            var test = "Test string"u8;
+            fixed (byte* pTest = test)
+                ImGuiNative.ImFont_CalcTextSizeA(&dim, fontPtr, fontPtr.FontSize, float.MaxValue, 0, pTest, null, null);
+            Log.Information($"{nameof(GamePrebakedFontsTestWidget)}: {handle} => {dim}");
+        }
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/GamePrebakedFontsTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/GamePrebakedFontsTestWidget.cs
@@ -163,6 +163,7 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
                           .ToArray());
 
         var offsetX = ImGui.CalcTextSize("99.9pt").X + (ImGui.GetStyle().FramePadding.X * 2);
+        var counter = 0;
         foreach (var (family, items) in this.fontHandles)
         {
             if (!ImGui.CollapsingHeader($"{family} Family"))
@@ -188,10 +189,21 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
                     {
                         if (!this.useGlobalScale)
                             ImGuiNative.igSetWindowFontScale(1 / ImGuiHelpers.GlobalScale);
-                        using var pushPop = handle.Value.Push();
-                        ImGuiNative.igTextUnformatted(
-                            this.testStringBuffer.Data,
-                            this.testStringBuffer.Data + this.testStringBuffer.Length);
+                        if (counter++ % 2 == 0)
+                        {
+                            using var pushPop = handle.Value.Push();
+                            ImGuiNative.igTextUnformatted(
+                                this.testStringBuffer.Data,
+                                this.testStringBuffer.Data + this.testStringBuffer.Length);
+                        }
+                        else
+                        {
+                            handle.Value.Push();
+                            ImGuiNative.igTextUnformatted(
+                                this.testStringBuffer.Data,
+                                this.testStringBuffer.Data + this.testStringBuffer.Length);
+                            handle.Value.Pop();
+                        }
                     }
                 }
                 finally

--- a/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs
@@ -69,6 +69,7 @@ internal class SettingsWindow : Window
         var fontAtlasFactory = Service<FontAtlasFactory>.Get();
 
         var rebuildFont = fontAtlasFactory.UseAxis != configuration.UseAxisFontsFromGame;
+        rebuildFont |= !Equals(ImGui.GetIO().FontGlobalScale, configuration.GlobalUiScale);
 
         ImGui.GetIO().FontGlobalScale = configuration.GlobalUiScale;
         fontAtlasFactory.UseAxisOverride = null;

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlas.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlas.cs
@@ -122,6 +122,10 @@ public interface IFontAtlas : IDisposable
     /// Note that <see cref="BuildTask"/> would not necessarily get changed from calling this function.
     /// </summary>
     /// <exception cref="InvalidOperationException">If <see cref="AutoRebuildMode"/> is <see cref="FontAtlasAutoRebuildMode.Async"/>.</exception>
+    /// <remarks>
+    /// Using this method will block the main thread on rebuilding fonts, effectively calling
+    /// <see cref="BuildFontsImmediately"/> from the main thread. Consider migrating to <see cref="BuildFontsAsync"/>.
+    /// </remarks>
     void BuildFontsOnNextFrame();
 
     /// <summary>

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPreBuild.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPreBuild.cs
@@ -54,11 +54,11 @@ public interface IFontAtlasBuildToolkitPreBuild : IFontAtlasBuildToolkit
 
     /// <summary>
     /// Adds a font from memory region allocated using <see cref="ImGuiHelpers.AllocateMemory"/>.<br />
-    /// <strong>It WILL crash if you try to use a memory pointer allocated in some other way.</strong><br />
-    /// <strong>
+    /// <b>It WILL crash if you try to use a memory pointer allocated in some other way.</b><br />
+    /// <b>
     /// Do NOT call <see cref="ImGuiNative.igMemFree"/> on the <paramref name="dataPointer"/> once this function has
     /// been called, unless <paramref name="freeOnException"/> is set and the function has thrown an error.
-    /// </strong>
+    /// </b>
     /// </summary>
     /// <param name="dataPointer">Memory address for the data allocated using <see cref="ImGuiHelpers.AllocateMemory"/>.</param>
     /// <param name="dataSize">The size of the font file..</param>
@@ -81,9 +81,11 @@ public interface IFontAtlasBuildToolkitPreBuild : IFontAtlasBuildToolkit
 
     /// <summary>
     /// Adds a font from memory region allocated using <see cref="ImGuiHelpers.AllocateMemory"/>.<br />
-    /// <strong>It WILL crash if you try to use a memory pointer allocated in some other way.</strong><br />
-    /// <strong>Do NOT call <see cref="ImGuiNative.igMemFree"/> on the <paramref name="dataPointer"/> once this
-    /// function has been called.</strong>
+    /// <b>It WILL crash if you try to use a memory pointer allocated in some other way.</b><br />
+    /// <b>
+    /// Do NOT call <see cref="ImGuiNative.igMemFree"/> on the <paramref name="dataPointer"/> once this function has
+    /// been called, unless <paramref name="freeOnException"/> is set and the function has thrown an error.
+    /// </b>
     /// </summary>
     /// <param name="dataPointer">Memory address for the data allocated using <see cref="ImGuiHelpers.AllocateMemory"/>.</param>
     /// <param name="dataSize">The size of the font file..</param>

--- a/Dalamud/Interface/ManagedFontAtlas/IFontHandle.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontHandle.cs
@@ -1,4 +1,6 @@
-﻿using Dalamud.Utility;
+﻿using System.Threading.Tasks;
+
+using Dalamud.Utility;
 
 using ImGuiNET;
 
@@ -10,6 +12,11 @@ namespace Dalamud.Interface.ManagedFontAtlas;
 public interface IFontHandle : IDisposable
 {
     /// <summary>
+    /// Called when the built instance of <see cref="ImFontPtr"/> has been changed.
+    /// </summary>
+    event Action<IFontHandle> ImFontChanged;
+
+    /// <summary>
     /// Represents a reference counting handle for fonts. Dalamud internal use only.
     /// </summary>
     internal interface IInternal : IFontHandle
@@ -18,7 +25,8 @@ public interface IFontHandle : IDisposable
         /// Gets the font.<br />
         /// Use of this properly is safe only from the UI thread.<br />
         /// Use <see cref="IFontHandle.Push"/> if the intended purpose of this property is <see cref="ImGui.PushFont"/>.<br />
-        /// Futures changes may make simple <see cref="ImGui.PushFont"/> not enough.
+        /// Futures changes may make simple <see cref="ImGui.PushFont"/> not enough.<br />
+        /// If you need to access a font outside the UI thread, consider using <see cref="IFontHandle.Lock"/>.
         /// </summary>
         ImFontPtr ImFont { get; }
     }
@@ -29,10 +37,26 @@ public interface IFontHandle : IDisposable
     Exception? LoadException { get; }
 
     /// <summary>
-    /// Gets a value indicating whether this font is ready for use.<br />
-    /// Use <see cref="Push"/> directly if you want to keep the current ImGui font if the font is not ready.
+    /// Gets a value indicating whether this font is ready for use.
     /// </summary>
+    /// <remarks>
+    /// Once set to <c>true</c>, it will remain <c>true</c>.<br />
+    /// Use <see cref="Push"/> directly if you want to keep the current ImGui font if the font is not ready.<br />
+    /// Alternatively, use <see cref="WaitAsync"/> to wait for this property to become <c>true</c>.
+    /// </remarks>
     bool Available { get; }
+
+    /// <summary>
+    /// Locks the fully constructed instance of <see cref="ImFontPtr"/> corresponding to the this
+    /// <see cref="IFontHandle"/>, for <b>read-only</b> use in any thread.
+    /// </summary>
+    /// <returns>An instance of <see cref="ImFontLocked"/> that <b>must</b> be disposed after use.</returns>
+    /// <remarks>
+    /// Calling <see cref="IFontHandle"/>.<see cref="IDisposable.Dispose"/> will not unlock the <see cref="ImFontPtr"/>
+    /// locked by this function.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">If <see cref="Available"/> is <c>false</c>.</exception>
+    ImFontLocked Lock();
 
     /// <summary>
     /// Pushes the current font into ImGui font stack using <see cref="ImGui.PushFont"/>, if available.<br />
@@ -46,6 +70,54 @@ public interface IFontHandle : IDisposable
     /// Should you store or transfer the return value to somewhere else, use <see cref="IDisposable"/> as the type.
     /// </remarks>
     FontPopper Push();
+
+    /// <summary>
+    /// Waits for <see cref="Available"/> to become <c>true</c>.
+    /// </summary>
+    /// <returns>A task containing this <see cref="IFontHandle"/>.</returns>
+    Task<IFontHandle> WaitAsync();
+
+    /// <summary>
+    /// The wrapper for <see cref="ImFontPtr"/>, guaranteeing that the associated data will be available as long as
+    /// this struct is not disposed.
+    /// </summary>
+    public struct ImFontLocked : IDisposable
+    {
+        /// <summary>
+        /// The associated <see cref="ImFontPtr"/>.
+        /// </summary>
+        public ImFontPtr ImFont;
+
+        private IRefCountable? owner;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImFontLocked"/> struct,
+        /// and incrase the reference count of <paramref name="owner"/>.
+        /// </summary>
+        /// <param name="imFont">The contained font.</param>
+        /// <param name="owner">The owner.</param>
+        internal ImFontLocked(ImFontPtr imFont, IRefCountable owner)
+        {
+            owner.AddRef();
+            this.ImFont = imFont;
+            this.owner = owner;
+        }
+
+        public static implicit operator ImFontPtr(ImFontLocked l) => l.ImFont;
+
+        public static unsafe implicit operator ImFont*(ImFontLocked l) => l.ImFont.NativePtr;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (this.owner is null)
+                return;
+
+            this.owner.Release();
+            this.owner = null;
+            this.ImFont = default;
+        }
+    }
 
     /// <summary>
     /// The wrapper for popping fonts.

--- a/Dalamud/Interface/ManagedFontAtlas/IFontHandle.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontHandle.cs
@@ -12,7 +12,12 @@ namespace Dalamud.Interface.ManagedFontAtlas;
 public interface IFontHandle : IDisposable
 {
     /// <summary>
-    /// Called when the built instance of <see cref="ImFontPtr"/> has been changed.
+    /// Called when the built instance of <see cref="ImFontPtr"/> has been changed.<br />
+    /// This event will be invoked on the same thread with
+    /// <see cref="IFontAtlas"/>.<see cref="IFontAtlas.BuildStepChange"/>,
+    /// when the build step is <see cref="FontAtlasBuildStep.PostPromotion"/>.<br />
+    /// See <see cref="IFontAtlas.BuildFontsOnNextFrame"/>, <see cref="IFontAtlas.BuildFontsImmediately"/>, and
+    /// <see cref="IFontAtlas.BuildFontsAsync"/>.
     /// </summary>
     event Action<IFontHandle> ImFontChanged;
 

--- a/Dalamud/Interface/ManagedFontAtlas/IFontHandle.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontHandle.cs
@@ -53,7 +53,8 @@ public interface IFontHandle : IDisposable
 
     /// <summary>
     /// Locks the fully constructed instance of <see cref="ImFontPtr"/> corresponding to the this
-    /// <see cref="IFontHandle"/>, for <b>read-only</b> use in any thread.
+    /// <see cref="IFontHandle"/>, for use in any thread.<br />
+    /// Modification of the font will exhibit undefined behavior if some other thread also uses the font.
     /// </summary>
     /// <returns>An instance of <see cref="ImFontLocked"/> that <b>must</b> be disposed after use.</returns>
     /// <remarks>

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/DelegateFontHandle.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/DelegateFontHandle.cs
@@ -2,11 +2,14 @@
 using System.Linq;
 using System.Threading.Tasks;
 
+using Dalamud.Interface.Internal;
 using Dalamud.Interface.Utility;
 using Dalamud.Logging.Internal;
 using Dalamud.Utility;
 
 using ImGuiNET;
+
+using Serilog;
 
 namespace Dalamud.Interface.ManagedFontAtlas.Internals;
 
@@ -15,7 +18,10 @@ namespace Dalamud.Interface.ManagedFontAtlas.Internals;
 /// </summary>
 internal class DelegateFontHandle : IFontHandle.IInternal
 {
+    private readonly List<IDisposable> pushedFonts = new(8);
+
     private IFontHandleManager? manager;
+    private long lastCumulativePresentCalls;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DelegateFontHandle"/> class.
@@ -53,6 +59,8 @@ internal class DelegateFontHandle : IFontHandle.IInternal
     /// <inheritdoc/>
     public void Dispose()
     {
+        if (this.pushedFonts.Count > 0)
+            Log.Warning($"{nameof(IFontHandle)}.{nameof(IDisposable.Dispose)}: fonts were still in a stack.");
         this.manager?.FreeFontHandle(this);
         this.manager = null;
         this.Disposed?.InvokeSafely(this);
@@ -96,7 +104,33 @@ internal class DelegateFontHandle : IFontHandle.IInternal
     }
 
     /// <inheritdoc/>
-    public IFontHandle.FontPopper Push() => new(this.ImFont, this.Available);
+    public IDisposable Push()
+    {
+        ThreadSafety.AssertMainThread();
+        var cumulativePresentCalls = Service<InterfaceManager>.GetNullable()?.CumulativePresentCalls ?? 0L;
+        if (this.lastCumulativePresentCalls != cumulativePresentCalls)
+        {
+            this.lastCumulativePresentCalls = cumulativePresentCalls;
+            if (this.pushedFonts.Count > 0)
+            {
+                Log.Warning(
+                    $"{nameof(this.Push)} has been called, but the handle-private stack was not empty. " +
+                    $"You might be missing a call to {nameof(this.Pop)}.");
+                this.pushedFonts.Clear();
+            }
+        }
+
+        var rented = SimplePushedFont.Rent(this.pushedFonts, this.ImFont, this.Available);
+        this.pushedFonts.Add(rented);
+        return rented;
+    }
+
+    /// <inheritdoc/>
+    public void Pop()
+    {
+        ThreadSafety.AssertMainThread();
+        this.pushedFonts[^1].Dispose();
+    }
 
     /// <inheritdoc/>
     public Task<IFontHandle> WaitAsync()

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/IFontHandleManager.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/IFontHandleManager.cs
@@ -1,3 +1,5 @@
+using Dalamud.Utility;
+
 namespace Dalamud.Interface.ManagedFontAtlas.Internals;
 
 /// <summary>
@@ -27,6 +29,12 @@ internal interface IFontHandleManager : IDisposable
     /// <summary>
     /// Creates a new substance of the font atlas.
     /// </summary>
+    /// <param name="dataRoot">The data root.</param>
     /// <returns>The new substance.</returns>
-    IFontHandleSubstance NewSubstance();
+    IFontHandleSubstance NewSubstance(IRefCountable dataRoot);
+
+    /// <summary>
+    /// Invokes <see cref="IFontHandle.ImFontChanged"/>.
+    /// </summary>
+    void InvokeFontHandleImFontChanged();
 }

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/IFontHandleSubstance.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/IFontHandleSubstance.cs
@@ -10,6 +10,11 @@ namespace Dalamud.Interface.ManagedFontAtlas.Internals;
 internal interface IFontHandleSubstance : IDisposable
 {
     /// <summary>
+    /// Gets the data root relevant to this instance of <see cref="IFontHandleSubstance"/>.
+    /// </summary>
+    IRefCountable DataRoot { get; }
+
+    /// <summary>
     /// Gets the manager relevant to this instance of <see cref="IFontHandleSubstance"/>.
     /// </summary>
     IFontHandleManager Manager { get; }

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/SimplePushedFont.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/SimplePushedFont.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Dalamud.Interface.Utility;
+
+using ImGuiNET;
+
+using Microsoft.Extensions.ObjectPool;
+
+using Serilog;
+
+namespace Dalamud.Interface.ManagedFontAtlas.Internals;
+
+/// <summary>
+/// Reusable font push/popper.
+/// </summary>
+internal sealed class SimplePushedFont : IDisposable
+{
+    // Using constructor instead of DefaultObjectPoolProvider, since we do not want the pool to call Dispose.
+    private static readonly ObjectPool<SimplePushedFont> Pool =
+        new DefaultObjectPool<SimplePushedFont>(new DefaultPooledObjectPolicy<SimplePushedFont>());
+
+    private List<IDisposable>? stack;
+    private ImFontPtr font;
+
+    /// <summary>
+    /// Pushes the font, and return an instance of <see cref="SimplePushedFont"/>.
+    /// </summary>
+    /// <param name="stack">The <see cref="IFontHandle"/>-private stack.</param>
+    /// <param name="fontPtr">The font pointer being pushed.</param>
+    /// <param name="push">Whether to push.</param>
+    /// <returns><c>this</c>.</returns>
+    public static SimplePushedFont Rent(List<IDisposable> stack, ImFontPtr fontPtr, bool push)
+    {
+        push &= !fontPtr.IsNull();
+
+        var rented = Pool.Get();
+        Debug.Assert(rented.font.IsNull(), "Rented object must not have its font set");
+        rented.stack = stack;
+
+        if (push)
+        {
+            rented.font = fontPtr;
+            ImGui.PushFont(fontPtr);
+        }
+
+        return rented;
+    }
+
+    /// <inheritdoc />
+    public unsafe void Dispose()
+    {
+        if (this.stack is null || !ReferenceEquals(this.stack[^1], this))
+        {
+            throw new InvalidOperationException("Tried to pop a non-pushed font.");
+        }
+
+        this.stack.RemoveAt(this.stack.Count - 1);
+
+        if (!this.font.IsNull())
+        {
+            if (ImGui.GetFont().NativePtr == this.font.NativePtr)
+            {
+                ImGui.PopFont();
+            }
+            else
+            {
+                Log.Warning(
+                    $"{nameof(IFontHandle.Pop)}: The font currently being popped does not match the pushed font. " +
+                    $"Doing nothing.");
+            }
+        }
+
+        this.font = default;
+        this.stack = null;
+        Pool.Return(this);
+    }
+}

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -140,9 +140,9 @@ public sealed class UiBuilder : IDisposable
     /// * <see cref="Interface.Internal.Windows.Data.Widgets.GamePrebakedFontsTestWidget"/>.<br />
     /// * <see cref="Interface.Internal.Windows.TitleScreenMenuWindow"/> ctor.<br />
     /// * <see cref="Interface.Internal.Windows.Settings.Tabs.SettingsTabAbout"/>:
-    /// note how a new instance of <see cref="IFontAtlas"/> is constructed, and
-    /// <see cref="IFontAtlas.NewGameFontHandle"/> is called from another function, without having to manually
-    /// initialize font rebuild process.
+    /// note how the construction of a new instance of <see cref="IFontAtlas"/> and
+    /// call of <see cref="IFontAtlas.NewGameFontHandle"/> are done in different functions,
+    /// without having to manually initiate font rebuild process.
     /// </remarks>
     [Obsolete("See remarks.", false)]
     [Api10ToDo(Api10ToDoAttribute.DeleteCompatBehavior)]

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -762,8 +762,10 @@ public sealed class UiBuilder : IDisposable
         public IFontHandle.ImFontLocked Lock() =>
             this.wrapped?.Lock() ?? throw new ObjectDisposedException(nameof(FontHandleWrapper));
 
-        public IFontHandle.FontPopper Push() => 
+        public IDisposable Push() => 
             this.wrapped?.Push() ?? throw new ObjectDisposedException(nameof(FontHandleWrapper));
+
+        public void Pop() => this.wrapped?.Pop();
 
         public Task<IFontHandle> WaitAsync() =>
             this.wrapped?.WaitAsync().ContinueWith(_ => (IFontHandle)this) ??

--- a/Dalamud/Storage/Assets/DalamudAssetManager.cs
+++ b/Dalamud/Storage/Assets/DalamudAssetManager.cs
@@ -69,6 +69,14 @@ internal sealed class DalamudAssetManager : IServiceType, IDisposable, IDalamudA
                         .Select(x => x.ToContentDisposedTask()))
                 .ContinueWith(_ => loadTimings.Dispose()),
             "Prevent Dalamud from loading more stuff, until we've ensured that all required assets are available.");
+
+        Task.WhenAll(
+            Enum.GetValues<DalamudAsset>()
+                .Where(x => x is not DalamudAsset.Empty4X4)
+                .Where(x => x.GetAttribute<DalamudAssetAttribute>()?.Required is false)
+                .Select(this.CreateStreamAsync)
+                .Select(x => x.ToContentDisposedTask()))
+            .ContinueWith(r => Log.Verbose($"Optional assets load state: {r}"));
     }
 
     /// <inheritdoc/>

--- a/Dalamud/Utility/IRefCountable.cs
+++ b/Dalamud/Utility/IRefCountable.cs
@@ -1,0 +1,77 @@
+using System.Diagnostics;
+using System.Threading;
+
+namespace Dalamud.Utility;
+
+/// <summary>
+/// Interface for reference counting.
+/// </summary>
+internal interface IRefCountable : IDisposable
+{
+    /// <summary>
+    /// Result for <see cref="IRefCountable.AlterRefCount"/>.
+    /// </summary>
+    public enum RefCountResult
+    {
+        /// <summary>
+        /// The object still has remaining references. No futher action should be done.
+        /// </summary>
+        StillAlive = 1,
+
+        /// <summary>
+        /// The last reference to the object has been released. The object should be fully released.
+        /// </summary>
+        FinalRelease = 2,
+
+        /// <summary>
+        /// The object already has been disposed. <see cref="ObjectDisposedException"/> may be thrown.
+        /// </summary>
+        AlreadyDisposed = 3,
+    }
+
+    /// <summary>
+    /// Adds a reference to this reference counted object.
+    /// </summary>
+    /// <returns>The new number of references.</returns>
+    int AddRef();
+
+    /// <summary>
+    /// Releases a reference from this reference counted object.<br />
+    /// When all references are released, the object will be fully disposed.
+    /// </summary>
+    /// <returns>The new number of references.</returns>
+    int Release();
+
+    /// <summary>
+    /// Alias for <see cref="Release()"/>.
+    /// </summary>
+    void IDisposable.Dispose() => this.Release();
+
+    /// <summary>
+    /// Alters <paramref name="refCount"/> by <paramref name="delta"/>.
+    /// </summary>
+    /// <param name="delta">The delta to the reference count.</param>
+    /// <param name="refCount">The reference to the reference count.</param>
+    /// <param name="newRefCount">The new reference count.</param>
+    /// <returns>The followup action that should be done.</returns>
+    public static RefCountResult AlterRefCount(int delta, ref int refCount, out int newRefCount)
+    {
+        Debug.Assert(delta is 1 or -1, "delta must be 1 or -1");
+
+        while (true)
+        {
+            var refCountCopy = refCount;
+            if (refCountCopy <= 0)
+            {
+                newRefCount = refCountCopy;
+                return RefCountResult.AlreadyDisposed;
+            }
+
+            newRefCount = refCountCopy + delta;
+            if (refCountCopy != Interlocked.CompareExchange(ref refCount, newRefCount, refCountCopy))
+                continue;
+
+            return newRefCount == 0 ? RefCountResult.FinalRelease : RefCountResult.StillAlive;
+        }
+    }
+}


### PR DESCRIPTION
[Context (Discord #plugin-dev)](https://discord.com/channels/581875019861328007/653504487352303619/1198290859343487038)

### Changes
* Added `Task<IFontHandle> IFontHandle.WaitAsync` so that a plugin can wait for a font to be loaded.
* Added `ImFontLocked IFontHandle.Lock()` so that a plugin can access a `ImFontPtr` from any thread in a safe manner. Intended usage is for use with `ImGuiNative.ImFont_CalcTextSizeA`.
    * Above two: see `GamePrebakedFontTestWidget.TestLock` for an example usage.
* Added `Action<IFontHandle> IFontHandle.ImFontChanged` which will be called upon the underlying built font changes.
* Added `dalamudPluginInterface.UiBuilder.DefaultFontHandle` which wraps `InterfaceManager.DefaultFontHandle`, so that `ImFontChanged` can be accessed for the default fonts.

### Changes (2)
* Turned back `IFontHandle.Push` to return an `IDisposable`, which will be pooled.
* Added `IFontHandle.Pop`.