### PR TITLE
Sanitize PDB root name from loaded modules

### DIFF
--- a/Dalamud.Boot/Dalamud.Boot.vcxproj
+++ b/Dalamud.Boot/Dalamud.Boot.vcxproj
@@ -58,7 +58,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Version.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\lib\CoreCLR;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -137,6 +137,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="ntdll.cpp" />
     <ClCompile Include="unicode.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
@@ -176,6 +177,7 @@
     <ClInclude Include="DalamudStartInfo.h" />
     <ClInclude Include="hooks.h" />
     <ClInclude Include="logging.h" />
+    <ClInclude Include="ntdll.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="unicode.h" />
     <ClInclude Include="utils.h" />

--- a/Dalamud.Boot/Dalamud.Boot.vcxproj.filters
+++ b/Dalamud.Boot/Dalamud.Boot.vcxproj.filters
@@ -73,6 +73,9 @@
     <ClCompile Include="DalamudStartInfo.cpp">
       <Filter>Dalamud.Boot DLL</Filter>
     </ClCompile>
+    <ClCompile Include="ntdll.cpp">
+      <Filter>Dalamud.Boot DLL</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\lib\CoreCLR\CoreCLR.h">
@@ -140,6 +143,9 @@
     </ClInclude>
     <ClInclude Include="resource.h" />
     <ClInclude Include="crashhandler_shared.h" />
+    <ClInclude Include="ntdll.h">
+      <Filter>Dalamud.Boot DLL</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Dalamud.Boot.rc" />

--- a/Dalamud.Boot/hooks.cpp
+++ b/Dalamud.Boot/hooks.cpp
@@ -2,38 +2,8 @@
 
 #include "hooks.h"
 
+#include "ntdll.h"
 #include "logging.h"
-
-enum {
-    LDR_DLL_NOTIFICATION_REASON_LOADED = 1,
-    LDR_DLL_NOTIFICATION_REASON_UNLOADED = 2,
-};
-
-struct LDR_DLL_UNLOADED_NOTIFICATION_DATA {
-    ULONG Flags;                    //Reserved.
-    const UNICODE_STRING* FullDllName;   //The full path name of the DLL module.
-    const UNICODE_STRING* BaseDllName;   //The base file name of the DLL module.
-    PVOID DllBase;                  //A pointer to the base address for the DLL in memory.
-    ULONG SizeOfImage;              //The size of the DLL image, in bytes.
-};
-
-struct LDR_DLL_LOADED_NOTIFICATION_DATA {
-    ULONG Flags;                    //Reserved.
-    const UNICODE_STRING* FullDllName;   //The full path name of the DLL module.
-    const UNICODE_STRING* BaseDllName;   //The base file name of the DLL module.
-    PVOID DllBase;                  //A pointer to the base address for the DLL in memory.
-    ULONG SizeOfImage;              //The size of the DLL image, in bytes.
-};
-
-union LDR_DLL_NOTIFICATION_DATA {
-    LDR_DLL_LOADED_NOTIFICATION_DATA Loaded;
-    LDR_DLL_UNLOADED_NOTIFICATION_DATA Unloaded;
-};
-
-using PLDR_DLL_NOTIFICATION_FUNCTION = VOID CALLBACK(_In_ ULONG NotificationReason, _In_ const LDR_DLL_NOTIFICATION_DATA* NotificationData, _In_opt_ PVOID Context);
-
-static const auto LdrRegisterDllNotification = utils::loaded_module(GetModuleHandleW(L"ntdll.dll")).get_exported_function<NTSTATUS(NTAPI)(ULONG Flags, PLDR_DLL_NOTIFICATION_FUNCTION NotificationFunction, PVOID Context, PVOID* Cookie)>("LdrRegisterDllNotification");
-static const auto LdrUnregisterDllNotification = utils::loaded_module(GetModuleHandleW(L"ntdll.dll")).get_exported_function<NTSTATUS(NTAPI)(PVOID Cookie)>("LdrUnregisterDllNotification");
 
 hooks::getprocaddress_singleton_import_hook::getprocaddress_singleton_import_hook()
     : m_pfnGetProcAddress(GetProcAddress)

--- a/Dalamud.Boot/hooks.h
+++ b/Dalamud.Boot/hooks.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <limits>
 #include <map>
 
 #include "utils.h"

--- a/Dalamud.Boot/ntdll.cpp
+++ b/Dalamud.Boot/ntdll.cpp
@@ -1,0 +1,15 @@
+#include "pch.h"
+
+#include "ntdll.h"
+
+#include "utils.h"
+
+NTSTATUS LdrRegisterDllNotification(ULONG Flags, PLDR_DLL_NOTIFICATION_FUNCTION NotificationFunction, PVOID Context, PVOID* Cookie) {
+    static const auto pfn = utils::loaded_module(GetModuleHandleW(L"ntdll.dll")).get_exported_function<NTSTATUS(NTAPI)(ULONG Flags, PLDR_DLL_NOTIFICATION_FUNCTION NotificationFunction, PVOID Context, PVOID* Cookie)>("LdrRegisterDllNotification");
+    return pfn(Flags, NotificationFunction, Context, Cookie);
+}
+
+NTSTATUS LdrUnregisterDllNotification(PVOID Cookie) {
+    static const auto pfn = utils::loaded_module(GetModuleHandleW(L"ntdll.dll")).get_exported_function<NTSTATUS(NTAPI)(PVOID Cookie)>("LdrUnregisterDllNotification");
+    return pfn(Cookie);
+}

