### PR TITLE
[FIX] Remove the .git suffix from CS submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/goatcorp/ImGuiScene
 [submodule "lib/FFXIVClientStructs"]
 	path = lib/FFXIVClientStructs
-	url = https://github.com/aers/FFXIVClientStructs.git
+	url = https://github.com/aers/FFXIVClientStructs
 [submodule "lib/Nomade040-nmd"]
 	path = lib/Nomade040-nmd
 	url = https://github.com/Nomade040/nmd.git


### PR DESCRIPTION
The "View source" URL's generated on dalamud.dev for client structs point to the wrong url due to a `.git` suffix. This should remove that and use the correct URL.

Note that this doesn't fix the docs pointing to the "main" branch of Dalamud, rather than "master" though. Still not sure what causes that one...
