### PR TITLE
Suppress DAssetM dispose exceptions

### DIFF
--- a/Dalamud/Storage/Assets/DalamudAssetManager.cs
+++ b/Dalamud/Storage/Assets/DalamudAssetManager.cs
@@ -75,7 +75,7 @@ internal sealed class DalamudAssetManager : IServiceType, IDisposable, IDalamudA
                 .Where(x => x is not DalamudAsset.Empty4X4)
                 .Where(x => x.GetAttribute<DalamudAssetAttribute>()?.Required is false)
                 .Select(this.CreateStreamAsync)
-                .Select(x => x.ToContentDisposedTask()))
+                .Select(x => x.ToContentDisposedTask(true)))
             .ContinueWith(r => Log.Verbose($"Optional assets load state: {r}"));
     }
 
@@ -99,6 +99,7 @@ internal sealed class DalamudAssetManager : IServiceType, IDisposable, IDalamudA
                  .Concat(this.fileStreams.Values)
                  .Concat(this.textureWraps.Values)
                  .Where(x => x is not null)
+                 .Select(x => x.ContinueWith(r => { _ = r.Exception; }))
                  .ToArray());
         this.scopedFinalizer.Dispose();
     }


### PR DESCRIPTION
Whether an asset being unavailable should be an error is decided on Dalamud startup time. This suppresses assets unavailable exceptions on Dispose.