### PR TITLE
DalamudPluginInterface functions for opening Settings and DevMenu

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 
 using Dalamud.Game.Text;
+using Dalamud.Interface;
 using Dalamud.Interface.FontIdentifier;
 using Dalamud.Interface.Internal.Windows.PluginInstaller;
 using Dalamud.Interface.Style;
@@ -452,7 +453,7 @@ internal sealed class DalamudConfiguration : IInternalDisposableService
     /// <summary>
     /// Gets or sets the page of the plugin installer that is shown by default when opened.
     /// </summary>
-    public PluginInstallerWindow.PluginInstallerOpenKind PluginInstallerOpen { get; set; } = PluginInstallerWindow.PluginInstallerOpenKind.AllPlugins;
+    public PluginInstallerOpenKind PluginInstallerOpen { get; set; } = PluginInstallerOpenKind.AllPlugins;
 
     /// <summary>
     /// Load a configuration from the provided path.

--- a/Dalamud/Game/ChatHandlers.cs
+++ b/Dalamud/Game/ChatHandlers.cs
@@ -12,6 +12,7 @@ using Dalamud.Game.Gui;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
+using Dalamud.Interface;
 using Dalamud.Interface.ImGuiNotification.Internal;
 using Dalamud.Interface.Internal;
 using Dalamud.Interface.Internal.Notifications;
@@ -125,7 +126,7 @@ internal class ChatHandlers : IServiceType
 
         this.openInstallerWindowLink = chatGui.AddChatLinkHandler("Dalamud", 1001, (i, m) =>
         {
-            Service<DalamudInterface>.GetNullable()?.OpenPluginInstallerTo(PluginInstallerWindow.PluginInstallerOpenKind.InstalledPlugins);
+            Service<DalamudInterface>.GetNullable()?.OpenPluginInstallerTo(PluginInstallerOpenKind.InstalledPlugins);
         });
     }
 

--- a/Dalamud/Interface/DalamudWindowOpenKinds.cs
+++ b/Dalamud/Interface/DalamudWindowOpenKinds.cs
@@ -1,0 +1,53 @@
+namespace Dalamud.Interface;
+
+/// <summary>
+/// Enum describing pages the plugin installer can be opened to.
+/// </summary>
+public enum PluginInstallerOpenKind
+{
+    /// <summary>
+    /// Open to the "All Plugins" page.
+    /// </summary>
+    AllPlugins,
+
+    /// <summary>
+    /// Open to the "Installed Plugins" page.
+    /// </summary>
+    InstalledPlugins,
+
+    /// <summary>
+    /// Open to the "Changelogs" page.
+    /// </summary>
+    Changelogs,
+}
+
+/// <summary>
+/// Enum describing tabs the settings window can be opened to.
+/// </summary>
+public enum SettingsOpenKind
+{
+    /// <summary>
+    /// Open to the "General" page.
+    /// </summary>
+    General,
+    
+    /// <summary>
+    /// Open to the "Look &#038; Feel" page.
+    /// </summary>
+    LookAndFeel,
+
+    /// <summary>
+    /// Open to the "Server Info Bar" page.
+    /// </summary>
+    ServerInfoBar,
+
+    /// <summary>
+    /// Open to the "Experimental" page.
+    /// </summary>
+    Experimental,
+
+    /// <summary>
+    /// Open to the "About" page.
+    /// </summary>
+    About,
+}

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -290,10 +290,10 @@ internal class DalamudInterface : IInternalDisposableService
     }
 
     /// <summary>
-    /// Opens the <see cref="PluginInstallerWindow"/> on the plugin installed.
+    /// Opens the <see cref="PluginInstallerWindow"/> on the specified page.
     /// </summary>
     /// <param name="kind">The page of the installer to open.</param>
