### PR TITLE
Fix language selector throwing a exception, use native name for Taiwan

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
@@ -31,17 +31,20 @@ public sealed class LanguageChooserSettingsEntry : SettingsEntry
         try
         {
             var locLanguagesList = new List<string>();
-            string locLanguage;
             foreach (var language in this.languages)
             {
-                if (language != "ko")
+                switch (language)
                 {
-                    locLanguage = CultureInfo.GetCultureInfo(language).NativeName;
-                    locLanguagesList.Add(char.ToUpper(locLanguage[0]) + locLanguage[1..]);
-                }
-                else
-                {
-                    locLanguagesList.Add("Korean");
+                    case "ko":
+                        locLanguagesList.Add("Korean");
+                        break;
+                    case "tw":
+                        locLanguagesList.Add("中華民國國語");
+                        break;
+                    default:
+                        string locLanguage = CultureInfo.GetCultureInfo(language).NativeName;
+                        locLanguagesList.Add(char.ToUpper(locLanguage[0]) + locLanguage[1..]);
+                        break;
                 }
             }
 


### PR DESCRIPTION
The language selector has only been showing language codes and not the actual language names since  dd0159ae5a2174819c1541644e5cdbd4ddd98a1d because "tw" (Taiwan Mandarin) was added and it's not supported by CultureInfo.

This adds a specific check like the language code to work around this and stop throwing exceptions. Also converts to a switch so it looks a bit nicer.