### PR TITLE
fix: Attempt to better handle hook disposal

### DIFF
--- a/Dalamud/Hooking/AsmHook.cs
+++ b/Dalamud/Hooking/AsmHook.cs
@@ -20,6 +20,8 @@ public sealed class AsmHook : IDisposable, IDalamudHook
     private bool isEnabled = false;
 
     private DynamicMethod statsMethod;
+    
+    private Guid hookId = Guid.NewGuid();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AsmHook"/> class.
@@ -44,7 +46,7 @@ public sealed class AsmHook : IDisposable, IDalamudHook
         this.statsMethod.GetILGenerator().Emit(OpCodes.Ret);
         var dele = this.statsMethod.CreateDelegate(typeof(Action));
 
-        HookManager.TrackedHooks.TryAdd(Guid.NewGuid(), new HookInfo(this, dele, Assembly.GetCallingAssembly()));
+        HookManager.TrackedHooks.TryAdd(this.hookId, new HookInfo(this, dele, Assembly.GetCallingAssembly()));
     }
 
     /// <summary>
@@ -70,7 +72,7 @@ public sealed class AsmHook : IDisposable, IDalamudHook
         this.statsMethod.GetILGenerator().Emit(OpCodes.Ret);
         var dele = this.statsMethod.CreateDelegate(typeof(Action));
 
-        HookManager.TrackedHooks.TryAdd(Guid.NewGuid(), new HookInfo(this, dele, Assembly.GetCallingAssembly()));
+        HookManager.TrackedHooks.TryAdd(this.hookId, new HookInfo(this, dele, Assembly.GetCallingAssembly()));
     }
 
     /// <summary>
@@ -115,6 +117,8 @@ public sealed class AsmHook : IDisposable, IDalamudHook
             return;
 
         this.IsDisposed = true;
+
+        HookManager.TrackedHooks.TryRemove(this.hookId, out _);
 
         if (this.isEnabled)
         {

--- a/Dalamud/Hooking/Hook.cs
+++ b/Dalamud/Hooking/Hook.cs
@@ -72,6 +72,11 @@ public abstract class Hook<T> : IDalamudHook where T : Delegate
     public virtual string BackendName => throw new NotImplementedException();
     
     /// <summary>
+    /// Gets the unique GUID for this hook.
+    /// </summary>
+    protected Guid HookId { get; } = Guid.NewGuid();
+    
+    /// <summary>
     /// Remove a hook from the current process.
     /// </summary>
     public virtual void Dispose()

--- a/Dalamud/Hooking/Internal/FunctionPointerVariableHook.cs
+++ b/Dalamud/Hooking/Internal/FunctionPointerVariableHook.cs
@@ -100,7 +100,7 @@ internal class FunctionPointerVariableHook<T> : Hook<T>
 
             unhooker.TrimAfterHook();
 
-            HookManager.TrackedHooks.TryAdd(Guid.NewGuid(), new HookInfo(this, detour, callingAssembly));
+            HookManager.TrackedHooks.TryAdd(this.HookId, new HookInfo(this, detour, callingAssembly));
         }
     }
 
@@ -136,6 +136,8 @@ internal class FunctionPointerVariableHook<T> : Hook<T>
         }
 
         this.Disable();
+
+        HookManager.TrackedHooks.TryRemove(this.HookId, out _);
 
         var index = HookManager.MultiHookTracker[this.Address].IndexOf(this);
         HookManager.MultiHookTracker[this.Address][index] = null;

--- a/Dalamud/Hooking/Internal/GameInteropProviderPluginScoped.cs
+++ b/Dalamud/Hooking/Internal/GameInteropProviderPluginScoped.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Concurrent;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Linq;
 
 using Dalamud.Game;
@@ -7,6 +6,7 @@ using Dalamud.IoC;
 using Dalamud.IoC.Internal;
 using Dalamud.Plugin.Internal.Types;
 using Dalamud.Plugin.Services;
+using Dalamud.Utility;
 using Dalamud.Utility.Signatures;
 using Serilog;
 
@@ -26,7 +26,7 @@ internal class GameInteropProviderPluginScoped : IGameInteropProvider, IInternal
     private readonly LocalPlugin plugin;
     private readonly SigScanner scanner;
 
-    private readonly ConcurrentBag<IDalamudHook> trackedHooks = new();
+    private readonly WeakConcurrentCollection<IDalamudHook> trackedHooks = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GameInteropProviderPluginScoped"/> class.

