### PR TITLE
Replace U+202F with Indent payload

### DIFF
--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -155,22 +155,25 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
         {
             var chat = this.chatQueue.Dequeue();
 
-            var replacedMessage = new SeStringBuilder();
-            foreach (var payload in chat.Message.Payloads)
+            // Normalize Unicode NBSP to the built-in one, as the former won't render
             {
-                if (payload is TextPayload { Text: not null } textPayload)
+                var replacedMessage = new SeStringBuilder();
+                foreach (var payload in chat.Message.Payloads)
                 {
-                    var split = textPayload.Text.Split("\u202f"); // french NBSP
-                    for (var i = 0; i < split.Length; i++)
+                    if (payload is TextPayload { Text: not null } textPayload)
                     {
-                        replacedMessage.AddText(split[i]);
-                        if (i + 1 < split.Length)
-                            replacedMessage.Add(new RawPayload([0x02, (byte)Lumina.Text.Payloads.PayloadType.Indent, 0x01, 0x03]));
+                        var split = textPayload.Text.Split("\u202f"); // NARROW NO-BREAK SPACE
+                        for (var i = 0; i < split.Length; i++)
+                        {
+                            replacedMessage.AddText(split[i]);
+                            if (i + 1 < split.Length)
+                                replacedMessage.Add(new RawPayload([0x02, (byte)Lumina.Text.Payloads.PayloadType.Indent, 0x01, 0x03]));
+                        }
                     }
-                }
-                else
-                {
-                    replacedMessage.Add(payload);
+                    else
+                    {
+                        replacedMessage.Add(payload);
+                    }
                 }
             }
 

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -154,26 +154,24 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
         while (this.chatQueue.Count > 0)
         {
             var chat = this.chatQueue.Dequeue();
+            var replacedMessage = new SeStringBuilder();
 
-            // Normalize Unicode NBSP to the built-in one, as the former won't render
+            // Normalize Unicode NBSP to the built-in one, as the former won't renderl
+            foreach (var payload in chat.Message.Payloads)
             {
-                var replacedMessage = new SeStringBuilder();
-                foreach (var payload in chat.Message.Payloads)
+                if (payload is TextPayload { Text: not null } textPayload)
                 {
-                    if (payload is TextPayload { Text: not null } textPayload)
+                    var split = textPayload.Text.Split("\u202f"); // NARROW NO-BREAK SPACE
+                    for (var i = 0; i < split.Length; i++)
                     {
-                        var split = textPayload.Text.Split("\u202f"); // NARROW NO-BREAK SPACE
-                        for (var i = 0; i < split.Length; i++)
-                        {
-                            replacedMessage.AddText(split[i]);
-                            if (i + 1 < split.Length)
-                                replacedMessage.Add(new RawPayload([0x02, (byte)Lumina.Text.Payloads.PayloadType.Indent, 0x01, 0x03]));
-                        }
+                        replacedMessage.AddText(split[i]);
+                        if (i + 1 < split.Length)
+                            replacedMessage.Add(new RawPayload([0x02, (byte)Lumina.Text.Payloads.PayloadType.Indent, 0x01, 0x03]));
                     }
-                    else
-                    {
-                        replacedMessage.Add(payload);
-                    }
+                }
+                else
+                {
+                    replacedMessage.Add(payload);
                 }
             }
 


### PR DESCRIPTION
This is a fix for users that have the French number format using U+202F as thousand split.

The PR checks each message text payload if it contains any U+202F and replaces each of them with the Indent payload (0x1D) to render correctly in chat.