### PR TITLE
Fix RGB returning wrong color and change it to RGBA

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/Payloads/UIForegroundPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/UIForegroundPayload.cs
@@ -86,7 +86,7 @@ public class UIForegroundPayload : Payload
     /// Gets the ABGR value for this foreground color, as ImGui requires it in PushColor.
     /// </summary>
     [JsonIgnore]
-    public uint ABGR => Utility.Util.RGBAToABGR(this.UIColor.UIForeground);
+    public uint ABGR => Interface.ColorHelpers.RGBAToABGR(this.UIColor.UIForeground);
 
     /// <inheritdoc/>
     public override string ToString()

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/UIForegroundPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/UIForegroundPayload.cs
@@ -77,10 +77,10 @@ public class UIForegroundPayload : Payload
     }
 
     /// <summary>
-    /// Gets the Red/Green/Blue values for this foreground color, encoded as a typical hex color.
+    /// Gets the Red/Green/Blue/Alpha values for this foreground color, encoded as a typical hex color.
     /// </summary>
     [JsonIgnore]
-    public uint RGB => this.UIColor.UIForeground & 0xFFFFFF;
+    public uint RGBA => this.UIColor.UIForeground;
 
     /// <inheritdoc/>
     public override string ToString()

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/UIForegroundPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/UIForegroundPayload.cs
@@ -85,7 +85,7 @@ public class UIForegroundPayload : Payload
     /// <inheritdoc/>
     public override string ToString()
     {
-        return $"{this.Type} - UIColor: {this.colorKey} color: {(this.IsEnabled ? this.RGB : 0)}";
+        return $"{this.Type} - UIColor: {this.colorKey} color: {(this.IsEnabled ? this.RGBA : 0)}";
     }
 
     /// <inheritdoc/>

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/UIForegroundPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/UIForegroundPayload.cs
@@ -86,7 +86,7 @@ public class UIForegroundPayload : Payload
     /// Gets the ABGR value for this foreground color, as ImGui requires it in PushColor.
     /// </summary>
     [JsonIgnore]
-    public uint ABGR => Interface.ColorHelpers.RGBAToABGR(this.UIColor.UIForeground);
+    public uint ABGR => Interface.ColorHelpers.SwapEndianness(this.UIColor.UIForeground);
 
     /// <inheritdoc/>
     public override string ToString()

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/UIForegroundPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/UIForegroundPayload.cs
@@ -82,6 +82,12 @@ public class UIForegroundPayload : Payload
     [JsonIgnore]
     public uint RGBA => this.UIColor.UIForeground;
 
+    /// <summary>
+    /// Gets the ABGR value for this foreground color, as ImGui requires it in PushColor.
+    /// </summary>
+    [JsonIgnore]
+    public uint ABGR => Utility.Util.RGBAToABGR(this.UIColor.UIForeground);
+
     /// <inheritdoc/>
     public override string ToString()
     {

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/UIGlowPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/UIGlowPayload.cs
@@ -77,7 +77,7 @@ public class UIGlowPayload : Payload
     /// Gets the ABGR value for this glow color, as ImGui requires it in PushColor.
     /// </summary>
     [JsonIgnore]
-    public uint ABGR => Interface.ColorHelpers.RGBAToABGR(this.UIColor.UIGlow);
+    public uint ABGR => Interface.ColorHelpers.SwapEndianness(this.UIColor.UIGlow);
 
     /// <summary>
     /// Gets a Lumina UIColor object representing this payload.  The actual color data is at UIColor.UIGlow.

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/UIGlowPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/UIGlowPayload.cs
@@ -71,7 +71,7 @@ public class UIGlowPayload : Payload
     /// Gets the Red/Green/Blue values for this glow color, encoded as a typical hex color.
     /// </summary>
     [JsonIgnore]
-    public uint RGB => this.UIColor.UIGlow & 0xFFFFFF;
+    public uint RGBA => this.UIColor.UIGlow;
 
     /// <summary>
     /// Gets a Lumina UIColor object representing this payload.  The actual color data is at UIColor.UIGlow.
@@ -85,7 +85,7 @@ public class UIGlowPayload : Payload
     /// <inheritdoc/>
     public override string ToString()
     {
-        return $"{this.Type} - UIColor: {this.colorKey} color: {(this.IsEnabled ? this.RGB : 0)}";
+        return $"{this.Type} - UIColor: {this.colorKey} color: {(this.IsEnabled ? this.RGBA : 0)}";
     }
 
     /// <inheritdoc/>

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/UIGlowPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/UIGlowPayload.cs
@@ -77,7 +77,7 @@ public class UIGlowPayload : Payload
     /// Gets the ABGR value for this glow color, as ImGui requires it in PushColor.
     /// </summary>
     [JsonIgnore]
-    public uint ABGR => Utility.Util.RGBAToABGR(this.UIColor.UIGlow);
+    public uint ABGR => Interface.ColorHelpers.RGBAToABGR(this.UIColor.UIGlow);
 
     /// <summary>
     /// Gets a Lumina UIColor object representing this payload.  The actual color data is at UIColor.UIGlow.

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/UIGlowPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/UIGlowPayload.cs
@@ -68,10 +68,16 @@ public class UIGlowPayload : Payload
     public bool IsEnabled => this.ColorKey != 0;
 
     /// <summary>
-    /// Gets the Red/Green/Blue values for this glow color, encoded as a typical hex color.
+    /// Gets the Red/Green/Blue/Alpha values for this glow color, encoded as a typical hex color.
     /// </summary>
     [JsonIgnore]
     public uint RGBA => this.UIColor.UIGlow;
+
+    /// <summary>
+    /// Gets the ABGR value for this glow color, as ImGui requires it in PushColor.
+    /// </summary>
+    [JsonIgnore]
+    public uint ABGR => Utility.Util.RGBAToABGR(this.UIColor.UIGlow);
 
     /// <summary>
     /// Gets a Lumina UIColor object representing this payload.  The actual color data is at UIColor.UIGlow.

--- a/Dalamud/Interface/ColorHelpers.cs
+++ b/Dalamud/Interface/ColorHelpers.cs
@@ -160,6 +160,17 @@ public static class ColorHelpers
     }
 
     /// <summary>
