### PR TITLE
Implement FontChooserDialog

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 
 using Dalamud.Game.Text;
+using Dalamud.Interface.FontIdentifier;
 using Dalamud.Interface.Internal.Windows.PluginInstaller;
 using Dalamud.Interface.Style;
 using Dalamud.IoC.Internal;
@@ -145,7 +146,13 @@ internal sealed class DalamudConfiguration : IServiceType, IDisposable
     /// <summary>
     /// Gets or sets a value indicating whether to use AXIS fonts from the game.
     /// </summary>
-    public bool UseAxisFontsFromGame { get; set; } = false;
+    [Obsolete($"See {nameof(DefaultFontId)}")]
+    public bool UseAxisFontsFromGame { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the default font ID.
+    /// </summary>
+    public IFontId? DefaultFontId { get; set; }
 
     /// <summary>
     /// Gets or sets the gamma value to apply for Dalamud fonts. Do not use.

--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -146,13 +146,13 @@ internal sealed class DalamudConfiguration : IServiceType, IDisposable
     /// <summary>
     /// Gets or sets a value indicating whether to use AXIS fonts from the game.
     /// </summary>
-    [Obsolete($"See {nameof(DefaultFontId)}")]
+    [Obsolete($"See {nameof(DefaultFontSpec)}")]
     public bool UseAxisFontsFromGame { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets the default font ID.
+    /// Gets or sets the default font spec.
     /// </summary>
-    public IFontId? DefaultFontId { get; set; }
+    public IFontSpec? DefaultFontSpec { get; set; }
 
     /// <summary>
     /// Gets or sets the gamma value to apply for Dalamud fonts. Do not use.

--- a/Dalamud/Interface/FontIdentifier/DalamudAssetFontAndFamilyId.cs
+++ b/Dalamud/Interface/FontIdentifier/DalamudAssetFontAndFamilyId.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+
+using Dalamud.Interface.ManagedFontAtlas;
+using Dalamud.Storage.Assets;
+
+using ImGuiNET;
+
+using Newtonsoft.Json;
+
+using TerraFX.Interop.DirectX;
+
+namespace Dalamud.Interface.FontIdentifier;
+
+/// <summary>
+/// Represents a font from Dalamud assets.
+/// </summary>
+public sealed class DalamudAssetFontAndFamilyId : IFontFamilyId, IFontId
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DalamudAssetFontAndFamilyId"/> class.
+    /// </summary>
+    /// <param name="asset">The font asset.</param>
+    public DalamudAssetFontAndFamilyId(DalamudAsset asset)
+    {
+        if (asset.GetPurpose() != DalamudAssetPurpose.Font)
+            throw new ArgumentOutOfRangeException(nameof(asset), asset, "The specified asset is not a font asset.");
+        this.Asset = asset;
+    }
+
+    /// <inheritdoc cref="IFontId.TypeName"/>
+    [JsonProperty]
+    public string TypeName => nameof(DalamudAssetFontAndFamilyId);
+
+    /// <summary>
+    /// Gets the font asset.
+    /// </summary>
+    [JsonProperty]
+    public DalamudAsset Asset { get; init; }
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public string EnglishName => $"Dalamud: {this.Asset}";
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public string LocalizedName => $"Dalamud: {this.Asset}";
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public IReadOnlyList<IFontId> Fonts => new List<IFontId> { this }.AsReadOnly();
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public IFontFamilyId Family => this;
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public int Weight => (int)DWRITE_FONT_WEIGHT.DWRITE_FONT_WEIGHT_NORMAL;
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public int Stretch => (int)DWRITE_FONT_STRETCH.DWRITE_FONT_STRETCH_NORMAL;
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public int Style => (int)DWRITE_FONT_STYLE.DWRITE_FONT_STYLE_NORMAL;
+
+    public static bool operator ==(DalamudAssetFontAndFamilyId? left, DalamudAssetFontAndFamilyId? right) =>
+        Equals(left, right);
+
+    public static bool operator !=(DalamudAssetFontAndFamilyId? left, DalamudAssetFontAndFamilyId? right) =>
+        !Equals(left, right);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is DalamudAssetFontAndFamilyId other && this.Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => (int)this.Asset;
+
+    /// <inheritdoc/>
+    public override string ToString() => $"{nameof(DalamudAssetFontAndFamilyId)}:{this.Asset}";
+
+    /// <inheritdoc/>
+    public int FindBestMatch(int weight, int stretch, int style) => 0;
+
+    /// <inheritdoc/>
+    public ImFontPtr AddToBuildToolkit(
+        IFontAtlasBuildToolkitPreBuild tk,
+        float sizePx,
+        ushort[]? glyphRanges,
+        ImFontPtr mergeFont) =>
+        tk.AddDalamudAssetFont(
+            this.Asset,
+            new()
+            {
+                SizePx = sizePx,
+                GlyphRanges = glyphRanges,
+                MergeFont = mergeFont,
+            });
+
+    private bool Equals(DalamudAssetFontAndFamilyId other) => this.Asset == other.Asset;
+}

--- a/Dalamud/Interface/FontIdentifier/DalamudAssetFontAndFamilyId.cs
+++ b/Dalamud/Interface/FontIdentifier/DalamudAssetFontAndFamilyId.cs
@@ -27,10 +27,6 @@ public sealed class DalamudAssetFontAndFamilyId : IFontFamilyId, IFontId
         this.Asset = asset;
     }
 
-    /// <inheritdoc cref="IFontId.TypeName"/>
-    [JsonProperty]
-    public string TypeName => nameof(DalamudAssetFontAndFamilyId);
-
     /// <summary>
     /// Gets the font asset.
     /// </summary>
@@ -43,7 +39,7 @@ public sealed class DalamudAssetFontAndFamilyId : IFontFamilyId, IFontId
 
     /// <inheritdoc/>
     [JsonIgnore]
-    public string LocalizedName => $"Dalamud: {this.Asset}";
+    public IReadOnlyDictionary<string, string>? LocaleNames => null;
 
     /// <inheritdoc/>
     [JsonIgnore]
@@ -84,19 +80,8 @@ public sealed class DalamudAssetFontAndFamilyId : IFontFamilyId, IFontId
     public int FindBestMatch(int weight, int stretch, int style) => 0;
 
     /// <inheritdoc/>
-    public ImFontPtr AddToBuildToolkit(
-        IFontAtlasBuildToolkitPreBuild tk,
-        float sizePx,
-        ushort[]? glyphRanges,
-        ImFontPtr mergeFont) =>
-        tk.AddDalamudAssetFont(
-            this.Asset,
-            new()
-            {
-                SizePx = sizePx,
-                GlyphRanges = glyphRanges,
-                MergeFont = mergeFont,
-            });
+    public ImFontPtr AddToBuildToolkit(IFontAtlasBuildToolkitPreBuild tk, in SafeFontConfig config) =>
+        tk.AddDalamudAssetFont(this.Asset, config);
 
     private bool Equals(DalamudAssetFontAndFamilyId other) => this.Asset == other.Asset;
 }

--- a/Dalamud/Interface/FontIdentifier/DalamudDefaultFontAndFamilyId.cs
+++ b/Dalamud/Interface/FontIdentifier/DalamudDefaultFontAndFamilyId.cs
@@ -24,17 +24,13 @@ public sealed class DalamudDefaultFontAndFamilyId : IFontId, IFontFamilyId
     {
     }
 
-    /// <inheritdoc cref="IFontId.TypeName"/>
-    [JsonProperty]
-    public string TypeName => nameof(DalamudDefaultFontAndFamilyId);
-
     /// <inheritdoc/>
     [JsonIgnore]
     public string EnglishName => "(Default)";
 
     /// <inheritdoc/>
     [JsonIgnore]
-    public string LocalizedName => "(Default)";
+    public IReadOnlyDictionary<string, string>? LocaleNames => null;
 
     /// <inheritdoc/>
     [JsonIgnore]
@@ -72,12 +68,8 @@ public sealed class DalamudDefaultFontAndFamilyId : IFontId, IFontFamilyId
     public override string ToString() => nameof(DalamudDefaultFontAndFamilyId);
 
     /// <inheritdoc/>
-    public ImFontPtr AddToBuildToolkit(
-        IFontAtlasBuildToolkitPreBuild tk,
-        float sizePx,
-        ushort[]? glyphRanges,
-        ImFontPtr mergeFont)
-        => tk.AddDalamudDefaultFont(sizePx, glyphRanges);
+    public ImFontPtr AddToBuildToolkit(IFontAtlasBuildToolkitPreBuild tk, in SafeFontConfig config)
+        => tk.AddDalamudDefaultFont(config.SizePx, config.GlyphRanges);
     // TODO: mergeFont
 
     /// <inheritdoc/>

--- a/Dalamud/Interface/FontIdentifier/DalamudDefaultFontAndFamilyId.cs
+++ b/Dalamud/Interface/FontIdentifier/DalamudDefaultFontAndFamilyId.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+
+using Dalamud.Interface.ManagedFontAtlas;
+
+using ImGuiNET;
+
+using Newtonsoft.Json;
+
+using TerraFX.Interop.DirectX;
+
+namespace Dalamud.Interface.FontIdentifier;
+
+/// <summary>
+/// Represents the default Dalamud font.
+/// </summary>
+public sealed class DalamudDefaultFontAndFamilyId : IFontId, IFontFamilyId
+{
+    /// <summary>
+    /// The shared instance of <see cref="DalamudDefaultFontAndFamilyId"/>.
+    /// </summary>
+    public static readonly DalamudDefaultFontAndFamilyId Instance = new();
+
+    private DalamudDefaultFontAndFamilyId()
+    {
+    }
+
+    /// <inheritdoc cref="IFontId.TypeName"/>
+    [JsonProperty]
+    public string TypeName => nameof(DalamudDefaultFontAndFamilyId);
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public string EnglishName => "(Default)";
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public string LocalizedName => "(Default)";
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public IFontFamilyId Family => this;
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public int Weight => (int)DWRITE_FONT_WEIGHT.DWRITE_FONT_WEIGHT_NORMAL;
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public int Stretch => (int)DWRITE_FONT_STRETCH.DWRITE_FONT_STRETCH_NORMAL;
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public int Style => (int)DWRITE_FONT_STYLE.DWRITE_FONT_STYLE_NORMAL;
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public IReadOnlyList<IFontId> Fonts => new List<IFontId> { this }.AsReadOnly();
+
+    public static bool operator ==(DalamudDefaultFontAndFamilyId? left, DalamudDefaultFontAndFamilyId? right) =>
+        left is null == right is null;
+
+    public static bool operator !=(DalamudDefaultFontAndFamilyId? left, DalamudDefaultFontAndFamilyId? right) =>
+        left is null != right is null;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is DalamudDefaultFontAndFamilyId;
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => 12345678;
+
+    /// <inheritdoc/>
+    public override string ToString() => nameof(DalamudDefaultFontAndFamilyId);
+
+    /// <inheritdoc/>
+    public ImFontPtr AddToBuildToolkit(
+        IFontAtlasBuildToolkitPreBuild tk,
+        float sizePx,
+        ushort[]? glyphRanges,
+        ImFontPtr mergeFont)
+        => tk.AddDalamudDefaultFont(sizePx, glyphRanges);
+    // TODO: mergeFont
+
+    /// <inheritdoc/>
+    public int FindBestMatch(int weight, int stretch, int style) => 0;
+}

--- a/Dalamud/Interface/FontIdentifier/GameFontAndFamilyId.cs
+++ b/Dalamud/Interface/FontIdentifier/GameFontAndFamilyId.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+
+using Dalamud.Interface.GameFonts;
+using Dalamud.Interface.ManagedFontAtlas;
+
+using ImGuiNET;
+
+using Newtonsoft.Json;
+
+using TerraFX.Interop.DirectX;
+
+namespace Dalamud.Interface.FontIdentifier;
+
+/// <summary>
+/// Represents a font from the game.
+/// </summary>
+public sealed class GameFontAndFamilyId : IFontId, IFontFamilyId
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GameFontAndFamilyId"/> class.
+    /// </summary>
+    /// <param name="family">The game font family.</param>
+    public GameFontAndFamilyId(GameFontFamily family) => this.GameFontFamily = family;
+
+    /// <inheritdoc cref="IFontId.TypeName"/>
+    [JsonProperty]
+    public string TypeName => nameof(GameFontAndFamilyId);
+
+    /// <summary>
+    /// Gets the game font family.
+    /// </summary>
+    [JsonProperty]
+    public GameFontFamily GameFontFamily { get; init; }
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public string EnglishName => $"Game: {Enum.GetName(this.GameFontFamily) ?? throw new NotSupportedException()}";
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public string LocalizedName => this.EnglishName;
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public IFontFamilyId Family => this;
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public int Weight => (int)DWRITE_FONT_WEIGHT.DWRITE_FONT_WEIGHT_NORMAL;
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public int Stretch => (int)DWRITE_FONT_STRETCH.DWRITE_FONT_STRETCH_NORMAL;
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public int Style => (int)DWRITE_FONT_STYLE.DWRITE_FONT_STYLE_NORMAL;
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public IReadOnlyList<IFontId> Fonts => new List<IFontId> { this }.AsReadOnly();
+
+    public static bool operator ==(GameFontAndFamilyId? left, GameFontAndFamilyId? right) => Equals(left, right);
+
+    public static bool operator !=(GameFontAndFamilyId? left, GameFontAndFamilyId? right) => !Equals(left, right);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) =>
+        ReferenceEquals(this, obj) || (obj is GameFontAndFamilyId other && this.Equals(other));
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => (int)this.GameFontFamily;
+
+    /// <inheritdoc/>
+    public int FindBestMatch(int weight, int stretch, int style) => 0;
+
+    /// <inheritdoc/>
+    public override string ToString() => $"{nameof(GameFontAndFamilyId)}:{this.GameFontFamily}";
+
+    /// <inheritdoc/>
+    public ImFontPtr AddToBuildToolkit(
+        IFontAtlasBuildToolkitPreBuild tk,
+        float sizePx,
+        ushort[]? glyphRanges, ImFontPtr mergeFont) =>
+        tk.AddGameGlyphs(new(this.GameFontFamily, sizePx), glyphRanges, mergeFont);
+    
+    private bool Equals(GameFontAndFamilyId other) => this.GameFontFamily == other.GameFontFamily;
+}

--- a/Dalamud/Interface/FontIdentifier/GameFontAndFamilyId.cs
+++ b/Dalamud/Interface/FontIdentifier/GameFontAndFamilyId.cs
@@ -22,10 +22,6 @@ public sealed class GameFontAndFamilyId : IFontId, IFontFamilyId
     /// <param name="family">The game font family.</param>
     public GameFontAndFamilyId(GameFontFamily family) => this.GameFontFamily = family;
 
-    /// <inheritdoc cref="IFontId.TypeName"/>
-    [JsonProperty]
-    public string TypeName => nameof(GameFontAndFamilyId);
-
     /// <summary>
     /// Gets the game font family.
     /// </summary>
@@ -38,7 +34,7 @@ public sealed class GameFontAndFamilyId : IFontId, IFontFamilyId
 
     /// <inheritdoc/>
     [JsonIgnore]
-    public string LocalizedName => this.EnglishName;
+    public IReadOnlyDictionary<string, string>? LocaleNames => null;
 
     /// <inheritdoc/>
     [JsonIgnore]
@@ -78,11 +74,8 @@ public sealed class GameFontAndFamilyId : IFontId, IFontFamilyId
     public override string ToString() => $"{nameof(GameFontAndFamilyId)}:{this.GameFontFamily}";
 
     /// <inheritdoc/>
-    public ImFontPtr AddToBuildToolkit(
-        IFontAtlasBuildToolkitPreBuild tk,
-        float sizePx,
-        ushort[]? glyphRanges, ImFontPtr mergeFont) =>
-        tk.AddGameGlyphs(new(this.GameFontFamily, sizePx), glyphRanges, mergeFont);
-    
+    public ImFontPtr AddToBuildToolkit(IFontAtlasBuildToolkitPreBuild tk, in SafeFontConfig config) =>
+        tk.AddGameGlyphs(new(this.GameFontFamily, config.SizePx), config.GlyphRanges, config.MergeFont);
+
     private bool Equals(GameFontAndFamilyId other) => this.GameFontFamily == other.GameFontFamily;
 }

--- a/Dalamud/Interface/FontIdentifier/IFontFamilyId.cs
+++ b/Dalamud/Interface/FontIdentifier/IFontFamilyId.cs
@@ -1,11 +1,9 @@
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 using Dalamud.Interface.GameFonts;
 using Dalamud.Utility;
 
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
@@ -15,15 +13,8 @@ namespace Dalamud.Interface.FontIdentifier;
 /// <summary>
 /// Represents a font family identifier.
 /// </summary>
