### PR TITLE
Add support for using Server GC

### DIFF
--- a/Dalamud.Boot/DalamudStartInfo.cpp
+++ b/Dalamud.Boot/DalamudStartInfo.cpp
@@ -108,6 +108,7 @@ void from_json(const nlohmann::json& json, DalamudStartInfo& config) {
     config.BootVehEnabled = json.value("BootVehEnabled", config.BootVehEnabled);
     config.BootVehFull = json.value("BootVehFull", config.BootVehFull);
     config.BootEnableEtw = json.value("BootEnableEtw", config.BootEnableEtw);
+    config.BootEnableGcServer = json.value("BootEnableGcServer", config.BootEnableGcServer);
     config.BootDotnetOpenProcessHookMode = json.value("BootDotnetOpenProcessHookMode", config.BootDotnetOpenProcessHookMode);
     if (const auto it = json.find("BootEnabledGameFixes"); it != json.end() && it->is_array()) {
         config.BootEnabledGameFixes.clear();
@@ -133,6 +134,7 @@ void DalamudStartInfo::from_envvars() {
     BootVehEnabled = utils::get_env<bool>(L"DALAMUD_IS_VEH");
     BootVehFull = utils::get_env<bool>(L"DALAMUD_IS_VEH_FULL");
     BootEnableEtw = utils::get_env<bool>(L"DALAMUD_ENABLE_ETW");
+    BootEnableGcServer = utils::get_env<bool>(L"DALAMUD_ENABLE_GCSERVER");
     BootDotnetOpenProcessHookMode = static_cast<DotNetOpenProcessHookMode>(utils::get_env<int>(L"DALAMUD_DOTNET_OPENPROCESS_HOOKMODE"));
     for (const auto& item : utils::get_env_list<std::string>(L"DALAMUD_GAMEFIX_LIST"))
         BootEnabledGameFixes.insert(unicode::convert<std::string>(item, &unicode::lower));

--- a/Dalamud.Boot/DalamudStartInfo.h
+++ b/Dalamud.Boot/DalamudStartInfo.h
@@ -54,6 +54,7 @@ struct DalamudStartInfo {
     bool BootVehEnabled = false;
     bool BootVehFull = false;
     bool BootEnableEtw = false;
+    bool BootEnableGcServer = false;
     DotNetOpenProcessHookMode BootDotnetOpenProcessHookMode = DotNetOpenProcessHookMode::ImportHooks;
     std::set<std::string> BootEnabledGameFixes{};
     std::set<std::string> BootUnhookDlls{};

--- a/Dalamud.Boot/dllmain.cpp
+++ b/Dalamud.Boot/dllmain.cpp
@@ -117,6 +117,7 @@ HRESULT WINAPI InitializeImpl(LPVOID lpParam, HANDLE hMainThreadContinue) {
     const auto result = InitializeClrAndGetEntryPoint(
         g_hModule,
         g_startInfo.BootEnableEtw,
+        g_startInfo.BootEnableGcServer,
         runtimeconfig_path,
         module_path,
         L"Dalamud.EntryPoint, Dalamud",

--- a/Dalamud.Common/DalamudStartInfo.cs
+++ b/Dalamud.Common/DalamudStartInfo.cs
@@ -125,6 +125,11 @@ public record DalamudStartInfo
     public bool BootEnableEtw { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether or not GC Server should be enabled.
+    /// </summary>
+    public bool BootEnableGcServer { get; set; }
+
+    /// <summary>
     /// Gets or sets a value choosing the OpenProcess hookmode.
     /// </summary>
     public int BootDotnetOpenProcessHookMode { get; set; }

--- a/Dalamud.Injector.Boot/main.cpp
+++ b/Dalamud.Injector.Boot/main.cpp
@@ -26,6 +26,7 @@ int wmain(int argc, wchar_t** argv)
     const auto result = InitializeClrAndGetEntryPoint(
         GetModuleHandleW(nullptr),
         false,
+        false,
         runtimeconfig_path,
         module_path,
         L"Dalamud.Injector.EntryPoint, Dalamud.Injector",

--- a/Dalamud.Injector/EntryPoint.cs
+++ b/Dalamud.Injector/EntryPoint.cs
@@ -394,6 +394,7 @@ namespace Dalamud.Injector
             // Set boot defaults
             startInfo.BootShowConsole = args.Contains("--console");
             startInfo.BootEnableEtw = args.Contains("--etw");
+            startInfo.BootEnableGcServer = args.Contains("--gc-server");
             startInfo.BootLogPath = GetLogPath(startInfo.LogPath, "dalamud.boot", startInfo.LogName);
             startInfo.BootEnabledGameFixes = new()
             {

--- a/lib/CoreCLR/boot.cpp
+++ b/lib/CoreCLR/boot.cpp
@@ -30,6 +30,7 @@ std::optional<CoreCLR> g_clr;
 HRESULT InitializeClrAndGetEntryPoint(
     void* calling_module,
     bool enable_etw,
+    bool enable_gcServer,
     std::wstring runtimeconfig_path,
     std::wstring module_path,
     std::wstring entrypoint_assembly_name,
@@ -55,6 +56,7 @@ HRESULT InitializeClrAndGetEntryPoint(
     SetEnvironmentVariable(L"DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3SUPPORT", L"0");
 
     SetEnvironmentVariable(L"COMPlus_ETWEnabled", enable_etw ? L"1" : L"0");
+    SetEnvironmentVariable(L"DOTNET_gcServer", enable_gcServer ? L"1" : L"0");
 
     wchar_t* dotnet_path;
     wchar_t* _appdata;

--- a/lib/CoreCLR/boot.h
+++ b/lib/CoreCLR/boot.h
@@ -4,6 +4,7 @@ void ConsoleTeardown();
 HRESULT InitializeClrAndGetEntryPoint(
     void* calling_module,
     bool enable_etw,
+    bool enable_gcServer,
     std::wstring runtimeconfig_path,
     std::wstring module_path,
     std::wstring entrypoint_assembly_name,


### PR DESCRIPTION
This PR Attempts to add support for using the Server GC instead of the default Workstation GC.

Server GC is another variant of Garbage Collector designed heavier workloads, optimized for throughput.

It tends to provide a smoother experience in my case however I have read that in some cases it may cause memory usage to grow drastically. While I have not seen it happen on my limited testing, YMMV.

Related launcher PR: https://github.com/goatcorp/FFXIVQuickLauncher/pull/1447