-    public void OpenPluginInstallerTo(PluginInstallerWindow.PluginInstallerOpenKind kind)
+    public void OpenPluginInstallerTo(PluginInstallerOpenKind kind)
     {
         this.pluginWindow.OpenTo(kind);
         this.pluginWindow.BringToFront();
@@ -305,6 +305,16 @@ internal class DalamudInterface : IInternalDisposableService
     public void OpenSettings()
     {
         this.settingsWindow.IsOpen = true;
+        this.settingsWindow.BringToFront();
+    }
+
+    /// <summary>
+    /// Opens the <see cref="SettingsWindow"/> on the specified tab.
+    /// </summary>
+    /// <param name="kind">The tab of the settings to open.</param>
+    public void OpenSettingsTo(SettingsOpenKind kind)
+    {
+        this.settingsWindow.OpenTo(kind);
         this.settingsWindow.BringToFront();
     }
 
@@ -418,7 +428,7 @@ internal class DalamudInterface : IInternalDisposableService
     /// Toggles the <see cref="PluginInstallerWindow"/>.
     /// </summary>
     /// <param name="kind">The page of the installer to open.</param>
-    public void TogglePluginInstallerWindowTo(PluginInstallerWindow.PluginInstallerOpenKind kind) => this.pluginWindow.ToggleTo(kind);
+    public void TogglePluginInstallerWindowTo(PluginInstallerOpenKind kind) => this.pluginWindow.ToggleTo(kind);
 
     /// <summary>
     /// Toggles the <see cref="SettingsWindow"/>.
@@ -454,6 +464,15 @@ internal class DalamudInterface : IInternalDisposableService
     public void SetPluginInstallerSearchText(string text)
     {
         this.pluginWindow.SetSearchText(text);
+    }
+
+    /// <summary>
+    /// Sets the current search text for the settings window.
+    /// </summary>
+    /// <param name="text">The search term.</param>
+    public void SetSettingsSearchText(string text)
+    {
+        this.settingsWindow.SetSearchText(text);
     }
 
     /// <summary>

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
@@ -128,8 +128,8 @@ public class SettingsTabLook : SettingsTab
         new SettingsEntry<bool>(
             Loc.Localize("DalamudSettingInstallerOpenDefault", "Open the Plugin Installer to the \"Installed Plugins\" tab by default"),
             Loc.Localize("DalamudSettingInstallerOpenDefaultHint", "This will allow you to open the Plugin Installer to the \"Installed Plugins\" tab by default, instead of the \"Available Plugins\" tab."),
-            c => c.PluginInstallerOpen == PluginInstallerWindow.PluginInstallerOpenKind.InstalledPlugins,
-            (v, c) => c.PluginInstallerOpen = v ? PluginInstallerWindow.PluginInstallerOpenKind.InstalledPlugins : PluginInstallerWindow.PluginInstallerOpenKind.AllPlugins),
+            c => c.PluginInstallerOpen == PluginInstallerOpenKind.InstalledPlugins,
+            (v, c) => c.PluginInstallerOpen = v ? PluginInstallerOpenKind.InstalledPlugins : PluginInstallerOpenKind.AllPlugins),
         
         new SettingsEntry<bool>(
             Loc.Localize("DalamudSettingReducedMotion", "Reduce motions"),

--- a/Dalamud/Interface/Utility/Raii/EndObjects.cs
+++ b/Dalamud/Interface/Utility/Raii/EndObjects.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using System.Text;
 
 using ImGuiNET;
 
@@ -36,7 +37,7 @@ public static partial class ImRaii
 
     public static IEndObject Popup(string id, ImGuiWindowFlags flags)
         => new EndConditionally(ImGui.EndPopup, ImGui.BeginPopup(id, flags));
-    
+
     public static IEndObject PopupModal(string id)
         => new EndConditionally(ImGui.EndPopup, ImGui.BeginPopupModal(id));
 
@@ -103,8 +104,43 @@ public static partial class ImRaii
     public static IEndObject TabItem(string label)
         => new EndConditionally(ImGui.EndTabItem, ImGui.BeginTabItem(label));
 
-    public static unsafe IEndObject TabItem(byte* label, ImGuiTabItemFlags flags)
-        => new EndConditionally(ImGuiNative.igEndTabItem, ImGuiNative.igBeginTabItem(label, null, flags) != 0);
+    public static unsafe IEndObject TabItem(string label, ImGuiTabItemFlags flags)
+    {
+        // I am so sorry for this.
+        const int ImGuiNET_Util_StackAllocationSizeLimit = 2048;
+
+        byte* native_label;
+        int label_byteCount = 0;
+        if (label != null)
+        {
+            label_byteCount = Encoding.UTF8.GetByteCount(label);
+
+            if (label_byteCount > ImGuiNET_Util_StackAllocationSizeLimit)
+            {
+                throw new ArgumentOutOfRangeException("label", "Label is too long. (Longer than 2048 bytes)");
+            }
+
+            byte* native_label_stackBytes = stackalloc byte[label_byteCount + 1];
+            native_label = native_label_stackBytes;
+
+            int native_label_offset;
+            fixed (char* utf16Ptr = label)
+            {
+                native_label_offset = Encoding.UTF8.GetBytes(utf16Ptr, label.Length, native_label, label_byteCount);
+            }
+
+            native_label[native_label_offset] = 0;
+        }
+        else
+        {
+            native_label = null;
+        }
+
+        byte* p_open = null;
+        byte ret = ImGuiNative.igBeginTabItem(native_label, p_open, flags);
+
+        return new EndUnconditionally(ImGuiNative.igEndTabItem, ret != 0);
+    }
 
     public static IEndObject TabItem(string label, ref bool open)
         => new EndConditionally(ImGui.EndTabItem, ImGui.BeginTabItem(label, ref open));
@@ -174,7 +210,7 @@ public static partial class ImRaii
         return new EndUnconditionally(Widget.EndFramedGroup, true);
     }
     */