-[JsonConverter(typeof(FontFamilyIdConverter))]
 public interface IFontFamilyId : IObjectWithLocalizableName
 {
-    /// <summary>
-    /// Gets the type name of the current object.
-    /// </summary>
-    [JsonProperty]
-    public string TypeName { get; }
-
     /// <summary>
     /// Gets the list of fonts under this family.
     /// </summary>
@@ -106,41 +97,5 @@ public interface IFontFamilyId : IObjectWithLocalizableName
         }
 
         return result;
-    }
-
-    /// <summary>
-    /// A class for properly de/serializing the outer class.
-    /// </summary>
-    private class FontFamilyIdConverter : JsonConverter<IFontFamilyId>
-    {
-        public override bool CanWrite => false;
-
-        public override bool CanRead => true;
-
-        public override void WriteJson(JsonWriter writer, IFontFamilyId? value, JsonSerializer serializer) =>
-            throw new NotSupportedException();
-
-        public override IFontFamilyId? ReadJson(
-            JsonReader reader, Type objectType, IFontFamilyId? existingValue, bool hasExistingValue,
-            JsonSerializer serializer)
-        {
-            var jsonObject = JObject.Load(reader);
-            existingValue = jsonObject["TypeName"]?.Value<string>() switch
-            {
-                nameof(SystemFontFamilyId) =>
-                    (IFontFamilyId)RuntimeHelpers.GetUninitializedObject(typeof(SystemFontFamilyId)),
-                nameof(GameFontAndFamilyId) =>
-                    (IFontFamilyId)RuntimeHelpers.GetUninitializedObject(typeof(GameFontAndFamilyId)),
-                nameof(DalamudDefaultFontAndFamilyId) =>
-                    (IFontFamilyId)RuntimeHelpers.GetUninitializedObject(typeof(DalamudDefaultFontAndFamilyId)),
-                nameof(DalamudAssetFontAndFamilyId) =>
-                    (IFontFamilyId)RuntimeHelpers.GetUninitializedObject(typeof(DalamudAssetFontAndFamilyId)),
-                _ => null,
-            };
-
-            if (existingValue is not null)
-                serializer.Populate(jsonObject.CreateReader(), existingValue);
-            return existingValue;
-        }
     }
 }

