### PR TITLE
Fix ConsoleWindow regex handling

### DIFF
--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -731,8 +731,6 @@ internal class ConsoleWindow : Window, IDisposable
             return false;
         }
 
-        this.regexError = false;
-        
         // else we couldn't find a filter for this entry, if we have any filters, we need to block this entry.
         return !this.pluginFilters.Any();
     }
@@ -741,6 +739,7 @@ internal class ConsoleWindow : Window, IDisposable
     {
         lock (this.renderLock)
         {
+            this.regexError = false;
             this.FilteredLogEntries = this.logText.Where(this.IsFilterApplicable).ToList();
         }
     }


### PR DESCRIPTION
Alright so I would like to give us a challenge

The challenge begins as follows:
1. Open the **Dalamud Console** window.
2. Write an invalid global regex at the upper right and press Enter
3. Enjoy as the logs are replaced with a red message saying **Regex Filter Error*

The challenge is to figure a way out of it and make the Dalamud Console window useable again.

The only place the `regexError` flag is being reset is after a quick return from it being `true` in `IsFilterApplicable`.

Quick fix in this PR, enjoy!

![image](https://github.com/goatcorp/Dalamud/assets/27633480/c0e74023-72f4-4256-b5d3-cec84b4593c4)
