### PR TITLE
Hide scheduler from RunOnFrameworkThread

### DIFF
--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -139,6 +139,38 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     }
 
     /// <inheritdoc/>
+    public Task RunOnFrameworkThreadAwaitable(Action action, CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken == default)
+            cancellationToken = this.FrameworkThreadTaskFactory.CancellationToken;
+        return this.FrameworkThreadTaskFactory.StartNew(action, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public Task<T> RunOnFrameworkThreadAwaitable<T>(Func<T> action, CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken == default)
+            cancellationToken = this.FrameworkThreadTaskFactory.CancellationToken;
+        return this.FrameworkThreadTaskFactory.StartNew(action, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public Task RunOnFrameworkThreadAwaitable(Func<Task> action, CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken == default)
+            cancellationToken = this.FrameworkThreadTaskFactory.CancellationToken;
+        return this.FrameworkThreadTaskFactory.StartNew(action, cancellationToken).Unwrap();
+    }
+
+    /// <inheritdoc/>
+    public Task<T> RunOnFrameworkThreadAwaitable<T>(Func<Task<T>> action, CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken == default)
+            cancellationToken = this.FrameworkThreadTaskFactory.CancellationToken;
+        return this.FrameworkThreadTaskFactory.StartNew(action, cancellationToken).Unwrap();
+    }
+
+    /// <inheritdoc/>
     public Task<T> RunOnFrameworkThread<T>(Func<T> func) =>
         this.IsInFrameworkUpdateThread || this.IsFrameworkUnloading ? Task.FromResult(func()) : this.RunOnTick(func);
 
@@ -193,7 +225,9 @@ internal sealed class Framework : IInternalDisposableService, IFramework
                 this.DelayTicks(delayTicks, cancellationToken),
             },
             _ => func(),
-            cancellationToken);
+            cancellationToken,
+            TaskContinuationOptions.HideScheduler,
+            this.frameworkThreadTaskScheduler);
     }
 
     /// <inheritdoc/>
@@ -218,7 +252,9 @@ internal sealed class Framework : IInternalDisposableService, IFramework
                 this.DelayTicks(delayTicks, cancellationToken),
             },
             _ => action(),
-            cancellationToken);
+            cancellationToken,
+            TaskContinuationOptions.HideScheduler,
+            this.frameworkThreadTaskScheduler);
     }
 
     /// <inheritdoc/>
@@ -243,7 +279,9 @@ internal sealed class Framework : IInternalDisposableService, IFramework
                 this.DelayTicks(delayTicks, cancellationToken),
             },
             _ => func(),
-            cancellationToken).Unwrap();
+            cancellationToken,
+            TaskContinuationOptions.HideScheduler,
+            this.frameworkThreadTaskScheduler).Unwrap();
     }
 
     /// <inheritdoc/>
@@ -268,7 +306,9 @@ internal sealed class Framework : IInternalDisposableService, IFramework
                 this.DelayTicks(delayTicks, cancellationToken),
             },
             _ => func(),
-            cancellationToken).Unwrap();
+            cancellationToken,
+            TaskContinuationOptions.HideScheduler,
+            this.frameworkThreadTaskScheduler).Unwrap();
     }
 
     /// <summary>