--- a/Dalamud/Interface/FontIdentifier/IFontFamilyId.cs
+++ b/Dalamud/Interface/FontIdentifier/IFontFamilyId.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+using Dalamud.Interface.GameFonts;
+using Dalamud.Utility;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
+
+namespace Dalamud.Interface.FontIdentifier;
+
+/// <summary>
+/// Represents a font family identifier.
+/// </summary>
+[JsonConverter(typeof(FontFamilyIdConverter))]
+public interface IFontFamilyId : IObjectWithLocalizableName
+{
+    /// <summary>
+    /// Gets the type name of the current object.
+    /// </summary>
+    [JsonProperty]
+    public string TypeName { get; }
+
+    /// <summary>
+    /// Gets the list of fonts under this family.
+    /// </summary>
+    [JsonIgnore]
+    IReadOnlyList<IFontId> Fonts { get; }
+
+    /// <summary>
+    /// Finds the index of the font inside <see cref="Fonts"/> that best matches the given parameters.
+    /// </summary>
+    /// <param name="weight">The weight of the font.</param>
+    /// <param name="stretch">The stretch of the font.</param>
+    /// <param name="style">The style of the font.</param>
+    /// <returns>The index of the font. Guaranteed to be a valid index.</returns>
+    int FindBestMatch(int weight, int stretch, int style);
+
+    /// <summary>
+    /// Gets the list of Dalamud-provided fonts.
+    /// </summary>
+    /// <returns>The list of fonts.</returns>
+    public static List<IFontFamilyId> ListDalamudFonts() =>
+        new()
+        {
+            new DalamudAssetFontAndFamilyId(DalamudAsset.NotoSansJpMedium),
+            new DalamudAssetFontAndFamilyId(DalamudAsset.InconsolataRegular),
+            new DalamudAssetFontAndFamilyId(DalamudAsset.FontAwesomeFreeSolid),
+        };
+
+    /// <summary>
+    /// Gets the list of Game-provided fonts.
+    /// </summary>
+    /// <returns>The list of fonts.</returns>
+    public static List<IFontFamilyId> ListGameFonts() => new()
+    {
+        new GameFontAndFamilyId(GameFontFamily.Axis),
+        new GameFontAndFamilyId(GameFontFamily.Jupiter),
+        new GameFontAndFamilyId(GameFontFamily.JupiterNumeric),
+        new GameFontAndFamilyId(GameFontFamily.Meidinger),
+        new GameFontAndFamilyId(GameFontFamily.MiedingerMid),
+        new GameFontAndFamilyId(GameFontFamily.TrumpGothic),
+    };
+
+    /// <summary>
+    /// Gets the list of System-provided fonts.
+    /// </summary>
+    /// <param name="refresh">If <c>true</c>, try to refresh the list.</param>
+    /// <returns>The list of fonts.</returns>
+    public static unsafe List<IFontFamilyId> ListSystemFonts(bool refresh)
+    {
+        using var dwf = default(ComPtr<IDWriteFactory>);
+        fixed (Guid* piid = &IID.IID_IDWriteFactory)
+        {
+            DirectX.DWriteCreateFactory(
+                DWRITE_FACTORY_TYPE.DWRITE_FACTORY_TYPE_SHARED,
+                piid,
+                (IUnknown**)dwf.GetAddressOf()).ThrowOnError();
+        }
+
+        using var sfc = default(ComPtr<IDWriteFontCollection>);
+        dwf.Get()->GetSystemFontCollection(sfc.GetAddressOf(), refresh).ThrowOnError();
+
+        var count = (int)sfc.Get()->GetFontFamilyCount();
+        var result = new List<IFontFamilyId>(count);
+        for (var i = 0; i < count; i++)
+        {
+            using var ff = default(ComPtr<IDWriteFontFamily>);
+            if (sfc.Get()->GetFontFamily((uint)i, ff.GetAddressOf()).FAILED)
+            {
+                // Ignore errors, if any
+                continue;
+            }
+
+            try
+            {
+                result.Add(SystemFontFamilyId.FromDWriteFamily(ff));
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// A class for properly de/serializing the outer class.
+    /// </summary>
+    private class FontFamilyIdConverter : JsonConverter<IFontFamilyId>
+    {
+        public override bool CanWrite => false;
+
+        public override bool CanRead => true;
+
+        public override void WriteJson(JsonWriter writer, IFontFamilyId? value, JsonSerializer serializer) =>
+            throw new NotSupportedException();
+
+        public override IFontFamilyId? ReadJson(
+            JsonReader reader, Type objectType, IFontFamilyId? existingValue, bool hasExistingValue,
+            JsonSerializer serializer)
+        {
+            var jsonObject = JObject.Load(reader);
+            existingValue = jsonObject["TypeName"]?.Value<string>() switch
+            {
+                nameof(SystemFontFamilyId) =>
+                    (IFontFamilyId)RuntimeHelpers.GetUninitializedObject(typeof(SystemFontFamilyId)),
+                nameof(GameFontAndFamilyId) =>
+                    (IFontFamilyId)RuntimeHelpers.GetUninitializedObject(typeof(GameFontAndFamilyId)),
+                nameof(DalamudDefaultFontAndFamilyId) =>
+                    (IFontFamilyId)RuntimeHelpers.GetUninitializedObject(typeof(DalamudDefaultFontAndFamilyId)),
+                nameof(DalamudAssetFontAndFamilyId) =>
+                    (IFontFamilyId)RuntimeHelpers.GetUninitializedObject(typeof(DalamudAssetFontAndFamilyId)),
+                _ => null,
+            };
+
+            if (existingValue is not null)
+                serializer.Populate(jsonObject.CreateReader(), existingValue);
+            return existingValue;
+        }
+    }
+}

--- a/Dalamud/Interface/FontIdentifier/IFontFamilyId.cs
+++ b/Dalamud/Interface/FontIdentifier/IFontFamilyId.cs
@@ -11,7 +11,8 @@ using TerraFX.Interop.Windows;
 namespace Dalamud.Interface.FontIdentifier;
 
 /// <summary>
-/// Represents a font family identifier.
+/// Represents a font family identifier.<br />
+/// Not intended for plugins to implement.
 /// </summary>
 public interface IFontFamilyId : IObjectWithLocalizableName
 {

--- a/Dalamud/Interface/FontIdentifier/IFontId.cs
+++ b/Dalamud/Interface/FontIdentifier/IFontId.cs
@@ -5,7 +5,8 @@ using ImGuiNET;
 namespace Dalamud.Interface.FontIdentifier;
 
 /// <summary>
-/// Represents a font identifier.
+/// Represents a font identifier.<br />
+/// Not intended for plugins to implement.
 /// </summary>
 public interface IFontId : IObjectWithLocalizableName
 {

--- a/Dalamud/Interface/FontIdentifier/IFontId.cs
+++ b/Dalamud/Interface/FontIdentifier/IFontId.cs
@@ -1,26 +1,14 @@
-using System.Runtime.CompilerServices;
-
 using Dalamud.Interface.ManagedFontAtlas;
 
 using ImGuiNET;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Dalamud.Interface.FontIdentifier;
 
 /// <summary>
 /// Represents a font identifier.
 /// </summary>
-[JsonConverter(typeof(FontIdConverter))]
 public interface IFontId : IObjectWithLocalizableName
 {
-    /// <summary>
-    /// Gets the type name of the current object.
-    /// </summary>
-    [JsonProperty]
-    string TypeName { get; }
-
     /// <summary>
     /// Gets the associated font family.
     /// </summary>
@@ -45,49 +33,7 @@ public interface IFontId : IObjectWithLocalizableName
     /// Adds this font to the given font build toolkit.
     /// </summary>
     /// <param name="tk">The font build toolkit.</param>
-    /// <param name="sizePx">The font size.</param>
-    /// <param name="glyphRanges">The glyph range.</param>
-    /// <param name="mergeFont">The font to merge to.</param>
+    /// <param name="config">The font configuration. Some parameters may be ignored.</param>
     /// <returns>The added font.</returns>
-    ImFontPtr AddToBuildToolkit(
-        IFontAtlasBuildToolkitPreBuild tk,
-        float sizePx,
-        ushort[]? glyphRanges = null,
-        ImFontPtr mergeFont = default);
-
-    /// <summary>
-    /// A class for properly de/serializing the outer class.
-    /// </summary>
-    private class FontIdConverter : JsonConverter<IFontId>
-    {
-        public override bool CanWrite => false;
-
-        public override bool CanRead => true;
-
-        public override void WriteJson(JsonWriter writer, IFontId? value, JsonSerializer serializer) =>
-            throw new NotSupportedException();
-
-        public override IFontId? ReadJson(
-            JsonReader reader, Type objectType, IFontId? existingValue, bool hasExistingValue,
-            JsonSerializer serializer)
-        {
-            var jsonObject = JObject.Load(reader);
-            existingValue = jsonObject["TypeName"]?.Value<string>() switch
-            {
-                nameof(SystemFontId) =>
-                    (IFontId)RuntimeHelpers.GetUninitializedObject(typeof(SystemFontId)),
-                nameof(GameFontAndFamilyId) =>
-                    (IFontId)RuntimeHelpers.GetUninitializedObject(typeof(GameFontAndFamilyId)),
-                nameof(DalamudDefaultFontAndFamilyId) =>
-                    (IFontId)RuntimeHelpers.GetUninitializedObject(typeof(DalamudDefaultFontAndFamilyId)),
-                nameof(DalamudAssetFontAndFamilyId) =>
-                    (IFontId)RuntimeHelpers.GetUninitializedObject(typeof(DalamudAssetFontAndFamilyId)),
-                _ => null,
-            };
-
-            if (existingValue is not null)
-                serializer.Populate(jsonObject.CreateReader(), existingValue);
-            return existingValue;
-        }
-    }
+    ImFontPtr AddToBuildToolkit(IFontAtlasBuildToolkitPreBuild tk, in SafeFontConfig config);
 }

--- a/Dalamud/Interface/FontIdentifier/IFontId.cs
+++ b/Dalamud/Interface/FontIdentifier/IFontId.cs
@@ -1,0 +1,93 @@
+using System.Runtime.CompilerServices;
+
+using Dalamud.Interface.ManagedFontAtlas;
+
+using ImGuiNET;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Dalamud.Interface.FontIdentifier;
+
+/// <summary>
+/// Represents a font identifier.
+/// </summary>
+[JsonConverter(typeof(FontIdConverter))]
+public interface IFontId : IObjectWithLocalizableName
+{
+    /// <summary>
+    /// Gets the type name of the current object.
+    /// </summary>
+    [JsonProperty]
+    string TypeName { get; }
+
+    /// <summary>
+    /// Gets the associated font family.
+    /// </summary>
+    IFontFamilyId Family { get; }
+
+    /// <summary>
+    /// Gets the font weight, ranging from 1 to 999.
+    /// </summary>
+    int Weight { get; }
+
+    /// <summary>
+    /// Gets the font stretch, ranging from 1 to 9.
+    /// </summary>
+    int Stretch { get; }
+
+    /// <summary>
+    /// Gets the font style. Treat as an opaque value.
+    /// </summary>
+    int Style { get; }
+
+    /// <summary>
+    /// Adds this font to the given font build toolkit.
+    /// </summary>
+    /// <param name="tk">The font build toolkit.</param>
+    /// <param name="sizePx">The font size.</param>
+    /// <param name="glyphRanges">The glyph range.</param>
+    /// <param name="mergeFont">The font to merge to.</param>
+    /// <returns>The added font.</returns>
+    ImFontPtr AddToBuildToolkit(
+        IFontAtlasBuildToolkitPreBuild tk,
+        float sizePx,
+        ushort[]? glyphRanges = null,
+        ImFontPtr mergeFont = default);
+
+    /// <summary>
+    /// A class for properly de/serializing the outer class.
+    /// </summary>
+    private class FontIdConverter : JsonConverter<IFontId>
+    {
+        public override bool CanWrite => false;
+
+        public override bool CanRead => true;
+
+        public override void WriteJson(JsonWriter writer, IFontId? value, JsonSerializer serializer) =>
+            throw new NotSupportedException();
+
+        public override IFontId? ReadJson(
+            JsonReader reader, Type objectType, IFontId? existingValue, bool hasExistingValue,
+            JsonSerializer serializer)
+        {
+            var jsonObject = JObject.Load(reader);
+            existingValue = jsonObject["TypeName"]?.Value<string>() switch
+            {
+                nameof(SystemFontId) =>
+                    (IFontId)RuntimeHelpers.GetUninitializedObject(typeof(SystemFontId)),
+                nameof(GameFontAndFamilyId) =>
+                    (IFontId)RuntimeHelpers.GetUninitializedObject(typeof(GameFontAndFamilyId)),
+                nameof(DalamudDefaultFontAndFamilyId) =>
+                    (IFontId)RuntimeHelpers.GetUninitializedObject(typeof(DalamudDefaultFontAndFamilyId)),
+                nameof(DalamudAssetFontAndFamilyId) =>
+                    (IFontId)RuntimeHelpers.GetUninitializedObject(typeof(DalamudAssetFontAndFamilyId)),
+                _ => null,
+            };
+
+            if (existingValue is not null)
+                serializer.Populate(jsonObject.CreateReader(), existingValue);
+            return existingValue;
+        }
+    }
+}

--- a/Dalamud/Interface/FontIdentifier/IFontSpec.cs
+++ b/Dalamud/Interface/FontIdentifier/IFontSpec.cs
@@ -1,0 +1,42 @@
+using Dalamud.Interface.ManagedFontAtlas;
+
+using ImGuiNET;
+
+namespace Dalamud.Interface.FontIdentifier;
+
+/// <summary>
+/// Represents a user's choice of font(s).
+/// </summary>
+public interface IFontSpec
+{
+    /// <summary>
+    /// Gets the font size in pixels.
+    /// </summary>
+    public float SizePx { get; }
+
+    /// <summary>
+    /// Gets the font size in points.
+    /// </summary>
+    public float SizePt { get; }
+
+    /// <summary>
+    /// Gets the line height in pixels.
+    /// </summary>
+    public float LineHeightPx { get; }
+
+    /// <summary>
+    /// Creates a font handle corresponding to this font specification.
+    /// </summary>
+    /// <param name="atlas">The atlas to bind this font handle to.</param>
+    /// <param name="callback">Optional callback to be called after creating the font handle.</param>
+    /// <returns>The new font handle.</returns>
+    public IFontHandle CreateFontHandle(IFontAtlas atlas, FontAtlasBuildStepDelegate? callback = null);
+
+    /// <summary>
+    /// Adds this font to the given font build toolkit.
+    /// </summary>
+    /// <param name="tk">The font build toolkit.</param>
+    /// <param name="mergeFont">The font to merge to.</param>
+    /// <returns>The added font.</returns>
+    public ImFontPtr AddToBuildToolkit(IFontAtlasBuildToolkitPreBuild tk, ImFontPtr mergeFont = default);
+}

--- a/Dalamud/Interface/FontIdentifier/IFontSpec.cs
+++ b/Dalamud/Interface/FontIdentifier/IFontSpec.cs
@@ -5,7 +5,8 @@ using ImGuiNET;
 namespace Dalamud.Interface.FontIdentifier;
 
 /// <summary>
-/// Represents a user's choice of font(s).
+/// Represents a user's choice of font(s).<br />
+/// Not intended for plugins to implement.
 /// </summary>
 public interface IFontSpec
 {

--- a/Dalamud/Interface/FontIdentifier/IFontSpec.cs
+++ b/Dalamud/Interface/FontIdentifier/IFontSpec.cs
@@ -12,17 +12,17 @@ public interface IFontSpec
     /// <summary>
     /// Gets the font size in pixels.
     /// </summary>
-    public float SizePx { get; }
+    float SizePx { get; }
 
     /// <summary>
     /// Gets the font size in points.
     /// </summary>
-    public float SizePt { get; }
+    float SizePt { get; }
 
     /// <summary>
     /// Gets the line height in pixels.
     /// </summary>
-    public float LineHeightPx { get; }
+    float LineHeightPx { get; }
 
     /// <summary>
     /// Creates a font handle corresponding to this font specification.
@@ -30,7 +30,7 @@ public interface IFontSpec
     /// <param name="atlas">The atlas to bind this font handle to.</param>
     /// <param name="callback">Optional callback to be called after creating the font handle.</param>
     /// <returns>The new font handle.</returns>
-    public IFontHandle CreateFontHandle(IFontAtlas atlas, FontAtlasBuildStepDelegate? callback = null);
+    IFontHandle CreateFontHandle(IFontAtlas atlas, FontAtlasBuildStepDelegate? callback = null);
 
     /// <summary>
     /// Adds this font to the given font build toolkit.
@@ -38,5 +38,12 @@ public interface IFontSpec
     /// <param name="tk">The font build toolkit.</param>
     /// <param name="mergeFont">The font to merge to.</param>
     /// <returns>The added font.</returns>
-    public ImFontPtr AddToBuildToolkit(IFontAtlasBuildToolkitPreBuild tk, ImFontPtr mergeFont = default);
+    ImFontPtr AddToBuildToolkit(IFontAtlasBuildToolkitPreBuild tk, ImFontPtr mergeFont = default);
+
+    /// <summary>
+    /// Represents this font specification, preferrably in the requested locale.
+    /// </summary>
+    /// <param name="localeCode">The locale code. Must be in lowercase(invariant).</param>
+    /// <returns>The value.</returns>
+    string ToLocalizedString(string localeCode);
 }

--- a/Dalamud/Interface/FontIdentifier/IObjectWithLocalizableName.cs
+++ b/Dalamud/Interface/FontIdentifier/IObjectWithLocalizableName.cs
@@ -26,7 +26,7 @@ public interface IObjectWithLocalizableName
     /// </summary>
     /// <param name="localeCode">The locale code. Must be in lowercase(invariant).</param>
     /// <returns>The value.</returns>
-    string GetLocaleName(string localeCode)
+    string GetLocalizedName(string localeCode)
     {
         if (this.LocaleNames is null)
             return this.EnglishName;

--- a/Dalamud/Interface/FontIdentifier/IObjectWithLocalizableName.cs
+++ b/Dalamud/Interface/FontIdentifier/IObjectWithLocalizableName.cs
@@ -1,0 +1,50 @@
+using Dalamud.Utility;
+
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
+
+namespace Dalamud.Interface.FontIdentifier;
+
+/// <summary>
+/// Represents an object with localizable names.
+/// </summary>
+public interface IObjectWithLocalizableName
+{
+    /// <summary>
+    /// Gets the name in English.
+    /// </summary>
+    string EnglishName { get; }
+
+    /// <summary>
+    /// Gets the name in the system language.
+    /// </summary>
+    string LocalizedName { get; }
+
+    /// <summary>
+    /// Gets the localized name, or the first name if unavailable.
+    /// </summary>
+    /// <param name="fn">The names.</param>
+    /// <param name="locales">The locales.</param>
+    /// <returns>The string in the first-matching locale, or the first string.</returns>
+    internal static unsafe string GetLocalizedNameOrFirst(IDWriteLocalizedStrings* fn, params string[] locales)
+    {
+        var index = 0u;
+        BOOL exists = false;
+        foreach (var locale in locales)
+        {
+            fixed (void* pName = locale)
+                fn->FindLocaleName((ushort*)pName, &index, &exists).ThrowOnError();
+            if (exists)
+                break;
+        }
+
+        if (!exists)
+            index = 0u;
+
+        var length = 0;
+        fn->GetStringLength(index, (uint*)&length).ThrowOnError();
+        var name = stackalloc char[length + 1];
+        fn->GetString(index, (ushort*)name, (uint)length + 1u).ThrowOnError();
+        return new(name, 0, length);
+    }
+}

--- a/Dalamud/Interface/FontIdentifier/SingleFontSpec.cs
+++ b/Dalamud/Interface/FontIdentifier/SingleFontSpec.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+
+using Dalamud.Interface.ManagedFontAtlas;
+using Dalamud.Interface.Utility;
+
+using ImGuiNET;
+
+using Newtonsoft.Json;
+
+namespace Dalamud.Interface.FontIdentifier;
+
+/// <summary>
+/// Represents a user's choice of a single font.
+/// </summary>
+[SuppressMessage(
+    "StyleCop.CSharp.OrderingRules",
+    "SA1206:Declaration keywords should follow order",
+    Justification = "public required")]
+public record SingleFontSpec : IFontSpec
+{
+    /// <summary>
+    /// Gets the font id.
+    /// </summary>
+    [JsonProperty]
+    public required IFontId FontId { get; init; }
+
+    /// <inheritdoc/>
+    [JsonProperty]
+    public float SizePx { get; init; } = 16;
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public float SizePt
+    {
+        get => (this.SizePx * 3) / 4;
+        init => this.SizePx = (value * 4) / 3;
+    }
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public float LineHeightPx => MathF.Round(this.SizePx * this.LineHeight);
+
+    /// <summary>
+    /// Gets the line height ratio to the font size.
+    /// </summary>
+    [JsonProperty]
+    public float LineHeight { get; init; } = 1f;
+
+    /// <summary>
+    /// Gets the glyph offset in pixels.
+    /// </summary>
+    [JsonProperty]
+    public Vector2 GlyphOffset { get; init; }
+
+    /// <summary>
+    /// Gets the glyph extra spacing in pixels.
+    /// </summary>
+    [JsonProperty]
+    public Vector2 GlyphExtraSpacing { get; init; }
+
+    /// <summary>
+    /// Gets the glyph ranges.
+    /// </summary>
+    [JsonProperty]
+    public ushort[]? GlyphRanges { get; init; }
+
+    /// <inheritdoc/>
+    public IFontHandle CreateFontHandle(IFontAtlas atlas, FontAtlasBuildStepDelegate? callback = null) =>
+        atlas.NewDelegateFontHandle(tk =>
+        {
+            tk.OnPreBuild(e => e.Font = this.AddToBuildToolkit(e));
+            callback?.Invoke(tk);
+        });
+
+    /// <inheritdoc/>
+    public ImFontPtr AddToBuildToolkit(IFontAtlasBuildToolkitPreBuild tk, ImFontPtr mergeFont = default)
+    {
+        var font = this.FontId.AddToBuildToolkit(
+            tk,
+            new()
+            {
+                SizePx = this.SizePx,
+                GlyphRanges = this.GlyphRanges,
+                GlyphOffset = this.GlyphOffset,
+                GlyphExtraSpacing = this.GlyphExtraSpacing,
+                MergeFont = mergeFont,
+            });
+
+        tk.RegisterPostBuild(
+            () =>
+            {
+                var roundUnit = tk.IsGlobalScaleIgnored(font) ? 1 : 1 / tk.Scale;
+                var newAscent = MathF.Round((font.Ascent * this.LineHeight) / roundUnit) * roundUnit;
+                var newFontSize = MathF.Round((font.FontSize * this.LineHeight) / roundUnit) * roundUnit;
+                var shiftDown = MathF.Round((newFontSize - font.FontSize) / 2f / roundUnit) * roundUnit;
+
+                font.Ascent = newAscent;
+                font.FontSize = newFontSize;
+                font.Descent = newFontSize - font.Ascent;
+                if (shiftDown != 0f)
+                {
+                    foreach (ref var glyphReal in font.GlyphsWrapped().DataSpan)
+                    {
+                        glyphReal.Y0 += shiftDown;
+                        glyphReal.Y1 += shiftDown;
+                    }
+                }
+            });
+
+        return font;
+    }
+}

--- a/Dalamud/Interface/FontIdentifier/SingleFontSpec.cs
+++ b/Dalamud/Interface/FontIdentifier/SingleFontSpec.cs
@@ -56,10 +56,10 @@ public record SingleFontSpec : IFontSpec
     public Vector2 GlyphOffset { get; init; }
 
     /// <summary>
-    /// Gets the glyph extra spacing in pixels.
+    /// Gets the letter spacing in pixels.
     /// </summary>
     [JsonProperty]
-    public Vector2 GlyphExtraSpacing { get; init; }
+    public float LetterSpacing { get; init; }
 
     /// <summary>
     /// Gets the glyph ranges.
@@ -74,11 +74,11 @@ public record SingleFontSpec : IFontSpec
         sb.Append(this.FontId.Family.GetLocalizedName(localeCode));
         sb.Append($"({this.FontId.GetLocalizedName(localeCode)}, {this.SizePt}pt");
         if (Math.Abs(this.LineHeight - 1f) > 0.000001f)
-            sb.Append($", L={this.LineHeight:0.##}");
+            sb.Append($", LH={this.LineHeight:0.##}");
         if (this.GlyphOffset != default)
             sb.Append($", O={this.GlyphOffset.X:0.##},{this.GlyphOffset.Y:0.##}");
-        if (this.GlyphExtraSpacing != default)
-            sb.Append($", S={this.GlyphExtraSpacing.X:0.##},{this.GlyphExtraSpacing.Y:0.##}");
+        if (this.LetterSpacing != 0f)
+            sb.Append($", LS={this.LetterSpacing:0.##}");
         sb.Append(')');
         return sb.ToString();
     }
@@ -130,7 +130,7 @@ public record SingleFontSpec : IFontSpec
                 }
 
                 // `/ roundUnit` = `* scale`
-                var dax = MathF.Round(this.GlyphExtraSpacing.X / roundUnit / roundUnit) * roundUnit;
+                var dax = MathF.Round(this.LetterSpacing / roundUnit / roundUnit) * roundUnit;
                 var dxy0 = this.GlyphOffset / roundUnit;
 
                 dxy0 /= roundUnit;

--- a/Dalamud/Interface/FontIdentifier/SingleFontSpec.cs
+++ b/Dalamud/Interface/FontIdentifier/SingleFontSpec.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using System.Text;
 
 using Dalamud.Interface.ManagedFontAtlas;
 using Dalamud.Interface.Utility;
@@ -65,6 +66,25 @@ public record SingleFontSpec : IFontSpec
     /// </summary>
     [JsonProperty]
     public ushort[]? GlyphRanges { get; init; }
+
+    /// <inheritdoc/>
+    public string ToLocalizedString(string localeCode)
+    {
+        var sb = new StringBuilder();
+        sb.Append(this.FontId.Family.GetLocalizedName(localeCode));
+        sb.Append($"({this.FontId.GetLocalizedName(localeCode)}, {this.SizePt}pt");
+        if (Math.Abs(this.LineHeight - 1f) > 0.000001f)
+            sb.Append($", L={this.LineHeight:0.##}");
+        if (this.GlyphOffset != default)
+            sb.Append($", O={this.GlyphOffset.X:0.##},{this.GlyphOffset.Y:0.##}");
+        if (this.GlyphExtraSpacing != default)
+            sb.Append($", S={this.GlyphExtraSpacing.X:0.##},{this.GlyphExtraSpacing.Y:0.##}");
+        sb.Append(')');
+        return sb.ToString();
+    }
+
+    /// <inheritdoc/>
+    public override string ToString() => this.ToLocalizedString("en");
 
     /// <inheritdoc/>
     public IFontHandle CreateFontHandle(IFontAtlas atlas, FontAtlasBuildStepDelegate? callback = null) =>

--- a/Dalamud/Interface/FontIdentifier/SystemFontFamilyId.cs
+++ b/Dalamud/Interface/FontIdentifier/SystemFontFamilyId.cs
@@ -1,0 +1,175 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+
+using Dalamud.Utility;
+
+using Newtonsoft.Json;
+
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
+
+namespace Dalamud.Interface.FontIdentifier;
+
+/// <summary>
+/// Represents a font from system.
+/// </summary>
+public sealed class SystemFontFamilyId : IFontFamilyId
+{
+    [JsonIgnore]
+    private IReadOnlyList<IFontId>? fontsLazy;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SystemFontFamilyId"/> class.
+    /// </summary>
+    /// <param name="englishName">The font name in English.</param>
+    /// <param name="localizedName">The localized font name for display purposes.</param>
+    public SystemFontFamilyId(string englishName, string localizedName)
+    {
+        this.EnglishName = englishName;
+        this.LocalizedName = localizedName;
+    }
+
+    /// <inheritdoc/>
+    [JsonProperty]
+    public string TypeName => nameof(SystemFontFamilyId);
+
+    /// <inheritdoc/>
+    [JsonProperty]
+    public string EnglishName { get; init; }
+
+    /// <inheritdoc/>
+    [JsonProperty]
+    public string LocalizedName { get; init; }
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public IReadOnlyList<IFontId> Fonts => this.fontsLazy ??= this.GetFonts();
+
+    public static bool operator ==(SystemFontFamilyId? left, SystemFontFamilyId? right) => Equals(left, right);
+
+    public static bool operator !=(SystemFontFamilyId? left, SystemFontFamilyId? right) => !Equals(left, right);
+
+    /// <inheritdoc/>
+    public int FindBestMatch(int weight, int stretch, int style)
+    {
+        using var matchingFont = default(ComPtr<IDWriteFont>);
+
+        var candidates = this.Fonts.ToList();
+        var minGap = int.MaxValue;
+        foreach (var c in candidates)
+            minGap = Math.Min(minGap, Math.Abs(c.Weight - weight));
+        candidates.RemoveAll(c => Math.Abs(c.Weight - weight) != minGap);
+
+        minGap = int.MaxValue;
+        foreach (var c in candidates)
+            minGap = Math.Min(minGap, Math.Abs(c.Stretch - stretch));
+        candidates.RemoveAll(c => Math.Abs(c.Stretch - stretch) != minGap);
+
+        if (candidates.Any(x => x.Style == style))
+            candidates.RemoveAll(x => x.Style != style);
+        else if (candidates.Any(x => x.Style == (int)DWRITE_FONT_STYLE.DWRITE_FONT_STYLE_NORMAL))
+            candidates.RemoveAll(x => x.Style != (int)DWRITE_FONT_STYLE.DWRITE_FONT_STYLE_NORMAL);
+
+        if (!candidates.Any())
+            return 0;
+
+        for (var i = 0; i < this.Fonts.Count; i++)
+        {
+            if (Equals(this.Fonts[i], candidates[0]))
+                return i;
+        }
+
+        return 0;
+    }
+
+    /// <inheritdoc/>
+    public override string ToString() => $"{nameof(SystemFontFamilyId)}:{this.EnglishName}";
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) =>
+        ReferenceEquals(this, obj) || (obj is SystemFontFamilyId other && this.Equals(other));
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => this.EnglishName.GetHashCode();
+
+    /// <summary>
+    /// Create a new instance of <see cref="SystemFontFamilyId"/> from an <see cref="IDWriteFontFamily"/>.
+    /// </summary>
+    /// <param name="family">The family.</param>
+    /// <returns>The new instance.</returns>
+    internal static unsafe SystemFontFamilyId FromDWriteFamily(ComPtr<IDWriteFontFamily> family)
+    {
+        using var fn = default(ComPtr<IDWriteLocalizedStrings>);
+        family.Get()->GetFamilyNames(fn.GetAddressOf()).ThrowOnError();
+        var en = IObjectWithLocalizableName.GetLocalizedNameOrFirst(fn, "en-us", "en");
+        var loc = IObjectWithLocalizableName.GetLocalizedNameOrFirst(
+            fn,
+            CultureInfo.CurrentUICulture.Name,
+            CultureInfo.CurrentUICulture.TwoLetterISOLanguageName);
+        return new(en, loc);
+    }
+
+    private unsafe IReadOnlyList<IFontId> GetFonts()
+    {
+        using var dwf = default(ComPtr<IDWriteFactory>);
+        fixed (Guid* piid = &IID.IID_IDWriteFactory)
+        {
+            DirectX.DWriteCreateFactory(
+                DWRITE_FACTORY_TYPE.DWRITE_FACTORY_TYPE_SHARED,
+                piid,
+                (IUnknown**)dwf.GetAddressOf()).ThrowOnError();
+        }
+
+        using var sfc = default(ComPtr<IDWriteFontCollection>);
+        dwf.Get()->GetSystemFontCollection(sfc.GetAddressOf(), false).ThrowOnError();
+
+        var familyIndex = 0u;
+        BOOL exists = false;
+        fixed (void* pName = this.EnglishName)
+            sfc.Get()->FindFamilyName((ushort*)pName, &familyIndex, &exists).ThrowOnError();
+        if (!exists)
+            throw new FileNotFoundException($"Font \"{this.EnglishName}\" not found.");
+
+        using var family = default(ComPtr<IDWriteFontFamily>);
+        sfc.Get()->GetFontFamily(familyIndex, family.GetAddressOf()).ThrowOnError();
+
+        var fontCount = (int)family.Get()->GetFontCount();
+        var fonts = new List<IFontId>(fontCount);
+        for (var i = 0; i < fontCount; i++)
+        {
+            using var font = default(ComPtr<IDWriteFont>);
+            if (family.Get()->GetFont((uint)i, font.GetAddressOf()).FAILED)
+            {
+                // Ignore errors, if any
+                continue;
+            }
+
+            if (font.Get()->GetSimulations() != DWRITE_FONT_SIMULATIONS.DWRITE_FONT_SIMULATIONS_NONE)
+            {
+                // No simulation support
+                continue;
+            }
+
+            fonts.Add(new SystemFontId(this, font));
+        }
+
+        fonts.Sort(
+            (a, b) =>
+            {
+                var comp = a.Weight.CompareTo(b.Weight);
+                if (comp != 0)
+                    return comp;
+
+                comp = a.Stretch.CompareTo(b.Stretch);
+                if (comp != 0)
+                    return comp;
+
+                return a.Style.CompareTo(b.Style);
+            });
+        return fonts;
+    }
+    
+    private bool Equals(SystemFontFamilyId other) => this.EnglishName == other.EnglishName;
+}

--- a/Dalamud/Interface/FontIdentifier/SystemFontId.cs
+++ b/Dalamud/Interface/FontIdentifier/SystemFontId.cs
@@ -1,0 +1,164 @@
+using System.Globalization;
+using System.IO;
+
+using Dalamud.Interface.ManagedFontAtlas;
+using Dalamud.Utility;
+
+using ImGuiNET;
+
+using Newtonsoft.Json;
+
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
+
+namespace Dalamud.Interface.FontIdentifier;
+
+/// <summary>
+/// Represents a font installed in the system.
+/// </summary>
+public sealed class SystemFontId : IFontId
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SystemFontId"/> class.
+    /// </summary>
+    /// <param name="family">The parent font family.</param>
+    /// <param name="font">The font.</param>
+    internal unsafe SystemFontId(SystemFontFamilyId family, ComPtr<IDWriteFont> font)
+    {
+        this.Family = family;
+        this.Weight = (int)font.Get()->GetWeight();
+        this.Stretch = (int)font.Get()->GetStretch();
+        this.Style = (int)font.Get()->GetStyle();
+
+        using var fn = default(ComPtr<IDWriteLocalizedStrings>);
+        font.Get()->GetFaceNames(fn.GetAddressOf()).ThrowOnError();
+        this.EnglishName = IObjectWithLocalizableName.GetLocalizedNameOrFirst(fn, "en-us", "en");
+        this.LocalizedName = IObjectWithLocalizableName.GetLocalizedNameOrFirst(
+            fn,
+            CultureInfo.CurrentUICulture.Name,
+            CultureInfo.CurrentUICulture.TwoLetterISOLanguageName);
+    }
+
+    /// <inheritdoc/>
+    [JsonProperty]
+    public string TypeName => nameof(SystemFontId);
+
+    /// <inheritdoc/>
+    [JsonProperty]
+    public string EnglishName { get; init; }
+
+    /// <inheritdoc/>
+    [JsonProperty]
+    public string LocalizedName { get; init; }
+
+    /// <inheritdoc/>
+    [JsonProperty]
+    public IFontFamilyId Family { get; init; }
+
+    /// <inheritdoc/>
+    [JsonProperty]
+    public int Weight { get; init; }
+
+    /// <inheritdoc/>
+    [JsonProperty]
+    public int Stretch { get; init; }
+
+    /// <inheritdoc/>
+    [JsonProperty]
+    public int Style { get; init; }
+
+    public static bool operator ==(SystemFontId? left, SystemFontId? right) => Equals(left, right);
+
+    public static bool operator !=(SystemFontId? left, SystemFontId? right) => !Equals(left, right);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) =>
+        ReferenceEquals(this, obj) || (obj is SystemFontId other && this.Equals(other));
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(this.Family, this.Weight, this.Stretch, this.Style);
+
+    /// <inheritdoc/>
+    public override string ToString() =>
+        $"{nameof(SystemFontId)}:{this.Weight}:{this.Stretch}:{this.Style}:{this.Family}";
+
+    /// <inheritdoc/>
+    public ImFontPtr AddToBuildToolkit(
+        IFontAtlasBuildToolkitPreBuild tk, float sizePx, ushort[]? glyphRanges, ImFontPtr mergeFont)
+    {
+        var (path, index) = this.GetFileAndIndex();
+        return tk.AddFontFromFile(
+            path,
+            new()
+            {
+                FontNo = index,
+                SizePx = sizePx,
+                GlyphRanges = glyphRanges,
+                MergeFont = mergeFont,
+            });
+    }
+
+    /// <summary>
+    /// Gets the file containing this font, and the font index within.
+    /// </summary>
+    /// <returns>The path and index.</returns>
+    public unsafe (string Path, int Index) GetFileAndIndex()
+    {
+        using var dwf = default(ComPtr<IDWriteFactory>);
+        fixed (Guid* piid = &IID.IID_IDWriteFactory)
+        {
+            DirectX.DWriteCreateFactory(
+                DWRITE_FACTORY_TYPE.DWRITE_FACTORY_TYPE_SHARED,
+                piid,
+                (IUnknown**)dwf.GetAddressOf()).ThrowOnError();
+        }
+
+        using var sfc = default(ComPtr<IDWriteFontCollection>);
+        dwf.Get()->GetSystemFontCollection(sfc.GetAddressOf(), false).ThrowOnError();
+
+        var familyIndex = 0u;
+        BOOL exists = false;
+        fixed (void* name = this.Family.EnglishName)
+            sfc.Get()->FindFamilyName((ushort*)name, &familyIndex, &exists).ThrowOnError();
+        if (!exists)
+            throw new FileNotFoundException($"Font \"{this.Family.EnglishName}\" not found.");
+
+        using var family = default(ComPtr<IDWriteFontFamily>);
+        sfc.Get()->GetFontFamily(familyIndex, family.GetAddressOf()).ThrowOnError();
+
+        using var font = default(ComPtr<IDWriteFont>);
+        family.Get()->GetFirstMatchingFont(
+            (DWRITE_FONT_WEIGHT)this.Weight,
+            (DWRITE_FONT_STRETCH)this.Stretch,
+            (DWRITE_FONT_STYLE)this.Style,
+            font.GetAddressOf()).ThrowOnError();
+
+        using var fface = default(ComPtr<IDWriteFontFace>);
+        font.Get()->CreateFontFace(fface.GetAddressOf()).ThrowOnError();
+        var fileCount = 0;
+        fface.Get()->GetFiles((uint*)&fileCount, null).ThrowOnError();
+        if (fileCount != 1)
+            throw new NotSupportedException();
+
+        using var ffile = default(ComPtr<IDWriteFontFile>);
+        fface.Get()->GetFiles((uint*)&fileCount, ffile.GetAddressOf()).ThrowOnError();
+        void* refKey;
+        var refKeySize = 0u;
+        ffile.Get()->GetReferenceKey(&refKey, &refKeySize).ThrowOnError();
+
+        using var floader = default(ComPtr<IDWriteFontFileLoader>);
+        ffile.Get()->GetLoader(floader.GetAddressOf()).ThrowOnError();
+
+        using var flocal = default(ComPtr<IDWriteLocalFontFileLoader>);
+        floader.As(&flocal).ThrowOnError();
+
+        var pathSize = 0u;
+        flocal.Get()->GetFilePathLengthFromKey(refKey, refKeySize, &pathSize).ThrowOnError();
+
+        var path = stackalloc char[(int)pathSize + 1];
+        flocal.Get()->GetFilePathFromKey(refKey, refKeySize, (ushort*)path, pathSize + 1).ThrowOnError();
+        return (new(path, 0, (int)pathSize), (int)fface.Get()->GetIndex());
+    }
+    
+    private bool Equals(SystemFontId other) => this.Family.Equals(other.Family) && this.Weight == other.Weight && this.Stretch == other.Stretch && this.Style == other.Style;
+}

--- a/Dalamud/Interface/ImGuiFontChooserDialog/FontChooserDialog.cs
+++ b/Dalamud/Interface/ImGuiFontChooserDialog/FontChooserDialog.cs
@@ -295,7 +295,7 @@ public sealed class FontChooserDialog : IDisposable
             changed |= this.DrawFontListColumn(changed);
 
             ImGui.TableNextColumn();
-            changed |= this.DrawSystemSizeListColumn();
+            changed |= this.DrawSizeListColumn();
 
             if ((changed || this.fontHandle is null) && this.SelectedFontId is { } fontId)
             {
@@ -445,7 +445,7 @@ public sealed class FontChooserDialog : IDisposable
                     return 0;
                 }))
         {
-            if (!string.IsNullOrWhiteSpace(this.familySearch))
+            if (!string.IsNullOrWhiteSpace(this.familySearch) && !changed)
             {
                 this.selectedFamilyIndex = families.FindIndex(x => this.TestName(x, this.familySearch));
                 changed = true;
@@ -612,7 +612,7 @@ public sealed class FontChooserDialog : IDisposable
                     return 0;
                 }))
         {
-            if (!string.IsNullOrWhiteSpace(this.fontSearch))
+            if (!string.IsNullOrWhiteSpace(this.fontSearch) && !changed)
             {
                 this.selectedFontIndex = fonts.FindIndex(x => this.TestName(x, this.fontSearch));
                 changed = true;
@@ -673,7 +673,7 @@ public sealed class FontChooserDialog : IDisposable
         return changed;
     }
 
-    private unsafe bool DrawSystemSizeListColumn()
+    private unsafe bool DrawSizeListColumn()
     {
         var changed = false;
         ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);

--- a/Dalamud/Interface/ImGuiFontChooserDialog/FontChooserDialog.cs
+++ b/Dalamud/Interface/ImGuiFontChooserDialog/FontChooserDialog.cs
@@ -1,0 +1,876 @@
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Dalamud.Interface.Colors;
+using Dalamud.Interface.FontIdentifier;
+using Dalamud.Interface.ManagedFontAtlas;
+using Dalamud.Interface.Utility;
+using Dalamud.Utility;
+
+using ImGuiNET;
+
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
+
+namespace Dalamud.Interface.ImGuiFontChooserDialog;
+
+/// <summary>
+/// A dialog for choosing a font and its size.
+/// </summary>
+public sealed class FontChooserDialog : IDisposable
+{
+    private static readonly List<IFontId> EmptyIFontList = new();
+
+    private static readonly (string Name, float Value)[] FontSizeList =
+    {
+        ("9.6", 9.6f),
+        ("10", 10f),
+        ("12", 12f),
+        ("14", 14f),
+        ("16", 16f),
+        ("18", 18f),
+        ("18.4", 18.4f),
+        ("20", 20),
+        ("23", 23),
+        ("34", 34),
+        ("36", 36),
+        ("40", 40),
+        ("45", 45),
+        ("46", 46),
+        ("68", 68),
+        ("90", 90),
+    };
+
+    private static int counterStatic;
+
+    private readonly int counter;
+    private readonly byte[] fontPreviewText = new byte[2048];
+    private readonly TaskCompletionSource<(IFontId Font, float SizePx)> tcs = new();
+    private readonly IFontAtlas atlas;
+
+    private string popupImGuiName;
+    private string title;
+
+    private bool firstDraw = true;
+    private bool firstDrawAfterRefresh;
+    private int setFocusOn = -1;
+
+    private Task<List<IFontFamilyId>>? fontFamilies;
+    private int selectedFamilyIndex = -1;
+    private int selectedFontIndex = -1;
+    private int selectedFontWeight = (int)DWRITE_FONT_WEIGHT.DWRITE_FONT_WEIGHT_NORMAL;
+    private int selectedFontStretch = (int)DWRITE_FONT_STRETCH.DWRITE_FONT_STRETCH_NORMAL;
+    private int selectedFontStyle = (int)DWRITE_FONT_STYLE.DWRITE_FONT_STYLE_NORMAL;
+
+    private string familySearch = string.Empty;
+    private string fontSearch = string.Empty;
+    private string fontSizeSearch = "12";
+    private IFontHandle? fontHandle;
+    private IFontId? selectedFontId;
+    private float fontSizePt = 12;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FontChooserDialog"/> class.
+    /// </summary>
+    /// <param name="newAsyncAtlas">A new instance of <see cref="IFontAtlas"/> created using
+    /// <see cref="FontAtlasAutoRebuildMode.Async"/> as its auto-rebuild mode.</param>
+    public FontChooserDialog(IFontAtlas newAsyncAtlas)
+    {
+        this.counter = Interlocked.Increment(ref counterStatic);
+        this.title = "Choose a font...";
+        this.popupImGuiName = $"{this.title}##{nameof(FontChooserDialog)}[{this.counter}]";
+        this.atlas = newAsyncAtlas;
+        Encoding.UTF8.GetBytes("Font preview. 0123456789", this.fontPreviewText);
+    }
+
+    /// <summary>
+    /// Gets or sets the title of this font chooser dialog popup.
+    /// </summary>
+    public string Title
+    {
+        get => this.title;
+        set
+        {
+            this.title = value;
+            this.popupImGuiName = $"{this.title}##{nameof(FontChooserDialog)}[{this.counter}]";
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the preview text. A text too long may be truncated on assignment.
+    /// </summary>
+    public string PreviewText
+    {
+        get
+        {
+            var n = this.fontPreviewText.AsSpan().IndexOf((byte)0);
+            return n < 0
+                       ? Encoding.UTF8.GetString(this.fontPreviewText)
+                       : Encoding.UTF8.GetString(this.fontPreviewText, 0, n);
+        }
+        set => Encoding.UTF8.GetBytes(value, this.fontPreviewText);
+    }
+
+    /// <summary>
+    /// Gets the task that resolves upon choosing a font or cancellation.
+    /// </summary>
+    public Task<(IFontId Font, float SizePx)> ResultTask => this.tcs.Task;
+
+    /// <summary>
+    /// Gets or sets the selected family and font.
+    /// </summary>
+    public IFontId? SelectedFontId
+    {
+        get => this.selectedFontId;
+        set
+        {
+            this.selectedFontId = value;
+
+            var familyName = value?.Family.ToString() ?? string.Empty;
+            var fontName = value?.ToString() ?? string.Empty;
+            this.familySearch = value is null ? string.Empty : this.ExtractName(value.Family);
+            this.fontSearch = value is null ? string.Empty : this.ExtractName(value);
+            if (this.fontFamilies?.IsCompletedSuccessfully is true)
+                this.UpdateSelectedFamilyAndFontIndices(this.fontFamilies.Result, familyName, fontName);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the font size in points.
+    /// </summary>
+    public float FontSizePt
+    {
+        get => this.fontSizePt;
+        set
+        {
+            this.fontSizePt = value;
+            this.fontSizeSearch = $"{this.fontSizePt:##.###}";
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the font size in pixels.
+    /// </summary>
+    public float FontSizePx
+    {
+        get => (this.FontSizePt * 4) / 3;
+        set => this.FontSizePt = (value * 3) / 4;
+    }
+
+    /// <summary>
+    /// Gets or sets the font family exclusion filter predicate.
+    /// </summary>
+    public Predicate<IFontFamilyId>? FontFamilyExcludeFilter { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to ignore the global scale on preview text input.
+    /// </summary>
+    public bool IgnorePreviewGlobalScale { get; set; }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="FontChooserDialog"/> that will automatically draw and dispose itself as
+    /// needed.
+    /// </summary>
+    /// <param name="uiBuilder">An instance of <see cref="UiBuilder"/>.</param>
+    /// <returns>The new instance of <see cref="FontChooserDialog"/>.</returns>
+    public static FontChooserDialog CreateAuto(UiBuilder uiBuilder)
+    {
+        var fcd = new FontChooserDialog(uiBuilder.CreateFontAtlas(FontAtlasAutoRebuildMode.Async));
+        uiBuilder.Draw += fcd.Draw;
+        fcd.tcs.Task.ContinueWith(
+            _ =>
+            {
+                uiBuilder.Draw -= fcd.Draw;
+                fcd.Dispose();
+            });
+
+        return fcd;
+    }
+
+    /// <inheritdoc/> 
+    public void Dispose()
+    {
+        this.fontHandle?.Dispose();
+        this.atlas.Dispose();
+    }
+
+    /// <summary>
+    /// Draws this dialog.
+    /// </summary>
+    public void Draw()
+    {
+        if (this.firstDraw)
+            ImGui.OpenPopup(this.popupImGuiName);
+
+        ImGui.SetNextWindowSize(new(640, 480), ImGuiCond.Appearing);
+        var open = true;
+        if (!ImGui.BeginPopupModal(this.popupImGuiName, ref open) || !open)
+        {
+            this.tcs.SetCanceled();
+            return;
+        }
+
+        var framePad = ImGui.GetStyle().FramePadding;
+        var windowPad = ImGui.GetStyle().WindowPadding;
+        var baseOffset = ImGui.GetCursorPos() - windowPad;
+
+        var actionSize = Vector2.Zero;
+        actionSize = Vector2.Max(actionSize, ImGui.CalcTextSize("OK"));
+        actionSize = Vector2.Max(actionSize, ImGui.CalcTextSize("Cancel"));
+        actionSize = Vector2.Max(actionSize, ImGui.CalcTextSize("Refresh"));
+        actionSize += framePad * 2;
+
+        var bodySize = ImGui.GetContentRegionAvail();
+        ImGui.SetCursorPos(baseOffset + windowPad);
+        if (ImGui.BeginChild(
+                "##choicesBlock",
+                bodySize with { X = bodySize.X - windowPad.X - actionSize.X },
+                false,
+                ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse))
+        {
+            this.DrawChoices();
+        }
+
+        ImGui.EndChild();
+
+        ImGui.SetCursorPos(baseOffset + windowPad + new Vector2(bodySize.X - actionSize.X, 0));
+
+        if (ImGui.BeginChild("##actionsBlock", bodySize with { X = actionSize.X }))
+        {
+            this.DrawActionButtons(actionSize);
+        }
+
+        ImGui.EndChild();
+
+        ImGui.EndPopup();
+
+        this.firstDraw = false;
+        this.firstDrawAfterRefresh = false;
+    }
+
+    private void DrawChoices()
+    {
+        var lineHeight = ImGui.GetTextLineHeight();
+        var previewHeight = (ImGui.GetFrameHeightWithSpacing() - lineHeight) +
+                            Math.Max(lineHeight, (this.FontSizePt * 4) / 3);
+
+        var tableSize = ImGui.GetContentRegionAvail() -
+                        new Vector2(0, ImGui.GetStyle().WindowPadding.Y + previewHeight);
+        if (ImGui.BeginChild(
+                "##tableContainer",
+                tableSize,
+                false,
+                ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse)
+            && ImGui.BeginTable("##table", 3, ImGuiTableFlags.None))
+        {
+            ImGui.PushStyleColor(ImGuiCol.TableHeaderBg, Vector4.Zero);
+            ImGui.PushStyleColor(ImGuiCol.HeaderHovered, Vector4.Zero);
+            ImGui.PushStyleColor(ImGuiCol.HeaderActive, Vector4.Zero);
+            ImGui.TableSetupColumn(
+                "Font:##familyColumn",
+                ImGuiTableColumnFlags.WidthStretch,
+                0.4f);
+            ImGui.TableSetupColumn(
+                "Style:##fontColumn",
+                ImGuiTableColumnFlags.WidthStretch,
+                0.4f);
+            ImGui.TableSetupColumn(
+                "Size:##sizeColumn",
+                ImGuiTableColumnFlags.WidthStretch,
+                0.2f);
+            ImGui.TableHeadersRow();
+            ImGui.PopStyleColor(3);
+
+            ImGui.TableNextRow();
+
+            var pad = (int)MathF.Round(8 * ImGuiHelpers.GlobalScale);
+            ImGui.PushStyleVar(ImGuiStyleVar.CellPadding, new Vector2(pad));
+            ImGui.TableNextColumn();
+            var changed = this.DrawFamilyListColumn();
+
+            ImGui.TableNextColumn();
+            changed |= this.DrawFontListColumn(changed);
+
+            ImGui.TableNextColumn();
+            changed |= this.DrawSystemSizeListColumn();
+
+            if ((changed || this.fontHandle is null) && this.SelectedFontId is { } fontId)
+            {
+                this.fontHandle?.Dispose();
+                this.fontHandle = this.atlas.NewDelegateFontHandle(
+                    tk => tk.OnPreBuild(e => { e.Font = fontId.AddToBuildToolkit(e, this.FontSizePt * 4 / 3); }));
+            }
+
+            ImGui.PopStyleVar();
+
+            ImGui.EndTable();
+        }
+
+        ImGui.EndChild();
+
+        ImGui.SetCursorPosY(ImGui.GetCursorPosY() + ImGui.GetStyle().WindowPadding.Y - ImGui.GetStyle().ItemSpacing.Y);
+
+        if (this.fontHandle is null)
+        {
+            ImGui.SetCursorPos(ImGui.GetCursorPos() + ImGui.GetStyle().FramePadding);
+            ImGui.TextUnformatted("Select a font.");
+        }
+        else if (this.fontHandle.LoadException is { } loadException)
+        {
+            ImGui.SetCursorPos(ImGui.GetCursorPos() + ImGui.GetStyle().FramePadding);
+            ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
+            ImGui.TextUnformatted(loadException.Message);
+            ImGui.PopStyleColor();
+        }
+        else if (!this.fontHandle.Available)
+        {
+            ImGui.SetCursorPos(ImGui.GetCursorPos() + ImGui.GetStyle().FramePadding);
+            ImGui.TextUnformatted("Loading font...");
+        }
+        else
+        {
+            ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
+            var pfgs = ImGui.GetIO().FontGlobalScale;
+            if (this.IgnorePreviewGlobalScale)
+                ImGui.GetIO().FontGlobalScale = 1;
+            using (this.fontHandle?.Push())
+                ImGui.InputText("##fontPreviewText", this.fontPreviewText, (uint)this.fontPreviewText.Length);
+            ImGui.GetIO().FontGlobalScale = pfgs;
+        }
+    }
+
+    private unsafe bool DrawFamilyListColumn()
+    {
+        if (this.fontFamilies?.IsCompleted is not true)
+        {
+            ImGui.SetScrollY(0);
+            ImGui.TextUnformatted("Loading...");
+            return false;
+        }
+
+        if (!this.fontFamilies.IsCompletedSuccessfully)
+        {
+            ImGui.SetScrollY(0);
+            ImGui.TextUnformatted("Error: " + this.fontFamilies.Exception);
+            return false;
+        }
+
+        var families = this.fontFamilies.Result;
+        ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
+
+        if (this.setFocusOn == 0)
+        {
+            this.setFocusOn = -1;
+            ImGui.SetKeyboardFocusHere();
+        }
+
+        var changed = false;
+        if (ImGui.InputText(
+                "##familySearch",
+                ref this.familySearch,
+                255,
+                ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.CallbackHistory,
+                data =>
+                {
+                    if (families.Count == 0)
+                        return 0;
+
+                    var baseIndex = this.selectedFamilyIndex;
+                    if (data->SelectionStart == 0 && data->SelectionEnd == data->BufTextLen)
+                    {
+                        switch (data->EventKey)
+                        {
+                            case ImGuiKey.DownArrow:
+                                this.selectedFamilyIndex = (this.selectedFamilyIndex + 1) % families.Count;
+                                changed = true;
+                                break;
+                            case ImGuiKey.UpArrow:
+                                this.selectedFamilyIndex =
+                                    (this.selectedFamilyIndex + families.Count - 1) % families.Count;
+                                changed = true;
+                                break;
+                        }
+
+                        if (changed)
+                        {
+                            ImGuiHelpers.SetTextFromCallback(
+                                data,
+                                this.ExtractName(families[this.selectedFamilyIndex]));
+                        }
+                    }
+                    else
+                    {
+                        switch (data->EventKey)
+                        {
+                            case ImGuiKey.DownArrow:
+                                this.selectedFamilyIndex = families.FindIndex(
+                                    baseIndex + 1,
+                                    x => this.TestName(x, this.familySearch));
+                                if (this.selectedFamilyIndex < 0)
+                                {
+                                    this.selectedFamilyIndex = families.FindIndex(
+                                        0,
+                                        baseIndex + 1,
+                                        x => this.TestName(x, this.familySearch));
+                                }
+
+                                changed = true;
+                                break;
+                            case ImGuiKey.UpArrow:
+                                if (baseIndex > 0)
+                                {
+                                    this.selectedFamilyIndex = families.FindLastIndex(
+                                        baseIndex - 1,
+                                        x => this.TestName(x, this.familySearch));
+                                }
+
+                                if (this.selectedFamilyIndex < 0)
+                                {
+                                    if (baseIndex < 0)
+                                        baseIndex = 0;
+                                    this.selectedFamilyIndex = families.FindLastIndex(
+                                        families.Count - 1,
+                                        families.Count - baseIndex,
+                                        x => this.TestName(x, this.familySearch));
+                                }
+
+                                changed = true;
+                                break;
+                        }
+                    }
+
+                    return 0;
+                }))
+        {
+            if (!string.IsNullOrWhiteSpace(this.familySearch))
+            {
+                this.selectedFamilyIndex = families.FindIndex(x => this.TestName(x, this.familySearch));
+                changed = true;
+            }
+        }
+
+        if (ImGui.BeginChild("##familyList", ImGui.GetContentRegionAvail()))
+        {
+            var clipper = new ImGuiListClipperPtr(ImGuiNative.ImGuiListClipper_ImGuiListClipper());
+            var lineHeight = ImGui.GetTextLineHeightWithSpacing();
+
+            if ((changed || this.firstDrawAfterRefresh) && this.selectedFamilyIndex != -1)
+            {
+                ImGui.SetScrollY(
+                    (lineHeight * this.selectedFamilyIndex) -
+                    ((ImGui.GetContentRegionAvail().Y - lineHeight) / 2));
+            }
+
+            clipper.Begin(families.Count, lineHeight);
+            while (clipper.Step())
+            {
+                for (var i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
+                {
+                    if (i < 0)
+                    {
+                        ImGui.TextUnformatted(" ");
+                        continue;
+                    }
+
+                    var selected = this.selectedFamilyIndex == i;
+                    if (ImGui.Selectable(
+                            this.ExtractName(families[i]),
+                            ref selected,
+                            ImGuiSelectableFlags.DontClosePopups))
+                    {
+                        this.selectedFamilyIndex = families.IndexOf(families[i]);
+                        this.familySearch = this.ExtractName(families[i]);
+                        this.setFocusOn = 0;
+                        changed = true;
+                    }
+                }
+            }
+
+            clipper.Destroy();
+        }
+
+        if (changed && this.selectedFamilyIndex >= 0)
+        {
+            var family = families[this.selectedFamilyIndex];
+            using var matchingFont = default(ComPtr<IDWriteFont>);
+            this.selectedFontIndex = family.FindBestMatch(
+                this.selectedFontWeight,
+                this.selectedFontStretch,
+                this.selectedFontStyle);
+            this.selectedFontId = family.Fonts[this.selectedFontIndex];
+        }
+
+        ImGui.EndChild();
+        return changed;
+    }
+
+    private unsafe bool DrawFontListColumn(bool changed)
+    {
+        if (this.fontFamilies?.IsCompleted is not true)
+        {
+            ImGui.TextUnformatted("Loading...");
+            return changed;
+        }
+
+        if (!this.fontFamilies.IsCompletedSuccessfully)
+        {
+            ImGui.TextUnformatted("Error: " + this.fontFamilies.Exception);
+            return changed;
+        }
+
+        var families = this.fontFamilies.Result;
+        var family = this.selectedFamilyIndex >= 0
+                     && this.selectedFamilyIndex < families.Count
+                         ? families[this.selectedFamilyIndex]
+                         : null;
+        var fonts = family?.Fonts ?? EmptyIFontList;
+
+        ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
+
+        if (this.setFocusOn == 1)
+        {
+            this.setFocusOn = -1;
+            ImGui.SetKeyboardFocusHere();
+        }
+
+        if (ImGui.InputText(
+                "##fontSearch",
+                ref this.fontSearch,
+                255,
+                ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.CallbackHistory,
+                data =>
+                {
+                    if (fonts.Count == 0)
+                        return 0;
+
+                    var baseIndex = this.selectedFontIndex;
+                    if (data->SelectionStart == 0 && data->SelectionEnd == data->BufTextLen)
+                    {
+                        switch (data->EventKey)
+                        {
+                            case ImGuiKey.DownArrow:
+                                this.selectedFontIndex = (this.selectedFontIndex + 1) % fonts.Count;
+                                changed = true;
+                                break;
+                            case ImGuiKey.UpArrow:
+                                this.selectedFontIndex = (this.selectedFontIndex + fonts.Count - 1) % fonts.Count;
+                                changed = true;
+                                break;
+                        }
+
+                        if (changed)
+                        {
+                            ImGuiHelpers.SetTextFromCallback(
+                                data,
+                                this.ExtractName(fonts[this.selectedFontIndex]));
+                        }
+                    }
+                    else
+                    {
+                        switch (data->EventKey)
+                        {
+                            case ImGuiKey.DownArrow:
+                                this.selectedFontIndex = fonts.FindIndex(
+                                    baseIndex + 1,
+                                    x => this.TestName(x, this.fontSearch));
+                                if (this.selectedFontIndex < 0)
+                                {
+                                    this.selectedFontIndex = fonts.FindIndex(
+                                        0,
+                                        baseIndex + 1,
+                                        x => this.TestName(x, this.fontSearch));
+                                }
+
+                                changed = true;
+                                break;
+                            case ImGuiKey.UpArrow:
+                                if (baseIndex > 0)
+                                {
+                                    this.selectedFontIndex = fonts.FindLastIndex(
+                                        baseIndex - 1,
+                                        x => this.TestName(x, this.fontSearch));
+                                }
+
+                                if (this.selectedFontIndex < 0)
+                                {
+                                    if (baseIndex < 0)
+                                        baseIndex = 0;
+                                    this.selectedFontIndex = fonts.FindLastIndex(
+                                        fonts.Count - 1,
+                                        fonts.Count - baseIndex,
+                                        x => this.TestName(x, this.fontSearch));
+                                }
+
+                                changed = true;
+                                break;
+                        }
+                    }
+
+                    return 0;
+                }))
+        {
+            if (!string.IsNullOrWhiteSpace(this.fontSearch))
+            {
+                this.selectedFontIndex = fonts.FindIndex(x => this.TestName(x, this.fontSearch));
+                changed = true;
+            }
+        }
+
+        if (ImGui.BeginChild("##fontList"))
+        {
+            var clipper = new ImGuiListClipperPtr(ImGuiNative.ImGuiListClipper_ImGuiListClipper());
+            var lineHeight = ImGui.GetTextLineHeightWithSpacing();
+
+            if ((changed || this.firstDrawAfterRefresh) && this.selectedFontIndex != -1)
+            {
+                ImGui.SetScrollY(
+                    (lineHeight * this.selectedFontIndex) -
+                    ((ImGui.GetContentRegionAvail().Y - lineHeight) / 2));
+            }
+
+            clipper.Begin(fonts.Count, lineHeight);
+            while (clipper.Step())
+            {
+                for (var i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
+                {
+                    if (i < 0)
+                    {
+                        ImGui.TextUnformatted(" ");
+                        continue;
+                    }
+
+                    var selected = this.selectedFontIndex == i;
+                    if (ImGui.Selectable(
+                            this.ExtractName(fonts[i]),
+                            ref selected,
+                            ImGuiSelectableFlags.DontClosePopups))
+                    {
+                        this.selectedFontIndex = fonts.IndexOf(fonts[i]);
+                        this.fontSearch = this.ExtractName(fonts[i]);
+                        this.setFocusOn = 1;
+                        changed = true;
+                    }
+                }
+            }
+
+            clipper.Destroy();
+        }
+
+        ImGui.EndChild();
+
+        if (changed && family is not null && this.selectedFontIndex >= 0)
+        {
+            var font = family.Fonts[this.selectedFontIndex];
+            this.selectedFontWeight = font.Weight;
+            this.selectedFontStretch = font.Stretch;
+            this.selectedFontStyle = font.Style;
+            this.selectedFontId = font;
+        }
+
+        return changed;
+    }
+
+    private unsafe bool DrawSystemSizeListColumn()
+    {
+        var changed = false;
+        ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
+
+        if (this.setFocusOn == 2)
+        {
+            this.setFocusOn = -1;
+            ImGui.SetKeyboardFocusHere();
+        }
+
+        if (ImGui.InputText(
+                "##fontSizeSearch",
+                ref this.fontSizeSearch,
+                255,
+                ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.CallbackHistory |
+                ImGuiInputTextFlags.CharsDecimal,
+                data =>
+                {
+                    switch (data->EventKey)
+                    {
+                        case ImGuiKey.DownArrow:
+                            this.fontSizePt = Math.Min(127, MathF.Floor(this.FontSizePt) + 1);
+                            changed = true;
+                            break;
+                        case ImGuiKey.UpArrow:
+                            this.fontSizePt = Math.Max(1, MathF.Ceiling(this.FontSizePt) - 1);
+                            changed = true;
+                            break;
+                    }
+
+                    if (changed)
+                        ImGuiHelpers.SetTextFromCallback(data, $"{this.FontSizePt:##.###}");
+
+                    return 0;
+                }))
+        {
+            if (float.TryParse(this.fontSizeSearch, out var fontSizePt1))
+            {
+                this.fontSizePt = fontSizePt1;
+                changed = true;
+            }
+        }
+
+        if (ImGui.BeginChild("##fontSizeList"))
+        {
+            var clipper = new ImGuiListClipperPtr(ImGuiNative.ImGuiListClipper_ImGuiListClipper());
+            var lineHeight = ImGui.GetTextLineHeightWithSpacing();
+
+            if (changed && this.selectedFontIndex != -1)
+            {
+                ImGui.SetScrollY(
+                    (lineHeight * this.selectedFontIndex) -
+                    ((ImGui.GetContentRegionAvail().Y - lineHeight) / 2));
+            }
+
+            clipper.Begin(FontSizeList.Length, lineHeight);
+            while (clipper.Step())
+            {
+                for (var i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
+                {
+                    if (i < 0)
+                    {
+                        ImGui.TextUnformatted(" ");
+                        continue;
+                    }
+
+                    var selected = Equals(FontSizeList[i].Value, this.FontSizePt);
+                    if (ImGui.Selectable(
+                            FontSizeList[i].Name,
+                            ref selected,
+                            ImGuiSelectableFlags.DontClosePopups))
+                    {
+                        this.fontSizePt = FontSizeList[i].Value;
+                        this.setFocusOn = 2;
+                        changed = true;
+                    }
+                }
+            }
+
+            clipper.Destroy();
+        }
+
+        ImGui.EndChild();
+
+        if (this.FontSizePt < 1)
+        {
+            this.fontSizePt = 1;
+            changed = true;
+        }
+
+        if (this.FontSizePt > 127)
+        {
+            this.fontSizePt = 127;
+            changed = true;
+        }
+
+        if (changed)
+            this.fontSizeSearch = $"{this.FontSizePt:##.###}";
+
+        return changed;
+    }
+
+    private void DrawActionButtons(Vector2 buttonSize)
+    {
+        if (this.fontHandle?.Available is not true || this.SelectedFontId is null)
+        {
+            ImGui.BeginDisabled();
+            ImGui.Button("OK", buttonSize);
+            ImGui.EndDisabled();
+        }
+        else if (ImGui.Button("OK", buttonSize))
+        {
+            this.tcs.SetResult((this.SelectedFontId, this.FontSizePt * 4 / 3));
+        }
+
+        if (ImGui.Button("Cancel", buttonSize))
+        {
+            this.tcs.SetCanceled();
+        }
+
+        var doRefresh = false;
+        var isFirst = false;
+        if (this.fontFamilies?.IsCompleted is not true)
+        {
+            isFirst = doRefresh = this.fontFamilies is null;
+            ImGui.BeginDisabled();
+            ImGui.Button("Refresh", buttonSize);
+            ImGui.EndDisabled();
+        }
+        else if (ImGui.Button("Refresh", buttonSize))
+        {
+            doRefresh = true;
+        }
+
+        if (doRefresh)
+        {
+            this.fontFamilies =
+                this.fontFamilies?.ContinueWith(_ => RefreshBody())
+                ?? Task.Run(RefreshBody);
+            this.fontFamilies.ContinueWith(_ => this.firstDrawAfterRefresh = true);
+
+            List<IFontFamilyId> RefreshBody()
+            {
+                var familyName = this.SelectedFontId?.Family.ToString() ?? string.Empty;
+                var fontName = this.SelectedFontId?.ToString() ?? string.Empty;
+
+                var newFonts = new List<IFontFamilyId> { DalamudDefaultFontAndFamilyId.Instance };
+                newFonts.AddRange(IFontFamilyId.ListDalamudFonts());
+                newFonts.AddRange(IFontFamilyId.ListGameFonts());
+                var systemFonts = IFontFamilyId.ListSystemFonts(!isFirst);
+                systemFonts.Sort(
+                    (a, b) => string.Compare(
+                        this.ExtractName(a),
+                        this.ExtractName(b),
+                        StringComparison.CurrentCultureIgnoreCase));
+                newFonts.AddRange(systemFonts);
+                if (this.FontFamilyExcludeFilter is not null)
+                    newFonts.RemoveAll(this.FontFamilyExcludeFilter);
+
+                this.UpdateSelectedFamilyAndFontIndices(newFonts, familyName, fontName);
+                return newFonts;
+            }
+        }
+    }
+
+    private void UpdateSelectedFamilyAndFontIndices(
+        IReadOnlyList<IFontFamilyId> fonts,
+        string familyName,
+        string fontName)
+    {
+        this.selectedFamilyIndex = fonts.FindIndex(x => x.ToString() == familyName);
+        if (this.selectedFamilyIndex == -1)
+        {
+            this.selectedFontIndex = -1;
+            this.selectedFontId = null;
+        }
+        else
+        {
+            this.selectedFontIndex = -1;
+            var family = fonts[this.selectedFamilyIndex];
+            for (var i = 0; i < family.Fonts.Count; i++)
+            {
+                if (family.Fonts[i].ToString() == fontName)
+                {
+                    this.selectedFontIndex = i;
+                    break;
+                }
+            }
+
+            if (this.selectedFontIndex == -1)
+                this.selectedFontIndex = 0;
+            this.selectedFontId = fonts[this.selectedFamilyIndex].Fonts[this.selectedFontIndex];
+        }
+    }
+
+    private string ExtractName(IObjectWithLocalizableName what) => what.LocalizedName;
+
+    private bool TestName(IObjectWithLocalizableName what, string search) =>
+        this.ExtractName(what).Contains(search, StringComparison.CurrentCultureIgnoreCase);
+}

--- a/Dalamud/Interface/ImGuiFontChooserDialog/FontChooserDialog.cs
+++ b/Dalamud/Interface/ImGuiFontChooserDialog/FontChooserDialog.cs
@@ -301,7 +301,20 @@ public sealed class FontChooserDialog : IDisposable
             {
                 this.fontHandle?.Dispose();
                 this.fontHandle = this.atlas.NewDelegateFontHandle(
-                    tk => tk.OnPreBuild(e => { e.Font = fontId.AddToBuildToolkit(e, this.FontSizePt * 4 / 3); }));
+                    tk =>
+                        tk.OnPreBuild(
+                              e =>
+                              {
+                                  e.Font = fontId.AddToBuildToolkit(e, this.FontSizePt * 4 / 3);
+                                  if (this.IgnorePreviewGlobalScale)
+                                    e.IgnoreGlobalScale(e.Font);
+                              })
+                          .OnPostBuild(
+                              e =>
+                              {
+                                  if (this.IgnorePreviewGlobalScale)
+                                      e.Font.AdjustGlyphMetrics(1f / e.Scale);
+                              }));
             }
 
             ImGui.PopStyleVar();
@@ -333,12 +346,10 @@ public sealed class FontChooserDialog : IDisposable
         else
         {
             ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
-            var pfgs = ImGui.GetIO().FontGlobalScale;
-            if (this.IgnorePreviewGlobalScale)
-                ImGui.GetIO().FontGlobalScale = 1;
             using (this.fontHandle?.Push())
+            {
                 ImGui.InputText("##fontPreviewText", this.fontPreviewText, (uint)this.fontPreviewText.Length);
-            ImGui.GetIO().FontGlobalScale = pfgs;
+            }
         }
     }
 

--- a/Dalamud/Interface/ImGuiFontChooserDialog/FontChooserDialog.cs
+++ b/Dalamud/Interface/ImGuiFontChooserDialog/FontChooserDialog.cs
@@ -181,8 +181,9 @@ public sealed class FontChooserDialog : IDisposable
         var fcd = new FontChooserDialog(uiBuilder.CreateFontAtlas(FontAtlasAutoRebuildMode.Async));
         uiBuilder.Draw += fcd.Draw;
         fcd.tcs.Task.ContinueWith(
-            _ =>
+            r =>
             {
+                _ = r.Exception;
                 uiBuilder.Draw -= fcd.Draw;
                 fcd.Dispose();
             });

--- a/Dalamud/Interface/ImGuiFontChooserDialog/SingleFontChooserDialog.cs
+++ b/Dalamud/Interface/ImGuiFontChooserDialog/SingleFontChooserDialog.cs
@@ -273,12 +273,7 @@ public sealed class SingleFontChooserDialog : IDisposable
         var previewHeight = (ImGui.GetFrameHeightWithSpacing() - lineHeight) +
                             Math.Max(lineHeight, this.selectedFont.LineHeightPx * 2);
 
-        ImGui.Checkbox("Show advanced options", ref this.useAdvancedOptions);
-
-        var advancedOptionsHeight =
-            this.useAdvancedOptions
-                ? ImGui.GetFrameHeightWithSpacing() * 3
-                : 0;
+        var advancedOptionsHeight = ImGui.GetFrameHeightWithSpacing() * (this.useAdvancedOptions ? 4 : 1);
 
         var tableSize = ImGui.GetContentRegionAvail() -
                         new Vector2(0, ImGui.GetStyle().WindowPadding.Y + previewHeight + advancedOptionsHeight);
@@ -333,9 +328,7 @@ public sealed class SingleFontChooserDialog : IDisposable
 
         ImGui.EndChild();
 
-        ImGui.SetCursorPosY(
-            ImGui.GetCursorPosY() + (ImGui.GetStyle().WindowPadding.Y - ImGui.GetStyle().ItemSpacing.Y));
-
+        ImGui.Checkbox("Show advanced options", ref this.useAdvancedOptions);
         if (this.useAdvancedOptions)
         {
             if (this.DrawAdvancedOptions())

--- a/Dalamud/Interface/ImGuiFontChooserDialog/SingleFontChooserDialog.cs
+++ b/Dalamud/Interface/ImGuiFontChooserDialog/SingleFontChooserDialog.cs
@@ -922,17 +922,18 @@ public sealed class SingleFontChooserDialog : IDisposable
             };
         }
 
-        if (FloatInputText(
-                "##glyphExtraSpacingYInput",
-                ref this.advUiState.ExtraSpacingYText,
-                this.selectedFont.GlyphExtraSpacing.Y) is { } newGlyphExtraSpacingY)
-        {
-            changed = true;
-            this.selectedFont = this.selectedFont with
-            {
-                GlyphExtraSpacing = this.selectedFont.GlyphExtraSpacing with { Y = newGlyphExtraSpacingY },
-            };
-        }
+        // This value currently does nothing
+        // if (FloatInputText(
+        //         "##glyphExtraSpacingYInput",
+        //         ref this.advUiState.ExtraSpacingYText,
+        //         this.selectedFont.GlyphExtraSpacing.Y) is { } newGlyphExtraSpacingY)
+        // {
+        //     changed = true;
+        //     this.selectedFont = this.selectedFont with
+        //     {
+        //         GlyphExtraSpacing = this.selectedFont.GlyphExtraSpacing with { Y = newGlyphExtraSpacingY },
+        //     };
+        // }
 
         ImGui.PopStyleVar();
         ImGui.EndTable();

--- a/Dalamud/Interface/ImGuiFontChooserDialog/SingleFontChooserDialog.cs
+++ b/Dalamud/Interface/ImGuiFontChooserDialog/SingleFontChooserDialog.cs
@@ -1061,7 +1061,7 @@ public sealed class SingleFontChooserDialog : IDisposable
 
         if (this.useAdvancedOptions)
         {
-            if (ImGui.Button("Reset"))
+            if (ImGui.Button("Reset", buttonSize))
             {
                 this.selectedFont = this.selectedFont with
                 {

--- a/Dalamud/Interface/ImGuiFontChooserDialog/SingleFontChooserDialog.cs
+++ b/Dalamud/Interface/ImGuiFontChooserDialog/SingleFontChooserDialog.cs
@@ -1102,7 +1102,7 @@ public sealed class SingleFontChooserDialog : IDisposable
     }
 
     private string ExtractName(IObjectWithLocalizableName what) =>
-        what.GetLocaleName(Service<DalamudConfiguration>.Get().EffectiveLanguage);
+        what.GetLocalizedName(Service<DalamudConfiguration>.Get().EffectiveLanguage);
     // Note: EffectiveLanguage can be incorrect but close enough for now
 
     private bool TestName(IObjectWithLocalizableName what, string search) =>

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -705,13 +705,13 @@ internal class InterfaceManager : IDisposable, IServiceType
         using (this.dalamudAtlas.SuppressAutoRebuild())
         {
             this.DefaultFontHandle = (FontHandle)this.dalamudAtlas.NewDelegateFontHandle(
-                e => e.OnPreBuild(tk => tk.AddDalamudDefaultFont(DefaultFontSizePx)));
+                e => e.OnPreBuild(tk => tk.AddDalamudDefaultFont(-1)));
             this.IconFontHandle = (FontHandle)this.dalamudAtlas.NewDelegateFontHandle(
                 e => e.OnPreBuild(
                     tk => tk.AddFontAwesomeIconFont(
                         new()
                         {
-                            SizePx = DefaultFontSizePx,
+                            SizePx = Service<FontAtlasFactory>.Get().DefaultFontSpec.SizePx,
                             GlyphMinAdvanceX = DefaultFontSizePx,
                             GlyphMaxAdvanceX = DefaultFontSizePx,
                         })));
@@ -719,7 +719,10 @@ internal class InterfaceManager : IDisposable, IServiceType
                 e => e.OnPreBuild(
                     tk => tk.AddDalamudAssetFont(
                         DalamudAsset.InconsolataRegular,
-                        new() { SizePx = DefaultFontSizePx })));
+                        new()
+                        {
+                            SizePx = Service<FontAtlasFactory>.Get().DefaultFontSpec.SizePx,
+                        })));
             this.dalamudAtlas.BuildStepChange += e => e.OnPostBuild(
                 tk =>
                 {

--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -152,8 +152,11 @@ internal class ConsoleWindow : Window, IDisposable
             ImGui.SetCursorPosX(ImGui.GetContentRegionMax().X / 2.0f - ImGui.CalcTextSize(regexErrorString).X / 2.0f);
             ImGui.TextColored(ImGuiColors.DalamudRed, regexErrorString);
         }
-        
-        ImGui.BeginChild("scrolling", new Vector2(0, ImGui.GetFrameHeightWithSpacing() - 55 * ImGuiHelpers.GlobalScale), false, ImGuiWindowFlags.AlwaysHorizontalScrollbar | ImGuiWindowFlags.AlwaysVerticalScrollbar);
+
+        var sendButtonSize = ImGui.CalcTextSize("Send") +
+                             ((new Vector2(16, 0) + (ImGui.GetStyle().FramePadding * 2)) * ImGuiHelpers.GlobalScale);
+        var scrollingHeight = ImGui.GetContentRegionAvail().Y - sendButtonSize.Y;
+        ImGui.BeginChild("scrolling", new Vector2(0, scrollingHeight), false, ImGuiWindowFlags.AlwaysHorizontalScrollbar | ImGuiWindowFlags.AlwaysVerticalScrollbar);
 
         if (this.clearLog) this.Clear();
 
@@ -173,9 +176,10 @@ internal class ConsoleWindow : Window, IDisposable
         var childDrawList = ImGui.GetWindowDrawList();
         var childSize = ImGui.GetWindowSize();
 
-        var cursorDiv = ImGuiHelpers.GlobalScale * 93;
-        var cursorLogLevel = ImGuiHelpers.GlobalScale * 100;
-        var cursorLogLine = ImGuiHelpers.GlobalScale * 135;
+        var cursorDiv = ImGui.CalcTextSize("00:00:00.000 ").X;
+        var cursorLogLevel = ImGui.CalcTextSize("00:00:00.000 | ").X;
+        var dividerOffset = ImGui.CalcTextSize("00:00:00.000 | AAA ").X + (ImGui.CalcTextSize(" ").X / 2);
+        var cursorLogLine = ImGui.CalcTextSize("00:00:00.000 | AAA | ").X;
 
         lock (this.renderLock)
         {
@@ -242,8 +246,7 @@ internal class ConsoleWindow : Window, IDisposable
         }
 
         // Draw dividing line
-        var offset = ImGuiHelpers.GlobalScale * 127;
-        childDrawList.AddLine(new Vector2(childPos.X + offset, childPos.Y), new Vector2(childPos.X + offset, childPos.Y + childSize.Y), 0x4FFFFFFF, 1.0f);
+        childDrawList.AddLine(new Vector2(childPos.X + dividerOffset, childPos.Y), new Vector2(childPos.X + dividerOffset, childPos.Y + childSize.Y), 0x4FFFFFFF, 1.0f);
 
         ImGui.EndChild();
 
@@ -261,7 +264,7 @@ internal class ConsoleWindow : Window, IDisposable
             }
         }
 
-        ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X - (80.0f * ImGuiHelpers.GlobalScale) - (ImGui.GetStyle().ItemSpacing.X * ImGuiHelpers.GlobalScale));
+        ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X - sendButtonSize.X - (ImGui.GetStyle().ItemSpacing.X * ImGuiHelpers.GlobalScale));
 
         var getFocus = false;
         unsafe
@@ -280,7 +283,7 @@ internal class ConsoleWindow : Window, IDisposable
 
         if (hadColor) ImGui.PopStyleColor();
 
-        if (ImGui.Button("Send", ImGuiHelpers.ScaledVector2(80.0f, 23.0f)))
+        if (ImGui.Button("Send", sendButtonSize))
         {
             this.ProcessCommand();
         }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/GamePrebakedFontsTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/GamePrebakedFontsTestWidget.cs
@@ -138,6 +138,7 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
                             return;
 
                         this.fontSpec = r.Result;
+                        Log.Information("Selected font: {font}", this.fontSpec);
                         this.fontDialogHandle?.Dispose();
                         this.fontDialogHandle = null;
                     }));

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/GamePrebakedFontsTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/GamePrebakedFontsTestWidget.cs
@@ -160,7 +160,7 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
                         labelPtr,
                         this.testStringBuffer.Data,
                         (uint)this.testStringBuffer.Capacity,
