### PR TITLE
[Api10] Update XivChatEntry types and names

### DIFF
--- a/Dalamud/Game/ChatHandlers.cs
+++ b/Dalamud/Game/ChatHandlers.cs
@@ -139,7 +139,7 @@ internal class ChatHandlers : IServiceType
     /// </summary>
     public bool IsAutoUpdateComplete { get; private set; }
 
-    private void OnCheckMessageHandled(XivChatType type, uint senderid, ref SeString sender, ref SeString message, ref bool isHandled)
+    private void OnCheckMessageHandled(XivChatType type, int timestamp, ref SeString sender, ref SeString message, ref bool isHandled)
     {
         var textVal = message.TextValue;
 
@@ -165,7 +165,7 @@ internal class ChatHandlers : IServiceType
         }
     }
 
-    private void OnChatMessage(XivChatType type, uint senderId, ref SeString sender, ref SeString message, ref bool isHandled)
+    private void OnChatMessage(XivChatType type, int timestamp, ref SeString sender, ref SeString message, ref bool isHandled)
     {
         var clientState = Service<ClientState.ClientState>.GetNullable();
         if (clientState == null)

--- a/Dalamud/Game/Command/CommandManager.cs
+++ b/Dalamud/Game/Command/CommandManager.cs
@@ -135,9 +135,9 @@ internal sealed class CommandManager : IInternalDisposableService, ICommandManag
         this.chatGui.CheckMessageHandled -= this.OnCheckMessageHandled;
     }
 
