### PR TITLE
Prevent automatic plugin updates during Duties

### DIFF
--- a/Dalamud/Game/ChatHandlers.cs
+++ b/Dalamud/Game/ChatHandlers.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 using CheapLoc;
 using Dalamud.Configuration.Internal;
+using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.Gui;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
@@ -290,10 +291,17 @@ internal class ChatHandlers : IServiceType
         var chatGui = Service<ChatGui>.GetNullable();
         var pluginManager = Service<PluginManager>.GetNullable();
         var notifications = Service<NotificationManager>.GetNullable();
+        var condition = Service<Condition>.GetNullable();
 
-        if (chatGui == null || pluginManager == null || notifications == null)
+        if (chatGui == null || pluginManager == null || notifications == null || condition == null)
         {
             Log.Warning("Aborting auto-update because a required service was not loaded.");
+            return false;
+        }
+
+        if (condition.Any(ConditionFlag.BoundByDuty, ConditionFlag.BoundByDuty56, ConditionFlag.BoundByDuty95))
+        {
+            Log.Warning("Aborting auto-update because the player is in a duty.");
             return false;
         }
 


### PR DESCRIPTION
After a game crash during a duty, the player will reconnect without a message of the day in chat. When a notice message is printed in the chat at any time during the duty, Dalamud will print its welcome message and auto-update the plugins. If any plugins are updated, this will cause lag, most likely during a fight.

To prevent this, I added a simple condition check to abort the update process if the player is in a duty.
I used the same ConditionFlags that the [DutyState](https://github.com/goatcorp/Dalamud/blob/87b9edb/Dalamud/Game/DutyState/DutyState.cs#L153-L156) service uses.

Dalamuds welcome message is not affected by this check.