### PR TITLE
Expose manifest to plugins

### DIFF
--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -129,7 +129,7 @@ public sealed class DalamudPluginInterface : IDisposable
     public string InternalName => this.plugin.InternalName;
 
     /// <summary>
-    /// Gets the plugin manifest to expose values like author and version without plugins having to look up there own assembly.
+    /// Gets the plugin's manifest.
     /// </summary>
     public IPluginManifest Manifest => this.plugin.Manifest;
 

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -129,6 +129,11 @@ public sealed class DalamudPluginInterface : IDisposable
     public string InternalName => this.plugin.InternalName;
 
     /// <summary>
+    /// Gets the plugin manifest to expose values like author and version without plugins having to look up there own assembly.
+    /// </summary>
+    public IPluginManifest Manifest => this.plugin.Manifest;
+
+    /// <summary>
     /// Gets a value indicating whether this is a dev plugin.
     /// </summary>
     public bool IsDev => this.plugin.IsDev;


### PR DESCRIPTION
This PR aims to expose the manifest, which is already used all through PluginInterface, to the plugins themself.

With this plugin can now easily do things like
`Plugin.Interface.Manifest.AssemblyVersion.ToString(3)` 
or 
`Plugin.Interface.Manifest.Author` to get the specifics fields

For example author can be an exclusive json/yaml field, making it more effort to get for plugins directly