### PR TITLE
Fix log window layout

### DIFF
--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -90,11 +90,6 @@ internal class ConsoleWindow : Window, IDisposable
         this.Size = new Vector2(500, 400);
         this.SizeCondition = ImGuiCond.FirstUseEver;
 
-        this.SizeConstraints = new WindowSizeConstraints
-        {
-            MinimumSize = new Vector2(600.0f, 200.0f),
-        };
-
         this.RespectCloseHotkey = false;
 
         this.logLinesLimit = configuration.LogLinesLimit;
@@ -555,10 +550,24 @@ internal class ConsoleWindow : Window, IDisposable
         if (ImGui.IsItemHovered()) ImGui.SetTooltip("Kill game");
 
         ImGui.SameLine();
-        ImGui.SetCursorPosX(
-            ImGui.GetContentRegionMax().X - (2 * 200.0f * ImGuiHelpers.GlobalScale) - ImGui.GetStyle().ItemSpacing.X);
 
-        ImGui.PushItemWidth(200.0f * ImGuiHelpers.GlobalScale);
+        var inputWidth = 200.0f * ImGuiHelpers.GlobalScale;
+        var nextCursorPosX = ImGui.GetContentRegionMax().X - (2 * inputWidth) - ImGui.GetStyle().ItemSpacing.X;
+        var breakInputLines = nextCursorPosX < 0;
+        if (ImGui.GetCursorPosX() > nextCursorPosX)
+        {
+            ImGui.NewLine();
+            inputWidth = ImGui.GetWindowWidth() - (ImGui.GetStyle().WindowPadding.X * 2);
+
+            if (!breakInputLines)
+                inputWidth = (inputWidth - ImGui.GetStyle().ItemSpacing.X) / 2; 
+        }
+        else
+        {
+            ImGui.SetCursorPosX(nextCursorPosX);
+        }
+
+        ImGui.PushItemWidth(inputWidth);
         if (ImGui.InputTextWithHint(
                 "##textHighlight",
                 "regex highlight",
@@ -583,8 +592,10 @@ internal class ConsoleWindow : Window, IDisposable
                 log.HighlightMatches = null;
         }
 
-        ImGui.SameLine();
-        ImGui.PushItemWidth(200.0f * ImGuiHelpers.GlobalScale);
+        if (!breakInputLines)
+            ImGui.SameLine();
+
+        ImGui.PushItemWidth(inputWidth);
         if (ImGui.InputTextWithHint(
                 "##textFilter",
                 "regex global filter",
@@ -1082,6 +1093,8 @@ internal class ConsoleWindow : Window, IDisposable
                 lastc = currc;
             }
         }
+
+        ImGui.Dummy(screenPos - ImGui.GetCursorScreenPos());
     }
 
     private record LogEntry

--- a/Dalamud/Interface/Utility/ImGuiHelpers.cs
+++ b/Dalamud/Interface/Utility/ImGuiHelpers.cs
@@ -3,7 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using System.Reactive.Disposables;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Unicode;
@@ -533,12 +532,6 @@ public static class ImGuiHelpers
     /// <returns><paramref name="self"/> if it is not default; otherwise, <paramref name="other"/>.</returns>
     public static unsafe ImFontPtr OrElse(this ImFontPtr self, ImFontPtr other) =>
         self.NativePtr is null ? other : self;
-
-    /// <summary>Converts the wrong struct to a correct struct.</summary>
-    /// <param name="glyph">The glyph being corrected.</param>
-    /// <returns>The correct struct.</returns>
-    internal static unsafe ref ImFontGlyphReal ToReal(in this ImFontGlyphPtr glyph) =>
-        ref *(ImFontGlyphReal*)glyph.NativePtr;
 
     /// <summary>
     /// Mark 4K page as used, after adding a codepoint to a font.

--- a/Dalamud/Interface/Utility/ImGuiHelpers.cs
+++ b/Dalamud/Interface/Utility/ImGuiHelpers.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using System.Reactive.Disposables;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Unicode;
@@ -532,6 +533,12 @@ public static class ImGuiHelpers
     /// <returns><paramref name="self"/> if it is not default; otherwise, <paramref name="other"/>.</returns>
     public static unsafe ImFontPtr OrElse(this ImFontPtr self, ImFontPtr other) =>
         self.NativePtr is null ? other : self;
+
+    /// <summary>Converts the wrong struct to a correct struct.</summary>
+    /// <param name="glyph">The glyph being corrected.</param>
+    /// <returns>The correct struct.</returns>
+    internal static unsafe ref ImFontGlyphReal ToReal(in this ImFontGlyphPtr glyph) =>
+        ref *(ImFontGlyphReal*)glyph.NativePtr;
 
     /// <summary>
     /// Mark 4K page as used, after adding a codepoint to a font.


### PR DESCRIPTION
Fixed custom line rendering from not advancing ImGui cursor, and move input boxes around as log window is resized to become narrower.

![image](https://github.com/goatcorp/Dalamud/assets/3614868/8610067d-828a-4406-befa-c451c39420a6)
![image](https://github.com/goatcorp/Dalamud/assets/3614868/7dc842b1-fb81-4c92-8c36-c96d34e73208)
![image](https://github.com/goatcorp/Dalamud/assets/3614868/33fa7c0b-14bf-4e60-b7f5-b96e883c64ec)
