### PR TITLE
Remove EnableWindowsTargeting from build.sh's run step

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,4 +59,4 @@ fi
 echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false /p:EnableWindowsTargeting=true -nologo -clp:NoSummary --verbosity quiet
-"$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- /p:EnableWindowsTargeting=true "$@"
+"$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"


### PR DESCRIPTION
This removes the property that shouldn't be there, because it was considered a target.