-    
+
     // Used to avoid tree pops when flag for no push is set.
     private static void Nop()
     {
@@ -210,15 +246,15 @@ public static partial class ImRaii
     {
         private Action EndAction { get; }
 
-        public  bool   Success   { get; }
+        public bool Success { get; }
 
-        public  bool   Disposed  { get; private set; }
+        public bool Disposed { get; private set; }
 
         public EndUnconditionally(Action endAction, bool success)
         {
             this.EndAction = endAction;
-            this.Success   = success;
-            this.Disposed  = false;
+            this.Success = success;
+            this.Disposed = false;
         }
 
         public void Dispose()
@@ -240,11 +276,11 @@ public static partial class ImRaii
             this.Success = success;
             this.Disposed = false;
         }
-        
+
         public bool Success { get; }
 
         public bool Disposed { get; private set; }
-        
+
         private Action EndAction { get; }
 
         public void Dispose()

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -18,6 +18,7 @@ using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Interface;
 using Dalamud.Interface.Internal;
 using Dalamud.Interface.Internal.Windows.PluginInstaller;
+using Dalamud.Interface.Internal.Windows.Settings;
 using Dalamud.Plugin.Internal;
 using Dalamud.Plugin.Internal.Types;
 using Dalamud.Plugin.Internal.Types.Manifest;
@@ -215,10 +216,11 @@ public sealed class DalamudPluginInterface : IDisposable
     public IEnumerable<InstalledPluginState> InstalledPlugins => Service<PluginManager>.Get().InstalledPlugins.Select(p => new InstalledPluginState(p.Name, p.Manifest.InternalName, p.IsLoaded, p.EffectiveVersion));
 
     /// <summary>
-    /// Opens the <see cref="PluginInstallerWindow"/> with the plugin name set as search target.
+    /// Opens the <see cref="PluginInstallerWindow"/>, with the plugin name set as search target by default.
     /// </summary>
+    /// <param name="filterByPluginInternalName">Whether to filter the plugin list by the plugin's internal name. (Default is true)</param>
     /// <returns>Returns false if the DalamudInterface was null.</returns>
-    public bool OpenPluginInstaller()
+    public bool OpenPluginInstaller(bool filterByPluginInternalName = true)
     {
         var dalamudInterface = Service<DalamudInterface>.GetNullable(); // Can be null during boot
         if (dalamudInterface == null)
@@ -227,8 +229,43 @@ public sealed class DalamudPluginInterface : IDisposable
         }
 
         dalamudInterface.OpenPluginInstallerTo(PluginInstallerWindow.PluginInstallerOpenKind.InstalledPlugins);
-        dalamudInterface.SetPluginInstallerSearchText(this.plugin.InternalName);
+        if (filterByPluginInternalName)
+        {
+            dalamudInterface.SetPluginInstallerSearchText(this.plugin.InternalName);
+        }
 
+        return true;
+    }
+
+    /// <summary>
+    /// Opens the <see cref="SettingsWindow"/>
+    /// </summary>
+    /// <returns>Returns false if the DalamudInterface was null.</returns>
+    public bool OpenDalamudSettings()
+    {
+        var dalamudInterface = Service<DalamudInterface>.GetNullable(); // Can be null during boot
+        if (dalamudInterface == null)
+        {
+            return false;
+        }
+
+        dalamudInterface.OpenSettings();
+        return true;
+    }
+
+    /// <summary>
+    /// Opens the dev menu bar.
+    /// </summary>
+    /// <returns>Returns false if the DalamudInterface was null.</returns>
+    public bool OpenDeveloperMenu()
+    {
+        var dalamudInterface = Service<DalamudInterface>.GetNullable(); // Can be null during boot
+        if (dalamudInterface == null)
+        {
+            return false;
+        }
+
+        dalamudInterface.OpenDevMenu();
         return true;
     }
 

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -25,6 +25,9 @@ using Dalamud.Plugin.Internal.Types.Manifest;
 using Dalamud.Plugin.Ipc;
 using Dalamud.Plugin.Ipc.Exceptions;
 using Dalamud.Plugin.Ipc.Internal;
