### PR TITLE
Change "Enable AntiDebug" label to "Disable Debugging Protections" to make it clearer

### DIFF
--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -667,7 +667,7 @@ internal class DalamudInterface : IDisposable, IServiceType
                     }
 
                     var antiDebug = Service<AntiDebug>.Get();
-                    if (ImGui.MenuItem("Enable AntiDebug", null, antiDebug.IsEnabled))
+                    if (ImGui.MenuItem("Disable Debugging Protections", null, antiDebug.IsEnabled))
                     {
                         var newEnabled = !antiDebug.IsEnabled;
                         if (newEnabled)


### PR DESCRIPTION
You need to enable this to allow debugging, but the label has the negative which doesn't make sense.