### PR TITLE
fix duty pop message

### DIFF
--- a/Dalamud/Game/Network/Internal/NetworkHandlers.cs
+++ b/Dalamud/Game/Network/Internal/NetworkHandlers.cs
@@ -268,7 +268,7 @@ internal unsafe class NetworkHandlers : IDisposable, IServiceType
                 return result;
             }
 
-            var cfcName = cfCondition.Name.ToString();
+            var cfcName = cfCondition.Name.RawString;
             if (cfcName.IsNullOrEmpty())
             {
                 cfcName = "Duty Roulette";


### PR DESCRIPTION
fix for unexpected payload strings in the duty pop chat message introduced by a recent change in lumina