-                        new(ImGui.GetContentRegionAvail().X, 32 * ImGuiHelpers.GlobalScale),
+                        new(ImGui.GetContentRegionAvail().X, ImGui.GetTextLineHeight() * 3),
                         0,
                         null,
                         null) != 0)

--- a/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs
@@ -68,11 +68,11 @@ internal class SettingsWindow : Window
         var interfaceManager = Service<InterfaceManager>.Get();
         var fontAtlasFactory = Service<FontAtlasFactory>.Get();
 
-        var rebuildFont = fontAtlasFactory.UseAxis != configuration.UseAxisFontsFromGame;
+        var rebuildFont = !Equals(fontAtlasFactory.DefaultFontId, configuration.DefaultFontId);
         rebuildFont |= !Equals(ImGui.GetIO().FontGlobalScale, configuration.GlobalUiScale);
 
         ImGui.GetIO().FontGlobalScale = configuration.GlobalUiScale;
-        fontAtlasFactory.UseAxisOverride = null;
+        fontAtlasFactory.DefaultFontIdOverride = null;
 
         if (rebuildFont)
             interfaceManager.RebuildFonts();

--- a/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs
@@ -68,11 +68,11 @@ internal class SettingsWindow : Window
         var interfaceManager = Service<InterfaceManager>.Get();
         var fontAtlasFactory = Service<FontAtlasFactory>.Get();
 
