### PR TITLE
Add missing space in cross-world PF links

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -381,7 +381,7 @@ public class SeString
         {
             new PartyFinderPayload(listingId, isCrossWorld ? PartyFinderPayload.PartyFinderLinkType.NotSpecified : PartyFinderPayload.PartyFinderLinkType.LimitedToHomeWorld),
             // ->
-            new TextPayload($"Looking for Party ({recruiterName})"),
+            new TextPayload($"Looking for Party ({recruiterName})" + (isCrossWorld ? " " : string.Empty)),
         };
 
         payloads.InsertRange(1, TextArrowPayloads);


### PR DESCRIPTION
Okay, I know this is a silly change, but I noticed while working with these links and it bugged me

For cross-world PF links, the game inserts a space between the text and icon:
![image](https://github.com/goatcorp/Dalamud/assets/27009727/dfb7509a-bdb6-49e0-b157-a90604cd820b)

Dalamud did not:
![image](https://github.com/goatcorp/Dalamud/assets/27009727/8ee01875-2aa8-4671-930e-ce70edf366fd)
