### PR TITLE
DalamudCrashHandler: handle log-directory pointing to a file

### DIFF
--- a/Dalamud.Boot/utils.cpp
+++ b/Dalamud.Boot/utils.cpp
@@ -578,16 +578,6 @@ std::vector<std::string> utils::get_env_list(const wchar_t* pcszName) {
     return res;
 }
 
-std::wstring utils::to_wstring(const std::string& str) {
-    if (str.empty()) return std::wstring();
-    size_t convertedChars = 0;
-    size_t newStrSize = str.size() + 1;
-    std::wstring wstr(newStrSize, L'\0');
-    mbstowcs_s(&convertedChars, &wstr[0], newStrSize, str.c_str(), _TRUNCATE);
-    wstr.resize(convertedChars - 1);
-    return wstr;
-}
-
 std::filesystem::path utils::get_module_path(HMODULE hModule) {
     std::wstring buf(MAX_PATH, L'\0');
     while (true) {

--- a/Dalamud.Boot/utils.h
+++ b/Dalamud.Boot/utils.h
@@ -264,8 +264,6 @@ namespace utils {
         return get_env_list<T>(unicode::convert<std::wstring>(pcszName).c_str());
     }
 
-    std::wstring to_wstring(const std::string& str);
-
     std::filesystem::path get_module_path(HMODULE hModule);
 
     /// @brief Find the game main window.

--- a/Dalamud.Boot/veh.cpp
+++ b/Dalamud.Boot/veh.cpp
@@ -110,13 +110,13 @@ static void append_injector_launch_args(std::vector<std::wstring>& args)
     case DalamudStartInfo::LoadMethod::DllInject:
         args.emplace_back(L"--mode=inject");
     }
-    args.emplace_back(L"--logpath=\"" + utils::to_wstring(g_startInfo.BootLogPath) + L"\"");
-    args.emplace_back(L"--dalamud-working-directory=\"" + utils::to_wstring(g_startInfo.WorkingDirectory) + L"\"");
-    args.emplace_back(L"--dalamud-configuration-path=\"" + utils::to_wstring(g_startInfo.ConfigurationPath) + L"\"");
-    args.emplace_back(L"--dalamud-plugin-directory=\"" + utils::to_wstring(g_startInfo.PluginDirectory) + L"\"");
-    args.emplace_back(L"--dalamud-asset-directory=\"" + utils::to_wstring(g_startInfo.AssetDirectory) + L"\"");
-    args.emplace_back(L"--dalamud-client-language=" + std::to_wstring(static_cast<int>(g_startInfo.Language)));
-    args.emplace_back(L"--dalamud-delay-initialize=" + std::to_wstring(g_startInfo.DelayInitializeMs));
+    args.emplace_back(L"--logpath=\"" + unicode::convert<std::wstring>(g_startInfo.BootLogPath) + L"\"");
+    args.emplace_back(L"--dalamud-working-directory=\"" + unicode::convert<std::wstring>(g_startInfo.WorkingDirectory) + L"\"");
+    args.emplace_back(L"--dalamud-configuration-path=\"" + unicode::convert<std::wstring>(g_startInfo.ConfigurationPath) + L"\"");
+    args.emplace_back(L"--dalamud-plugin-directory=\"" + unicode::convert<std::wstring>(g_startInfo.PluginDirectory) + L"\"");
+    args.emplace_back(L"--dalamud-asset-directory=\"" + unicode::convert<std::wstring>(g_startInfo.AssetDirectory) + L"\"");
+    args.emplace_back(std::format(L"--dalamud-client-language={}", static_cast<int>(g_startInfo.Language)));
+    args.emplace_back(std::format(L"--dalamud-delay-initialize={}", g_startInfo.DelayInitializeMs));
     if (g_startInfo.BootShowConsole)
         args.emplace_back(L"--console");
     if (g_startInfo.BootEnableEtw)


### PR DESCRIPTION
* Changed A->W conversions to u8->W conversions, as DalamudStartInfo contains UTF-8 strings.
* Something is passing `dalamud.boot.log` to `--log-directory` but as I couldn't find where it was happening, made crash handler adjust the path to its parent directory if the path ends with `.log`.