-        var rebuildFont = !Equals(fontAtlasFactory.DefaultFontId, configuration.DefaultFontId);
+        var rebuildFont = !Equals(fontAtlasFactory.DefaultFontSpec, configuration.DefaultFontSpec);
         rebuildFont |= !Equals(ImGui.GetIO().FontGlobalScale, configuration.GlobalUiScale);
 
         ImGui.GetIO().FontGlobalScale = configuration.GlobalUiScale;
-        fontAtlasFactory.DefaultFontIdOverride = null;
+        fontAtlasFactory.DefaultFontSpecOverride = null;
 
         if (rebuildFont)
             interfaceManager.RebuildFonts();

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
@@ -26,12 +26,12 @@ public class SettingsTabLook : SettingsTab
 {
     private static readonly (string, float)[] GlobalUiScalePresets = 
     {
-        ("9.6pt##DalamudSettingsGlobalUiScaleReset96", 9.6f / InterfaceManager.DefaultFontSizePt),
-        ("12pt##DalamudSettingsGlobalUiScaleReset12", 12f / InterfaceManager.DefaultFontSizePt),
-        ("14pt##DalamudSettingsGlobalUiScaleReset14", 14f / InterfaceManager.DefaultFontSizePt),
-        ("18pt##DalamudSettingsGlobalUiScaleReset18", 18f / InterfaceManager.DefaultFontSizePt),
-        ("24pt##DalamudSettingsGlobalUiScaleReset24", 24f / InterfaceManager.DefaultFontSizePt),
-        ("36pt##DalamudSettingsGlobalUiScaleReset36", 36f / InterfaceManager.DefaultFontSizePt),
+        ("80%##DalamudSettingsGlobalUiScaleReset96", 0.8f),
+        ("100%##DalamudSettingsGlobalUiScaleReset12", 1f),
+        ("117%##DalamudSettingsGlobalUiScaleReset14", 14 / 12f),
+        ("150%##DalamudSettingsGlobalUiScaleReset18", 1.5f),
+        ("200%##DalamudSettingsGlobalUiScaleReset24", 2f),
+        ("300%##DalamudSettingsGlobalUiScaleReset36", 3f),
     };
 
     private float globalUiScale;
@@ -171,10 +171,10 @@ public class SettingsTabLook : SettingsTab
             }
         }
 