@@ -514,6 +554,22 @@ internal class FrameworkPluginScoped : IInternalDisposableService, IFramework
     /// <inheritdoc/>
     public Task DelayTicks(long numTicks, CancellationToken cancellationToken = default) =>
         this.frameworkService.DelayTicks(numTicks, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task RunOnFrameworkThreadAwaitable(Action action, CancellationToken cancellationToken = default) =>
+        this.frameworkService.RunOnFrameworkThreadAwaitable(action, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<T> RunOnFrameworkThreadAwaitable<T>(Func<T> action, CancellationToken cancellationToken = default) =>
+        this.frameworkService.RunOnFrameworkThreadAwaitable(action, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task RunOnFrameworkThreadAwaitable(Func<Task> action, CancellationToken cancellationToken = default) =>
+        this.frameworkService.RunOnFrameworkThreadAwaitable(action, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<T> RunOnFrameworkThreadAwaitable<T>(Func<Task<T>> action, CancellationToken cancellationToken = default) =>
+        this.frameworkService.RunOnFrameworkThreadAwaitable(action, cancellationToken);
 
     /// <inheritdoc/>
     public Task<T> RunOnFrameworkThread<T>(Func<T> func)

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -104,9 +104,6 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     public DateTime LastUpdateUTC { get; private set; } = DateTime.MinValue;
 
     /// <inheritdoc/>
-    public TaskFactory FrameworkThreadTaskFactory { get; }
-
-    /// <inheritdoc/>
     public TimeSpan UpdateDelta { get; private set; } = TimeSpan.Zero;
 
     /// <inheritdoc/>
@@ -124,6 +121,11 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     /// Gets or sets a value indicating whether to dispatch update events.
     /// </summary>
     internal bool DispatchUpdateEvents { get; set; } = true;
+
+    private TaskFactory FrameworkThreadTaskFactory { get; }
+
+    /// <inheritdoc/>
+    public TaskFactory GetTaskFactory() => this.FrameworkThreadTaskFactory;
 
     /// <inheritdoc/>
     public Task DelayTicks(long numTicks, CancellationToken cancellationToken = default)
@@ -532,9 +534,6 @@ internal class FrameworkPluginScoped : IInternalDisposableService, IFramework
     public DateTime LastUpdateUTC => this.frameworkService.LastUpdateUTC;
 
     /// <inheritdoc/>
-    public TaskFactory FrameworkThreadTaskFactory => this.frameworkService.FrameworkThreadTaskFactory;
-
-    /// <inheritdoc/>
     public TimeSpan UpdateDelta => this.frameworkService.UpdateDelta;
     
     /// <inheritdoc/>
@@ -550,6 +549,9 @@ internal class FrameworkPluginScoped : IInternalDisposableService, IFramework
 
         this.Update = null;
     }
+
+    /// <inheritdoc/>
+    public TaskFactory GetTaskFactory() => this.frameworkService.GetTaskFactory();
 
     /// <inheritdoc/>
     public Task DelayTicks(long numTicks, CancellationToken cancellationToken = default) =>

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TaskSchedulerWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TaskSchedulerWidget.cs
@@ -146,7 +146,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Every 60 frames"))
+        if (ImGui.Button("Every 60f"))
         {
             _ = framework.RunOnTick(
                 async () =>
@@ -154,10 +154,66 @@ internal class TaskSchedulerWidget : IDataWindowWidget
                     for (var i = 0L; ; i++)
                     {
                         Log.Information($"Loop #{i}; MainThread={ThreadSafety.IsMainThread}");
+                        var it = i;
+                        _ = Task.Run(() => Log.Information($" => Sub #{it}; MainThread={ThreadSafety.IsMainThread}"));
                         await framework.DelayTicks(60, this.taskSchedulerCancelSource.Token);
                     }
                 },
                 cancellationToken: this.taskSchedulerCancelSource.Token);
+        }
+
+        ImGui.SameLine();
+
+        if (ImGui.Button("Every 1s"))
+        {
+            _ = framework.RunOnTick(
+                async () =>
+                {
+                    for (var i = 0L; ; i++)
+                    {
+                        Log.Information($"Loop #{i}; MainThread={ThreadSafety.IsMainThread}");
+                        var it = i;
+                        _ = Task.Run(() => Log.Information($" => Sub #{it}; MainThread={ThreadSafety.IsMainThread}"));
+                        await Task.Delay(TimeSpan.FromSeconds(1), this.taskSchedulerCancelSource.Token);
+                    }
+                },
+                cancellationToken: this.taskSchedulerCancelSource.Token);
+        }
+
+        ImGui.SameLine();
+
+        if (ImGui.Button("Every 60f (Await)"))
+        {
+            _ = framework.RunOnFrameworkThreadAwaitable(
+                async () =>
+                {
+                    for (var i = 0L; ; i++)
+                    {
+                        Log.Information($"Loop #{i}; MainThread={ThreadSafety.IsMainThread}");
+                        var it = i;
+                        _ = Task.Run(() => Log.Information($" => Sub #{it}; MainThread={ThreadSafety.IsMainThread}"));
+                        await framework.DelayTicks(60, this.taskSchedulerCancelSource.Token);
+                    }
+                },
+                this.taskSchedulerCancelSource.Token);
+        }
+
+        ImGui.SameLine();
+
+        if (ImGui.Button("Every 1s (Await)"))
+        {
+            _ = framework.RunOnFrameworkThreadAwaitable(
+                async () =>
+                {
+                    for (var i = 0L; ; i++)
+                    {
+                        Log.Information($"Loop #{i}; MainThread={ThreadSafety.IsMainThread}");
+                        var it = i;
+                        _ = Task.Run(() => Log.Information($" => Sub #{it}; MainThread={ThreadSafety.IsMainThread}"));
+                        await Task.Delay(TimeSpan.FromSeconds(1), this.taskSchedulerCancelSource.Token);
+                    }
+                },
+                this.taskSchedulerCancelSource.Token);
         }
 
         ImGui.SameLine();

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TaskSchedulerWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TaskSchedulerWidget.cs
@@ -155,7 +155,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
                     {
                         Log.Information($"Loop #{i}; MainThread={ThreadSafety.IsMainThread}");
                         var it = i;
-                        _ = Task.Run(() => Log.Information($" => Sub #{it}; MainThread={ThreadSafety.IsMainThread}"));
+                        _ = Task.Factory.StartNew(() => Log.Information($" => Sub #{it}; MainThread={ThreadSafety.IsMainThread}"));
                         await framework.DelayTicks(60, this.taskSchedulerCancelSource.Token);
                     }
                 },
@@ -173,7 +173,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
                     {
                         Log.Information($"Loop #{i}; MainThread={ThreadSafety.IsMainThread}");
                         var it = i;
-                        _ = Task.Run(() => Log.Information($" => Sub #{it}; MainThread={ThreadSafety.IsMainThread}"));
+                        _ = Task.Factory.StartNew(() => Log.Information($" => Sub #{it}; MainThread={ThreadSafety.IsMainThread}"));
                         await Task.Delay(TimeSpan.FromSeconds(1), this.taskSchedulerCancelSource.Token);
                     }
                 },
