### PR TITLE
Directly expose `CharacterData.ClassJob` from ClientStructs

### DIFF
--- a/Dalamud/Game/ClientState/Objects/Types/Character.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/Character.cs
@@ -67,6 +67,11 @@ public unsafe class Character : GameObject
     public byte ShieldPercentage => this.Struct->CharacterData.ShieldValue;
 
     /// <summary>
+    /// Gets the ClassJobID of this Chara.
+    /// </summary>
+    public byte ClassJobId => this.Struct->CharacterData.ClassJob;
+
+    /// <summary>
     /// Gets the ClassJob of this Chara.
     /// </summary>
     public ExcelResolver<ClassJob> ClassJob => new(this.Struct->CharacterData.ClassJob);


### PR DESCRIPTION
I know this is exposed through the ExcelResolver, but polling that on framework gets expensive quickly, as I found out more than half the time I spend resolving lumina sheets to get the very same value that's readily available. I don't really expect this to be merged, at the end of the day the scale of this performance difference is miniscule in comparison to ImGui shenanigans, but it's worth a shot.