-        var globalUiScaleInPt = 12f * this.globalUiScale;
-        if (ImGui.DragFloat("##DalamudSettingsGlobalUiScaleDrag", ref globalUiScaleInPt, 0.1f, 9.6f, 36f, "%.1fpt", ImGuiSliderFlags.AlwaysClamp))
+        var globalUiScaleInPct = 100f * this.globalUiScale;
+        if (ImGui.DragFloat("##DalamudSettingsGlobalUiScaleDrag", ref globalUiScaleInPct, 1f, 80f, 300f, "%.0f%%", ImGuiSliderFlags.AlwaysClamp))
         {
-            this.globalUiScale = globalUiScaleInPt / 12f;
+            this.globalUiScale = globalUiScaleInPct / 100f;
             ImGui.GetIO().FontGlobalScale = this.globalUiScale;
             interfaceManager.RebuildFonts();
         }
@@ -201,12 +201,8 @@ public class SettingsTabLook : SettingsTab
             var faf = Service<FontAtlasFactory>.Get();
             var fcd = new SingleFontChooserDialog(
                 faf.CreateFontAtlas($"{nameof(SettingsTabLook)}:Default", FontAtlasAutoRebuildMode.Async));
-            fcd.SelectedFont = (SingleFontSpec)this.defaultFontSpec with
-            {
-                SizePx = InterfaceManager.DefaultFontSizePx * this.globalUiScale,
-            };
+            fcd.SelectedFont = (SingleFontSpec)this.defaultFontSpec;
             fcd.FontFamilyExcludeFilter = x => x is DalamudDefaultFontAndFamilyId;
