### PR TITLE
Turn IDalamudAssetManager public

### DIFF
--- a/Dalamud/Storage/Assets/IDalamudAssetManager.cs
+++ b/Dalamud/Storage/Assets/IDalamudAssetManager.cs
@@ -16,7 +16,7 @@ namespace Dalamud.Storage.Assets;
 /// Think of C++ [[nodiscard]]. Also, like the intended meaning of the attribute, such methods will not have
 /// externally visible state changes.
 /// </summary>
-internal interface IDalamudAssetManager
+public interface IDalamudAssetManager
 {
     /// <summary>
     /// Gets the shared texture wrap for <see cref="DalamudAsset.Empty4X4"/>.


### PR DESCRIPTION
I thought I made it `public`, but turns out that it's `internal`.