### PR TITLE
Make the crash handler work on wine properly

### DIFF
--- a/Dalamud.Boot/DalamudStartInfo.cpp
+++ b/Dalamud.Boot/DalamudStartInfo.cpp
@@ -68,10 +68,25 @@ void from_json(const nlohmann::json& json, DalamudStartInfo::ClientLanguage& val
     }
 }
 
+void from_json(const nlohmann::json& json, DalamudStartInfo::LoadMethod& value) {
+    if (json.is_number_integer()) {
+        value = static_cast<DalamudStartInfo::LoadMethod>(json.get<int>());
+
+    }
+    else if (json.is_string()) {
+        const auto langstr = unicode::convert<std::string>(json.get<std::string>(), &unicode::lower);
+        if (langstr == "entrypoint")
+            value = DalamudStartInfo::LoadMethod::Entrypoint;
+        else if (langstr == "inject")
+            value = DalamudStartInfo::LoadMethod::DllInject;
+    }
+}
+
 void from_json(const nlohmann::json& json, DalamudStartInfo& config) {
     if (!json.is_object())
         return;
 
+    config.DalamudLoadMethod = json.value("LoadMethod", config.DalamudLoadMethod);
     config.WorkingDirectory = json.value("WorkingDirectory", config.WorkingDirectory);
     config.ConfigurationPath = json.value("ConfigurationPath", config.ConfigurationPath);
     config.PluginDirectory = json.value("PluginDirectory", config.PluginDirectory);

--- a/Dalamud.Boot/DalamudStartInfo.h
+++ b/Dalamud.Boot/DalamudStartInfo.h
@@ -26,6 +26,13 @@ struct DalamudStartInfo {
     };
     friend void from_json(const nlohmann::json&, ClientLanguage&);
 
+    enum class LoadMethod : int {
+        Entrypoint,
+        DllInject,
+    };
+    friend void from_json(const nlohmann::json&, LoadMethod&);
+
+    LoadMethod DalamudLoadMethod = LoadMethod::Entrypoint;
     std::string WorkingDirectory;
     std::string ConfigurationPath;
     std::string PluginDirectory;

--- a/Dalamud.Boot/crashhandler_shared.h
+++ b/Dalamud.Boot/crashhandler_shared.h
@@ -14,6 +14,7 @@ struct exception_info
     CONTEXT ContextRecord;
     uint64_t nLifetime;
     HANDLE hThreadHandle;
+    HANDLE hEventHandle;
     DWORD dwStackTraceLength;
     DWORD dwTroubleshootingPackDataLength;
 };

