### PR TITLE
Add SetFontScaleMode(ImFontPtr, FontScaleMode)

### DIFF
--- a/Dalamud/Interface/FontIdentifier/IFontSpec.cs
+++ b/Dalamud/Interface/FontIdentifier/IFontSpec.cs
@@ -31,6 +31,8 @@ public interface IFontSpec
     /// <param name="atlas">The atlas to bind this font handle to.</param>
     /// <param name="callback">Optional callback to be called after creating the font handle.</param>
     /// <returns>The new font handle.</returns>
+    /// <remarks><see cref="IFontAtlasBuildToolkit.Font"/> will be set when <paramref name="callback"/> is invoked.
+    /// </remarks>
     IFontHandle CreateFontHandle(IFontAtlas atlas, FontAtlasBuildStepDelegate? callback = null);
 
     /// <summary>

--- a/Dalamud/Interface/FontIdentifier/SingleFontSpec.cs
+++ b/Dalamud/Interface/FontIdentifier/SingleFontSpec.cs
@@ -109,6 +109,8 @@ public record SingleFontSpec : IFontSpec
         tk.RegisterPostBuild(
             () =>
             {
+                // Multiplication by scale will be done with global scale, outside of this handling.
+                var scale = tk.GetFontScaleMode(font) == FontScaleMode.UndoGlobalScale ? 1 / tk.Scale : 1;
                 var roundUnit = tk.GetFontScaleMode(font) == FontScaleMode.SkipHandling ? 1 : 1 / tk.Scale;
                 var newAscent = MathF.Round((font.Ascent * this.LineHeight) / roundUnit) * roundUnit;
                 var newFontSize = MathF.Round((font.FontSize * this.LineHeight) / roundUnit) * roundUnit;
@@ -129,13 +131,10 @@ public record SingleFontSpec : IFontSpec
                     }
                 }
 
-                // `/ roundUnit` = `* scale`
-                var dax = MathF.Round(this.LetterSpacing / roundUnit / roundUnit) * roundUnit;
-                var dxy0 = this.GlyphOffset / roundUnit;
-
+                var dax = MathF.Round((this.LetterSpacing * scale) / roundUnit) * roundUnit;
+                var dxy0 = this.GlyphOffset * scale;
                 dxy0 /= roundUnit;
-                dxy0.X = MathF.Round(dxy0.X);
-                dxy0.Y = MathF.Round(dxy0.Y);
+                dxy0 = new(MathF.Round(dxy0.X), MathF.Round(dxy0.Y));
                 dxy0 *= roundUnit;
 
                 dxy0.Y += shiftDown;