--- a/Dalamud/Hooking/Internal/MinHookHook.cs
+++ b/Dalamud/Hooking/Internal/MinHookHook.cs
@@ -35,7 +35,7 @@ internal class MinHookHook<T> : Hook<T> where T : Delegate
 
             unhooker.TrimAfterHook();
 
-            HookManager.TrackedHooks.TryAdd(Guid.NewGuid(), new HookInfo(this, detour, callingAssembly));
+            HookManager.TrackedHooks.TryAdd(this.HookId, new HookInfo(this, detour, callingAssembly));
         }
     }
 
@@ -75,6 +75,8 @@ internal class MinHookHook<T> : Hook<T> where T : Delegate
             var index = HookManager.MultiHookTracker[this.Address].IndexOf(this);
             HookManager.MultiHookTracker[this.Address][index] = null;
         }
+
+        HookManager.TrackedHooks.TryRemove(this.HookId, out _);
 
         base.Dispose();
     }

--- a/Dalamud/Hooking/Internal/ReloadedHook.cs
+++ b/Dalamud/Hooking/Internal/ReloadedHook.cs
@@ -30,7 +30,7 @@ internal class ReloadedHook<T> : Hook<T> where T : Delegate
 
             unhooker.TrimAfterHook();
 
-            HookManager.TrackedHooks.TryAdd(Guid.NewGuid(), new HookInfo(this, detour, callingAssembly));
+            HookManager.TrackedHooks.TryAdd(this.HookId, new HookInfo(this, detour, callingAssembly));
         }
     }
 
@@ -62,6 +62,8 @@ internal class ReloadedHook<T> : Hook<T> where T : Delegate
     {
         if (this.IsDisposed)
             return;
+
+        HookManager.TrackedHooks.TryRemove(this.HookId, out _);
 
         this.Disable();
 

--- a/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
@@ -258,8 +258,6 @@ internal class PluginStatWindow : Window
             ImGui.EndTabItem();
         }
 
-        var toRemove = new List<Guid>();
-
         if (ImGui.BeginTabItem("Hooks"))
         {
             ImGui.Checkbox("Show Dalamud Hooks", ref this.showDalamudHooks);
@@ -291,9 +289,6 @@ internal class PluginStatWindow : Window
                 {
                     try
                     {
-                        if (trackedHook.Hook.IsDisposed)
-                            toRemove.Add(guid);
-
                         if (!this.showDalamudHooks && trackedHook.Assembly == Assembly.GetExecutingAssembly())
                             continue;
 
@@ -352,14 +347,6 @@ internal class PluginStatWindow : Window
                 }
 
                 ImGui.EndTable();
-            }
-        }
-
-        if (ImGui.IsWindowAppearing())
-        {
-            foreach (var guid in toRemove)
-            {
-                HookManager.TrackedHooks.TryRemove(guid, out _);
             }
         }
 

--- a/Dalamud/Utility/WeakConcurrentCollection.cs
+++ b/Dalamud/Utility/WeakConcurrentCollection.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Dalamud.Utility;
+
+/// <summary>
+/// An implementation of a weak concurrent set based on a <see cref="ConditionalWeakTable{TKey,TValue}"/>.
+/// </summary>
+/// <typeparam name="T">The type of object that we're tracking.</typeparam>
+public class WeakConcurrentCollection<T> : ICollection<T> where T : class
+{
+    private readonly ConditionalWeakTable<T, object> cwt = new();
+    
+    /// <inheritdoc/>
+    public int Count => this.cwt.Count();
+
+    /// <inheritdoc/>
+    public bool IsReadOnly => false;
+    
+    private IEnumerable<T> Keys => this.cwt.Select(pair => pair.Key);
+
+    /// <inheritdoc/>
+    public IEnumerator<T> GetEnumerator() => this.cwt.Select(pair => pair.Key).GetEnumerator();
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator() => this.cwt.Select(pair => pair.Key).GetEnumerator();
+
+    /// <inheritdoc/>
+    public void Add(T item) => this.cwt.AddOrUpdate(item, null);
+    
+    /// <inheritdoc/>
+    public void Clear() => this.cwt.Clear();
+
+    /// <inheritdoc/>
+    public bool Contains(T item) => this.Keys.Contains(item);
+
+    /// <inheritdoc/>
+    public void CopyTo(T[] array, int arrayIndex) => this.Keys.ToArray().CopyTo(array, arrayIndex);
+
+    /// <inheritdoc/>
+    public bool Remove(T item) => this.cwt.Remove(item);
+}


### PR DESCRIPTION
- Use a Weak Concurrent Collection to track scoped hooks
- Make `Hook`s remove themselves from the Tracked Hook list.