### PR TITLE
Synchronize DalamudStartInfo between cpp and cs

### DIFF
--- a/Dalamud.Boot/DalamudStartInfo.cpp
+++ b/Dalamud.Boot/DalamudStartInfo.cpp
@@ -89,13 +89,16 @@ void from_json(const nlohmann::json& json, DalamudStartInfo& config) {
     config.DalamudLoadMethod = json.value("LoadMethod", config.DalamudLoadMethod);
     config.WorkingDirectory = json.value("WorkingDirectory", config.WorkingDirectory);
     config.ConfigurationPath = json.value("ConfigurationPath", config.ConfigurationPath);
+    config.LogPath = json.value("LogPath", config.LogPath);
+    config.LogName = json.value("LogName", config.LogName);
     config.PluginDirectory = json.value("PluginDirectory", config.PluginDirectory);
-    config.DefaultPluginDirectory = json.value("DefaultPluginDirectory", config.DefaultPluginDirectory);
     config.AssetDirectory = json.value("AssetDirectory", config.AssetDirectory);
     config.Language = json.value("Language", config.Language);
     config.GameVersion = json.value("GameVersion", config.GameVersion);
-    config.DelayInitializeMs = json.value("DelayInitializeMs", config.DelayInitializeMs);
     config.TroubleshootingPackData = json.value("TroubleshootingPackData", std::string{});
+    config.DelayInitializeMs = json.value("DelayInitializeMs", config.DelayInitializeMs);
+    config.NoLoadPlugins = json.value("NoLoadPlugins", config.NoLoadPlugins);
+    config.NoLoadThirdPartyPlugins = json.value("NoLoadThirdPartyPlugins", config.NoLoadThirdPartyPlugins);
 
     config.BootLogPath = json.value("BootLogPath", config.BootLogPath);
     config.BootShowConsole = json.value("BootShowConsole", config.BootShowConsole);

--- a/Dalamud.Boot/DalamudStartInfo.h
+++ b/Dalamud.Boot/DalamudStartInfo.h
@@ -35,13 +35,16 @@ struct DalamudStartInfo {
     LoadMethod DalamudLoadMethod = LoadMethod::Entrypoint;
     std::string WorkingDirectory;
     std::string ConfigurationPath;
+    std::string LogPath;
+    std::string LogName;
     std::string PluginDirectory;
-    std::string DefaultPluginDirectory;
     std::string AssetDirectory;
     ClientLanguage Language = ClientLanguage::English;
     std::string GameVersion;
-    int DelayInitializeMs = 0;
     std::string TroubleshootingPackData;
+    int DelayInitializeMs = 0;
+    bool NoLoadPlugins;
+    bool NoLoadThirdPartyPlugins;
 
     std::string BootLogPath;
     bool BootShowConsole = false;

--- a/Dalamud.Boot/veh.cpp
+++ b/Dalamud.Boot/veh.cpp
@@ -112,13 +112,16 @@ static void append_injector_launch_args(std::vector<std::wstring>& args)
     case DalamudStartInfo::LoadMethod::DllInject:
         args.emplace_back(L"--mode=inject");
     }
-    args.emplace_back(L"--logpath=\"" + unicode::convert<std::wstring>(g_startInfo.BootLogPath) + L"\"");
     args.emplace_back(L"--dalamud-working-directory=\"" + unicode::convert<std::wstring>(g_startInfo.WorkingDirectory) + L"\"");
     args.emplace_back(L"--dalamud-configuration-path=\"" + unicode::convert<std::wstring>(g_startInfo.ConfigurationPath) + L"\"");
+    args.emplace_back(L"--logpath=\"" + unicode::convert<std::wstring>(g_startInfo.LogPath) + L"\"");
+    args.emplace_back(L"--logname=\"" + unicode::convert<std::wstring>(g_startInfo.LogName) + L"\"");
     args.emplace_back(L"--dalamud-plugin-directory=\"" + unicode::convert<std::wstring>(g_startInfo.PluginDirectory) + L"\"");
     args.emplace_back(L"--dalamud-asset-directory=\"" + unicode::convert<std::wstring>(g_startInfo.AssetDirectory) + L"\"");
     args.emplace_back(std::format(L"--dalamud-client-language={}", static_cast<int>(g_startInfo.Language)));
     args.emplace_back(std::format(L"--dalamud-delay-initialize={}", g_startInfo.DelayInitializeMs));
+    // NoLoadPlugins/NoLoadThirdPartyPlugins: supplied from DalamudCrashHandler
+
     if (g_startInfo.BootShowConsole)
         args.emplace_back(L"--console");
     if (g_startInfo.BootEnableEtw)

--- a/Dalamud.Common/DalamudStartInfo.cs
+++ b/Dalamud.Common/DalamudStartInfo.cs
@@ -5,6 +5,7 @@ namespace Dalamud.Common;
 
 /// <summary>
 /// Struct containing information needed to initialize Dalamud.
+/// Modify DalamudStartInfo.h and DalamudStartInfo.cpp along with this record.
 /// </summary>
 [Serializable]
 public record DalamudStartInfo

--- a/Dalamud.Injector/EntryPoint.cs
+++ b/Dalamud.Injector/EntryPoint.cs
@@ -389,6 +389,7 @@ namespace Dalamud.Injector
 #else
             startInfo.LogPath ??= xivlauncherDir;
 #endif
+            startInfo.LogName ??= string.Empty;
 
             // Set boot defaults
             startInfo.BootShowConsole = args.Contains("--console");

--- a/DalamudCrashHandler/DalamudCrashHandler.cpp
+++ b/DalamudCrashHandler/DalamudCrashHandler.cpp
@@ -896,7 +896,6 @@ int main() {
         SYSTEMTIME st;
         GetLocalTime(&st);
         const auto dalamudLogPath = logDir.empty() ? std::filesystem::path() : logDir / L"Dalamud.log";
-        const auto dalamudBootLogPath = logDir.empty() ? std::filesystem::path() : logDir / L"Dalamud.boot.log";
         const auto dumpPath = logDir.empty() ? std::filesystem::path() : logDir / std::format(L"dalamud_appcrash_{:04}{:02}{:02}_{:02}{:02}{:02}_{:03}_{}.dmp", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond, st.wMilliseconds, dwProcessId);
         const auto logPath = logDir.empty() ? std::filesystem::path() : logDir / std::format(L"dalamud_appcrash_{:04}{:02}{:02}_{:02}{:02}{:02}_{:03}_{}.log", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond, st.wMilliseconds, dwProcessId);
         std::wstring dumpError;


### PR DESCRIPTION
Dalamud Boot was using BootLogPath in place of LogPath, resulting in wrong log path.