### PR TITLE
Fix FontHandleWrapper and some docs

### DIFF
--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -744,10 +744,12 @@ public sealed class UiBuilder : IDisposable
 
         public event Action<IFontHandle>? ImFontChanged;
 
-        public Exception? LoadException =>
-            this.wrapped!.LoadException ?? new ObjectDisposedException(nameof(FontHandleWrapper));
+        public Exception? LoadException => this.WrappedNotDisposed.LoadException;
 
-        public bool Available => this.wrapped?.Available ?? false;
+        public bool Available => this.WrappedNotDisposed.Available;
+
+        private IFontHandle WrappedNotDisposed =>
+            this.wrapped ?? throw new ObjectDisposedException(nameof(FontHandleWrapper));
 
         public void Dispose()
         {
@@ -759,19 +761,17 @@ public sealed class UiBuilder : IDisposable
             // Note: do not dispose w; we do not own it
         }
 
-        public IFontHandle.ImFontLocked Lock() =>
-            this.wrapped?.Lock() ?? throw new ObjectDisposedException(nameof(FontHandleWrapper));
+        public IFontHandle.ImFontLocked Lock() => this.WrappedNotDisposed.Lock();
 
-        public IDisposable Push() => 
-            this.wrapped?.Push() ?? throw new ObjectDisposedException(nameof(FontHandleWrapper));
+        public IDisposable Push() => this.WrappedNotDisposed.Push();
 
-        public void Pop() => this.wrapped?.Pop();
+        public void Pop() => this.WrappedNotDisposed.Pop();
 
         public Task<IFontHandle> WaitAsync() =>
-            this.wrapped?.WaitAsync().ContinueWith(_ => (IFontHandle)this) ??
-            throw new ObjectDisposedException(nameof(FontHandleWrapper));
+            this.WrappedNotDisposed.WaitAsync().ContinueWith(_ => (IFontHandle)this);
 
-        public override string ToString() => $"{nameof(FontHandleWrapper)}({this.wrapped})";
+        public override string ToString() =>
+            $"{nameof(FontHandleWrapper)}({this.wrapped?.ToString() ?? "disposed"})";
 
         private void WrappedOnImFontChanged(IFontHandle obj) => this.ImFontChanged.InvokeSafely(this);
     } 

--- a/Dalamud/Storage/Assets/IDalamudAssetManager.cs
+++ b/Dalamud/Storage/Assets/IDalamudAssetManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.Contracts;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -64,8 +65,9 @@ internal interface IDalamudAssetManager
     /// </summary>
     /// <param name="asset">The texture asset.</param>
     /// <param name="defaultWrap">The default return value, if the asset is not ready for whatever reason.</param>
-    /// <returns>The texture wrap.</returns>
+    /// <returns>The texture wrap. Can be <c>null</c> only if <paramref name="defaultWrap"/> is <c>null</c>.</returns>
     [Pure]
+    [return: NotNullIfNotNull(nameof(defaultWrap))]
     IDalamudTextureWrap? GetDalamudTextureWrap(DalamudAsset asset, IDalamudTextureWrap? defaultWrap);
 
     /// <summary>


### PR DESCRIPTION
* Fixed inconsistent behavior for disposed `FontHandleWrapper`, and let `LoadException` be null if it is null instead of throwing an `ObjectDisposedException`.
* Fixed interface definition for `IDalamudAssetManager.GetDalamudTextWrap` to signify that it can only be null under specific conditions. This is not ABI breaking.