-    private void OnCheckMessageHandled(XivChatType type, uint senderId, ref SeString sender, ref SeString message, ref bool isHandled)
+    private void OnCheckMessageHandled(XivChatType type, int timestamp, ref SeString sender, ref SeString message, ref bool isHandled)
     {
-        if (type == XivChatType.ErrorMessage && senderId == 0)
+        if (type == XivChatType.ErrorMessage && timestamp == 0)
         {
             var cmdMatch = this.currentLangCommandRegex.Match(message.TextValue).Groups["command"];
             if (cmdMatch.Success)

--- a/Dalamud/Game/Text/XivChatEntry.cs
+++ b/Dalamud/Game/Text/XivChatEntry.cs
@@ -1,5 +1,3 @@
-using System;
-
 using Dalamud.Game.Text.SeStringHandling;
 
 namespace Dalamud.Game.Text;
@@ -15,9 +13,9 @@ public sealed class XivChatEntry
     public XivChatType Type { get; set; } = XivChatType.Debug;
 
     /// <summary>
-    /// Gets or sets the sender ID.
+    /// Gets or sets the message timestamp.
     /// </summary>
-    public uint SenderId { get; set; }
+    public int Timestamp { get; set; }
 
     /// <summary>
     /// Gets or sets the sender name.
@@ -30,7 +28,7 @@ public sealed class XivChatEntry
     public SeString Message { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the message parameters.
+    /// Gets or sets a value indicating whether new message sounds should be silenced or not.
     /// </summary>
-    public IntPtr Parameters { get; set; }
+    public bool Silent { get; set; }
 }

--- a/Dalamud/Game/Text/XivChatType.cs
+++ b/Dalamud/Game/Text/XivChatType.cs
@@ -1,9 +1,9 @@
 namespace Dalamud.Game.Text;
 
 /// <summary>
-/// The FFXIV chat types as seen in the LogKind ex table.
+/// The FFXIV chat types as seen in the LogKind excel sheet.
 /// </summary>
-public enum XivChatType : ushort // FIXME: this is a single byte
+public enum XivChatType : ushort
 {
     /// <summary>
     /// No chat type.

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/ChatAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/ChatAgingStep.cs
@@ -62,7 +62,7 @@ internal class ChatAgingStep : IAgingStep
     }
 
     private void ChatOnOnChatMessage(
-        XivChatType type, uint senderid, ref SeString sender, ref SeString message, ref bool ishandled)
+        XivChatType type, int timestamp, ref SeString sender, ref SeString message, ref bool ishandled)
     {
         if (type == XivChatType.Echo && message.TextValue == "DALAMUD")
         {

--- a/Dalamud/Plugin/Services/IChatGui.cs
+++ b/Dalamud/Plugin/Services/IChatGui.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 using Dalamud.Game.Gui;
 using Dalamud.Game.Text;
@@ -15,39 +15,39 @@ public interface IChatGui
     /// A delegate type used with the <see cref="ChatGui.ChatMessage"/> event.
     /// </summary>
     /// <param name="type">The type of chat.</param>
-    /// <param name="senderId">The sender ID.</param>
+    /// <param name="timestamp">The timestamp of when the message was sent.</param>
     /// <param name="sender">The sender name.</param>
     /// <param name="message">The message sent.</param>
     /// <param name="isHandled">A value indicating whether the message was handled or should be propagated.</param>
-    public delegate void OnMessageDelegate(XivChatType type, uint senderId, ref SeString sender, ref SeString message, ref bool isHandled);
+    public delegate void OnMessageDelegate(XivChatType type, int timestamp, ref SeString sender, ref SeString message, ref bool isHandled);
 
     /// <summary>
     /// A delegate type used with the <see cref="ChatGui.CheckMessageHandled"/> event.
     /// </summary>
     /// <param name="type">The type of chat.</param>
-    /// <param name="senderId">The sender ID.</param>
+    /// <param name="timestamp">The timestamp of when the message was sent.</param>
     /// <param name="sender">The sender name.</param>
     /// <param name="message">The message sent.</param>
     /// <param name="isHandled">A value indicating whether the message was handled or should be propagated.</param>
-    public delegate void OnCheckMessageHandledDelegate(XivChatType type, uint senderId, ref SeString sender, ref SeString message, ref bool isHandled);
+    public delegate void OnCheckMessageHandledDelegate(XivChatType type, int timestamp, ref SeString sender, ref SeString message, ref bool isHandled);
 
     /// <summary>
     /// A delegate type used with the <see cref="ChatGui.ChatMessageHandled"/> event.
     /// </summary>
     /// <param name="type">The type of chat.</param>
-    /// <param name="senderId">The sender ID.</param>
+    /// <param name="timestamp">The timestamp of when the message was sent.</param>
     /// <param name="sender">The sender name.</param>
     /// <param name="message">The message sent.</param>
-    public delegate void OnMessageHandledDelegate(XivChatType type, uint senderId, SeString sender, SeString message);
+    public delegate void OnMessageHandledDelegate(XivChatType type, int timestamp, SeString sender, SeString message);
 
     /// <summary>
     /// A delegate type used with the <see cref="ChatGui.ChatMessageUnhandled"/> event.
     /// </summary>
     /// <param name="type">The type of chat.</param>
-    /// <param name="senderId">The sender ID.</param>
+    /// <param name="timestamp">The timestamp of when the message was sent.</param>
     /// <param name="sender">The sender name.</param>
     /// <param name="message">The message sent.</param>
-    public delegate void OnMessageUnhandledDelegate(XivChatType type, uint senderId, SeString sender, SeString message);
+    public delegate void OnMessageUnhandledDelegate(XivChatType type, int timestamp, SeString sender, SeString message);
     
     /// <summary>
     /// Event that will be fired when a chat message is sent to chat by the game.


### PR DESCRIPTION
This PR changes the XivChatEntry props `uint SenderId` to `int Timestamp` and `IntPtr Parameters` to `bool Silent`.

---

I don't know why XivChatType had a comment to change the underlying type from ushort to byte, as it is passed to `Client::UI::Misc::RaptureLogModule_PrintMessage` which indeed takes a ushort.

At 0x140680DEB you can see, that it copies the 16 bit value to a 32 bit register (https://www.felixcloutier.com/x86/movzx):
```asm
0F B7 F2    movzx   esi, dx
```

I removed the comment and left it as is.