### PR TITLE
Handle static declares in AddonLifecycleWidget

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonLifecycleWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonLifecycleWidget.cs
@@ -90,7 +90,7 @@ public class AddonLifecycleWidget : IDataWindowWidget
                         ImGui.Text(listener.AddonName is "" ? "GLOBAL" : listener.AddonName);
 
                         ImGui.TableNextColumn();
-                        ImGui.Text($"{listener.FunctionDelegate.Target}::{listener.FunctionDelegate.Method.Name}");
+                        ImGui.Text($"{listener.FunctionDelegate.Method.DeclaringType.Name}::{listener.FunctionDelegate.Method.Name}");
                     }
                     
                     ImGui.EndTable();

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonLifecycleWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonLifecycleWidget.cs
@@ -90,7 +90,7 @@ public class AddonLifecycleWidget : IDataWindowWidget
                         ImGui.Text(listener.AddonName is "" ? "GLOBAL" : listener.AddonName);
 
                         ImGui.TableNextColumn();
-                        ImGui.Text($"{listener.FunctionDelegate.Method.DeclaringType.Name}::{listener.FunctionDelegate.Method.Name}");
+                        ImGui.Text($"{listener.FunctionDelegate.Method.DeclaringType.FullName}::{listener.FunctionDelegate.Method.Name}");
                     }
                     
                     ImGui.EndTable();


### PR DESCRIPTION
Just a fix to where if someone declares a static method for the event handler the `Delegate.Target` doesn't get the object out.

This switches it over to a `Type` inspection way of figuring out where the method is declared from.