### PR TITLE
AddonLifcycle Unregistration Fix

### DIFF
--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -133,6 +133,9 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
     /// <param name="listener">The listener to unregister.</param>
     internal void UnregisterListener(AddonLifecycleEventListener listener)
     {
+        // Set removed state to true immediately, then lazily remove it from the EventListeners list on next Framework Update.
+        listener.Removed = true;
+        
         this.framework.RunOnTick(() =>
         {
             this.EventListeners.Remove(listener);
@@ -167,6 +170,10 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
             if (listener.EventType != eventType)
                 continue;
 
+            // If the listener is pending removal, and is waiting until the next Framework Update, don't invoke listener.
+            if (listener.Removed)
+                continue;
+            
             // Match on string.empty for listeners that want events for all addons.
             if (!string.IsNullOrWhiteSpace(listener.AddonName) && !args.IsAddon(listener.AddonName))
                 continue;

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycleEventListener.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycleEventListener.cs
@@ -27,6 +27,11 @@ internal class AddonLifecycleEventListener
     public string AddonName { get; init; }
     
     /// <summary>
+    /// Gets or sets a value indicating whether this event has been unregistered.
+    /// </summary>
+    public bool Removed { get; set; }
+    
+    /// <summary>
     /// Gets the event type this listener is looking for.
     /// </summary>
     public AddonEvent EventType { get; init; }

--- a/Dalamud/Game/Gui/Dtr/DtrBarEntry.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBarEntry.cs
@@ -11,7 +11,7 @@ namespace Dalamud.Game.Gui.Dtr;
 public sealed unsafe class DtrBarEntry : IDisposable
 {
     private bool shownBacking = true;
-    private SeString? textBacking = null;
+    private SeString? textBacking;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DtrBarEntry"/> class.
@@ -73,17 +73,17 @@ public sealed unsafe class DtrBarEntry : IDisposable
     /// <summary>
     /// Gets a value indicating whether this entry should be removed.
     /// </summary>
-    internal bool ShouldBeRemoved { get; private set; } = false;
+    internal bool ShouldBeRemoved { get; private set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether this entry is dirty.
     /// </summary>
-    internal bool Dirty { get; set; } = false;
+    internal bool Dirty { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether this entry has just been added.
     /// </summary>
-    internal bool Added { get; set; } = false;
+    internal bool Added { get; set; }
 
     /// <summary>
     /// Remove this entry from the bar.


### PR DESCRIPTION
When events are unregistered they become queued for removal, and then removed on the following framework update.

This can cause issues where an unregistered event is still called, due to an event occurring after the un-registration, but before the next framework update. In particular, Update and Draw events are susceptible to this problem, though it could happen with any of the events.

This PR addresses this in a very simple way, when the un-registration is requested, the listener is immediately marked for removal, and any listeners that are marked for removal will not be invoked.

closes #1768

aside, I was going to also apply this fix to DtrBar, but decided it wasn't necessary as nothing about the DtrBar is time critical, so instead this includes a minor style cleanup that was suggested by the current stylecop dalamud uses.