-            fcd.IgnorePreviewGlobalScale = true;
             interfaceManager.Draw += fcd.Draw;
             fcd.ResultTask.ContinueWith(
                 r => Service<Framework>.Get().RunOnFrameworkThread(
@@ -220,8 +216,6 @@ public class SettingsTabLook : SettingsTab
                             return;
 
                         faf.DefaultFontSpecOverride = this.defaultFontSpec = r.Result;
-                        ImGui.GetIO().FontGlobalScale =
-                            this.globalUiScale = r.Result.SizePx / InterfaceManager.DefaultFontSizePx;
                         interfaceManager.RebuildFonts();
                     }));
         }

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
@@ -199,7 +199,7 @@ public class SettingsTabLook : SettingsTab
         {
             var faf = Service<FontAtlasFactory>.Get();
             var fcd = new FontChooserDialog(
-                faf.CreateFontAtlas($"{nameof(SettingsTabLook)}:Default", FontAtlasAutoRebuildMode.Async, false));
+                faf.CreateFontAtlas($"{nameof(SettingsTabLook)}:Default", FontAtlasAutoRebuildMode.Async));
             fcd.SelectedFontId = this.defaultFontId;
             fcd.FontSizePx = InterfaceManager.DefaultFontSizePx * this.globalUiScale;
             fcd.FontFamilyExcludeFilter = x => x is DalamudDefaultFontAndFamilyId;

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlas.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlas.cs
@@ -93,6 +93,10 @@ public interface IFontAtlas : IDisposable
     /// </summary>
     /// <param name="buildStepDelegate">Callback for <see cref="IFontAtlas.BuildStepChange"/>.</param>
     /// <returns>Handle to a font that may or may not be ready yet.</returns>
+    /// <remarks>
+    /// Consider calling <see cref="IFontAtlasBuildToolkitPreBuild.AttachExtraGlyphsForDalamudLanguage"/> to support
+    /// glyphs that are not supplied by the game by default; this mostly affects Chinese and Korean language users.
+    /// </remarks>
     /// <example>
     /// <b>On initialization</b>:
     /// <code>

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlas.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlas.cs
@@ -101,7 +101,7 @@ public interface IFontAtlas : IDisposable
     /// <b>On initialization</b>:
     /// <code>
     /// this.fontHandle = atlas.NewDelegateFontHandle(e => e.OnPreBuild(tk => {
-    ///     var config = new SafeFontConfig { SizePx = 16 };
+    ///     var config = new SafeFontConfig { SizePx = UiBuilder.DefaultFontSizePx };
     ///     config.MergeFont = tk.AddFontFromFile(@"C:\Windows\Fonts\comic.ttf", config);
     ///     tk.AddGameSymbol(config);
     ///     tk.AddExtraGlyphsForDalamudLanguage(config);

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlas.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlas.cs
@@ -8,7 +8,8 @@ using ImGuiNET;
 namespace Dalamud.Interface.ManagedFontAtlas;
 
 /// <summary>
