### PR TITLE
Resolve stale pointer issues

### DIFF
--- a/Dalamud/Game/ClientState/Objects/ObjectTable.cs
+++ b/Dalamud/Game/ClientState/Objects/ObjectTable.cs
@@ -154,12 +154,6 @@ internal sealed partial class ObjectTable : IServiceType, IObjectTable
         return true;
     }
 
-    private void FrameworkOnBeforeUpdate(IFramework unused)
-    {
-        for (var i = 0; i < ObjectTableLength; i++)
-            this.cachedObjectTable[i].Update(this.GetObjectAddressUnsafe(i));
-    }
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private unsafe nint GetObjectAddressUnsafe(int index) =>
         *(nint*)(this.clientState.AddressResolver.ObjectTable + (8 * index));


### PR DESCRIPTION
As discussed in #dalamud-dev, Framework runs before Draw and thus could yield stale pointers to the ObjectTable if accessed from Draw.
This PR attempts to remedy the issue while keeping the spirit of the cache intact.