### PR TITLE
Locale name standardize

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -36,10 +36,13 @@ public sealed class LanguageChooserSettingsEntry : SettingsEntry
                 switch (language)
                 {
                     case "ko":
-                        locLanguagesList.Add("Korean");
+                        locLanguagesList.Add("한국어");
+                        break;
+                    case "cn":
+                        locLanguagesList.Add("简体中文");
                         break;
                     case "tw":
-                        locLanguagesList.Add("中華民國國語");
+                        locLanguagesList.Add("繁体中文");
                         break;
                     default:
                         string locLanguage = CultureInfo.GetCultureInfo(language).NativeName;


### PR DESCRIPTION
This commit changes the locale name to a more standardize state according to [ISO 15924](https://en.m.wikipedia.org/wiki/ISO_15924) which is the locale name options that other games/programs usually use.