### PR TITLE
Remove unnecessary stuff from ObjectTable

### DIFF
--- a/Dalamud/Game/ClientState/Objects/ObjectTable.cs
+++ b/Dalamud/Game/ClientState/Objects/ObjectTable.cs
@@ -296,7 +296,7 @@ internal sealed partial class ObjectTable
             if (this.owner is not { } o)
                 return;
 
-            if (this.index == -1)
+            if (this.slotId == -1)
                 o.multiThreadedEnumerators.Return(this);
             else
                 o.frameworkThreadEnumerators[this.slotId] = this;

--- a/Dalamud/Game/ClientState/Objects/ObjectTable.cs
+++ b/Dalamud/Game/ClientState/Objects/ObjectTable.cs
@@ -100,11 +100,11 @@ internal sealed partial class ObjectTable : IServiceType, IObjectTable
     }
 
     /// <inheritdoc/>
-    public nint GetObjectAddress(int index)
+    public unsafe nint GetObjectAddress(int index)
     {
         _ = this.WarnMultithreadedUsage();
 
-        return index is < 0 or >= ObjectTableLength ? nint.Zero : this.GetObjectAddressUnsafe(index);
+        return index is < 0 or >= ObjectTableLength ? nint.Zero : (nint)this.cachedObjectTable[index].Address;
     }
 
     /// <inheritdoc/>
@@ -154,10 +154,6 @@ internal sealed partial class ObjectTable : IServiceType, IObjectTable
 
         return true;
     }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private unsafe nint GetObjectAddressUnsafe(int index) =>
-        *(nint*)(this.clientState.AddressResolver.ObjectTable + (8 * index));
 
     /// <summary>Stores an object table entry, with preallocated concrete types.</summary>
     internal readonly unsafe struct CachedEntry

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -499,6 +499,9 @@ internal class FrameworkPluginScoped : IDisposable, IServiceType, IFramework
     public DateTime LastUpdateUTC => this.frameworkService.LastUpdateUTC;
 
     /// <inheritdoc/>
+    public TaskFactory FrameworkThreadTaskFactory => this.frameworkService.FrameworkThreadTaskFactory;
+
+    /// <inheritdoc/>
     public TimeSpan UpdateDelta => this.frameworkService.UpdateDelta;
 
     /// <inheritdoc/>

--- a/Dalamud/Plugin/Services/IObjectTable.cs
+++ b/Dalamud/Plugin/Services/IObjectTable.cs
@@ -1,24 +1,27 @@
 ﻿using System.Collections.Generic;
 
 using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Utility;
 
 namespace Dalamud.Plugin.Services;
 
 /// <summary>
 /// This collection represents the currently spawned FFXIV game objects.
 /// </summary>
+[Api10ToDo(
+    "Make it an IEnumerable<GameObject> instead. Skipping null objects make IReadOnlyCollection<T>.Count yield incorrect values.")]
 public interface IObjectTable : IReadOnlyCollection<GameObject>
 {
     /// <summary>
     /// Gets the address of the object table.
     /// </summary>
     public nint Address { get; }
-    
+
     /// <summary>
     /// Gets the length of the object table.
     /// </summary>
     public int Length { get; }
-    
+
     /// <summary>
     /// Get an object at the specified spawn index.
     /// </summary>
@@ -32,14 +35,14 @@ public interface IObjectTable : IReadOnlyCollection<GameObject>
     /// <param name="objectId">Object ID to find.</param>
     /// <returns>A game object or null.</returns>
     public GameObject? SearchById(ulong objectId);
-    
+
     /// <summary>
     /// Gets the address of the game object at the specified index of the object table.
     /// </summary>
     /// <param name="index">The index of the object.</param>
     /// <returns>The memory address of the object.</returns>
     public nint GetObjectAddress(int index);
-    
+
     /// <summary>
     /// Create a reference to an FFXIV game object.
     /// </summary>


### PR DESCRIPTION
* Reduced framework thread pooled cached enumerators to 4. Even quadruple nested GameObject enumeration is unlikely.
* Removed `ActiveObject` from `CachedEntry`.
* Stored the corresponding `CSGameObject**` to each `CachedEntry`.
* Made it compile; FrameworkScoped was missing an alias.