### PR TITLE
Add FontAwesome fixed width

### DIFF
--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -23,10 +23,15 @@ using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
 using Dalamud.Utility;
 using Dalamud.Utility.Timing;
+
 using ImGuiNET;
+
 using ImGuiScene;
+
 using PInvoke;
+
 using Serilog;
+
 using SharpDX;
 using SharpDX.Direct3D;
 using SharpDX.Direct3D11;
@@ -129,6 +134,13 @@ internal class InterfaceManager : IDisposable, IServiceType
         WhenFontsReady().IconFontHandle!.LockUntilPostFrame().OrElse(ImGui.GetIO().FontDefault);
 
     /// <summary>
+    /// Gets an included FontAwesome icon font with fixed width.
+    /// <strong>Accessing this static property outside of the main thread is dangerous and not supported.</strong>
+    /// </summary>
+    public static ImFontPtr IconFontFixedWidth =>
+        WhenFontsReady().IconFontFixedWidthHandle!.LockUntilPostFrame().OrElse(ImGui.GetIO().FontDefault);
+
+    /// <summary>
     /// Gets an included monospaced font.<br />
     /// <strong>Accessing this static property outside of the main thread is dangerous and not supported.</strong>
     /// </summary>
@@ -144,6 +156,11 @@ internal class InterfaceManager : IDisposable, IServiceType
     /// Gets the icon font handle.
     /// </summary>
     public FontHandle? IconFontHandle { get; private set; }
+
+    /// <summary>
+    /// Gets the icon font handle with fixed width.
+    /// </summary>
+    public FontHandle? IconFontFixedWidthHandle { get; private set; }
 
     /// <summary>
     /// Gets the mono font handle.
@@ -379,7 +396,7 @@ internal class InterfaceManager : IDisposable, IServiceType
                 });
             }
         }
-        
+
         // no sampler for now because the ImGui implementation we copied doesn't allow for changing it
         return new DalamudTextureWrap(new D3DTextureWrap(resView, width, height));
     }
@@ -475,7 +492,7 @@ internal class InterfaceManager : IDisposable, IServiceType
             atlas.BuildTask.GetAwaiter().GetResult();
         return im;
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void RenderImGui(RawDX11Scene scene)
     {
@@ -710,6 +727,25 @@ internal class InterfaceManager : IDisposable, IServiceType
                             GlyphMinAdvanceX = DefaultFontSizePx,
                             GlyphMaxAdvanceX = DefaultFontSizePx,
                         })));
