### PR TITLE
Add IconTexture/Wrap to INotification (#1738)

### DIFF
--- a/Dalamud/Interface/ImGuiNotification/IActiveNotification.cs
+++ b/Dalamud/Interface/ImGuiNotification/IActiveNotification.cs
@@ -56,7 +56,7 @@ public interface IActiveNotification : INotification
     /// from <see cref="INotification.Icon"/>.</param>
     /// <remarks>
     /// <para>The texture passed will be disposed when the notification is dismissed or a new different texture is set
-    /// via another call to this function. You do not have to dispose it yourself.</para>
+    /// via another call to this function or overwriting the property. You do not have to dispose it yourself.</para>
     /// <para>If <see cref="DismissReason"/> is not <c>null</c>, then calling this function will simply dispose the
     /// passed <paramref name="textureWrap"/> without actually updating the icon.</para>
     /// </remarks>
@@ -68,14 +68,46 @@ public interface IActiveNotification : INotification
     /// revert back to the icon specified from <see cref="INotification.Icon"/>.</param>
     /// <remarks>
     /// <para>The texture resulted from the passed <see cref="Task{TResult}"/> will be disposed when the notification
-    /// is dismissed or a new different texture is set via another call to this function. You do not have to dispose the
-    /// resulted instance of <see cref="IDalamudTextureWrap"/> yourself.</para>
+    /// is dismissed or a new different texture is set via another call to this function over overwriting the property.
+    /// You do not have to dispose the resulted instance of <see cref="IDalamudTextureWrap"/> yourself.</para>
     /// <para>If the task fails for any reason, the exception will be silently ignored and the icon specified from
     /// <see cref="INotification.Icon"/> will be used instead.</para>
     /// <para>If <see cref="DismissReason"/> is not <c>null</c>, then calling this function will simply dispose the
     /// result of the passed <paramref name="textureWrapTask"/> without actually updating the icon.</para>
     /// </remarks>
     void SetIconTexture(Task<IDalamudTextureWrap?>? textureWrapTask);
+
+    /// <summary>Sets the icon from <see cref="IDalamudTextureWrap"/>, overriding the icon.</summary>
+    /// <param name="textureWrap">The new texture wrap to use, or null to clear and revert back to the icon specified
+    /// from <see cref="INotification.Icon"/>.</param>
+    /// <param name="leaveOpen">Whether to keep the passed <paramref name="textureWrap"/> not disposed.</param>
+    /// <remarks>
+    /// <para>If <paramref name="leaveOpen"/> is <c>false</c>, the texture passed will be disposed when the
+    /// notification is dismissed or a new different texture is set via another call to this function. You do not have
+    /// to dispose it yourself.</para>
+    /// <para>If <see cref="DismissReason"/> is not <c>null</c> and <paramref name="leaveOpen"/> is <c>false</c>, then
+    /// calling this function will simply dispose the passed <paramref name="textureWrap"/> without actually updating
+    /// the icon.</para>
+    /// </remarks>
+    void SetIconTexture(IDalamudTextureWrap? textureWrap, bool leaveOpen);
+
+    /// <summary>Sets the icon from <see cref="IDalamudTextureWrap"/>, overriding the icon, once the given task
+    /// completes.</summary>
+    /// <param name="textureWrapTask">The task that will result in a new texture wrap to use, or null to clear and
+    /// revert back to the icon specified from <see cref="INotification.Icon"/>.</param>
+    /// <param name="leaveOpen">Whether to keep the result from the passed <paramref name="textureWrapTask"/> not
+    /// disposed.</param>
+    /// <remarks>
+    /// <para>If <paramref name="leaveOpen"/> is <c>false</c>, the texture resulted from the passed
+    /// <see cref="Task{TResult}"/> will be disposed when the notification is dismissed or a new different texture is
+    /// set via another call to this function. You do not have to dispose the resulted instance of
+    /// <see cref="IDalamudTextureWrap"/> yourself.</para>
+    /// <para>If the task fails for any reason, the exception will be silently ignored and the icon specified from
+    /// <see cref="INotification.Icon"/> will be used instead.</para>
+    /// <para>If <see cref="DismissReason"/> is not <c>null</c>, then calling this function will simply dispose the
+    /// result of the passed <paramref name="textureWrapTask"/> without actually updating the icon.</para>
+    /// </remarks>
+    void SetIconTexture(Task<IDalamudTextureWrap?>? textureWrapTask, bool leaveOpen);
 
     /// <summary>Generates a new value to use for <see cref="Id"/>.</summary>
     /// <returns>The new value.</returns>

--- a/Dalamud/Interface/ImGuiNotification/INotification.cs
+++ b/Dalamud/Interface/ImGuiNotification/INotification.cs
@@ -22,19 +22,42 @@ public interface INotification
     /// <summary>Gets or sets the type of the notification.</summary>
     NotificationType Type { get; set; }
 
-    /// <summary>Gets or sets the icon source.</summary>
-    /// <remarks>Use <see cref="IActiveNotification.SetIconTexture(IDalamudTextureWrap?)"/> or
+    /// <summary>Gets or sets the icon source, in case <see cref="IconTextureTask"/> is not set or the task has faulted.
+    /// </summary>
+    INotificationIcon? Icon { get; set; }
+
+    /// <summary>Gets or sets a texture wrap that will be used in place of <see cref="Icon"/> if set.</summary>
+    /// <remarks>
+    /// <para>A texture wrap set via this property will <b>NOT</b> be disposed when the notification is dismissed.
+    /// Use <see cref="IActiveNotification.SetIconTexture(IDalamudTextureWrap?)"/> or
     /// <see cref="IActiveNotification.SetIconTexture(Task{IDalamudTextureWrap?}?)"/> to use a texture, after calling
     /// <see cref="INotificationManager.AddNotification"/>. Call either of those functions with <c>null</c> to revert
-    /// the effective icon back to this property.</remarks>
-    INotificationIcon? Icon { get; set; }
+    /// the effective icon back to this property.</para>
+    /// <para>This property and <see cref="IconTextureTask"/> are bound together. If the task is not <c>null</c> but
+    /// <see cref="Task.IsCompletedSuccessfully"/> is <c>false</c> (because the task is still in progress or faulted,)
+    /// the property will return <c>null</c>. Setting this property will set <see cref="IconTextureTask"/> to a new
+    /// completed <see cref="Task{TResult}"/> with the new value as its result.</para>
+    /// </remarks>
+    public IDalamudTextureWrap? IconTexture { get; set; }
+
+    /// <summary>Gets or sets a task that results in a texture wrap that will be used in place of <see cref="Icon"/> if
+    /// available.</summary>
+    /// <remarks>
+    /// <para>A texture wrap set via this property will <b>NOT</b> be disposed when the notification is dismissed.
+    /// Use <see cref="IActiveNotification.SetIconTexture(IDalamudTextureWrap?)"/> or
+    /// <see cref="IActiveNotification.SetIconTexture(Task{IDalamudTextureWrap?}?)"/> to use a texture, after calling
+    /// <see cref="INotificationManager.AddNotification"/>. Call either of those functions with <c>null</c> to revert
+    /// the effective icon back to this property.</para>
+    /// <para>This property and <see cref="IconTexture"/> are bound together.</para>
+    /// </remarks>
+    Task<IDalamudTextureWrap?>? IconTextureTask { get; set; }
 
     /// <summary>Gets or sets the hard expiry.</summary>
     /// <remarks>
     /// Setting this value will override <see cref="InitialDuration"/> and <see cref="ExtensionDurationSinceLastInterest"/>, in that
     /// the notification will be dismissed when this expiry expires.<br />
     /// Set to <see cref="DateTime.MaxValue"/> to make only <see cref="InitialDuration"/> take effect.<br />
-    /// If neither <see cref="HardExpiry"/> nor <see cref="InitialDuration"/> is not MaxValue, then the notification
+    /// If both <see cref="HardExpiry"/> and <see cref="InitialDuration"/> are MaxValue, then the notification
     /// will not expire after a set time. It must be explicitly dismissed by the user of via calling
     /// <see cref="IActiveNotification.DismissNow"/>.<br />
     /// Updating this value will reset the dismiss timer.

--- a/Dalamud/Interface/ImGuiNotification/INotification.cs
+++ b/Dalamud/Interface/ImGuiNotification/INotification.cs
@@ -58,7 +58,7 @@ public interface INotification
     /// the notification will be dismissed when this expiry expires.<br />
     /// Set to <see cref="DateTime.MaxValue"/> to make only <see cref="InitialDuration"/> take effect.<br />
     /// If both <see cref="HardExpiry"/> and <see cref="InitialDuration"/> are MaxValue, then the notification
-    /// will not expire after a set time. It must be explicitly dismissed by the user of via calling
+    /// will not expire after a set time. It must be explicitly dismissed by the user or via calling
     /// <see cref="IActiveNotification.DismissNow"/>.<br />
     /// Updating this value will reset the dismiss timer.
     /// </remarks>

--- a/Dalamud/Interface/ImGuiNotification/Internal/ActiveNotification.ImGui.cs
+++ b/Dalamud/Interface/ImGuiNotification/Internal/ActiveNotification.ImGui.cs
@@ -404,7 +404,7 @@ internal sealed partial class ActiveNotification
         var maxCoord = minCoord + size;
         var iconColor = this.Type.ToColor();
 
-        if (NotificationUtilities.DrawIconFrom(minCoord, maxCoord, this.iconTextureWrap))
+        if (NotificationUtilities.DrawIconFrom(minCoord, maxCoord, this.IconTextureTask))
             return;
 
         if (this.Icon?.DrawIcon(minCoord, maxCoord, iconColor) is true)

--- a/Dalamud/Interface/ImGuiNotification/Notification.cs
+++ b/Dalamud/Interface/ImGuiNotification/Notification.cs
@@ -1,4 +1,7 @@
+using System.Threading.Tasks;
+
 using Dalamud.Interface.ImGuiNotification.Internal;
+using Dalamud.Interface.Internal;
 using Dalamud.Interface.Internal.Notifications;
 
 namespace Dalamud.Interface.ImGuiNotification;
@@ -25,6 +28,16 @@ public sealed record Notification : INotification
 
     /// <inheritdoc/>
     public INotificationIcon? Icon { get; set; }
+
+    /// <inheritdoc/>
+    public IDalamudTextureWrap? IconTexture
+    {
+        get => this.IconTextureTask?.IsCompletedSuccessfully is true ? this.IconTextureTask.Result : null;
+        set => this.IconTextureTask = value is null ? null : Task.FromResult(value);
+    }
+
+    /// <inheritdoc/>
+    public Task<IDalamudTextureWrap?>? IconTextureTask { get; set; }
 
     /// <inheritdoc/>
     public DateTime HardExpiry { get; set; } = DateTime.MaxValue;

--- a/Dalamud/Interface/Textures/DalamudTextureWrapExtensions.cs
+++ b/Dalamud/Interface/Textures/DalamudTextureWrapExtensions.cs
@@ -1,0 +1,21 @@
+using Dalamud.Interface.Internal;
+
+namespace Dalamud.Interface.Textures;
+
+/// <summary>Extension methods for <see cref="IDalamudTextureWrap"/>.</summary>
+public static class DalamudTextureWrapExtensions
+{
+    /// <summary>Checks if two instances of <see cref="IDalamudTextureWrap"/> point to a same underlying resource.
+    /// </summary>
+    /// <param name="a">The resource 1.</param>
+    /// <param name="b">The resource 2.</param>
+    /// <returns><c>true</c> if both instances point to a same underlying resource.</returns>
+    public static bool ResourceEquals(this IDalamudTextureWrap? a, IDalamudTextureWrap? b)
+    {
+        if (a is null != b is null)
+            return false;
+        if (a is null)
+            return false;
+        return a.ImGuiHandle == b.ImGuiHandle;
+    }
+}


### PR DESCRIPTION
Notification record and IActiveNotification interface now supports setting or updating the texture wraps being used, and SetIconTexture has gotten more overloads to support leaveOpen mechanism that can commonly be found with Stream wrappers.

ImGui widget is updated to support testing setting "leaveOpen" and updating "IconTexture" property via setter, making it possible to check whether IDTW.Dispose is being called under given conditions.

Some changes to doccomments are made.