### PR TITLE
Crash Handler Improvements

### DIFF
--- a/DalamudCrashHandler/DalamudCrashHandler.cpp
+++ b/DalamudCrashHandler/DalamudCrashHandler.cpp
@@ -916,7 +916,7 @@ int main() {
 
         const TASKDIALOG_BUTTON buttons[]{
             {IdButtonRestart, L"Restart\nRestart the game with the above-selected option."},
-            {IdButtonSaveTsPack, L"Save Troubleshooting Pack\nSave a .tspack file containing information about this crash for analysis."},
+            {IdButtonSaveTsPack, L"Save Troubleshooting Info\nSave a .tspack file containing information about this crash for analysis."},
             {IdButtonExit, L"Exit\nExit the game."},
         };
 

--- a/DalamudCrashHandler/DalamudCrashHandler.cpp
+++ b/DalamudCrashHandler/DalamudCrashHandler.cpp
@@ -758,9 +758,9 @@ int main() {
         std::cout << "Creating progress window" << std::endl;
         IProgressDialog* pProgressDialog = NULL;
         if (SUCCEEDED(CoCreateInstance(CLSID_ProgressDialog, NULL, CLSCTX_ALL, IID_IProgressDialog, (void**)&pProgressDialog)) && pProgressDialog) {
-            pProgressDialog->SetTitle(L"Dalamud");
-            pProgressDialog->SetLine(1, L"The game has crashed", FALSE, NULL);
-            pProgressDialog->SetLine(2, L"Dalamud is collecting further information", FALSE, NULL);
+            pProgressDialog->SetTitle(L"Dalamud Crash Handler");
+            pProgressDialog->SetLine(1, L"The game has crashed!", FALSE, NULL);
+            pProgressDialog->SetLine(2, L"Dalamud is collecting further information...", FALSE, NULL);
             pProgressDialog->SetLine(3, L"Refreshing Game Module List", FALSE, NULL);
             pProgressDialog->StartProgressDialog(NULL, NULL, PROGDLG_MARQUEEPROGRESS | PROGDLG_NOCANCEL | PROGDLG_NOMINIMIZE, NULL);
             IOleWindow* pOleWindow;
@@ -904,47 +904,6 @@ int main() {
         print_exception_info_extended(exinfo.ExceptionPointers, exinfo.ContextRecord, log);
         std::wofstream(logPath) << log.str();
 
-        std::thread submitThread;
-        if (!getenv("DALAMUD_NO_METRIC")) {
-            auto url = std::format(L"/Dalamud/Metric/ReportCrash?lt={}&code={:x}", exinfo.nLifetime, exinfo.ExceptionRecord.ExceptionCode);
-
-            submitThread = std::thread([url = std::move(url)] {
-                const auto hInternet = WinHttpOpen(L"Dalamud Crash Handler/1.0", 
-                                     WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
-                                     WINHTTP_NO_PROXY_NAME, 
-                                     WINHTTP_NO_PROXY_BYPASS, 0);
-                const auto hConnect = !hInternet ? nullptr : WinHttpConnect(hInternet, L"kamori.goats.dev", INTERNET_DEFAULT_HTTP_PORT, 0);
-                const auto hRequest = !hConnect ? nullptr : WinHttpOpenRequest(hConnect, L"GET", url.c_str(), NULL, WINHTTP_NO_REFERER, 
-                                               WINHTTP_DEFAULT_ACCEPT_TYPES,
-                                               0);
-                if (hRequest) WinHttpAddRequestHeaders(hRequest, L"Host: kamori.goats.dev", (ULONG)-1L, WINHTTP_ADDREQ_FLAG_ADD);
-                const auto bSent = !hRequest ? false : WinHttpSendRequest(hRequest, WINHTTP_NO_ADDITIONAL_HEADERS,
-                                               0, WINHTTP_NO_REQUEST_DATA, 0, 
-                                               0, 0);
-
-                if (!bSent)
-                    std::cerr << std::format("Failed to send metric: 0x{:x}", GetLastError()) << std::endl;
-
-                if (WinHttpReceiveResponse(hRequest, nullptr))
-                {
-                    DWORD dwStatusCode = 0;
-                    DWORD dwStatusCodeSize = sizeof(DWORD);
-
-                    WinHttpQueryHeaders(hRequest,
-                                        WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
-                                        WINHTTP_HEADER_NAME_BY_INDEX,
-                                        &dwStatusCode, &dwStatusCodeSize, WINHTTP_NO_HEADER_INDEX);
-
-                    if (dwStatusCode != 200)
-                        std::cerr << std::format("Failed to send metric: {}", dwStatusCode) << std::endl;
-                }
-                
-                if (hRequest) WinHttpCloseHandle(hRequest);
-                if (hConnect) WinHttpCloseHandle(hConnect);
-                if (hInternet) WinHttpCloseHandle(hInternet);
-            });
-        }
-
         TASKDIALOGCONFIG config = { 0 };
 
         const TASKDIALOG_BUTTON radios[]{
@@ -1033,15 +992,7 @@ int main() {
             return (*reinterpret_cast<decltype(callback)*>(dwRefData))(hwnd, uNotification, wParam, lParam);
         };
         config.lpCallbackData = reinterpret_cast<LONG_PTR>(&callback);
-
-        if (pProgressDialog)
-            pProgressDialog->SetLine(3, L"Submitting Metrics", FALSE, NULL);
-
-        if (submitThread.joinable()) {
-            submitThread.join();
-            submitThread = {};
-        }
-
+        
         if (pProgressDialog) {
             pProgressDialog->StopProgressDialog();
             pProgressDialog->Release();


### PR DESCRIPTION
- Remove the metric submission from the crash handler. It served virtually no purpose and didn't give us much/any useful information anyways.
- Add a new button to save a troubleshooting pack, below restart for now.
- Require the user choose a restart mode before enabling the restart button.
- Reword a few things all around.

![image](https://github.com/goatcorp/Dalamud/assets/5192145/bcaa7e0b-c189-4ee8-8d89-57b62dd51140)

---

This will require some additional QA, as I can't actually get a tspack to save from the crash screen on a fake inject. Not sure why, but it happens without these changes too...