+            this.IconFontFixedWidthHandle = (FontHandle)this.dalamudAtlas.NewDelegateFontHandle(
+                e =>
+                {
+                    e.OnPreBuild(
+                    tk => tk.AddFontAwesomeIconFont(
+                        new()
+                        {
+                            SizePx = Service<FontAtlasFactory>.Get().DefaultFontSpec.SizePx,
+                            GlyphMinAdvanceX = DefaultFontSizePx,
+                            GlyphMaxAdvanceX = DefaultFontSizePx,
+                        }));
+                    e.OnPostBuild(
+                        tk =>
+                        {
+                            var font = tk.Font;
+                            tk.FitRatio(font);
+                            tk.BuildLookupTable(font);
+                        });
+                });
             this.MonoFontHandle = (FontHandle)this.dalamudAtlas.NewDelegateFontHandle(
                 e => e.OnPreBuild(
                     tk => tk.AddDalamudAssetFont(

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -728,7 +728,12 @@ internal class InterfaceManager : IDisposable, IServiceType
                             GlyphMaxAdvanceX = DefaultFontSizePx,
                         })));
             this.IconFontFixedWidthHandle = (FontHandle)this.dalamudAtlas.NewDelegateFontHandle(
-                e => e.OnPreBuild(tk => tk.AddDalamudDefaultFont(-1, new ushort[] { 0x20 })));
+                e => e.OnPreBuild(tk => tk.AddDalamudAssetFont(
+                    DalamudAsset.FontAwesomeFreeSolid,
+                    new()
+                    {
+                        GlyphRanges = new ushort[] { 0x20 },
+                    })));
             this.MonoFontHandle = (FontHandle)this.dalamudAtlas.NewDelegateFontHandle(
                 e => e.OnPreBuild(
                     tk => tk.AddDalamudAssetFont(

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -728,24 +728,7 @@ internal class InterfaceManager : IDisposable, IServiceType
                             GlyphMaxAdvanceX = DefaultFontSizePx,
                         })));
             this.IconFontFixedWidthHandle = (FontHandle)this.dalamudAtlas.NewDelegateFontHandle(
-                e =>
-                {
-                    e.OnPreBuild(
-                    tk => tk.AddFontAwesomeIconFont(
-                        new()
-                        {
-                            SizePx = Service<FontAtlasFactory>.Get().DefaultFontSpec.SizePx,
-                            GlyphMinAdvanceX = DefaultFontSizePx,
-                            GlyphMaxAdvanceX = DefaultFontSizePx,
-                        }));
-                    e.OnPostBuild(
-                        tk =>
-                        {
-                            var font = tk.Font;
-                            tk.FitRatio(font);
-                            tk.BuildLookupTable(font);
-                        });
-                });
+                e => e.OnPreBuild(tk => tk.AddDalamudDefaultFont(-1, new ushort[] { 0x20 })));
             this.MonoFontHandle = (FontHandle)this.dalamudAtlas.NewDelegateFontHandle(
                 e => e.OnPreBuild(
                     tk => tk.AddDalamudAssetFont(
@@ -762,6 +745,13 @@ internal class InterfaceManager : IDisposable, IServiceType
                         tk.GetFont(this.DefaultFontHandle),
                         tk.GetFont(this.MonoFontHandle),
                         missingOnly: true);
+
+                    // Fill missing glyphs in IconFontFixedWidth with IconFont and fit ratio
+                    tk.CopyGlyphsAcrossFonts(
+                        tk.GetFont(this.IconFontHandle),
+                        tk.GetFont(this.IconFontFixedWidthHandle),
+                        missingOnly: true);
+                    tk.FitRatio(tk.GetFont(this.IconFontFixedWidthHandle));
                 });
             this.DefaultFontHandle.ImFontChanged += (_, font) =>
             {

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPostBuild.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPostBuild.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Interface.Internal;
+using Dalamud.Interface.Internal;
 using Dalamud.Utility;
 
 using ImGuiNET;
@@ -26,6 +26,12 @@ public interface IFontAtlasBuildToolkitPostBuild : IFontAtlasBuildToolkit
     /// <param name="disposeOnError">Dispose the wrap on error.</param>
     /// <returns>The texture index.</returns>
     int StoreTexture(IDalamudTextureWrap textureWrap, bool disposeOnError);
+
+    /// <summary>
+    /// Fits a font to a fixed 1:1 ratio adjusting glyph positions horizontally and vertically to fit within font size boundaries.
+    /// </summary>
+    /// <param name="font">The font to fit.</param>
+    void FitRatio(ImFontPtr font);
 
     /// <summary>
     /// Copies glyphs across fonts, in a safer way.<br />

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPostBuild.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlasBuildToolkitPostBuild.cs
@@ -31,7 +31,8 @@ public interface IFontAtlasBuildToolkitPostBuild : IFontAtlasBuildToolkit
     /// Fits a font to a fixed 1:1 ratio adjusting glyph positions horizontally and vertically to fit within font size boundaries.
     /// </summary>
     /// <param name="font">The font to fit.</param>
-    void FitRatio(ImFontPtr font);
+    /// <param name="rebuildLookupTable">Whether to call target.BuildLookupTable().</param>
+    void FitRatio(ImFontPtr font, bool rebuildLookupTable = true);
 
     /// <summary>
     /// Copies glyphs across fonts, in a safer way.<br />

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
@@ -719,7 +719,7 @@ internal sealed partial class FontAtlasFactory
         }
 
         /// <inheritdoc/>
-        public void FitRatio(ImFontPtr font)
+        public void FitRatio(ImFontPtr font, bool rebuildLookupTable = true)
         {
             var nsize = font.FontSize;
             var glyphs = font.GlyphsWrapped();
@@ -738,6 +738,9 @@ internal sealed partial class FontAtlasFactory
                 glyph.Y1 = glyph.Y0 + h;
                 glyph.AdvanceX = nsize;
             }
+
+            if (rebuildLookupTable)
+                this.BuildLookupTable(font);
         }
     }
 }

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
@@ -389,12 +389,10 @@ internal sealed partial class FontAtlasFactory
                         });
 
                 case DalamudAsset.LodestoneGameSymbol when !this.factory.HasGameSymbolsFontFile:
-                    {
-                        return this.AddGameGlyphs(
-                            new(GameFontFamily.Axis, fontConfig.SizePx),
-                            fontConfig.GlyphRanges,
-                            fontConfig.MergeFont);
-                    }
+                    return this.AddGameGlyphs(
+                        new(GameFontFamily.Axis, fontConfig.SizePx),
+                        fontConfig.GlyphRanges,
+                        fontConfig.MergeFont);
 
                 default:
                     return this.factory.AddFont(

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
@@ -1,4 +1,4 @@
-﻿using System.Buffers;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -164,7 +164,7 @@ internal sealed partial class FontAtlasFactory
         /// <inheritdoc/>
         public int StoreTexture(IDalamudTextureWrap textureWrap, bool disposeOnError) =>
             this.data.AddNewTexture(textureWrap, disposeOnError);
-        
+
         /// <inheritdoc/>
         public void RegisterPostBuild(Action action) => this.registeredPostBuildActions.Add(action);
 
@@ -389,12 +389,12 @@ internal sealed partial class FontAtlasFactory
                         });
 
                 case DalamudAsset.LodestoneGameSymbol when !this.factory.HasGameSymbolsFontFile:
-                {
-                    return this.AddGameGlyphs(
-                        new(GameFontFamily.Axis, fontConfig.SizePx),
-                        fontConfig.GlyphRanges,
-                        fontConfig.MergeFont);
-                }
+                    {
+                        return this.AddGameGlyphs(
+                            new(GameFontFamily.Axis, fontConfig.SizePx),
+                            fontConfig.GlyphRanges,
+                            fontConfig.MergeFont);
+                    }
 
                 default:
                     return this.factory.AddFont(
@@ -717,6 +717,28 @@ internal sealed partial class FontAtlasFactory
                     indexedHotData[codepoint].AdvanceX = fallbackHotData.AdvanceX;
                     indexedHotData[codepoint].OccupiedWidth = fallbackHotData.OccupiedWidth;
                 }
+            }
+        }
+
+        /// <inheritdoc/>
+        public void FitRatio(ImFontPtr font)
+        {
+            var nsize = font.FontSize;
+            var glyphs = font.GlyphsWrapped();
+            foreach (ref var glyph in glyphs.DataSpan)
+            {
+                var ratio = 1f;
+                if (glyph.X1 - glyph.X0 > nsize)
+                    ratio = Math.Max(ratio, (glyph.X1 - glyph.X0) / nsize);
+                if (glyph.Y1 - glyph.Y0 > nsize)
+                    ratio = Math.Max(ratio, (glyph.Y1 - glyph.Y0) / nsize);
+                var w = MathF.Round((glyph.X1 - glyph.X0) / ratio, MidpointRounding.ToZero);
+                var h = MathF.Round((glyph.Y1 - glyph.Y0) / ratio, MidpointRounding.AwayFromZero);
+                glyph.X0 = MathF.Round((nsize - w) / 2f, MidpointRounding.ToZero);
+                glyph.Y0 = MathF.Round((nsize - h) / 2f, MidpointRounding.AwayFromZero);
+                glyph.X1 = glyph.X0 + w;
+                glyph.Y1 = glyph.Y0 + h;
+                glyph.AdvanceX = nsize;
             }
         }
     }

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -16,9 +16,13 @@ using Dalamud.Interface.ManagedFontAtlas;
 using Dalamud.Interface.ManagedFontAtlas.Internals;
 using Dalamud.Plugin.Internal.Types;
 using Dalamud.Utility;
+
 using ImGuiNET;
+
 using ImGuiScene;
+
 using Serilog;
+
 using SharpDX.Direct3D11;
 
 namespace Dalamud.Interface;
@@ -46,6 +50,7 @@ public sealed class UiBuilder : IDisposable
     private IFontHandle? defaultFontHandle;
     private IFontHandle? iconFontHandle;
     private IFontHandle? monoFontHandle;
+    private IFontHandle? iconFontFixedWidthHandle;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UiBuilder"/> class and registers it.
@@ -97,7 +102,7 @@ public sealed class UiBuilder : IDisposable
     /// Event that is fired when the plugin should open its configuration interface.
     /// </summary>
     public event Action OpenConfigUi;
-    
+
     /// <summary>
     /// Event that is fired when the plugin should open its main interface.
     /// </summary>
@@ -243,6 +248,16 @@ public sealed class UiBuilder : IDisposable
                     ?? throw new InvalidOperationException("Scene is not yet ready.")));
 
     /// <summary>
+    /// Gets the default Dalamud icon font based on FontAwesome 5 free solid with a fixed width and vertically centered glyphs.
+    /// </summary>
+    public IFontHandle IconFontFixedWidthHandle =>
+        this.iconFontFixedWidthHandle ??=
+            this.scopedFinalizer.Add(
+                new FontHandleWrapper(
+                    this.InterfaceManagerWithScene?.IconFontFixedWidthHandle
+                    ?? throw new InvalidOperationException("Scene is not yet ready.")));
+
+    /// <summary>
     /// Gets the default Dalamud monospaced font based on Inconsolata Regular.
     /// </summary>
     /// <remarks>
@@ -257,7 +272,7 @@ public sealed class UiBuilder : IDisposable
     ///             new() { SizePx = UiBuilder.DefaultFontSizePx })));
     /// </code>
     /// </remarks>
-    public IFontHandle MonoFontHandle => 
+    public IFontHandle MonoFontHandle =>
         this.monoFontHandle ??=
             this.scopedFinalizer.Add(
                 new FontHandleWrapper(
@@ -580,7 +595,7 @@ public sealed class UiBuilder : IDisposable
     {
         this.OpenConfigUi?.InvokeSafely();
     }
-    
+
     /// <summary>
     /// Open the registered configuration UI, if it exists.
     /// </summary>
@@ -788,5 +803,5 @@ public sealed class UiBuilder : IDisposable
 
         private void WrappedOnImFontChanged(IFontHandle obj, ILockedImFont lockedFont) =>
             this.ImFontChanged?.Invoke(obj, lockedFont);
-    } 
+    }
 }


### PR DESCRIPTION
This PR adds the `IconFontFixedWidthHandle` which is representing the FontAwesome font with a fixed width and vertically aligned height for each glyph.