### PR TITLE
Add proper name for BoundToDuty97

### DIFF
--- a/Dalamud/Game/ClientState/Conditions/ConditionFlag.cs
+++ b/Dalamud/Game/ClientState/Conditions/ConditionFlag.cs
@@ -428,7 +428,14 @@ public enum ConditionFlag
     /// <summary>
     /// Unable to execute command while bound by duty.
     /// </summary>
+    [Obsolete("Use InDutyQueue")]
     BoundToDuty97 = 91,
+    
+    /// <summary>
+    /// Unable to execute command while bound by duty.
+    /// Specifically triggered when you are in a queue for a duty but not inside a duty.
+    /// </summary>
+    InDutyQueue = 91,
 
     /// <summary>
     /// Unable to execute command while readying to visit another World.


### PR DESCRIPTION
BoundToDuty97 is only set while the player is in a duty finder queue waiting for duty.

Because this flag had the same name format as the other BoundToDuty flags, many devs mistakenly consider waiting for queue to be in a duty.

This PR sets the old value to a non-erroring obsolete, that I would encourage gets removed in API 10