+    /// Turns a RGBA color value into ABGR for usage in ImGui.PushColor
+    /// </summary>
+    /// <param name="rgba">Color value with byte order of RGBA.</param>
+    /// <returns>The color value in byte order of ABGR, the format that ImGui uses.</returns>
+    public static uint RGBAToABGR(uint rgba)
+    {
+        var tmp = ((rgba << 8) & 0xFF00FF00) | ((rgba >> 8) & 0xFF00FF);
+        return (tmp << 16) | (tmp >> 16);
+    }
+
+    /// <summary>
     /// Lighten a color.
     /// </summary>
     /// <param name="color">The color to lighten.</param>
@@ -259,7 +270,7 @@ public static class ColorHelpers
         hsv.A -= amount;
         return HsvToRgb(hsv);
     }
-    
+
     /// <summary>
     /// Set alpha of a color.
     /// </summary>
@@ -299,10 +310,10 @@ public static class ColorHelpers
     {
         // If any components are out of range, return original value.
         { W: > 255.0f or < 0.0f } or { X: > 255.0f or < 0.0f } or { Y: > 255.0f or < 0.0f } or { Z: > 255.0f or < 0.0f } => color,
-            
+
         // If all components are already unit range, return original value.
         { W: >= 0.0f and <= 1.0f, X: >= 0.0f and <= 1.0f, Y: >= 0.0f and <= 1.0f, Z: >= 0.0f and <= 1.0f } => color,
-            
+
         _ => color / 255.0f,
     };
 }

--- a/Dalamud/Interface/ColorHelpers.cs
+++ b/Dalamud/Interface/ColorHelpers.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Numerics;
@@ -160,15 +161,14 @@ public static class ColorHelpers
     }
 
     /// <summary>
-    /// Turns a RGBA color value into ABGR for usage in ImGui.PushColor
+    /// Performs a swap of endianness
+    /// Exmaple:
+    /// (FFXIV) RGBA to ABGR (ImGui)
     /// </summary>
-    /// <param name="rgba">Color value with byte order of RGBA.</param>
-    /// <returns>The color value in byte order of ABGR, the format that ImGui uses.</returns>
-    public static uint RGBAToABGR(uint rgba)
-    {
-        var tmp = ((rgba << 8) & 0xFF00FF00) | ((rgba >> 8) & 0xFF00FF);
-        return (tmp << 16) | (tmp >> 16);
-    }
+    /// <param name="rgba">Color value in byte order X Y Z W.</param>
+    /// <returns>Endian swapped color value with new byte order W Z Y X.</returns>
+    public static uint SwapEndianness(uint rgba)
+        => BinaryPrimitives.ReverseEndianness(rgba);
 
     /// <summary>
     /// Lighten a color.

--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -477,12 +477,12 @@ public static class Util
             case "MacOS": return OSPlatform.OSX;
             case "Linux": return OSPlatform.Linux;
         }
-        
+
         // n.b. we had some fancy code here to check if the Wine host version returned "Darwin" but apparently
         // *all* our Wines report Darwin if exports aren't hidden. As such, it is effectively impossible (without some
         // (very cursed and inaccurate heuristics) to determine if we're on macOS or Linux unless we're explicitly told
         // by our launcher. See commit a7aacb15e4603a367e2f980578271a9a639d8852 for the old check.
