### PR TITLE
Clear context menu callbacks when opening `AddonContextMenuTitle`

### DIFF
--- a/Dalamud/Game/Gui/ContextMenu/ContextMenu.cs
+++ b/Dalamud/Game/Gui/ContextMenu/ContextMenu.cs
@@ -363,6 +363,10 @@ internal sealed unsafe class ContextMenu : IInternalDisposableService, IContextM
                 Log.Verbose($"Opening {this.SelectedMenuType} submenu with {this.SubmenuItems.Count} custom items.");
             }
         }
+        else if (MemoryHelper.EqualsZeroTerminatedString("AddonContextMenuTitle", (nint)addonName))
+        {
+            this.MenuCallbackIds.Clear();
+        }
 
         var ret = this.raptureAtkModuleOpenAddonByAgentHook.Original(module, addonName, addon, valueCount, values, agent, a7, parentAddonId);
         if (values != oldValues)


### PR DESCRIPTION
Fixes custom callbacks for items in other context menus from leaking into the title menu by clearing the callback list when said menu is opened.

There may be a more sophisticated way to do this (e.g. by actually adding title menu support?) but this should fix the immediate issue for now.