### PR TITLE
Make IsResumeGameAfterPluginLoad work with DllInject

### DIFF
--- a/Dalamud.Boot/DalamudStartInfo.cpp
+++ b/Dalamud.Boot/DalamudStartInfo.cpp
@@ -74,10 +74,10 @@ void from_json(const nlohmann::json& json, DalamudStartInfo::LoadMethod& value) 
 
     }
     else if (json.is_string()) {
-        const auto langstr = unicode::convert<std::string>(json.get<std::string>(), &unicode::lower);
-        if (langstr == "entrypoint")
+        const auto loadstr = unicode::convert<std::string>(json.get<std::string>(), &unicode::lower);
+        if (loadstr == "entrypoint")
             value = DalamudStartInfo::LoadMethod::Entrypoint;
-        else if (langstr == "inject")
+        else if (loadstr == "inject")
             value = DalamudStartInfo::LoadMethod::DllInject;
     }
 }

--- a/Dalamud.Injector/GameStart.cs
+++ b/Dalamud.Injector/GameStart.cs
@@ -25,10 +25,10 @@ namespace Dalamud.Injector
         /// <param name="dontFixAcl">Don't actually fix the ACL.</param>
         /// <param name="beforeResume">Action to execute before the process is started.</param>
         /// <param name="waitForGameWindow">Wait for the game window to be ready before proceeding.</param>
-        /// <returns>The started process.</returns>
+        /// <returns>The started process and handle to the started main thread.</returns>
         /// <exception cref="Win32Exception">Thrown when a win32 error occurs.</exception>
         /// <exception cref="GameStartException">Thrown when the process did not start correctly.</exception>
-        public static Process LaunchGame(string workingDir, string exePath, string arguments, bool dontFixAcl, Action<Process> beforeResume, bool waitForGameWindow = true)
+        public static (Process GameProcess, nint MainThreadHandle) LaunchGame(string workingDir, string exePath, string arguments, bool dontFixAcl, Action<Process> beforeResume, bool waitForGameWindow = true)
         {
             Process process = null;
 
@@ -172,10 +172,20 @@ namespace Dalamud.Injector
             {
                 if (psecDesc != IntPtr.Zero)
                     Marshal.FreeHGlobal(psecDesc);
-                PInvoke.CloseHandle(lpProcessInformation.hThread);
             }
 
-            return process;
+            NativeFunctions.DuplicateHandle(
+                 PInvoke.GetCurrentProcess(),
+                 lpProcessInformation.hThread,
+                 lpProcessInformation.hProcess,
+                 out var mainThreadHandle,
+                 0,
+                 false,
+                 NativeFunctions.DuplicateOptions.SameAccess);
+
+            PInvoke.CloseHandle(lpProcessInformation.hThread);
+
+            return (process, mainThreadHandle);
         }
 
         /// <summary>

--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -44,8 +44,8 @@ internal sealed class Dalamud : IServiceType
     /// <param name="info">DalamudStartInfo instance.</param>
     /// <param name="fs">ReliableFileStorage instance.</param>
     /// <param name="configuration">The Dalamud configuration.</param>
-    /// <param name="mainThreadContinueEvent">Event used to signal the main thread to continue.</param>
-    public Dalamud(DalamudStartInfo info, ReliableFileStorage fs, DalamudConfiguration configuration, IntPtr mainThreadContinueEvent)
+    /// <param name="mainThreadHandle">Handle to the suspended main thread.</param>
+    public Dalamud(DalamudStartInfo info, ReliableFileStorage fs, DalamudConfiguration configuration, nint mainThreadHandle)
     {
         this.StartInfo = info;
         
@@ -72,7 +72,7 @@ internal sealed class Dalamud : IServiceType
 
         if (!configuration.IsResumeGameAfterPluginLoad)
         {
-            NativeFunctions.SetEvent(mainThreadContinueEvent);
+            this.ResumeThread(mainThreadHandle);
             ServiceManager.InitializeEarlyLoadableServices()
                           .ContinueWith(t =>
                           {
@@ -102,7 +102,7 @@ internal sealed class Dalamud : IServiceType
                     if (faultedTasks.Any())
                         throw new AggregateException(faultedTasks);
 
-                    NativeFunctions.SetEvent(mainThreadContinueEvent);
+                    this.ResumeThread(mainThreadHandle);
 
                     await Task.WhenAll(tasks);
                 }
@@ -113,7 +113,7 @@ internal sealed class Dalamud : IServiceType
                 }
                 finally
                 {
-                    NativeFunctions.SetEvent(mainThreadContinueEvent);
+                    this.ResumeThread(mainThreadHandle);
                 }
             });
         }
@@ -243,4 +243,25 @@ internal sealed class Dalamud : IServiceType
             FFXIVClientStructs.Interop.Resolver.GetInstance.Resolve();
         }
     }
+
+    /// <summary>
+    /// Resumes a thread by incrementing its suspend count to zero, and then closing its handle.
+    /// </summary>
+    /// <param name="threadHandle">Handle to the thread to be resumed.</param>
+    private void ResumeThread(nint threadHandle)
+    {
+        int previousSuspendCount;
+
+        while ((previousSuspendCount = (int)NativeFunctions.ResumeThread(threadHandle)) > 1)
+        {
+            if (previousSuspendCount == -1)
+            {
+                Log.Error("Failed to resume main thread");
+                return;
+            }
+        }
+
+        NativeFunctions.CloseHandle(threadHandle);
+    }
+
 }

--- a/Dalamud/NativeFunctions.cs
+++ b/Dalamud/NativeFunctions.cs
@@ -1917,6 +1917,40 @@ internal static partial class NativeFunctions
     /// <returns>The thread ID.</returns>
     [DllImport("kernel32.dll")]
     public static extern uint GetCurrentThreadId();
+
+    /// <summary>
+    /// Suspends a thread.
+    /// </summary>
+    /// <param name="hThread">Handle to the thread to be suspended.</param>
+    /// <returns>If the function succeeds, the return value is the thread's previous suspend count.
+    /// If the function fails, the return value is (DWORD) -1.</returns>
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern uint SuspendThread(IntPtr hThread);
+
+    /// <summary>
+    /// Resumes a thread that was suspended.
+    /// </summary>
+    /// <param name="hThread">Handle to the thread to be resumed.</param>
+    /// <returns>If the function succeeds, the return value is the thread's previous suspend count.
+    /// If the function fails, the return value is (DWORD) -1.</returns>
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern uint ResumeThread(IntPtr hThread);
+
+    /// <summary>
+    /// Closes an open object handle.
+    /// </summary>
+    /// <param name="hObject">
+    /// A valid handle to an open object.
+    /// </param>
+    /// <returns>
+    /// If the function succeeds, the return value is nonzero. If the function fails, the return value is zero. To get extended error
+    /// information, call GetLastError. If the application is running under a debugger, the function will throw an exception if it receives
+    /// either a handle value that is not valid or a pseudo-handle value. This can happen if you close a handle twice, or if you call
+    /// CloseHandle on a handle returned by the FindFirstFile function instead of calling the FindClose function.
+    /// </returns>
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool CloseHandle(IntPtr hObject);
 }
 
 /// <summary>


### PR DESCRIPTION
This contains only the part of https://github.com/goatcorp/Dalamud/pull/1668 that makes `DllInject` block correctly on startup instead of silently failing to do so.