### PR TITLE
Update Lumina to 3.17.0

### DIFF
--- a/Dalamud.CorePlugin/Dalamud.CorePlugin.csproj
+++ b/Dalamud.CorePlugin/Dalamud.CorePlugin.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Lumina" Version="3.16.0" />
+        <PackageReference Include="Lumina" Version="3.17.0" />
         <PackageReference Include="Lumina.Excel" Version="6.5.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333">

--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -70,7 +70,7 @@
         <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
         <PackageReference Include="Lumina" Version="3.17.0" />
         <PackageReference Include="Lumina.Excel" Version="6.5.2" />
-        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.0-preview.1.24081.5" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.46-beta">
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -68,7 +68,7 @@
         <PackageReference Include="goaaats.Reloaded.Hooks" Version="4.2.0-goat.4" />
         <PackageReference Include="goaaats.Reloaded.Assembler" Version="1.0.14-goat.2" />
         <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
-        <PackageReference Include="Lumina" Version="3.16.0" />
+        <PackageReference Include="Lumina" Version="3.17.0" />
         <PackageReference Include="Lumina.Excel" Version="6.5.2" />
         <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.1" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.46-beta">

--- a/Dalamud/Data/DataManager.cs
+++ b/Dalamud/Data/DataManager.cs
@@ -161,6 +161,7 @@ internal sealed class DataManager : IInternalDisposableService, IDataManager
     void IInternalDisposableService.DisposeService()
     {
         this.luminaCancellationTokenSource.Cancel();
+        this.GameData.Dispose();
     }
 
     private class LauncherTroubleshootingInfo


### PR DESCRIPTION
This PR updates Lumina to 3.17.0, which includes the following changes:

**https://github.com/NotAdam/Lumina/pull/78:**
Reverts the output of `SeString.ToString()` back to `RawString`, as the change was causing some confusion.
The macro code style output, which was introduced in 3.16.0, was moved to new method `ToMacroString()` instead.

**https://github.com/NotAdam/Lumina/pull/79:**
Improves the performance of `GetFile<T>` when using multiple threads.

> [!IMPORTANT]
> - This adds a dependency on v9.0.0-preview.1.24081.5 of `Microsoft.Extensions.ObjectPool`.  
    Dalamud currently uses v8.0.1, which would be a downgrade. I updated it to use the same version (in 1c34267f2f0dbdc1b2c656ae231fa33d280ccaa3) so that it will build successfully.
> - `GameData` implements `IDisposable` now, so I added a Dispose call to `DataManager.DisposeService` (561ee89ac3d1dc52d2f637b6e55c277cb8e2d010).

**https://github.com/NotAdam/Lumina/pull/80:**
Fixes the output of `BasePayload.ToString()` for StringExpressions, a bug introduced with PR 78 above.

**https://github.com/NotAdam/Lumina/pull/81:**
Adds a new efficient way to read and build SeStrings.
With this change, Lumina now also targets net8.0.

---

Full list of changes: https://github.com/NotAdam/Lumina/compare/3.16.0...3.17.0