--- a/Dalamud/Interface/FontIdentifier/SingleFontSpec.cs
+++ b/Dalamud/Interface/FontIdentifier/SingleFontSpec.cs
@@ -109,7 +109,7 @@ public record SingleFontSpec : IFontSpec
         tk.RegisterPostBuild(
             () =>
             {
-                var roundUnit = tk.IsGlobalScaleIgnored(font) ? 1 : 1 / tk.Scale;
+                var roundUnit = tk.GetFontScaleMode(font) == FontScaleMode.SkipHandling ? 1 : 1 / tk.Scale;
                 var newAscent = MathF.Round((font.Ascent * this.LineHeight) / roundUnit) * roundUnit;
                 var newFontSize = MathF.Round((font.FontSize * this.LineHeight) / roundUnit) * roundUnit;
                 var shiftDown = MathF.Round((newFontSize - font.FontSize) / 2f / roundUnit) * roundUnit;

--- a/Dalamud/Interface/ImGuiFontChooserDialog/SingleFontChooserDialog.cs
+++ b/Dalamud/Interface/ImGuiFontChooserDialog/SingleFontChooserDialog.cs
@@ -342,9 +342,7 @@ public sealed class SingleFontChooserDialog : IDisposable
         {
             this.fontHandle ??= this.selectedFont.CreateFontHandle(
                 this.atlas,
-                tk =>
-                    tk.OnPreBuild(e => e.IgnoreGlobalScale(e.Font))
-                      .OnPostBuild(e => e.Font.AdjustGlyphMetrics(1f / e.Scale)));
+                tk => tk.OnPreBuild(e => e.SetFontScaleMode(e.Font, FontScaleMode.UndoGlobalScale)));
         }
         else
         {
@@ -837,7 +835,7 @@ public sealed class SingleFontChooserDialog : IDisposable
         var changed = false;
 
         if (!ImGui.BeginTable("##advancedOptions", 4))
-            return changed;
+            return false;
 
         var labelWidth = ImGui.CalcTextSize("Letter Spacing:").X;
         labelWidth = Math.Max(labelWidth, ImGui.CalcTextSize("Offset:").X);

--- a/Dalamud/Interface/ManagedFontAtlas/FontScaleMode.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/FontScaleMode.cs
@@ -1,0 +1,33 @@
+using Dalamud.Interface.Utility;
+
+using ImGuiNET;
+
+namespace Dalamud.Interface.ManagedFontAtlas;
+
+/// <summary>
+/// Specifies how should global font scale affect a font.
+/// </summary>
+public enum FontScaleMode
+{
+    /// <summary>
+    /// Do the default handling. Dalamud will load the sufficienty large font that will accomodate the global scale,
+    /// and stretch the loaded glyphs so that they look pixel-perfect after applying global scale on drawing.
+    /// Note that bitmap fonts and game fonts will always look blurry if they're not in their original sizes.
+    /// </summary>
+    Default,
+    
+    /// <summary>
+    /// Do nothing with the font. Dalamud will load the font with the size that is exactly as specified.
+    /// On drawing, the font will look blurry due to stretching.
+    /// Intended for use with custom scale handling.
+    /// </summary>
+    SkipHandling,
+    
+    /// <summary>
+    /// Stretch the glyphs of the loaded font by the inverse of the global scale.
+    /// On drawing, the font will always render exactly as the requested size without blurring, as long as
+    /// <see cref="ImGuiHelpers.GlobalScale"/> and <see cref="ImGui.SetWindowFontScale"/> do not affect the scale any
+    /// further. Note that bitmap fonts and game fonts will always look blurry if they're not in their original sizes.
+    /// </summary>
+    UndoGlobalScale,
+}

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPostBuild.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPostBuild.cs
@@ -1,4 +1,5 @@
 ﻿using Dalamud.Interface.Internal;
+using Dalamud.Utility;
 
 using ImGuiNET;
 
@@ -10,12 +11,13 @@ namespace Dalamud.Interface.ManagedFontAtlas;
 /// </summary>
 public interface IFontAtlasBuildToolkitPostBuild : IFontAtlasBuildToolkit
 {
-    /// <summary>
-    /// Gets whether global scaling is ignored for the given font.
-    /// </summary>
-    /// <param name="fontPtr">The font.</param>
-    /// <returns>True if ignored.</returns>
-    bool IsGlobalScaleIgnored(ImFontPtr fontPtr);
+    /// <inheritdoc cref="IFontAtlasBuildToolkitPreBuild.IsGlobalScaleIgnored"/>
+    [Obsolete($"Use {nameof(this.GetFontScaleMode)}")]
+    [Api10ToDo(Api10ToDoAttribute.DeleteCompatBehavior)]
+    bool IsGlobalScaleIgnored(ImFontPtr fontPtr) => this.GetFontScaleMode(fontPtr) == FontScaleMode.UndoGlobalScale;
+
+    /// <inheritdoc cref="IFontAtlasBuildToolkitPreBuild.GetFontScaleMode"/>
+    FontScaleMode GetFontScaleMode(ImFontPtr fontPtr);
 
     /// <summary>
     /// Stores a texture to be managed with the atlas.

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPreBuild.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPreBuild.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using Dalamud.Interface.FontIdentifier;
 using Dalamud.Interface.GameFonts;
 using Dalamud.Interface.Utility;
+using Dalamud.Utility;
 
 using ImGuiNET;
 
@@ -45,14 +46,37 @@ public interface IFontAtlasBuildToolkitPreBuild : IFontAtlasBuildToolkit
     /// </summary>
     /// <param name="fontPtr">The font.</param>
     /// <returns>Same <see cref="ImFontPtr"/> with <paramref name="fontPtr"/>.</returns>
-    ImFontPtr IgnoreGlobalScale(ImFontPtr fontPtr);
+    [Obsolete(
+        $"Use {nameof(this.SetFontScaleMode)} with {nameof(FontScaleMode)}.{nameof(FontScaleMode.UndoGlobalScale)}")]
+    [Api10ToDo(Api10ToDoAttribute.DeleteCompatBehavior)]
+    ImFontPtr IgnoreGlobalScale(ImFontPtr fontPtr) => this.SetFontScaleMode(fontPtr, FontScaleMode.UndoGlobalScale);
 
     /// <summary>
     /// Gets whether global scaling is ignored for the given font.
     /// </summary>
     /// <param name="fontPtr">The font.</param>
     /// <returns>True if ignored.</returns>
-    bool IsGlobalScaleIgnored(ImFontPtr fontPtr);
+    [Obsolete($"Use {nameof(this.GetFontScaleMode)}")]
+    [Api10ToDo(Api10ToDoAttribute.DeleteCompatBehavior)]
+    bool IsGlobalScaleIgnored(ImFontPtr fontPtr) => this.GetFontScaleMode(fontPtr) == FontScaleMode.UndoGlobalScale;
+
+    /// <summary>
+    /// Sets the scaling mode for the given font.
+    /// </summary>
+    /// <param name="fontPtr">The font, returned from <see cref="AddFontFromFile"/> and alike.
+    /// Note that <see cref="IFontAtlasBuildToolkit.Font"/> property is not guaranteed to be automatically updated upon
+    /// calling font adding functions. Pass the return value from font adding functions, not
+    /// <see cref="IFontAtlasBuildToolkit.Font"/> property.</param>
+    /// <param name="mode">The scaling mode.</param>
+    /// <returns><paramref name="fontPtr"/>.</returns>
+    ImFontPtr SetFontScaleMode(ImFontPtr fontPtr, FontScaleMode mode);
+
+    /// <summary>
+    /// Gets the scaling mode for the given font.
+    /// </summary>
+    /// <param name="fontPtr">The font.</param>
+    /// <returns>The scaling mode.</returns>
+    FontScaleMode GetFontScaleMode(ImFontPtr fontPtr);
 
     /// <summary>
     /// Registers a function to be run after build.

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
@@ -85,7 +85,7 @@ internal sealed partial class FontAtlasFactory
         /// <summary>
         /// Gets the list of fonts to ignore global scale.
         /// </summary>
-        public List<ImFontPtr> GlobalScaleExclusions { get; } = new();
+        private Dictionary<ImFontPtr, FontScaleMode> GlobalScaleExclusions { get; } = new();
 
         /// <inheritdoc/>
         public void Dispose() => this.disposeAfterBuild.Dispose();
@@ -151,15 +151,15 @@ internal sealed partial class FontAtlasFactory
         }
 
         /// <inheritdoc/>
-        public ImFontPtr IgnoreGlobalScale(ImFontPtr fontPtr)
+        public ImFontPtr SetFontScaleMode(ImFontPtr fontPtr, FontScaleMode scaleMode)
         {
-            this.GlobalScaleExclusions.Add(fontPtr);
+            this.GlobalScaleExclusions[fontPtr] = scaleMode;
             return fontPtr;
         }
 
-        /// <inheritdoc cref="IFontAtlasBuildToolkitPreBuild.IsGlobalScaleIgnored"/>
-        public bool IsGlobalScaleIgnored(ImFontPtr fontPtr) =>
-            this.GlobalScaleExclusions.Contains(fontPtr);
+        /// <inheritdoc cref="IFontAtlasBuildToolkitPreBuild.GetFontScaleMode"/>
+        public FontScaleMode GetFontScaleMode(ImFontPtr fontPtr) =>
+            this.GlobalScaleExclusions.GetValueOrDefault(fontPtr, FontScaleMode.Default);
 
         /// <inheritdoc/>
         public int StoreTexture(IDalamudTextureWrap textureWrap, bool disposeOnError) =>
@@ -496,17 +496,17 @@ internal sealed partial class FontAtlasFactory
             var configData = this.data.ConfigData;
             foreach (ref var config in configData.DataSpan)
             {
-                if (this.GlobalScaleExclusions.Contains(new(config.DstFont)))
+                if (this.GetFontScaleMode(config.DstFont) != FontScaleMode.Default)
                     continue;
 
                 config.SizePixels *= this.Scale;
 
                 config.GlyphMaxAdvanceX *= this.Scale;
-                if (float.IsInfinity(config.GlyphMaxAdvanceX))
+                if (float.IsInfinity(config.GlyphMaxAdvanceX) || float.IsNaN(config.GlyphMaxAdvanceX))
                     config.GlyphMaxAdvanceX = config.GlyphMaxAdvanceX > 0 ? float.MaxValue : -float.MaxValue;
 
                 config.GlyphMinAdvanceX *= this.Scale;
-                if (float.IsInfinity(config.GlyphMinAdvanceX))
+                if (float.IsInfinity(config.GlyphMinAdvanceX) || float.IsNaN(config.GlyphMinAdvanceX))
                     config.GlyphMinAdvanceX = config.GlyphMinAdvanceX > 0 ? float.MaxValue : -float.MaxValue;
 
                 config.GlyphOffset *= this.Scale;
@@ -536,7 +536,7 @@ internal sealed partial class FontAtlasFactory
             var scale = this.Scale;
             foreach (ref var font in this.Fonts.DataSpan)
             {
-                if (!this.GlobalScaleExclusions.Contains(font))
+                if (this.GetFontScaleMode(font) != FontScaleMode.SkipHandling)
                     font.AdjustGlyphMetrics(1 / scale, 1 / scale);
 
                 foreach (var c in FallbackCodepoints)

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
@@ -83,9 +83,9 @@ internal sealed partial class FontAtlasFactory
         public ImVectorWrapper<ImFontPtr> Fonts => this.data.Fonts;
 
         /// <summary>
-        /// Gets the list of fonts to ignore global scale.
+        /// Gets the font scale modes.
         /// </summary>
-        private Dictionary<ImFontPtr, FontScaleMode> GlobalScaleExclusions { get; } = new();
+        private Dictionary<ImFontPtr, FontScaleMode> FontScaleModes { get; } = new();
 
         /// <inheritdoc/>
         public void Dispose() => this.disposeAfterBuild.Dispose();
@@ -153,13 +153,13 @@ internal sealed partial class FontAtlasFactory
         /// <inheritdoc/>
         public ImFontPtr SetFontScaleMode(ImFontPtr fontPtr, FontScaleMode scaleMode)
         {
-            this.GlobalScaleExclusions[fontPtr] = scaleMode;
+            this.FontScaleModes[fontPtr] = scaleMode;
             return fontPtr;
         }
 
         /// <inheritdoc cref="IFontAtlasBuildToolkitPreBuild.GetFontScaleMode"/>
         public FontScaleMode GetFontScaleMode(ImFontPtr fontPtr) =>
-            this.GlobalScaleExclusions.GetValueOrDefault(fontPtr, FontScaleMode.Default);
+            this.FontScaleModes.GetValueOrDefault(fontPtr, FontScaleMode.Default);
 
         /// <inheritdoc/>
         public int StoreTexture(IDalamudTextureWrap textureWrap, bool disposeOnError) =>


### PR DESCRIPTION
`IgnoreGlobalScale` was advertised as "excludes the given font from global scaling", but the intent I had in mind was "excludes the given font from being scaled in any manner **during the font build process**". As the latter functionality is needed, obsoleted `IgnoreGlobalScale` and added `SetFontScaleMode`.

Effects of different values can be checked using "Game Prebaked Fonts".
![image](https://github.com/goatcorp/Dalamud/assets/3614868/de420a7e-7e2a-44b1-8c24-c4f3fd0a3c68)