--- a/Dalamud.Boot/ntdll.h
+++ b/Dalamud.Boot/ntdll.h
@@ -1,0 +1,33 @@
+#pragma once
+
+// ntdll exports
+enum {
+    LDR_DLL_NOTIFICATION_REASON_LOADED = 1,
+    LDR_DLL_NOTIFICATION_REASON_UNLOADED = 2,
+};
+
+struct LDR_DLL_UNLOADED_NOTIFICATION_DATA {
+    ULONG Flags;                    //Reserved.
+    const UNICODE_STRING* FullDllName;   //The full path name of the DLL module.
+    const UNICODE_STRING* BaseDllName;   //The base file name of the DLL module.
+    PVOID DllBase;                  //A pointer to the base address for the DLL in memory.
+    ULONG SizeOfImage;              //The size of the DLL image, in bytes.
+};
+
+struct LDR_DLL_LOADED_NOTIFICATION_DATA {
+    ULONG Flags;                    //Reserved.
+    const UNICODE_STRING* FullDllName;   //The full path name of the DLL module.
+    const UNICODE_STRING* BaseDllName;   //The base file name of the DLL module.
+    PVOID DllBase;                  //A pointer to the base address for the DLL in memory.
+    ULONG SizeOfImage;              //The size of the DLL image, in bytes.
+};
+
+union LDR_DLL_NOTIFICATION_DATA {
+    LDR_DLL_LOADED_NOTIFICATION_DATA Loaded;
+    LDR_DLL_UNLOADED_NOTIFICATION_DATA Unloaded;
+};
+
+using PLDR_DLL_NOTIFICATION_FUNCTION = VOID CALLBACK(_In_ ULONG NotificationReason, _In_ const LDR_DLL_NOTIFICATION_DATA* NotificationData, _In_opt_ PVOID Context);
+
+NTSTATUS LdrRegisterDllNotification(ULONG Flags, PLDR_DLL_NOTIFICATION_FUNCTION NotificationFunction, PVOID Context, PVOID* Cookie);
+NTSTATUS LdrUnregisterDllNotification(PVOID Cookie);

--- a/Dalamud.Boot/pch.h
+++ b/Dalamud.Boot/pch.h
@@ -15,13 +15,19 @@
 #include <Windows.h>
 
 // Windows Header Files (2)
+#include <DbgHelp.h>
 #include <Dbt.h>
 #include <dwmapi.h>
+#include <iphlpapi.h>
 #include <PathCch.h>
 #include <Psapi.h>
 #include <ShlObj.h>
+#include <Shlwapi.h>
 #include <SubAuth.h>
 #include <TlHelp32.h>
+
+// Windows Header Files (3)
+#include <icmpapi.h> // Must be loaded after iphlpapi.h
 
 // MSVC Compiler Intrinsic
 #include <intrin.h>
@@ -30,6 +36,7 @@
 #include <comdef.h>
 
 // C++ Standard Libraries
+#include <algorithm>
 #include <cassert>
 #include <chrono>
 #include <cstdio>

--- a/Dalamud.Boot/xivfixes.h
+++ b/Dalamud.Boot/xivfixes.h
@@ -7,6 +7,7 @@ namespace xivfixes {
     void redirect_openprocess(bool bApply);
     void backup_userdata_save(bool bApply);
     void prevent_icmphandle_crashes(bool bApply);
+    void symbol_load_patches(bool bApply);
 
     void apply_all(bool bApply);
 }

--- a/Dalamud.Injector/EntryPoint.cs
+++ b/Dalamud.Injector/EntryPoint.cs
@@ -395,9 +395,15 @@ namespace Dalamud.Injector
             startInfo.BootShowConsole = args.Contains("--console");
             startInfo.BootEnableEtw = args.Contains("--etw");
             startInfo.BootLogPath = GetLogPath(startInfo.LogPath, "dalamud.boot", startInfo.LogName);
-            startInfo.BootEnabledGameFixes = new List<string> {
-                "prevent_devicechange_crashes", "disable_game_openprocess_access_check",
-                "redirect_openprocess", "backup_userdata_save", "prevent_icmphandle_crashes",
+            startInfo.BootEnabledGameFixes = new()
+            {
+                // See: xivfixes.h, xivfixes.cpp
+                "prevent_devicechange_crashes",
+                "disable_game_openprocess_access_check",
+                "redirect_openprocess",
+                "backup_userdata_save",
+                "prevent_icmphandle_crashes",
+                "symbol_load_patches",
             };
             startInfo.BootDotnetOpenProcessHookMode = 0;
             startInfo.BootWaitMessageBox |= args.Contains("--msgbox1") ? 1 : 0;


### PR DESCRIPTION
Dalamud is compiled from CI, which use `D:` as its root. But some people have a strange driver implementation, so that accessing `D:` when the card reader is not ready would result in a hang. This PR goes through all loaded modules and removes all references to absolute pdb path that points to non-system root directory (usually non-C: drive), and does the same for all future loaded modules.

Fixes #1686.