-/// Wrapper for <see cref="ImFontAtlasPtr"/>.
+/// Wrapper for <see cref="ImFontAtlasPtr"/>.<br />
+/// Not intended for plugins to implement.
 /// </summary>
 public interface IFontAtlas : IDisposable
 {

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkit.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkit.cs
@@ -9,7 +9,8 @@ using ImGuiNET;
 namespace Dalamud.Interface.ManagedFontAtlas;
 
 /// <summary>
-/// Common stuff for <see cref="IFontAtlasBuildToolkitPreBuild"/> and <see cref="IFontAtlasBuildToolkitPostBuild"/>.
+/// Common stuff for <see cref="IFontAtlasBuildToolkitPreBuild"/> and <see cref="IFontAtlasBuildToolkitPostBuild"/>.<br />
+/// Not intended for plugins to implement.
 /// </summary>
 public interface IFontAtlasBuildToolkit
 {

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPostBuild.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPostBuild.cs
@@ -5,7 +5,8 @@ using ImGuiNET;
 namespace Dalamud.Interface.ManagedFontAtlas;
 
 /// <summary>
-/// Toolkit for use when the build state is <see cref="FontAtlasBuildStep.PostBuild"/>.
+/// Toolkit for use when the build state is <see cref="FontAtlasBuildStep.PostBuild"/>.<br />
+/// Not intended for plugins to implement.
 /// </summary>
 public interface IFontAtlasBuildToolkitPostBuild : IFontAtlasBuildToolkit
 {

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPreBuild.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPreBuild.cs
@@ -53,6 +53,12 @@ public interface IFontAtlasBuildToolkitPreBuild : IFontAtlasBuildToolkit
     bool IsGlobalScaleIgnored(ImFontPtr fontPtr);
 
     /// <summary>
+    /// Registers a function to be run after build.
+    /// </summary>
+    /// <param name="action">The action to run.</param>
+    void RegisterPostBuild(Action action);
+
+    /// <summary>
     /// Adds a font from memory region allocated using <see cref="ImGuiHelpers.AllocateMemory"/>.<br />
     /// <b>It WILL crash if you try to use a memory pointer allocated in some other way.</b><br />
     /// <b>

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPreBuild.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPreBuild.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Runtime.InteropServices;
 
+using Dalamud.Interface.FontIdentifier;
 using Dalamud.Interface.GameFonts;
 using Dalamud.Interface.Utility;
 
@@ -140,7 +141,12 @@ public interface IFontAtlasBuildToolkitPreBuild : IFontAtlasBuildToolkit
     /// As this involves adding multiple fonts, calling this function will set <see cref="IFontAtlasBuildToolkit.Font"/>
     /// as the return value of this function, if it was empty before.
     /// </summary>
-    /// <param name="sizePx">Font size in pixels.</param>
+    /// <param name="sizePx">
+    /// Font size in pixels.
+    /// If a negative value is supplied,
+    /// (<see cref="UiBuilder.DefaultFontSpec"/>.<see cref="IFontSpec.SizePx"/> * <paramref name="sizePx"/>) will be
+    /// used as the font size. Specify -1 to use the default font size.
+    /// </param>
     /// <param name="glyphRanges">The glyph ranges. Use <see cref="FontAtlasBuildToolkitUtilities"/>.ToGlyphRange to build.</param>
     /// <returns>A font returned from <see cref="ImFontAtlasPtr.AddFont"/>.</returns>
     ImFontPtr AddDalamudDefaultFont(float sizePx, ushort[]? glyphRanges = null);

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPreBuild.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPreBuild.cs
@@ -11,6 +11,7 @@ namespace Dalamud.Interface.ManagedFontAtlas;
 
 /// <summary>
 /// Toolkit for use when the build state is <see cref="FontAtlasBuildStep.PreBuild"/>.<br />
+/// Not intended for plugins to implement.<br />
 /// <br />
 /// After <see cref="FontAtlasBuildStepDelegate"/> returns,
 /// either <see cref="IFontAtlasBuildToolkit.Font"/> must be set,

--- a/Dalamud/Interface/ManagedFontAtlas/IFontHandle.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontHandle.cs
@@ -5,7 +5,8 @@ using ImGuiNET;
 namespace Dalamud.Interface.ManagedFontAtlas;
 
 /// <summary>
-/// Represents a reference counting handle for fonts.
+/// Represents a reference counting handle for fonts.<br />
+/// Not intended for plugins to implement.
 /// </summary>
 public interface IFontHandle : IDisposable
 {

--- a/Dalamud/Interface/ManagedFontAtlas/ILockedImFont.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/ILockedImFont.cs
@@ -4,7 +4,8 @@ namespace Dalamud.Interface.ManagedFontAtlas;
 
 /// <summary>
 /// The wrapper for <see cref="ImFontPtr"/>, guaranteeing that the associated data will be available as long as
-/// this struct is not disposed.
+/// this struct is not disposed.<br />
+/// Not intended for plugins to implement.
 /// </summary>
 public interface ILockedImFont : IDisposable
 {

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Text.Unicode;
 
 using Dalamud.Configuration.Internal;
+using Dalamud.Interface.FontIdentifier;
 using Dalamud.Interface.GameFonts;
 using Dalamud.Interface.Internal;
 using Dalamud.Interface.Utility;
@@ -316,17 +317,11 @@ internal sealed partial class FontAtlasFactory
         {
             ImFontPtr font;
             glyphRanges ??= this.factory.DefaultGlyphRanges;
-            if (this.factory.UseAxis)
-            {
-                font = this.AddGameGlyphs(new(GameFontFamily.Axis, sizePx), glyphRanges, default);
-            }
-            else
-            {
-                font = this.AddDalamudAssetFont(
-                    DalamudAsset.NotoSansJpMedium,
-                    new() { SizePx = sizePx, GlyphRanges = glyphRanges });
+
+            var dfid = this.factory.DefaultFontId;
+            font = dfid.AddToBuildToolkit(this, sizePx, glyphRanges);
+            if (dfid is not GameFontAndFamilyId { GameFontFamily: GameFontFamily.Axis })
                 this.AddGameSymbol(new() { SizePx = sizePx, MergeFont = font });
-            }
 
             this.AttachExtraGlyphsForDalamudLanguage(new() { SizePx = sizePx, MergeFont = font });
             if (this.Font.IsNull())

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
@@ -319,9 +319,18 @@ internal sealed partial class FontAtlasFactory
             glyphRanges ??= this.factory.DefaultGlyphRanges;
 
             var dfid = this.factory.DefaultFontId;
-            font = dfid.AddToBuildToolkit(this, sizePx, glyphRanges);
-            if (dfid is not GameFontAndFamilyId { GameFontFamily: GameFontFamily.Axis })
-                this.AddGameSymbol(new() { SizePx = sizePx, MergeFont = font });
+            if (dfid is DalamudDefaultFontAndFamilyId)
+            {
+                // invalid; calling dfid.AddToBuildToolkit calls this function, causing infinite recursion
+                // fall back to AXIS fonts
+                font = this.AddGameGlyphs(new(GameFontFamily.Axis, sizePx), glyphRanges, default);
+            }
+            else
+            {
+                font = dfid.AddToBuildToolkit(this, sizePx, glyphRanges);
+                if (dfid is not GameFontAndFamilyId { GameFontFamily: GameFontFamily.Axis })
+                    this.AddGameSymbol(new() { SizePx = sizePx, MergeFont = font });
+            }
 
             this.AttachExtraGlyphsForDalamudLanguage(new() { SizePx = sizePx, MergeFont = font });
             if (this.Font.IsNull())

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
@@ -323,6 +323,9 @@ internal sealed partial class FontAtlasFactory
             glyphRanges ??= this.factory.DefaultGlyphRanges;
 
             var dfid = this.factory.DefaultFontSpec;
+            if (sizePx < 0f)
+                sizePx *= -dfid.SizePx;
+
             if (dfid is SingleFontSpec sfs)
             {
                 if (sfs.FontId is DalamudDefaultFontAndFamilyId)

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
@@ -539,16 +539,19 @@ internal sealed partial class FontAtlasFactory
                     break;
                 }
             }
-
-            foreach (var ac in this.registeredPostBuildActions)
-                ac.InvokeSafely();
-            this.registeredPostBuildActions.Clear();
         }
 
         public void PostBuildSubstances()
         {
             foreach (var substance in this.data.Substances)
                 substance.OnPostBuild(this);
+        }
+
+        public void PostBuildCallbacks()
+        {
+            foreach (var ac in this.registeredPostBuildActions)
+                ac.InvokeSafely();
+            this.registeredPostBuildActions.Clear();
         }
 
         public unsafe void UploadTextures()

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.Implementation.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.Implementation.cs
@@ -658,7 +658,7 @@ internal sealed partial class FontAtlasFactory
                     toolkit = res.CreateToolkit(this.factory, isAsync);
 
                     // PreBuildSubstances deals with toolkit.Add... function family. Do this first.
-                    var defaultFont = toolkit.AddDalamudDefaultFont(InterfaceManager.DefaultFontSizePx, null);
+                    var defaultFont = toolkit.AddDalamudDefaultFont(-1, null);
 
                     this.BuildStepChange?.Invoke(toolkit);
                     toolkit.PreBuildSubstances();

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.Implementation.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.Implementation.cs
@@ -679,6 +679,7 @@ internal sealed partial class FontAtlasFactory
 
                 toolkit.PostBuild();
                 toolkit.PostBuildSubstances();
+                toolkit.PostBuildCallbacks();
                 this.BuildStepChange?.Invoke(toolkit);
 
                 foreach (var font in toolkit.Fonts)

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.cs
@@ -122,8 +122,16 @@ internal sealed partial class FontAtlasFactory
 #pragma warning disable CS0618 // Type or member is obsolete
         ?? (Service<DalamudConfiguration>.Get().UseAxisFontsFromGame
 #pragma warning restore CS0618 // Type or member is obsolete
-                ? new() { FontId = new GameFontAndFamilyId(GameFontFamily.Axis) }
-                : new SingleFontSpec { FontId = new DalamudAssetFontAndFamilyId(DalamudAsset.NotoSansJpMedium) });
+                ? new()
+                {
+                    FontId = new GameFontAndFamilyId(GameFontFamily.Axis),
+                    SizePx = InterfaceManager.DefaultFontSizePx,
+                }
+                : new SingleFontSpec
+                {
+                    FontId = new DalamudAssetFontAndFamilyId(DalamudAsset.NotoSansJpMedium),
+                    SizePx = InterfaceManager.DefaultFontSizePx + 1,
+                });
 
     /// <summary>
     /// Gets the service instance of <see cref="Framework"/>.

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Dalamud.Configuration.Internal;
 using Dalamud.Data;
 using Dalamud.Game;
+using Dalamud.Interface.FontIdentifier;
 using Dalamud.Interface.GameFonts;
 using Dalamud.Interface.Internal;
 using Dalamud.Storage.Assets;
@@ -108,14 +109,21 @@ internal sealed partial class FontAtlasFactory
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether to override configuration for UseAxis.
+    /// Gets or sets a value indicating whether to override configuration for <see cref="DefaultFontId"/>.
     /// </summary>
-    public bool? UseAxisOverride { get; set; } = null;
+    public IFontId? DefaultFontIdOverride { get; set; } = null;
 
     /// <summary>
-    /// Gets a value indicating whether to use AXIS fonts.
+    /// Gets the default font ID.
     /// </summary>
-    public bool UseAxis => this.UseAxisOverride ?? Service<DalamudConfiguration>.Get().UseAxisFontsFromGame;
+    public IFontId DefaultFontId =>
+        this.DefaultFontIdOverride
+        ?? Service<DalamudConfiguration>.Get().DefaultFontId
+#pragma warning disable CS0618 // Type or member is obsolete
+        ?? (Service<DalamudConfiguration>.Get().UseAxisFontsFromGame
+#pragma warning restore CS0618 // Type or member is obsolete
+                ? new GameFontAndFamilyId(GameFontFamily.Axis)
+                : new DalamudAssetFontAndFamilyId(DalamudAsset.NotoSansJpMedium));
 
     /// <summary>
     /// Gets the service instance of <see cref="Framework"/>.

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.cs
@@ -109,21 +109,21 @@ internal sealed partial class FontAtlasFactory
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether to override configuration for <see cref="DefaultFontId"/>.
+    /// Gets or sets a value indicating whether to override configuration for <see cref="DefaultFontSpec"/>.
     /// </summary>
-    public IFontId? DefaultFontIdOverride { get; set; } = null;
+    public IFontSpec? DefaultFontSpecOverride { get; set; } = null;
 
     /// <summary>
     /// Gets the default font ID.
     /// </summary>
-    public IFontId DefaultFontId =>
-        this.DefaultFontIdOverride
-        ?? Service<DalamudConfiguration>.Get().DefaultFontId
+    public IFontSpec DefaultFontSpec =>
+        this.DefaultFontSpecOverride
+        ?? Service<DalamudConfiguration>.Get().DefaultFontSpec
 #pragma warning disable CS0618 // Type or member is obsolete
         ?? (Service<DalamudConfiguration>.Get().UseAxisFontsFromGame
 #pragma warning restore CS0618 // Type or member is obsolete
-                ? new GameFontAndFamilyId(GameFontFamily.Axis)
-                : new DalamudAssetFontAndFamilyId(DalamudAsset.NotoSansJpMedium));
+                ? new() { FontId = new GameFontAndFamilyId(GameFontFamily.Axis) }
+                : new SingleFontSpec { FontId = new DalamudAssetFontAndFamilyId(DalamudAsset.NotoSansJpMedium) });
 
     /// <summary>
     /// Gets the service instance of <see cref="Framework"/>.

--- a/Dalamud/Interface/ManagedFontAtlas/SafeFontConfig.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/SafeFontConfig.cs
@@ -26,7 +26,7 @@ public struct SafeFontConfig
         this.PixelSnapH = true;
         this.GlyphMaxAdvanceX = float.MaxValue;
         this.RasterizerMultiply = 1f;
-        this.RasterizerGamma = 1.4f;
+        this.RasterizerGamma = 1.7f;
         this.EllipsisChar = unchecked((char)-1);
         this.Raw.FontDataOwnedByAtlas = 1;
     }

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -7,6 +7,7 @@ using Dalamud.Game;
 using Dalamud.Game.ClientState;
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.Gui;
+using Dalamud.Interface.FontIdentifier;
 using Dalamud.Interface.GameFonts;
 using Dalamud.Interface.Internal;
 using Dalamud.Interface.Internal.ManagedAsserts;
@@ -197,6 +198,11 @@ public sealed class UiBuilder : IDisposable
     /// <strong>Accessing this static property outside of <see cref="Draw"/> is dangerous and not supported.</strong>
     /// </summary>
     public static ImFontPtr MonoFont => InterfaceManager.MonoFont;
+
+    /// <summary>
+    /// Gets the default font specifications.
+    /// </summary>
+    public IFontSpec DefaultFontSpec => Service<FontAtlasFactory>.Get().DefaultFontSpec;
 
     /// <summary>
     /// Gets the handle to the default Dalamud font - supporting all game languages and icons.

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -174,12 +174,12 @@ public sealed class UiBuilder : IDisposable
     /// <summary>
     /// Gets the default Dalamud font size in points.
     /// </summary>
-    public static float DefaultFontSizePt => InterfaceManager.DefaultFontSizePt;
+    public static float DefaultFontSizePt => Service<FontAtlasFactory>.Get().DefaultFontSpec.SizePt;
 
     /// <summary>
     /// Gets the default Dalamud font size in pixels.
     /// </summary>
-    public static float DefaultFontSizePx => InterfaceManager.DefaultFontSizePx;
+    public static float DefaultFontSizePx => Service<FontAtlasFactory>.Get().DefaultFontSpec.SizePx;
 
     /// <summary>
     /// Gets the default Dalamud font - supporting all game languages and icons.<br />

--- a/Dalamud/Interface/Utility/ImGuiHelpers.cs
+++ b/Dalamud/Interface/Utility/ImGuiHelpers.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using System.Reactive.Disposables;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Unicode;
 
 using Dalamud.Configuration.Internal;
@@ -542,6 +543,22 @@ public static class ImGuiHelpers
         // Mark 4K page as used
         var pageIndex = unchecked((ushort)(codepoint / 4096));
         font.NativePtr->Used4kPagesMap[pageIndex >> 3] |= unchecked((byte)(1 << (pageIndex & 7)));
+    }
+
+    /// <summary>
+    /// Sets the text for a text input, during the callback.
+    /// </summary>
+    /// <param name="data">The callback data.</param>
+    /// <param name="s">The new text.</param>
+    internal static unsafe void SetTextFromCallback(ImGuiInputTextCallbackData* data, string s)
+    {
+        ImGuiNative.ImGuiInputTextCallbackData_DeleteChars(data, 0, data->BufTextLen);
+        var len = Encoding.UTF8.GetByteCount(s);
+        var buf = len < 1024 ? stackalloc byte[len] : new byte[len];
+        Encoding.UTF8.GetBytes(s, buf);
+        fixed (byte* pBuf = buf)
+            ImGuiNative.ImGuiInputTextCallbackData_InsertChars(data, 0, pBuf, pBuf + len);
+        ImGuiNative.ImGuiInputTextCallbackData_SelectAll(data);
     }
     
     /// <summary>

--- a/Dalamud/Interface/Utility/ImGuiHelpers.cs
+++ b/Dalamud/Interface/Utility/ImGuiHelpers.cs
@@ -552,7 +552,9 @@ public static class ImGuiHelpers
     /// <param name="s">The new text.</param>
     internal static unsafe void SetTextFromCallback(ImGuiInputTextCallbackData* data, string s)
     {
-        ImGuiNative.ImGuiInputTextCallbackData_DeleteChars(data, 0, data->BufTextLen);
+        if (data->BufTextLen != 0)
+            ImGuiNative.ImGuiInputTextCallbackData_DeleteChars(data, 0, data->BufTextLen);
+
         var len = Encoding.UTF8.GetByteCount(s);
         var buf = len < 1024 ? stackalloc byte[len] : new byte[len];
         Encoding.UTF8.GetBytes(s, buf);

--- a/Dalamud/Utility/ArrayExtensions.cs
+++ b/Dalamud/Utility/ArrayExtensions.cs
@@ -97,4 +97,76 @@ internal static class ArrayExtensions
     /// <returns><paramref name="array"/> casted as a <see cref="IReadOnlyCollection{T}"/> if it is one; otherwise the result of <see cref="Enumerable.ToArray{TSource}"/>.</returns>
     public static IReadOnlyCollection<T> AsReadOnlyCollection<T>(this IEnumerable<T> array) =>
         array as IReadOnlyCollection<T> ?? array.ToArray();
+
+    /// <inheritdoc cref="List{T}.FindIndex(System.Predicate{T})"/>
+    public static int FindIndex<T>(this IReadOnlyList<T> list, Predicate<T> match)
+        => list.FindIndex(0, list.Count, match);
+
+    /// <inheritdoc cref="List{T}.FindIndex(int,System.Predicate{T})"/>
+    public static int FindIndex<T>(this IReadOnlyList<T> list, int startIndex, Predicate<T> match)
+        => list.FindIndex(startIndex, list.Count - startIndex, match);
+
+    /// <inheritdoc cref="List{T}.FindIndex(int,int,System.Predicate{T})"/>
+    public static int FindIndex<T>(this IReadOnlyList<T> list, int startIndex, int count, Predicate<T> match)
+    {
+        if ((uint)startIndex > (uint)list.Count)
+            throw new ArgumentOutOfRangeException(nameof(startIndex), startIndex, null);
+
+        if (count < 0 || startIndex > list.Count - count)
+            throw new ArgumentOutOfRangeException(nameof(count), count, null);
+
+        if (match == null)
+            throw new ArgumentNullException(nameof(match));
+
+        var endIndex = startIndex + count;
+        for (var i = startIndex; i < endIndex; i++)
+        {
+            if (match(list[i])) return i;
+        }
+
+        return -1;
+    }
+
+    /// <inheritdoc cref="List{T}.FindLastIndex(System.Predicate{T})"/>
+    public static int FindLastIndex<T>(this IReadOnlyList<T> list, Predicate<T> match)
+        => list.FindLastIndex(list.Count - 1, list.Count, match);
+
+    /// <inheritdoc cref="List{T}.FindLastIndex(int,System.Predicate{T})"/>
+    public static int FindLastIndex<T>(this IReadOnlyList<T> list, int startIndex, Predicate<T> match)
+        => list.FindLastIndex(startIndex, startIndex + 1, match);
+
+    /// <inheritdoc cref="List{T}.FindLastIndex(int,int,System.Predicate{T})"/>
+    public static int FindLastIndex<T>(this IReadOnlyList<T> list, int startIndex, int count, Predicate<T> match)
+    {
+        if (match == null)
+            throw new ArgumentNullException(nameof(match));
+
+        if (list.Count == 0)
+        {
+            // Special case for 0 length List
+            if (startIndex != -1)
+                throw new ArgumentOutOfRangeException(nameof(startIndex), startIndex, null);
+        }
+        else
+        {
+            // Make sure we're not out of range
+            if ((uint)startIndex >= (uint)list.Count)
+                throw new ArgumentOutOfRangeException(nameof(startIndex), startIndex, null);
+        }
+
+        // 2nd have of this also catches when startIndex == MAXINT, so MAXINT - 0 + 1 == -1, which is < 0.
+        if (count < 0 || startIndex - count + 1 < 0)
+            throw new ArgumentOutOfRangeException(nameof(count), count, null);
+
+        var endIndex = startIndex - count;
+        for (var i = startIndex; i > endIndex; i--)
+        {
+            if (match(list[i]))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
 }

--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -22,6 +22,9 @@ using Dalamud.Logging.Internal;
 using ImGuiNET;
 using Lumina.Excel.GeneratedSheets;
 using Serilog;
+
+using TerraFX.Interop.Windows;
+
 using Windows.Win32.Storage.FileSystem;
 
 namespace Dalamud.Utility;
@@ -682,6 +685,16 @@ public static class Util
         var rng = new Random();
 
         return names.ElementAt(rng.Next(0, names.Count() - 1)).Singular.RawString;
+    }
+
+    /// <summary>
+    /// Throws a corresponding exception if <see cref="HRESULT.FAILED"/> is true.
+    /// </summary>
+    /// <param name="hr">The result value.</param>
+    internal static void ThrowOnError(this HRESULT hr)
+    {
+        if (hr.FAILED)
+            Marshal.ThrowExceptionForHR(hr.Value);
     }
 
     /// <summary>


### PR DESCRIPTION
Plugin authors can now use the Dalamud-provided font chooser interface, so that they do not have to write font enumeration routines and stuff. They can store `IFontId` in configuration.

### Usage
```cs
var fcd = FontChooserDialog.CreateAuto(uiBuilderOrNewAsyncFontAtlas);
// or
// var fcd = new FontChooserDialog(uiBuilderOrNewAsyncFontAtlas);
// uiBuilder.Draw += fcd.Draw;
// fcd.ResultTask.ContinueWith(_ => { uiBuilder.Draw -= fcd.Draw; fcd.Dispose(); });

fcd.Title = "Blah...";
fcd.SelectedFont = previousFontSpec; // defaults to new SingleFontSpec() { FontId = DalamudDefaultFontAndFamilyId.Instance }
fcd.PreviewText = "Aaaaaa";
// To exclude the default font from being selected: fcd.FontFamilyExcludeFilter = x => x is DalamudDefaultFontAndFamilyId;
fcd.ResultTask.ContinueWith(r => { /* do stuff after selected; this block will probably be run off main thread */ });

// Using the result
var fontHandle = UiBuilder.FontAtlas.NewDelegateFontHandle(
    tk => tk.OnPreBuild(e => r.Result.AddToBuildToolkit(e)));
// or
var fontHandle = r.Result.CreateFontHandle(UiBuilder.FontAtlas);
```

### Screenshots
A user can now choose any font of their choice as their default font.
| a | b |
| --- | --- |
| ![image](https://github.com/goatcorp/Dalamud/assets/3614868/648c9bc9-92aa-4b3f-a5c2-e931bdc74c00) | ![image](https://github.com/goatcorp/Dalamud/assets/3614868/aa21c5e8-3f87-42ef-822d-56b6911fcdac) |

Unsupported fonts are prevented from being accepted.
| a | b |
| --- | --- |
| ![image](https://github.com/goatcorp/Dalamud/assets/3614868/e4c773aa-3cbd-4ac5-bd79-69fe4d025e12) | ![image](https://github.com/goatcorp/Dalamud/assets/3614868/a5761a30-854b-4657-82ab-bf740ef4a701) |
