### PR TITLE
Change Chinese Language Localization Names

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
@@ -36,7 +36,7 @@ public sealed class LanguageChooserSettingsEntry : SettingsEntry
                 switch (language)
                 {
                     case "ko":
-                        locLanguagesList.Add("한국어");
+                        locLanguagesList.Add("Korean");
                         break;
                     case "cn":
                         locLanguagesList.Add("简体中文");

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
@@ -36,17 +36,14 @@ public sealed class LanguageChooserSettingsEntry : SettingsEntry
                 switch (language)
                 {
                     case "ko":
+                        // We're intentionally keeping this in English, as the Korean fonts are not loaded in unless
+                        // the language is already Korean or other preconditions are met. It's excessive to load a font
+                        // for two characters.
                         locLanguagesList.Add("Korean");
                         break;
-                    case "zh":
-                        locLanguagesList.Add("简体中文");
-                        break;
-                    case "tw":
-                        locLanguagesList.Add("繁体中文");
-                        break;
                     default:
-                        string locLanguage = CultureInfo.GetCultureInfo(language).NativeName;
-                        locLanguagesList.Add(char.ToUpper(locLanguage[0]) + locLanguage[1..]);
+                        var loc = Localization.GetCultureInfoFromLangCode(language);
+                        locLanguagesList.Add(loc.TextInfo.ToTitleCase(loc.NativeName));
                         break;
                 }
             }

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
@@ -38,7 +38,7 @@ public sealed class LanguageChooserSettingsEntry : SettingsEntry
                     case "ko":
                         locLanguagesList.Add("Korean");
                         break;
-                    case "cn":
+                    case "zh":
                         locLanguagesList.Add("简体中文");
                         break;
                     case "tw":

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -36,10 +36,13 @@ public sealed class LanguageChooserSettingsEntry : SettingsEntry
                 switch (language)
                 {
                     case "ko":
-                        locLanguagesList.Add("Korean");
+                        locLanguagesList.Add("한국어");
+                        break;
+                    case "cn":
+                        locLanguagesList.Add("简体中文");
                         break;
                     case "tw":
-                        locLanguagesList.Add("中華民國國語");
+                        locLanguagesList.Add("繁体中文");
                         break;
                     default:
                         string locLanguage = CultureInfo.GetCultureInfo(language).NativeName;

--- a/Dalamud/Localization.cs
+++ b/Dalamud/Localization.cs
@@ -70,14 +70,15 @@ public class Localization : IServiceType
     public CultureInfo DalamudLanguageCultureInfo { get; private set; }
 
     /// <summary>
-    /// Gets an instance of <see cref="CultureInfo"/> that corresponds to <paramref name="langCode"/>.
+    /// Gets an instance of <see cref="CultureInfo"/> that corresponds to a Dalamud <paramref name="langCode"/>.
     /// </summary>
     /// <param name="langCode">The language code which should be in <see cref="ApplicableLangCodes"/>.</param>
     /// <returns>The corresponding instance of <see cref="CultureInfo"/>.</returns>
     public static CultureInfo GetCultureInfoFromLangCode(string langCode) =>
         CultureInfo.GetCultureInfo(langCode switch
         {
-            "tw" => "zh-tw",
+            "tw" => "zh-hant",
+            "zh" => "zh-hans",
             _ => langCode,
         });
 


### PR DESCRIPTION
Supersedes #1748.

Change `tw` to be listed as 中文（繁體） in the UI, and `zh` to 中文（简体）. Also use proper capitalization for all languages in the list.

![image](https://github.com/goatcorp/Dalamud/assets/5192145/8eb1aaa0-8c81-482f-bb44-aeab411e7f55)
