### PR TITLE
Easier SingleFontChooserDialog ctor, window pos/size/flags, and more docs

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/GamePrebakedFontsTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/GamePrebakedFontsTestWidget.cs
@@ -130,9 +130,8 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
         if (ImGui.Button("Choose Editor Font"))
         {
             var fcd = new SingleFontChooserDialog(
-                Service<FontAtlasFactory>.Get().CreateFontAtlas(
-                    $"{nameof(GamePrebakedFontsTestWidget)}:EditorFont",
-                    FontAtlasAutoRebuildMode.Async));
+                Service<FontAtlasFactory>.Get(),
+                $"{nameof(GamePrebakedFontsTestWidget)}:EditorFont");
             fcd.SelectedFont = this.fontSpec;
             fcd.IgnorePreviewGlobalScale = !this.atlasScaleMode;
             Service<InterfaceManager>.Get().Draw += fcd.Draw;

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
@@ -199,8 +199,7 @@ public class SettingsTabLook : SettingsTab
         if (ImGui.Button(Loc.Localize("DalamudSettingChooseDefaultFont", "Choose Default Font")))
         {
             var faf = Service<FontAtlasFactory>.Get();
-            var fcd = new SingleFontChooserDialog(
-                faf.CreateFontAtlas($"{nameof(SettingsTabLook)}:Default", FontAtlasAutoRebuildMode.Async));
+            var fcd = new SingleFontChooserDialog(faf, $"{nameof(SettingsTabLook)}:Default");
             fcd.SelectedFont = (SingleFontSpec)this.defaultFontSpec;
             fcd.FontFamilyExcludeFilter = x => x is DalamudDefaultFontAndFamilyId;
             interfaceManager.Draw += fcd.Draw;

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
@@ -12,7 +12,6 @@ using Dalamud.Interface.GameFonts;
 using Dalamud.Interface.ImGuiFontChooserDialog;
 using Dalamud.Interface.Internal.Windows.PluginInstaller;
 using Dalamud.Interface.Internal.Windows.Settings.Widgets;
-using Dalamud.Interface.ManagedFontAtlas;
 using Dalamud.Interface.ManagedFontAtlas.Internals;
 using Dalamud.Interface.Utility;
 using Dalamud.Utility;
@@ -202,6 +201,7 @@ public class SettingsTabLook : SettingsTab
             var fcd = new SingleFontChooserDialog(faf, $"{nameof(SettingsTabLook)}:Default");
             fcd.SelectedFont = (SingleFontSpec)this.defaultFontSpec;
             fcd.FontFamilyExcludeFilter = x => x is DalamudDefaultFontAndFamilyId;
+            fcd.SetPopupPositionAndSizeToCurrentWindowCenter();
             interfaceManager.Draw += fcd.Draw;
             fcd.ResultTask.ContinueWith(
                 r => Service<Framework>.Get().RunOnFrameworkThread(

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlas.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlas.cs
@@ -82,21 +82,25 @@ public interface IFontAtlas : IDisposable
     /// </example>
     public IDisposable SuppressAutoRebuild();
 
-    /// <summary>
-    /// Creates a new <see cref="IFontHandle"/> from game's built-in fonts.
-    /// </summary>
+    /// <summary>Creates a new <see cref="IFontHandle"/> from game's built-in fonts.</summary>
     /// <param name="style">Font to use.</param>
     /// <returns>Handle to a font that may or may not be ready yet.</returns>
+    /// <remarks>This function does not throw. <see cref="IFontHandle.LoadException"/> will be populated instead, if
+    /// the build procedure has failed. <see cref="IFontHandle.Push"/> can be used regardless of the state of the font
+    /// handle.</remarks>
     public IFontHandle NewGameFontHandle(GameFontStyle style);
 
-    /// <summary>
-    /// Creates a new IFontHandle using your own callbacks.
-    /// </summary>
+    /// <summary>Creates a new IFontHandle using your own callbacks.</summary>
     /// <param name="buildStepDelegate">Callback for <see cref="IFontAtlas.BuildStepChange"/>.</param>
     /// <returns>Handle to a font that may or may not be ready yet.</returns>
     /// <remarks>
-    /// Consider calling <see cref="IFontAtlasBuildToolkitPreBuild.AttachExtraGlyphsForDalamudLanguage"/> to support
-    /// glyphs that are not supplied by the game by default; this mostly affects Chinese and Korean language users.
+    /// <para>Consider calling <see cref="IFontAtlasBuildToolkitPreBuild.AttachExtraGlyphsForDalamudLanguage"/> to
+    /// support glyphs that are not supplied by the game by default; this mostly affects Chinese and Korean language
+    /// users.</para>
+    /// <para>This function does not throw, even if <paramref name="buildStepDelegate"/> would throw exceptions.
+    /// Instead, if it fails, the returned handle will contain an <see cref="IFontHandle.LoadException"/> property
+    /// containing the exception happened during the build process. <see cref="IFontHandle.Push"/> can be used even if
+    /// the build process has not been completed yet or failed.</para>
     /// </remarks>
     /// <example>
     /// <b>On initialization</b>:

--- a/Dalamud/Interface/ManagedFontAtlas/IFontHandle.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontHandle.cs
@@ -58,10 +58,27 @@ public interface IFontHandle : IDisposable
     /// <returns>A disposable object that will pop the font on dispose.</returns>
     /// <exception cref="InvalidOperationException">If called outside of the main thread.</exception>
     /// <remarks>
-    /// This function uses <see cref="ImGui.PushFont"/>, and may do extra things.
+    /// <para>This function uses <see cref="ImGui.PushFont"/>, and may do extra things. 
     /// Use <see cref="IDisposable.Dispose"/> or <see cref="Pop"/> to undo this operation.
-    /// Do not use <see cref="ImGui.PopFont"/>.
+    /// Do not use <see cref="ImGui.PopFont"/>.</para>
     /// </remarks>
+    /// <example>
+    /// <b>Push a font with `using` clause.</b>
+    /// <code>
+    /// using (fontHandle.Push())
+    ///     ImGui.TextUnformatted("Test");
+    /// </code>
+    /// <b>Push a font with a matching call to <see cref="Pop"/>.</b>
+    /// <code>
+    /// fontHandle.Push();
+    /// ImGui.TextUnformatted("Test 2");
+    /// </code>
+    /// <b>Push a font between two choices.</b>
+    /// <code>
+    /// using ((someCondition ? myFontHandle : dalamudPluginInterface.UiBuilder.MonoFontHandle).Push())
+    ///     ImGui.TextUnformatted("Test 3"); 
+    /// </code>
+    /// </example>
     IDisposable Push();
 
     /// <summary>

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontHandle.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontHandle.cs
@@ -136,13 +136,18 @@ internal abstract class FontHandle : IFontHandle
     /// An instance of <see cref="ILockedImFont"/> that <b>must</b> be disposed after use on success;
     /// <c>null</c> with <paramref name="errorMessage"/> populated on failure.
     /// </returns>
-    /// <exception cref="ObjectDisposedException">Still may be thrown.</exception>
     public ILockedImFont? TryLock(out string? errorMessage)
     {
         IFontHandleSubstance? prevSubstance = default;
         while (true)
         {
-            var substance = this.Manager.Substance;
+            if (this.manager is not { } nonDisposedManager)
+            {
+                errorMessage = "The font handle has been disposed.";
+                return null;
+            }
+
+            var substance = nonDisposedManager.Substance;
 
             // Does the associated IFontAtlas have a built substance?
             if (substance is null)


### PR DESCRIPTION
The current constructor expects a new fresh instance of IFontAtlas, which can be easy to miss, resulting in wasted time troubleshooting without enough clues. New constructor is added that directly takes an instance of UiBuilder, and the old constructor has been obsoleted and should be changed to private on api 10.

Added the following to `SingleFontChooserDialog`:
* `event Action<SingleFontSpec> SelectedFontSpecChanged`: called on the selected entry changes.
* `bool IsModal { get; set; }`: decides whether to call `ImGui.BeginPopupModal` or `ImGui.Begin`.
* `ImGuiWindowFlags WindowFlags { get; set; }`
* `Vector2 PopupPosition { get; set; }`
* `Vector2 PopupSize { get; set; }`
* `static Vector2 GetDefaultPopupSizeNonClamped()`: calculates the default popup size according to current font being used.
* `void SetPopupPositionAndSizeToCurrentWindowcenter(Vector2 preferredPopupSize = GetDefaultPopupSizeNonClamped())`

Documentation on `IFontAtlas` and `IFontHandle` has been changed to add more examples and exception safety notes.