-        
+
         return IsWine() ? OSPlatform.Linux : OSPlatform.Windows;
     }
 
@@ -545,7 +545,7 @@ public static class Util
                     }
                 }
             }
-        } 
+        }
         finally
         {
             foreach (var enumerator in enumerators)
@@ -586,7 +586,7 @@ public static class Util
     {
         WriteAllTextSafe(path, text, Encoding.UTF8);
     }
-    
+
     /// <summary>
     /// Overwrite text in a file by first writing it to a temporary file, and then
     /// moving that file to the path specified.
@@ -598,7 +598,7 @@ public static class Util
     {
         WriteAllBytesSafe(path, encoding.GetBytes(text));
     }
-    
+
     /// <summary>
     /// Overwrite data in a file by first writing it to a temporary file, and then
     /// moving that file to the path specified.
@@ -608,13 +608,13 @@ public static class Util
     public static unsafe void WriteAllBytesSafe(string path, byte[] bytes)
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
-        
+
         // Open the temp file
         var tempPath = path + ".tmp";
 
         using var tempFile = Windows.Win32.PInvoke.CreateFile(
-            tempPath, 
-            (uint)(FILE_ACCESS_RIGHTS.FILE_GENERIC_READ | FILE_ACCESS_RIGHTS.FILE_GENERIC_WRITE), 
+            tempPath,
+            (uint)(FILE_ACCESS_RIGHTS.FILE_GENERIC_READ | FILE_ACCESS_RIGHTS.FILE_GENERIC_WRITE),
             FILE_SHARE_MODE.FILE_SHARE_NONE,
             null,
             FILE_CREATION_DISPOSITION.CREATE_ALWAYS,
@@ -623,7 +623,7 @@ public static class Util
 
         if (tempFile.IsInvalid)
             throw new Win32Exception();
-        
+
         // Write the data
         uint bytesWritten = 0;
         if (!Windows.Win32.PInvoke.WriteFile(tempFile, new ReadOnlySpan<byte>(bytes), &bytesWritten, null))
@@ -634,11 +634,22 @@ public static class Util
 
         if (!Windows.Win32.PInvoke.FlushFileBuffers(tempFile))
             throw new Win32Exception();
-        
+
         tempFile.Close();
 
         if (!Windows.Win32.PInvoke.MoveFileEx(tempPath, path, MOVE_FILE_FLAGS.MOVEFILE_REPLACE_EXISTING | MOVE_FILE_FLAGS.MOVEFILE_WRITE_THROUGH))
             throw new Win32Exception();
+    }
+
+    /// <summary>
+    /// Turns a RGBA color value into ABGR for usage in ImGui.PushColor
+    /// </summary>
+    /// <param name="rgba">Color value with byte order of RGBA.</param>
+    /// <returns>The color value in byte order of ABGR, the format that ImGui uses.</returns>
+    public static uint RGBAToABGR(uint rgba)
+    {
+        var tmp = ((rgba << 8) & 0xFF00FF00) | ((rgba >> 8) & 0xFF00FF);
+        return (tmp << 16) | (tmp >> 16);
     }
 
     /// <summary>
@@ -751,7 +762,7 @@ public static class Util
             "-",
             MethodAttributes.Public | MethodAttributes.Static,
             CallingConventions.Standard,
-            null, 
+            null,
             new[] { typeof(object), typeof(IList<string>), typeof(ulong) },
             obj.GetType(),
             true);
@@ -908,7 +919,7 @@ public static class Util
             }
         }
     }
-    
+
     /// <summary>
     /// Show a structure in an ImGui context.
     /// </summary>

--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -642,17 +642,6 @@ public static class Util
     }
 
     /// <summary>
-    /// Turns a RGBA color value into ABGR for usage in ImGui.PushColor
-    /// </summary>
-    /// <param name="rgba">Color value with byte order of RGBA.</param>
-    /// <returns>The color value in byte order of ABGR, the format that ImGui uses.</returns>
-    public static uint RGBAToABGR(uint rgba)
-    {
-        var tmp = ((rgba << 8) & 0xFF00FF00) | ((rgba >> 8) & 0xFF00FF);
-        return (tmp << 16) | (tmp >> 16);
-    }
-
-    /// <summary>
     /// Gets a random, inoffensive, human-friendly string.
     /// </summary>
     /// <returns>A random human-friendly name.</returns>


### PR DESCRIPTION
The current function returns a color with the red channel set to FF instead the actual value, 
so either the function uses `UIForeground >> 8` or it returns the valid RGBA value, as none of the sheet colors has any real alpha.

For usage in ImGui you would also need the alpha channel back, so directly returning RGBA seems more useful.

Edit:
Also added a helper for converting from RGBA to ABGR, and expose these values directly in the payloads for easy usage with imgui