### PR TITLE
Add Reduced Motion for Notifications

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -368,6 +368,11 @@ internal sealed class DalamudConfiguration : IInternalDisposableService
     public bool ShowTsm { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether to reduce motions (animations).
+    /// </summary>
+    public bool ReduceMotions { get; set; } = false;
+
+    /// <summary>
     /// Gets or sets a value indicating whether or not market board data should be uploaded.
     /// </summary>
     public bool IsMbCollect { get; set; } = true;

--- a/Dalamud/Interface/ImGuiNotification/Internal/ActiveNotification.cs
+++ b/Dalamud/Interface/ImGuiNotification/Internal/ActiveNotification.cs
@@ -2,6 +2,7 @@ using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Dalamud.Configuration.Internal;
 using Dalamud.Interface.Animation;
 using Dalamud.Interface.Animation.EasingFunctions;
 using Dalamud.Interface.Internal;
@@ -187,16 +188,18 @@ internal sealed partial class ActiveNotification : IActiveNotification
         set => this.newProgress = value;
     }
 
+    private static bool ReducedMotions => Service<DalamudConfiguration>.Get().ReduceMotions;
+
     /// <summary>Gets the eased progress.</summary>
     private float ProgressEased
     {
         get
         {
             var underlyingProgress = this.underlyingNotification.Progress;
-            if (Math.Abs(underlyingProgress - this.progressBefore) < 0.000001f || this.progressEasing.IsDone)
+            if (Math.Abs(underlyingProgress - this.progressBefore) < 0.000001f || this.progressEasing.IsDone || ReducedMotions)
                 return underlyingProgress;
 
-            var state = Math.Clamp((float)this.progressEasing.Value, 0f, 1f);
+            var state = ReducedMotions ? 1f : Math.Clamp((float)this.progressEasing.Value, 0f, 1f);
             return this.progressBefore + (state * (underlyingProgress - this.progressBefore));
         }
     }

--- a/Dalamud/Interface/ImGuiNotification/Internal/NotificationConstants.cs
+++ b/Dalamud/Interface/ImGuiNotification/Internal/NotificationConstants.cs
@@ -41,6 +41,10 @@ internal static class NotificationConstants
     /// <summary>The duration of indeterminate progress bar loop in milliseconds.</summary>
     public const float IndeterminateProgressbarLoopDuration = 2000f;
 
+    /// <summary>The duration of indeterminate pie loop in milliseconds.</summary>
+    /// <remarks>Note that this value is applicable when reduced motion configuration is on.</remarks>
+    public const float IndeterminatePieLoopDuration = 8000f;
+
     /// <summary>The duration of the progress wave animation in milliseconds.</summary>
     public const float ProgressWaveLoopDuration = 2000f;
 

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
@@ -130,6 +130,12 @@ public class SettingsTabLook : SettingsTab
             Loc.Localize("DalamudSettingInstallerOpenDefaultHint", "This will allow you to open the Plugin Installer to the \"Installed Plugins\" tab by default, instead of the \"Available Plugins\" tab."),
             c => c.PluginInstallerOpen == PluginInstallerWindow.PluginInstallerOpenKind.InstalledPlugins,
             (v, c) => c.PluginInstallerOpen = v ? PluginInstallerWindow.PluginInstallerOpenKind.InstalledPlugins : PluginInstallerWindow.PluginInstallerOpenKind.AllPlugins),
+        
+        new SettingsEntry<bool>(
+            Loc.Localize("DalamudSettingReducedMotion", "Reduce motions"),
+            Loc.Localize("DalamudSettingReducedMotion", "This will suppress certain animations from Dalamud, such as the notification popup."),
+            c => c.ReduceMotions,
+            (v, c) => c.ReduceMotions = v),
     };
 
     public override string Title => Loc.Localize("DalamudSettingsVisual", "Look & Feel");

--- a/Dalamud/Utility/DateTimeSpanExtensions.cs
+++ b/Dalamud/Utility/DateTimeSpanExtensions.cs
@@ -44,8 +44,9 @@ public static class DateTimeSpanExtensions
 
     /// <summary>Formats an instance of <see cref="DateTime"/> as a localized relative time.</summary>
     /// <param name="when">When.</param>
+    /// <param name="floorBy">The alignment unit of time span.</param>
     /// <returns>The formatted string.</returns>
-    public static string LocRelativePastLong(this DateTime when)
+    public static string LocRelativePastLong(this DateTime when, TimeSpan floorBy)
     {
         var loc = Loc.Localize(
             "DateTimeSpanExtensions.RelativeFormatStringsLong",
@@ -55,13 +56,17 @@ public static class DateTimeSpanExtensions
         if (relativeFormatStringLong?.FormatStringLoc != loc)
             relativeFormatStringLong ??= new(loc);
 
-        return relativeFormatStringLong.Format(DateTime.Now - when);
+        return
+            floorBy == default
+                ? relativeFormatStringLong.Format(DateTime.Now - when)
+                : relativeFormatStringLong.Format(Math.Floor((DateTime.Now - when) / floorBy) * floorBy);
     }
 
     /// <summary>Formats an instance of <see cref="DateTime"/> as a localized relative time.</summary>
     /// <param name="when">When.</param>
+    /// <param name="floorBy">The alignment unit of time span.</param>
     /// <returns>The formatted string.</returns>
-    public static string LocRelativePastShort(this DateTime when)
+    public static string LocRelativePastShort(this DateTime when, TimeSpan floorBy)
     {
         var loc = Loc.Localize(
             "DateTimeSpanExtensions.RelativeFormatStringsShort",
@@ -71,8 +76,21 @@ public static class DateTimeSpanExtensions
         if (relativeFormatStringShort?.FormatStringLoc != loc)
             relativeFormatStringShort = new(loc);
 
-        return relativeFormatStringShort.Format(DateTime.Now - when);
+        return
+            floorBy == default
+                ? relativeFormatStringShort.Format(DateTime.Now - when)
+                : relativeFormatStringShort.Format(Math.Floor((DateTime.Now - when) / floorBy) * floorBy);
     }
+
+    /// <summary>Formats an instance of <see cref="DateTime"/> as a localized relative time.</summary>
+    /// <param name="when">When.</param>
+    /// <returns>The formatted string.</returns>
+    public static string LocRelativePastLong(this DateTime when) => when.LocRelativePastLong(TimeSpan.FromSeconds(1));
+
+    /// <summary>Formats an instance of <see cref="DateTime"/> as a localized relative time.</summary>
+    /// <param name="when">When.</param>
+    /// <returns>The formatted string.</returns>
+    public static string LocRelativePastShort(this DateTime when) => when.LocRelativePastShort(TimeSpan.FromSeconds(1));
 
     private sealed class ParsedRelativeFormatStrings
     {


### PR DESCRIPTION
When Reduced Motion configuration is on, the expiry progressbar is removed, and instead a pie on top right is shown, and relative time update interval increases to 15 seconds. Progress wave animation also is suppressed.

Preview animation at https://discord.com/channels/581875019861328007/860813266468732938/1219698149623468164