@@ -191,7 +191,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
                     {
                         Log.Information($"Loop #{i}; MainThread={ThreadSafety.IsMainThread}");
                         var it = i;
-                        _ = Task.Run(() => Log.Information($" => Sub #{it}; MainThread={ThreadSafety.IsMainThread}"));
+                        _ = Task.Factory.StartNew(() => Log.Information($" => Sub #{it}; MainThread={ThreadSafety.IsMainThread}"));
                         await framework.DelayTicks(60, this.taskSchedulerCancelSource.Token);
                     }
                 },
@@ -209,7 +209,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
                     {
                         Log.Information($"Loop #{i}; MainThread={ThreadSafety.IsMainThread}");
                         var it = i;
-                        _ = Task.Run(() => Log.Information($" => Sub #{it}; MainThread={ThreadSafety.IsMainThread}"));
+                        _ = Task.Factory.StartNew(() => Log.Information($" => Sub #{it}; MainThread={ThreadSafety.IsMainThread}"));
                         await Task.Delay(TimeSpan.FromSeconds(1), this.taskSchedulerCancelSource.Token);
                     }
                 },

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TaskSchedulerWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TaskSchedulerWidget.cs
@@ -287,7 +287,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
                 this.downloadState = default;
                 var factory = downloadUsingGlobalScheduler
                                   ? Task.Factory