--- a/Dalamud.Boot/dllmain.cpp
+++ b/Dalamud.Boot/dllmain.cpp
@@ -135,8 +135,6 @@ DWORD WINAPI InitializeImpl(LPVOID lpParam, HANDLE hMainThreadContinue) {
     logging::I("Initializing VEH...");
     if (g_startInfo.NoExceptionHandlers) {
         logging::W("=> Exception handlers are disabled from DalamudStartInfo.");
-    } else if (utils::is_running_on_wine()) {
-        logging::I("=> VEH was disabled, running on wine");
     } else if (g_startInfo.BootVehEnabled) {
         if (veh::add_handler(g_startInfo.BootVehFull, g_startInfo.WorkingDirectory))
             logging::I("=> Done!");

--- a/Dalamud.Boot/utils.cpp
+++ b/Dalamud.Boot/utils.cpp
@@ -578,23 +578,6 @@ std::vector<std::string> utils::get_env_list(const wchar_t* pcszName) {
     return res;
 }
 
-bool utils::is_running_on_wine() {
-    if (get_env<bool>(L"XL_WINEONLINUX"))
-        return true;
-    HMODULE hntdll = GetModuleHandleW(L"ntdll.dll");
-    if (!hntdll)
-        return true;
-    if (GetProcAddress(hntdll, "wine_get_version"))
-        return true;
-    if (GetProcAddress(hntdll, "wine_get_host_version"))
-        return true;
-    if (GetProcAddress(hntdll, "wine_server_call"))
-        return true;
-    if (GetProcAddress(hntdll, "wine_unix_to_nt_file_name"))
-        return true;
-    return false;
-}
-
 std::wstring utils::to_wstring(const std::string& str) {
     if (str.empty()) return std::wstring();
     size_t convertedChars = 0;

--- a/Dalamud.Boot/utils.cpp
+++ b/Dalamud.Boot/utils.cpp
@@ -595,6 +595,16 @@ bool utils::is_running_on_wine() {
     return false;
 }
 
+std::wstring utils::to_wstring(const std::string& str) {
+    if (str.empty()) return std::wstring();
+    size_t convertedChars = 0;
+    size_t newStrSize = str.size() + 1;
+    std::wstring wstr(newStrSize, L'\0');
+    mbstowcs_s(&convertedChars, &wstr[0], newStrSize, str.c_str(), _TRUNCATE);
+    wstr.resize(convertedChars - 1);
+    return wstr;
+}
+
 std::filesystem::path utils::get_module_path(HMODULE hModule) {
     std::wstring buf(MAX_PATH, L'\0');
     while (true) {

--- a/Dalamud.Boot/utils.h
+++ b/Dalamud.Boot/utils.h
@@ -264,8 +264,6 @@ namespace utils {
         return get_env_list<T>(unicode::convert<std::wstring>(pcszName).c_str());
     }
 
-    bool is_running_on_wine();
-
     std::wstring to_wstring(const std::string& str);
 
     std::filesystem::path get_module_path(HMODULE hModule);

--- a/Dalamud.Boot/utils.h
+++ b/Dalamud.Boot/utils.h
@@ -266,6 +266,8 @@ namespace utils {
 
     bool is_running_on_wine();
 
+    std::wstring to_wstring(const std::string& str);
+
     std::filesystem::path get_module_path(HMODULE hModule);
 
     /// @brief Find the game main window.

--- a/Dalamud.Boot/veh.cpp
+++ b/Dalamud.Boot/veh.cpp
@@ -101,8 +101,21 @@ bool is_ffxiv_address(const wchar_t* module_name, const DWORD64 address)
 
 static void append_injector_launch_args(std::vector<std::wstring>& args)
 {
-    args.emplace_back(L"-g");
-    args.emplace_back(utils::loaded_module::current_process().path().wstring());
+    args.emplace_back(L"--game=\"" + utils::loaded_module::current_process().path().wstring() + L"\"");
+    switch (g_startInfo.DalamudLoadMethod) {
+    case DalamudStartInfo::LoadMethod::Entrypoint:
+        args.emplace_back(L"--mode=entrypoint");
+        break;
+    case DalamudStartInfo::LoadMethod::DllInject:
+        args.emplace_back(L"--mode=inject");
+    }
+    args.emplace_back(L"--logpath=\"" + utils::to_wstring(g_startInfo.BootLogPath) + L"\"");
+    args.emplace_back(L"--dalamud-working-directory=\"" + utils::to_wstring(g_startInfo.WorkingDirectory) + L"\"");
+    args.emplace_back(L"--dalamud-configuration-path=\"" + utils::to_wstring(g_startInfo.ConfigurationPath) + L"\"");
+    args.emplace_back(L"--dalamud-plugin-directory=\"" + utils::to_wstring(g_startInfo.PluginDirectory) + L"\"");
+    args.emplace_back(L"--dalamud-asset-directory=\"" + utils::to_wstring(g_startInfo.AssetDirectory) + L"\"");
+    args.emplace_back(L"--dalamud-client-language=" + std::to_wstring(static_cast<int>(g_startInfo.Language)));
+    args.emplace_back(L"--dalamud-delay-initialize=" + std::to_wstring(g_startInfo.DelayInitializeMs));
     if (g_startInfo.BootShowConsole)
         args.emplace_back(L"--console");
     if (g_startInfo.BootEnableEtw)

--- a/Dalamud.Common/DalamudStartInfo.cs
+++ b/Dalamud.Common/DalamudStartInfo.cs
@@ -18,6 +18,11 @@ public record DalamudStartInfo
     }
 
     /// <summary>
+    /// Gets or sets the Dalamud load method.
+    /// </summary>
+    public LoadMethod LoadMethod { get; set; }
+
+    /// <summary>
     /// Gets or sets the working directory of the XIVLauncher installations.
     /// </summary>
     public string? WorkingDirectory { get; set; }

--- a/Dalamud.Common/LoadMethod.cs
+++ b/Dalamud.Common/LoadMethod.cs
@@ -1,0 +1,17 @@
+namespace Dalamud.Common;
+
+/// <summary>
+/// Enum describing the method Dalamud has been loaded.
+/// </summary>
+public enum LoadMethod
+{
+    /// <summary>
+    /// Load Dalamud by rewriting the games entrypoint.
+    /// </summary>
+    Entrypoint,
+
+    /// <summary>
+    /// Load Dalamud via DLL-injection.
+    /// </summary>
+    DllInject,
+}

--- a/Dalamud.Injector/EntryPoint.cs
+++ b/Dalamud.Injector/EntryPoint.cs
@@ -680,11 +680,11 @@ namespace Dalamud.Injector
             mode = mode == null ? "entrypoint" : mode.ToLowerInvariant();
             if (mode.Length > 0 && mode.Length <= 10 && "entrypoint"[0..mode.Length] == mode)
             {
-                mode = "entrypoint";
+                dalamudStartInfo.LoadMethod = LoadMethod.Entrypoint;
             }
             else if (mode.Length > 0 && mode.Length <= 6 && "inject"[0..mode.Length] == mode)
             {
-                mode = "inject";
+                dalamudStartInfo.LoadMethod = LoadMethod.DllInject;
             }
             else
             {
@@ -796,7 +796,7 @@ namespace Dalamud.Injector
                 noFixAcl,
                 p =>
                 {
-                    if (!withoutDalamud && mode == "entrypoint")
+                    if (!withoutDalamud && dalamudStartInfo.LoadMethod == LoadMethod.Entrypoint)
                     {
                         var startInfo = AdjustStartInfo(dalamudStartInfo, gamePath);
                         Log.Information("Using start info: {0}", JsonConvert.SerializeObject(startInfo));
@@ -813,7 +813,7 @@ namespace Dalamud.Injector
 
             Log.Verbose("Game process started with PID {0}", process.Id);
 
-            if (!withoutDalamud && mode == "inject")
+            if (!withoutDalamud && dalamudStartInfo.LoadMethod == LoadMethod.DllInject)
             {
                 var startInfo = AdjustStartInfo(dalamudStartInfo, gamePath);
                 Log.Information("Using start info: {0}", JsonConvert.SerializeObject(startInfo));

--- a/DalamudCrashHandler/DalamudCrashHandler.cpp
+++ b/DalamudCrashHandler/DalamudCrashHandler.cpp
@@ -612,7 +612,8 @@ void restart_game_using_injector(int nRadioButton, const std::vector<std::wstrin
     pathStr.resize(GetModuleFileNameExW(GetCurrentProcess(), GetModuleHandleW(nullptr), &pathStr[0], PATHCCH_MAX_CCH));
 
     std::vector<std::wstring> args;
-    args.emplace_back((std::filesystem::path(pathStr).parent_path() / L"Dalamud.Injector.exe").wstring());
+    std::wstring injectorPath = (std::filesystem::path(pathStr).parent_path() / L"Dalamud.Injector.exe").wstring();
+    args.emplace_back(L'\"' + injectorPath + L'\"');
     args.emplace_back(L"launch");
     switch (nRadioButton) {
         case IdRadioRestartWithout3pPlugins:
@@ -625,12 +626,11 @@ void restart_game_using_injector(int nRadioButton, const std::vector<std::wstrin
             args.emplace_back(L"--without-dalamud");
         break;
     }
-    args.emplace_back(L"--");
     args.insert(args.end(), launcherArgs.begin(), launcherArgs.end());
 
     std::wstring argstr;
     for (const auto& arg : args) {
-        argstr.append(escape_shell_arg(arg));
+        argstr.append(arg);
         argstr.push_back(L' ');
     }
     argstr.pop_back();
@@ -644,7 +644,7 @@ void restart_game_using_injector(int nRadioButton, const std::vector<std::wstrin
     si.wShowWindow = SW_SHOW;
 #endif
     PROCESS_INFORMATION pi{};
-    if (CreateProcessW(args[0].c_str(), &argstr[0], nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)) {
+    if (CreateProcessW(injectorPath.c_str(), &argstr[0], nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)) {
         CloseHandle(pi.hProcess);
         CloseHandle(pi.hThread);
     } else {

--- a/DalamudCrashHandler/DalamudCrashHandler.cpp
+++ b/DalamudCrashHandler/DalamudCrashHandler.cpp
@@ -992,7 +992,7 @@ int main() {
 
         int nButtonPressed = 0, nRadioButton = 0;
         if (FAILED(TaskDialogIndirect(&config, &nButtonPressed, &nRadioButton, nullptr))) {
-            ResumeThread(exinfo.hThreadHandle);
+            SetEvent(exinfo.hEventHandle);
         } else {
             switch (nButtonPressed) {
                 case IdButtonRestart:
@@ -1003,7 +1003,7 @@ int main() {
                 }
                 default:
                     if (attemptResume)
-                        ResumeThread(exinfo.hThreadHandle);
+                        SetEvent(exinfo.hEventHandle);
                     else
                         TerminateProcess(g_hProcess, exinfo.ExceptionRecord.ExceptionCode);
             }

--- a/DalamudCrashHandler/DalamudCrashHandler.cpp
+++ b/DalamudCrashHandler/DalamudCrashHandler.cpp
@@ -58,7 +58,7 @@ std::wstring u8_to_ws(const std::string& s) {
 }
 
 std::wstring get_window_string(HWND hWnd) {
-    std::wstring buf(GetWindowTextLengthW(hWnd), L'\0');
+    std::wstring buf(GetWindowTextLengthW(hWnd) + 1, L'\0');
     GetWindowTextW(hWnd, &buf[0], static_cast<int>(buf.size()));
     return buf;
 }

--- a/DalamudCrashHandler/DalamudCrashHandler.cpp
+++ b/DalamudCrashHandler/DalamudCrashHandler.cpp
@@ -840,7 +840,7 @@ int main() {
             log << std::format(L"Dump at: {}", dumpPath.wstring()) << std::endl;
         else
             log << std::format(L"Dump error: {}", dumpError) << std::endl;
-        log << L"Time: " << std::chrono::zoned_time{ std::chrono::current_zone(), std::chrono::system_clock::now() } << std::endl;
+        log << L"System Time: " << std::chrono::system_clock::now() << std::endl;
         log << L"\n" << stackTrace << std::endl;
 
         SymRefreshModuleList(GetCurrentProcess());


### PR DESCRIPTION
This includes a few fixes to make injector arg passing properly work (and passes in everything XL does).

VEH has been fully functional on wine 7+ from what I could gather (and the original Dalamud crash was into a VEH semi-stub on wine 6), however it currently chokes on `std::chrono::zoned_time`, which is only really used for debug logging and so it should be fine. 
In any case will try to get it fixed upstream.