### PR TITLE
IContextMenu Tweaks and Cleanup

### DIFF
--- a/Dalamud/Game/Gui/ContextMenu/MenuArgs.cs
+++ b/Dalamud/Game/Gui/ContextMenu/MenuArgs.cs
@@ -70,8 +70,18 @@ public abstract unsafe class MenuArgs
     /// Almost always an agent pointer. You can use this to find out what type of context menu it is.
     /// </summary>
     /// <exception cref="InvalidOperationException">Thrown when the context menu is not a <see cref="ContextMenuType.Default"/>.</exception>
-    public IReadOnlySet<nint> EventInterfaces =>
-        this.MenuType != ContextMenuType.Default ?
-            this.eventInterfaces :
-            throw new InvalidOperationException("Not a default context menu");
+    public IReadOnlySet<nint> EventInterfaces 
+    {
+        get
+        {
+            if (this.MenuType is ContextMenuType.Default)
+            {
+                return this.eventInterfaces ?? new HashSet<nint>();
+            }
+            else
+            {
+                throw new InvalidOperationException("Not a default context menu");
+            }
+        }
+    }
 }

--- a/Dalamud/Game/Gui/ContextMenu/MenuItem.cs
+++ b/Dalamud/Game/Gui/ContextMenu/MenuItem.cs
@@ -11,6 +11,16 @@ namespace Dalamud.Game.Gui.ContextMenu;
 public sealed record MenuItem
 {
     /// <summary>
+    /// The default prefix used if no specific preset is specified.
+    /// </summary>
+    public const SeIconChar DalamudDefaultPrefix = SeIconChar.BoxedLetterD;
+
+    /// <summary>
+    /// The default prefix color used if no specific preset is specified.
+    /// </summary>
+    public const ushort DalamudDefaultPrefixColor = 539;
+    
+    /// <summary>
     /// Gets or sets the display name of the menu item.
     /// </summary>
     public SeString Name { get; set; } = SeString.Empty;
@@ -46,6 +56,11 @@ public sealed record MenuItem
     /// Gets or sets the color of the <see cref="Prefix"/>. Specifies a <see cref="UIColor"/> row id.
     /// </summary>
     public ushort PrefixColor { get; set; }
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether the dev wishes to intentionally use the default prefix symbol and color.
+    /// </summary>
+    public bool UseDefaultPrefix { get; set; }
 
     /// <summary>
     /// Gets or sets the callback to be invoked when the menu item is clicked.

--- a/Dalamud/Plugin/Services/IContextMenu.cs
+++ b/Dalamud/Plugin/Services/IContextMenu.cs
@@ -1,6 +1,4 @@
 using Dalamud.Game.Gui.ContextMenu;
-using Dalamud.Game.Text;
-using Dalamud.Game.Text.SeStringHandling;
 
 namespace Dalamud.Plugin.Services;
 
@@ -16,8 +14,9 @@ public interface IContextMenu
     public delegate void OnMenuOpenedDelegate(MenuOpenedArgs args);
 
     /// <summary>
-    /// Event that gets fired every time the game framework updates.
+    /// Event that gets fired whenever any context menu is opened.
     /// </summary>
+    /// <remarks>Use this event and then check if the triggering addon is the desired addon, then add custom context menu items to the provided args.</remarks>
     event OnMenuOpenedDelegate OnMenuOpened;
 
     /// <summary>
@@ -25,6 +24,7 @@ public interface IContextMenu
     /// </summary>
     /// <param name="menuType">The type of context menu to add the item to.</param>
     /// <param name="item">The item to add.</param>
+    /// <remarks>Used to add a context menu entry to <em>all</em> context menus.</remarks>
     void AddMenuItem(ContextMenuType menuType, MenuItem item);
 
     /// <summary>
@@ -32,6 +32,7 @@ public interface IContextMenu
     /// </summary>
     /// <param name="menuType">The type of context menu to remove the item from.</param>
     /// <param name="item">The item to add.</param>
+    /// <remarks>Used to remove a context menu entry from <em>all</em> context menus.</remarks>
     /// <returns><see langword="true"/> if the item was removed, <see langword="false"/> if it was not found.</returns>
     bool RemoveMenuItem(ContextMenuType menuType, MenuItem item);
 }


### PR DESCRIPTION
Adds ability for a dev to specify that they wanted the default dalamud context menu icon.
Additionally provides the data used to generate the default icon if they want to use it in part or in whole.

Also cleaned up the code to reduce the number of warnings and suggestions provided by IDE.
The delegates didn't need to be declared as unsafe, as the whole class is declared as unsafe.