-                                  : framework.FrameworkThreadTaskFactory;
+                                  : framework.GetTaskFactory();
                 this.downloadState = default;
                 this.downloadTask = factory.StartNew(
                     async () =>

--- a/Dalamud/Plugin/Services/IFramework.cs
+++ b/Dalamud/Plugin/Services/IFramework.cs
@@ -48,11 +48,6 @@ public interface IFramework
     public DateTime LastUpdateUTC { get; }
 
     /// <summary>
-    /// Gets a <see cref="TaskFactory"/> that runs tasks during Framework Update event.
-    /// </summary>
-    public TaskFactory FrameworkThreadTaskFactory { get; }
-
-    /// <summary>
     /// Gets the delta between the last Framework Update and the currently executing one.
     /// </summary>
     public TimeSpan UpdateDelta { get; }
@@ -66,6 +61,10 @@ public interface IFramework
     /// Gets a value indicating whether game Framework is unloading.
     /// </summary>
     public bool IsFrameworkUnloading { get; }
+
+    /// <summary>Gets a <see cref="TaskFactory"/> that runs tasks during Framework Update event.</summary>
+    /// <returns>The task factory.</returns>
+    public TaskFactory GetTaskFactory();
 
     /// <summary>
     /// Returns a task that completes after the given number of ticks. 

--- a/Dalamud/Plugin/Services/IFramework.cs
+++ b/Dalamud/Plugin/Services/IFramework.cs
@@ -55,7 +55,42 @@ public interface IFramework
     /// <param name="numTicks">Number of ticks to delay.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A new <see cref="Task"/> that gets resolved after specified number of ticks happen.</returns>
+    /// <remarks>The continuation will run on the framework thread by default.</remarks>
     public Task DelayTicks(long numTicks, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Run given function right away if this function has been called from game's Framework.Update thread, or otherwise run on next Framework.Update call.
+    /// </summary>
+    /// <param name="action">Function to call.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>Task representing the pending or already completed function.</returns>
+    public Task RunOnFrameworkThreadAwaitable(Action action, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Run given function right away if this function has been called from game's Framework.Update thread, or otherwise run on next Framework.Update call.
+    /// </summary>
+    /// <typeparam name="T">Return type.</typeparam>
+    /// <param name="action">Function to call.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>Task representing the pending or already completed function.</returns>
+    public Task<T> RunOnFrameworkThreadAwaitable<T>(Func<T> action, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Run given function right away if this function has been called from game's Framework.Update thread, or otherwise run on next Framework.Update call.
+    /// </summary>
+    /// <param name="action">Function to call.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>Task representing the pending or already completed function.</returns>
+    public Task RunOnFrameworkThreadAwaitable(Func<Task> action, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Run given function right away if this function has been called from game's Framework.Update thread, or otherwise run on next Framework.Update call.
+    /// </summary>
+    /// <typeparam name="T">Return type.</typeparam>
+    /// <param name="action">Function to call.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>Task representing the pending or already completed function.</returns>
+    public Task<T> RunOnFrameworkThreadAwaitable<T>(Func<Task<T>> action, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Run given function right away if this function has been called from game's Framework.Update thread, or otherwise run on next Framework.Update call.
@@ -63,6 +98,7 @@ public interface IFramework
     /// <typeparam name="T">Return type.</typeparam>
     /// <param name="func">Function to call.</param>
     /// <returns>Task representing the pending or already completed function.</returns>
+    /// <remarks><c>await</c>, <see cref="Task.Run(Action)"/> or alike will continue off the framework thread.</remarks>
     public Task<T> RunOnFrameworkThread<T>(Func<T> func);
 
     /// <summary>
@@ -70,6 +106,7 @@ public interface IFramework
     /// </summary>
     /// <param name="action">Function to call.</param>
     /// <returns>Task representing the pending or already completed function.</returns>
+    /// <remarks><c>await</c>, <see cref="Task.Run(Action)"/> or alike will continue off the framework thread.</remarks>
     public Task RunOnFrameworkThread(Action action);
 
     /// <summary>
@@ -78,6 +115,7 @@ public interface IFramework
     /// <typeparam name="T">Return type.</typeparam>
     /// <param name="func">Function to call.</param>
     /// <returns>Task representing the pending or already completed function.</returns>
+    /// <remarks><c>await</c>, <see cref="Task.Run(Action)"/> or alike will continue off the framework thread.</remarks>
     [Obsolete($"Use {nameof(RunOnTick)} instead.")]
     public Task<T> RunOnFrameworkThread<T>(Func<Task<T>> func);
 
@@ -86,6 +124,7 @@ public interface IFramework
     /// </summary>
     /// <param name="func">Function to call.</param>
     /// <returns>Task representing the pending or already completed function.</returns>
+    /// <remarks><c>await</c>, <see cref="Task.Run(Action)"/> or alike will continue off the framework thread.</remarks>
     [Obsolete($"Use {nameof(RunOnTick)} instead.")]
     public Task RunOnFrameworkThread(Func<Task> func);
 
@@ -98,6 +137,7 @@ public interface IFramework
     /// <param name="delayTicks">Count given number of Framework.Tick calls before calling this function. This takes precedence over delay parameter.</param>
     /// <param name="cancellationToken">Cancellation token which will prevent the execution of this function if wait conditions are not met.</param>
     /// <returns>Task representing the pending function.</returns>
+    /// <remarks><c>await</c>, <see cref="Task.Run(Action)"/> or alike will continue off the framework thread.</remarks>
     public Task<T> RunOnTick<T>(Func<T> func, TimeSpan delay = default, int delayTicks = default, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -108,6 +148,7 @@ public interface IFramework
     /// <param name="delayTicks">Count given number of Framework.Tick calls before calling this function. This takes precedence over delay parameter.</param>
     /// <param name="cancellationToken">Cancellation token which will prevent the execution of this function if wait conditions are not met.</param>
     /// <returns>Task representing the pending function.</returns>
+    /// <remarks><c>await</c>, <see cref="Task.Run(Action)"/> or alike will continue off the framework thread.</remarks>
     public Task RunOnTick(Action action, TimeSpan delay = default, int delayTicks = default, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -119,6 +160,7 @@ public interface IFramework
     /// <param name="delayTicks">Count given number of Framework.Tick calls before calling this function. This takes precedence over delay parameter.</param>
     /// <param name="cancellationToken">Cancellation token which will prevent the execution of this function if wait conditions are not met.</param>
     /// <returns>Task representing the pending function.</returns>
+    /// <remarks><c>await</c>, <see cref="Task.Run(Action)"/> or alike will continue off the framework thread.</remarks>
     public Task<T> RunOnTick<T>(Func<Task<T>> func, TimeSpan delay = default, int delayTicks = default, CancellationToken cancellationToken = default);
     
     /// <summary>
@@ -129,5 +171,6 @@ public interface IFramework
     /// <param name="delayTicks">Count given number of Framework.Tick calls before calling this function. This takes precedence over delay parameter.</param>
     /// <param name="cancellationToken">Cancellation token which will prevent the execution of this function if wait conditions are not met.</param>
     /// <returns>Task representing the pending function.</returns>
+    /// <remarks><c>await</c>, <see cref="Task.Run(Action)"/> or alike will continue off the framework thread.</remarks>
     public Task RunOnTick(Func<Task> func, TimeSpan delay = default, int delayTicks = default, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
Creating new tasks via `Task.Factory.StartNew` and alike would fetch the current scheduler, which we do not want in case of running stuff from the framework thread. Change is to prevent the standard library from seeing the "current scheduler". If one wants to use `await` with an async function to be run in the framework thread, one can use `RunOnFrameworkThreadAwaitable` instead now.