### PR TITLE
IGameConfig: fix load-time race condition

### DIFF
--- a/Dalamud/Game/Config/GameConfig.cs
+++ b/Dalamud/Game/Config/GameConfig.cs
@@ -81,7 +81,9 @@ internal sealed class GameConfig : IServiceType, IGameConfig, IDisposable
     public event EventHandler<ConfigChangeEvent>? UiControlChanged;
 #pragma warning restore 67
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Gets a task representing the initialization state of this class.
+    /// </summary>
     public Task InitializationTask => this.tcsInitialization.Task;
 
     /// <inheritdoc/>
@@ -251,13 +253,15 @@ internal class GameConfigPluginScoped : IDisposable, IServiceType, IGameConfig
     [ServiceManager.ServiceDependency]
     private readonly GameConfig gameConfigService = Service<GameConfig>.Get();
 
+    private readonly Task initializationTask;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="GameConfigPluginScoped"/> class.
     /// </summary>
     internal GameConfigPluginScoped()
     {
         this.gameConfigService.Changed += this.ConfigChangedForward;
-        this.InitializationTask = this.gameConfigService.InitializationTask.ContinueWith(
+        this.initializationTask = this.gameConfigService.InitializationTask.ContinueWith(
             r =>
             {
                 if (!r.IsCompletedSuccessfully)
@@ -282,9 +286,6 @@ internal class GameConfigPluginScoped : IDisposable, IServiceType, IGameConfig
     public event EventHandler<ConfigChangeEvent>? UiControlChanged;
     
     /// <inheritdoc/>
-    public Task InitializationTask { get; }
-    
-    /// <inheritdoc/>
     public GameConfigSection System => this.gameConfigService.System;
 
     /// <inheritdoc/>
@@ -297,7 +298,7 @@ internal class GameConfigPluginScoped : IDisposable, IServiceType, IGameConfig
     public void Dispose()
     {
         this.gameConfigService.Changed -= this.ConfigChangedForward;
-        this.InitializationTask.ContinueWith(
+        this.initializationTask.ContinueWith(
             r =>
             {
                 if (!r.IsCompletedSuccessfully)

--- a/Dalamud/Plugin/Services/IGameConfig.cs
+++ b/Dalamud/Plugin/Services/IGameConfig.cs
@@ -1,14 +1,20 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
 
 using Dalamud.Game.Config;
-using FFXIVClientStructs.FFXIV.Common.Configuration;
+using Dalamud.Plugin.Internal.Types;
 
 namespace Dalamud.Plugin.Services;
 
 /// <summary>
 /// This class represents the game's configuration.
 /// </summary>
+/// <remarks>
+/// Avoid accessing configuration from your plugin constructor, especially if your plugin sets
+/// <see cref="PluginManifest.LoadRequiredState"/> to <c>2</c> and <see cref="PluginManifest.LoadSync"/> to <c>true</c>.
+/// If property access from the plugin constructor is desired, do the value retrieval asynchronously via
+/// <see cref="IFramework.RunOnFrameworkThread{T}(Func{T})"/>; do not wait for the result right away.
+/// </remarks>
 public interface IGameConfig
 {
     /// <summary>
@@ -30,6 +36,16 @@ public interface IGameConfig
     /// Event which is fired when a UiControl config option is changed.
     /// </summary>
     public event EventHandler<ConfigChangeEvent> UiControlChanged; 
+
+    /// <summary>
+    /// Gets a task representing the initialization state of this instance of <see cref="IGameConfig"/>.
+    /// </summary>
+    /// <remarks>
+    /// Accessing <see cref="GameConfigSection"/>-typed properties such as <see cref="System"/>, directly or indirectly
+    /// via <see cref="TryGet(Game.Config.SystemConfigOption,out bool)"/>,
+    /// <see cref="Set(Game.Config.SystemConfigOption,bool)"/>, or alike will block, if this task is incomplete.
+    /// </remarks>
+    public Task InitializationTask { get; }
 
     /// <summary>
     /// Gets the collection of config options that persist between characters.

--- a/Dalamud/Plugin/Services/IGameConfig.cs
+++ b/Dalamud/Plugin/Services/IGameConfig.cs
@@ -10,7 +10,10 @@ namespace Dalamud.Plugin.Services;
 /// This class represents the game's configuration.
 /// </summary>
 /// <remarks>
-/// Avoid accessing configuration from your plugin constructor, especially if your plugin sets
+/// Accessing <see cref="GameConfigSection"/>-typed properties such as <see cref="System"/>, directly or indirectly
+/// via <see cref="TryGet(Game.Config.SystemConfigOption,out bool)"/>,
+/// <see cref="Set(Game.Config.SystemConfigOption,bool)"/>, or alike will block, if the game is not done loading.<br />
+/// Therefore, avoid accessing configuration from your plugin constructor, especially if your plugin sets
 /// <see cref="PluginManifest.LoadRequiredState"/> to <c>2</c> and <see cref="PluginManifest.LoadSync"/> to <c>true</c>.
 /// If property access from the plugin constructor is desired, do the value retrieval asynchronously via
 /// <see cref="IFramework.RunOnFrameworkThread{T}(Func{T})"/>; do not wait for the result right away.
@@ -36,16 +39,6 @@ public interface IGameConfig
     /// Event which is fired when a UiControl config option is changed.
     /// </summary>
     public event EventHandler<ConfigChangeEvent> UiControlChanged; 
-
-    /// <summary>
-    /// Gets a task representing the initialization state of this instance of <see cref="IGameConfig"/>.
-    /// </summary>
-    /// <remarks>
-    /// Accessing <see cref="GameConfigSection"/>-typed properties such as <see cref="System"/>, directly or indirectly
-    /// via <see cref="TryGet(Game.Config.SystemConfigOption,out bool)"/>,
-    /// <see cref="Set(Game.Config.SystemConfigOption,bool)"/>, or alike will block, if this task is incomplete.
-    /// </remarks>
-    public Task InitializationTask { get; }
 
     /// <summary>
     /// Gets the collection of config options that persist between characters.

--- a/Dalamud/Storage/Assets/DalamudAssetManager.cs
+++ b/Dalamud/Storage/Assets/DalamudAssetManager.cs
@@ -194,12 +194,14 @@ internal sealed class DalamudAssetManager : IServiceType, IDisposable, IDalamudA
 
                         try
                         {
-                            await using var tempPathStream = File.Open(tempPath, FileMode.Create, FileAccess.Write);
-                            await url.DownloadAsync(
-                                this.httpClient.SharedHttpClient,
-                                tempPathStream,
-                                this.cancellationTokenSource.Token);
-                            tempPathStream.Dispose();
+                            await using (var tempPathStream = File.Open(tempPath, FileMode.Create, FileAccess.Write))
+                            {
+                                await url.DownloadAsync(
+                                    this.httpClient.SharedHttpClient,
+                                    tempPathStream,
+                                    this.cancellationTokenSource.Token);
+                            }
+
                             for (var j = RenameAttemptCount; ; j--)
                             {
                                 try
@@ -265,7 +267,7 @@ internal sealed class DalamudAssetManager : IServiceType, IDisposable, IDalamudA
     /// <inheritdoc/>
     [Pure]
     public IDalamudTextureWrap GetDalamudTextureWrap(DalamudAsset asset) =>
-        ExtractResult(this.GetDalamudTextureWrapAsync(asset));
+        this.GetDalamudTextureWrapAsync(asset).Result;
 
     /// <inheritdoc/>
     [Pure]
@@ -331,8 +333,6 @@ internal sealed class DalamudAssetManager : IServiceType, IDisposable, IDalamudA
             }
         }
     }
-
-    private static T ExtractResult<T>(Task<T> t) => t.IsCompleted ? t.Result : t.GetAwaiter().GetResult();
 
     private Task<TOut> TransformImmediate<TIn, TOut>(Task<TIn> task, Func<TIn, TOut> transformer)
     {

--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -10,6 +10,7 @@ using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading.Tasks;
 
 using Dalamud.Configuration.Internal;
 using Dalamud.Data;
@@ -695,6 +696,45 @@ public static class Util
     {
         if (hr.FAILED)
             Marshal.ThrowExceptionForHR(hr.Value);
+    }
+
+    /// <summary>
+    /// Calls <see cref="TaskCompletionSource.SetException(System.Exception)"/> if the task is incomplete.
+    /// </summary>
+    /// <param name="t">The task.</param>
+    /// <param name="ex">The exception to set.</param>
+    internal static void SetExceptionIfIncomplete(this TaskCompletionSource t, Exception ex)
+    {
+        if (t.Task.IsCompleted)
+            return;
+        try
+        {
+            t.SetException(ex);
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    /// <summary>
+    /// Calls <see cref="TaskCompletionSource.SetException(System.Exception)"/> if the task is incomplete.
+    /// </summary>
+    /// <typeparam name="T">The type of the result.</typeparam>
+    /// <param name="t">The task.</param>
+    /// <param name="ex">The exception to set.</param>
+    internal static void SetExceptionIfIncomplete<T>(this TaskCompletionSource<T> t, Exception ex)
+    {
+        if (t.Task.IsCompleted)
+            return;
+        try
+        {
+            t.SetException(ex);
+        }
+        catch
+        {
+            // ignore
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
This PR fixes #1672.

As some public properties of `IGameConfig` are being set on the first `Framework` tick, there was a short window that those properties were null, which goes against the interface declaration.

This commit fixes that, by making those properties block for the full initialization of the class.

A possible side effect is that a plugin that is set to block the game from loading until it loads will now hang the game if it tries to access the game configuration from its constructor, instead of throwing a `NullReferenceException`. As it would mean that the plugin was buggy at the first place and it would have sometimes failed to load anyway, it might as well be a non-breaking change.

Additionally, minor cleanup for `DalamudAssetManager` is done.