+using Dalamud.Utility;
+
+using static Dalamud.Interface.Internal.Windows.PluginInstaller.PluginInstallerWindow;
 
 namespace Dalamud.Plugin;
 
@@ -216,11 +219,22 @@ public sealed class DalamudPluginInterface : IDisposable
     public IEnumerable<InstalledPluginState> InstalledPlugins => Service<PluginManager>.Get().InstalledPlugins.Select(p => new InstalledPluginState(p.Name, p.Manifest.InternalName, p.IsLoaded, p.EffectiveVersion));
 
     /// <summary>
-    /// Opens the <see cref="PluginInstallerWindow"/>, with the plugin name set as search target by default.
+    /// Opens the <see cref="PluginInstallerWindow"/> with the plugin name set as search target.
     /// </summary>
-    /// <param name="filterByPluginInternalName">Whether to filter the plugin list by the plugin's internal name. (Default is true)</param>
     /// <returns>Returns false if the DalamudInterface was null.</returns>
-    public bool OpenPluginInstaller(bool filterByPluginInternalName = true)
+    [Api10ToDo(Api10ToDoAttribute.DeleteCompatBehavior)]
+    public bool OpenPluginInstaller()
+    {
+        return this.OpenPluginInstallerTo(PluginInstallerOpenKind.InstalledPlugins, this.plugin.InternalName);
+    }
+
+    /// <summary>
+    /// Opens the <see cref="PluginInstallerWindow"/>, with an optional search term.
+    /// </summary>
+    /// <param name="openTo">The page to open the installer to. Defaults to the "All Plugins" page.</param>
+    /// <param name="searchText">An optional search text to input in the search box.</param>
+    /// <returns>Returns false if the DalamudInterface was null.</returns>
+    public bool OpenPluginInstallerTo(PluginInstallerOpenKind openTo = PluginInstallerOpenKind.AllPlugins, string searchText = null)
     {
         var dalamudInterface = Service<DalamudInterface>.GetNullable(); // Can be null during boot
         if (dalamudInterface == null)
@@ -228,20 +242,19 @@ public sealed class DalamudPluginInterface : IDisposable
             return false;
         }
 
-        dalamudInterface.OpenPluginInstallerTo(PluginInstallerWindow.PluginInstallerOpenKind.InstalledPlugins);
-        if (filterByPluginInternalName)
-        {
-            dalamudInterface.SetPluginInstallerSearchText(this.plugin.InternalName);
-        }
+        dalamudInterface.OpenPluginInstallerTo(openTo);
+        dalamudInterface.SetPluginInstallerSearchText(searchText);
 
         return true;
     }
 
     /// <summary>
-    /// Opens the <see cref="SettingsWindow"/>
+    /// Opens the <see cref="SettingsWindow"/>, with an optional search term.
     /// </summary>
+    /// <param name="openTo">The tab to open the settings to. Defaults to the "General" tab.</param>
+    /// <param name="searchText">An optional search text to input in the search box.</param>
     /// <returns>Returns false if the DalamudInterface was null.</returns>
-    public bool OpenDalamudSettings()
+    public bool OpenDalamudSettingsTo(SettingsOpenKind openTo = SettingsOpenKind.General, string searchText = null)
     {
         var dalamudInterface = Service<DalamudInterface>.GetNullable(); // Can be null during boot
         if (dalamudInterface == null)
@@ -249,7 +262,9 @@ public sealed class DalamudPluginInterface : IDisposable
             return false;
         }
 
-        dalamudInterface.OpenSettings();
+        dalamudInterface.OpenSettingsTo(openTo);
+        dalamudInterface.SetSettingsSearchText(searchText);
+
         return true;
     }
 

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -19,6 +19,7 @@ using Dalamud.Game.Gui.Dtr;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
+using Dalamud.Interface;
 using Dalamud.Interface.Internal;
 using Dalamud.Interface.Internal.Windows.PluginInstaller;
 using Dalamud.IoC;
@@ -129,7 +130,7 @@ internal class PluginManager : IInternalDisposableService
                     (_, _) =>
                     {
                         Service<DalamudInterface>.GetNullable()?.OpenPluginInstallerTo(
-                            PluginInstallerWindow.PluginInstallerOpenKind.Changelogs);
+                            PluginInstallerOpenKind.Changelogs);
                     }));
 
         this.configuration.PluginTestingOptIns ??= new();


### PR DESCRIPTION
Changes to DalamudPluginInterface:

- Adds `OpenDalamudSettings()`
- Adds `OpenDeveloperMenu()`
- Changes `OpenPluginInstaller` signature to `OpenPluginInstaller(bool filterByPluginInternalName = true)` so opening the window without filtering by plugin name is possible, without breaking backwards compatibility