### PR TITLE
Make DalamudPluginInterface into IDalamudPluginInterface

### DIFF
--- a/Dalamud.CorePlugin/PluginImpl.cs
+++ b/Dalamud.CorePlugin/PluginImpl.cs
@@ -55,7 +55,7 @@ namespace Dalamud.CorePlugin
         /// </summary>
         /// <param name="pluginInterface">Dalamud plugin interface.</param>
         /// <param name="log">Logging service.</param>
-        public PluginImpl(DalamudPluginInterface pluginInterface, IPluginLog log)
+        public PluginImpl(IDalamudPluginInterface pluginInterface, IPluginLog log)
         {
             try
             {
@@ -86,7 +86,7 @@ namespace Dalamud.CorePlugin
         /// <summary>
         /// Gets the plugin interface.
         /// </summary>
-        internal DalamudPluginInterface Interface { get; private set; }
+        internal IDalamudPluginInterface Interface { get; private set; }
 
         /// <inheritdoc/>
         public void Dispose()

--- a/Dalamud/Interface/Internal/DalamudCommands.cs
+++ b/Dalamud/Interface/Internal/DalamudCommands.cs
@@ -401,11 +401,11 @@ internal class DalamudCommands : IServiceType
         {
             if (im.IsDispatchingEvents)
             {
-                plugin.DalamudInterface?.UiBuilder.NotifyShowUi();
+                plugin.DalamudInterface?.LocalUiBuilder.NotifyShowUi();
             }
             else
             {
-                plugin.DalamudInterface?.UiBuilder.NotifyHideUi();
+                plugin.DalamudInterface?.LocalUiBuilder.NotifyHideUi();
             }
         }
     }

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -3052,8 +3052,8 @@ internal class PluginInstallerWindow : Window, IDisposable
 
     private void DrawOpenPluginSettingsButton(LocalPlugin plugin)
     {
-        var hasMainUi = plugin.DalamudInterface?.UiBuilder.HasMainUi ?? false;
-        var hasConfig = plugin.DalamudInterface?.UiBuilder.HasConfigUi ?? false;
+        var hasMainUi = plugin.DalamudInterface?.LocalUiBuilder.HasMainUi ?? false;
+        var hasConfig = plugin.DalamudInterface?.LocalUiBuilder.HasConfigUi ?? false;
         if (hasMainUi)
         {
             ImGui.SameLine();
@@ -3061,7 +3061,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             {
                 try
                 {
-                    plugin.DalamudInterface.UiBuilder.OpenMain();
+                    plugin.DalamudInterface.LocalUiBuilder.OpenMain();
                 }
                 catch (Exception ex)
                 {
@@ -3088,7 +3088,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             {
                 try
                 {
-                    plugin.DalamudInterface.UiBuilder.OpenConfig();
+                    plugin.DalamudInterface.LocalUiBuilder.OpenConfig();
                 }
                 catch (Exception ex)
                 {

--- a/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
@@ -65,16 +65,16 @@ internal class PluginStatWindow : Window
                     {
                         if (plugin.DalamudInterface != null)
                         {
-                            plugin.DalamudInterface.UiBuilder.LastDrawTime = -1;
-                            plugin.DalamudInterface.UiBuilder.MaxDrawTime = -1;
-                            plugin.DalamudInterface.UiBuilder.DrawTimeHistory.Clear();
+                            plugin.DalamudInterface.LocalUiBuilder.LastDrawTime = -1;
+                            plugin.DalamudInterface.LocalUiBuilder.MaxDrawTime = -1;
+                            plugin.DalamudInterface.LocalUiBuilder.DrawTimeHistory.Clear();
                         }
                     }
                 }
 
                 var loadedPlugins = pluginManager.InstalledPlugins.Where(plugin => plugin.State == PluginState.Loaded);
-                var totalLast = loadedPlugins.Sum(plugin => plugin.DalamudInterface?.UiBuilder.LastDrawTime ?? 0);
-                var totalAverage = loadedPlugins.Sum(plugin => plugin.DalamudInterface?.UiBuilder.DrawTimeHistory.DefaultIfEmpty().Average() ?? 0);
+                var totalLast = loadedPlugins.Sum(plugin => plugin.DalamudInterface?.LocalUiBuilder.LastDrawTime ?? 0);
+                var totalAverage = loadedPlugins.Sum(plugin => plugin.DalamudInterface?.LocalUiBuilder.DrawTimeHistory.DefaultIfEmpty().Average() ?? 0);
 
                 ImGuiComponents.TextWithLabel("Total Last", $"{totalLast / 10000f:F4}ms", "All last draw times added together");
                 ImGui.SameLine();
@@ -113,11 +113,11 @@ internal class PluginStatWindow : Window
                                  ? loadedPlugins.OrderBy(plugin => plugin.Name)
                                  : loadedPlugins.OrderByDescending(plugin => plugin.Name),
                         2 => sortSpecs.Specs.SortDirection == ImGuiSortDirection.Ascending
-                                 ? loadedPlugins.OrderBy(plugin => plugin.DalamudInterface?.UiBuilder.MaxDrawTime ?? 0)
-                                 : loadedPlugins.OrderByDescending(plugin => plugin.DalamudInterface?.UiBuilder.MaxDrawTime ?? 0),
+                                 ? loadedPlugins.OrderBy(plugin => plugin.DalamudInterface?.LocalUiBuilder.MaxDrawTime ?? 0)
+                                 : loadedPlugins.OrderByDescending(plugin => plugin.DalamudInterface?.LocalUiBuilder.MaxDrawTime ?? 0),
                         3 => sortSpecs.Specs.SortDirection == ImGuiSortDirection.Ascending
-                                 ? loadedPlugins.OrderBy(plugin => plugin.DalamudInterface?.UiBuilder.DrawTimeHistory.DefaultIfEmpty().Average() ?? 0)
-                                 : loadedPlugins.OrderByDescending(plugin => plugin.DalamudInterface?.UiBuilder.DrawTimeHistory.DefaultIfEmpty().Average() ?? 0),
+                                 ? loadedPlugins.OrderBy(plugin => plugin.DalamudInterface?.LocalUiBuilder.DrawTimeHistory.DefaultIfEmpty().Average() ?? 0)
+                                 : loadedPlugins.OrderByDescending(plugin => plugin.DalamudInterface?.LocalUiBuilder.DrawTimeHistory.DefaultIfEmpty().Average() ?? 0),
                         _ => loadedPlugins,
                     };
 
@@ -137,14 +137,14 @@ internal class PluginStatWindow : Window
                         if (plugin.DalamudInterface != null)
                         {
                             ImGui.TableNextColumn();
-                            ImGui.Text($"{plugin.DalamudInterface.UiBuilder.LastDrawTime / 10000f:F4}ms");
+                            ImGui.Text($"{plugin.DalamudInterface.LocalUiBuilder.LastDrawTime / 10000f:F4}ms");
 
                             ImGui.TableNextColumn();
-                            ImGui.Text($"{plugin.DalamudInterface.UiBuilder.MaxDrawTime / 10000f:F4}ms");
+                            ImGui.Text($"{plugin.DalamudInterface.LocalUiBuilder.MaxDrawTime / 10000f:F4}ms");
 
                             ImGui.TableNextColumn();
-                            ImGui.Text(plugin.DalamudInterface.UiBuilder.DrawTimeHistory.Count > 0
-                                           ? $"{plugin.DalamudInterface.UiBuilder.DrawTimeHistory.Average() / 10000f:F4}ms"
+                            ImGui.Text(plugin.DalamudInterface.LocalUiBuilder.DrawTimeHistory.Count > 0
+                                           ? $"{plugin.DalamudInterface.LocalUiBuilder.DrawTimeHistory.Average() / 10000f:F4}ms"
                                            : "-");
                         }
                     }

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -24,10 +24,220 @@ using SharpDX.Direct3D11;
 namespace Dalamud.Interface;
 
 /// <summary>
+/// This interface represents the Dalamud UI that is drawn on top of the game.
+/// It can be used to draw custom windows and overlays.
+/// </summary>
+public interface IUiBuilder
+{
+    /// <summary>
+    /// The event that gets called when Dalamud is ready to draw your windows or overlays.
+    /// When it is called, you can use static ImGui calls.
+    /// </summary>
+    event Action? Draw;
+
+    /// <summary>
+    /// The event that is called when the game's DirectX device is requesting you to resize your buffers.
+    /// </summary>
+    event Action? ResizeBuffers;
+
+    /// <summary>
+    /// Event that is fired when the plugin should open its configuration interface.
+    /// </summary>
+    event Action? OpenConfigUi;
+
+    /// <summary>
+    /// Event that is fired when the plugin should open its main interface.
+    /// </summary>
+    event Action? OpenMainUi;
+
+    /// <summary>
+    /// Gets or sets an action that is called when plugin UI or interface modifications are supposed to be shown.
+    /// These may be fired consecutively.
+    /// </summary>
+    event Action? ShowUi;
+
+    /// <summary>
+    /// Gets or sets an action that is called when plugin UI or interface modifications are supposed to be hidden.
+    /// These may be fired consecutively.
+    /// </summary>
+    event Action? HideUi;
+
+    /// <summary>
+    /// Gets the handle to the default Dalamud font - supporting all game languages and icons.
+    /// </summary>
+    /// <remarks>
+    /// A font handle corresponding to this font can be obtained with:
+    /// <code>
+    /// fontAtlas.NewDelegateFontHandle(
+    ///     e => e.OnPreBuild(
+    ///         tk => tk.AddDalamudDefaultFont(UiBuilder.DefaultFontSizePx)));
+    /// </code>
+    /// </remarks>
+    IFontHandle DefaultFontHandle { get; }
+
+    /// <summary>
+    /// Gets the default Dalamud icon font based on FontAwesome 5 Free solid.
+    /// </summary>
+    /// <remarks>
+    /// A font handle corresponding to this font can be obtained with:
+    /// <code>
+    /// fontAtlas.NewDelegateFontHandle(
+    ///     e => e.OnPreBuild(
+    ///         tk => tk.AddFontAwesomeIconFont(new() { SizePt = UiBuilder.DefaultFontSizePt })));
+    /// // or use
+    ///         tk => tk.AddFontAwesomeIconFont(new() { SizePx = UiBuilder.DefaultFontSizePx })));
+    /// </code>
+    /// </remarks>
+    IFontHandle IconFontHandle { get; }
+
+    /// <summary>
+    /// Gets the default Dalamud monospaced font based on Inconsolata Regular.
+    /// </summary>
+    /// <remarks>
+    /// A font handle corresponding to this font can be obtained with:
+    /// <code>
+    /// fontAtlas.NewDelegateFontHandle(
+    ///     e => e.OnPreBuild(
+    ///         tk => tk.AddDalamudAssetFont(
+    ///             DalamudAsset.InconsolataRegular,
+    ///             new() { SizePt = UiBuilder.DefaultFontSizePt })));
+    /// // or use
+    ///             new() { SizePx = UiBuilder.DefaultFontSizePx })));
+    /// </code>
+    /// </remarks>
+    IFontHandle MonoFontHandle { get; }
+
+    /// <summary>
+    /// Gets the default Dalamud icon font based on FontAwesome 5 free solid with a fixed width and vertically centered glyphs.
+    /// </summary>
+    IFontHandle IconFontFixedWidthHandle { get; }
+
+    /// <summary>
+    /// Gets the default font specifications.
+    /// </summary>
+    IFontSpec DefaultFontSpec { get; }
+
+    /// <summary>
+    /// Gets the game's active Direct3D device.
+    /// </summary>
+    Device Device { get; }
+
+    /// <summary>
+    /// Gets the game's main window handle.
+    /// </summary>
+    IntPtr WindowHandlePtr { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this plugin should hide its UI automatically when the game's UI is hidden.
+    /// </summary>
+    bool DisableAutomaticUiHide { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this plugin should hide its UI automatically when the user toggles the UI.
+    /// </summary>
+    bool DisableUserUiHide { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this plugin should hide its UI automatically during cutscenes.
+    /// </summary>
+    bool DisableCutsceneUiHide { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this plugin should hide its UI automatically while gpose is active.
+    /// </summary>
+    bool DisableGposeUiHide { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not the game's cursor should be overridden with the ImGui cursor.
+    /// </summary>
+    bool OverrideGameCursor { get; set; }
+
+    /// <summary>
+    /// Gets the count of Draw calls made since plugin creation.
+    /// </summary>
+    ulong FrameCount { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether or not a cutscene is playing.
+    /// </summary>
+    bool CutsceneActive { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this plugin should modify the game's interface at this time.
+    /// </summary>
+    bool ShouldModifyUi { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether UI functions can be used.
+    /// </summary>
+    bool UiPrepared { get; }
+
+    /// <summary>
+    /// Gets the plugin-private font atlas.
+    /// </summary>
+    IFontAtlas FontAtlas { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether or not to use "reduced motion". This usually means that you should use less
+    /// intrusive animations, or disable them entirely.
+    /// </summary>
+    bool ShouldUseReducedMotion { get; }
+
+    /// <summary>
+    /// Loads an ULD file that can load textures containing multiple icons in a single texture.
+    /// </summary>
+    /// <param name="uldPath">The path of the requested ULD file.</param>
+    /// <returns>A wrapper around said ULD file.</returns>
+    UldWrapper LoadUld(string uldPath);
+
+    /// <summary>
+    /// Waits for UI to become available for use.
+    /// </summary>
+    /// <returns>A task that completes when the game's Present has been called at least once.</returns>
+    Task WaitForUi();
+
+    /// <summary>
+    /// Waits for UI to become available for use.
+    /// </summary>
+    /// <param name="func">Function to call.</param>
+    /// <param name="runInFrameworkThread">Specifies whether to call the function from the framework thread.</param>
+    /// <returns>A task that completes when the game's Present has been called at least once.</returns>
+    /// <typeparam name="T">Return type.</typeparam>
+    Task<T> RunWhenUiPrepared<T>(Func<T> func, bool runInFrameworkThread = false);
+
+    /// <summary>
+    /// Waits for UI to become available for use.
+    /// </summary>
+    /// <param name="func">Function to call.</param>
+    /// <param name="runInFrameworkThread">Specifies whether to call the function from the framework thread.</param>
+    /// <returns>A task that completes when the game's Present has been called at least once.</returns>
+    /// <typeparam name="T">Return type.</typeparam>
+    Task<T> RunWhenUiPrepared<T>(Func<Task<T>> func, bool runInFrameworkThread = false);
+
+    /// <summary>
+    /// Creates an isolated <see cref="IFontAtlas"/>.
+    /// </summary>
+    /// <param name="autoRebuildMode">Specify when and how to rebuild this atlas.</param>
+    /// <param name="isGlobalScaled">Whether the fonts in the atlas is global scaled.</param>
+    /// <param name="debugName">Name for debugging purposes.</param>
+    /// <returns>A new instance of <see cref="IFontAtlas"/>.</returns>
+    /// <remarks>
+    /// Use this to create extra font atlases, if you want to create and dispose fonts without having to rebuild all
+    /// other fonts together.<br />
+    /// If <paramref name="autoRebuildMode"/> is not <see cref="FontAtlasAutoRebuildMode.OnNewFrame"/>,
+    /// the font rebuilding functions must be called manually.
+    /// </remarks>
+    IFontAtlas CreateFontAtlas(
+        FontAtlasAutoRebuildMode autoRebuildMode,
+        bool isGlobalScaled = true,
+        string? debugName = null);
+}
+
+/// <summary>
 /// This class represents the Dalamud UI that is drawn on top of the game.
 /// It can be used to draw custom windows and overlays.
 /// </summary>
-public sealed class UiBuilder : IDisposable
+public sealed class UiBuilder : IDisposable, IUiBuilder
 {
     private readonly LocalPlugin plugin;
     private readonly Stopwatch stopwatch;
@@ -84,37 +294,22 @@ public sealed class UiBuilder : IDisposable
         }
     }
 
-    /// <summary>
-    /// The event that gets called when Dalamud is ready to draw your windows or overlays.
-    /// When it is called, you can use static ImGui calls.
-    /// </summary>
+    /// <inheritdoc/>
     public event Action? Draw;
 
-    /// <summary>
-    /// The event that is called when the game's DirectX device is requesting you to resize your buffers.
-    /// </summary>
+    /// <inheritdoc/>
     public event Action? ResizeBuffers;
 
-    /// <summary>
-    /// Event that is fired when the plugin should open its configuration interface.
-    /// </summary>
+    /// <inheritdoc/>
     public event Action? OpenConfigUi;
 
-    /// <summary>
-    /// Event that is fired when the plugin should open its main interface.
-    /// </summary>
+    /// <inheritdoc/>
     public event Action? OpenMainUi;
 
-    /// <summary>
-    /// Gets or sets an action that is called when plugin UI or interface modifications are supposed to be shown.
-    /// These may be fired consecutively.
-    /// </summary>
+    /// <inheritdoc/>
     public event Action? ShowUi;
 
-    /// <summary>
-    /// Gets or sets an action that is called when plugin UI or interface modifications are supposed to be hidden.
-    /// These may be fired consecutively.
-    /// </summary>
+    /// <inheritdoc/>
     public event Action? HideUi;
 
     /// <summary>

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -32,7 +32,7 @@ namespace Dalamud.Plugin;
 /// <summary>
 /// This class acts as an interface to various objects needed to interact with Dalamud and the game.
 /// </summary>
-public sealed class DalamudPluginInterface : IDisposable
+public sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposable
 {
     private readonly LocalPlugin plugin;
     private readonly PluginConfigurations configs;
@@ -81,28 +81,16 @@ public sealed class DalamudPluginInterface : IDisposable
         configuration.DalamudConfigurationSaved += this.OnDalamudConfigurationSaved;
     }
 
-    /// <summary>
-    /// Delegate for localization change with two-letter iso lang code.
-    /// </summary>
-    /// <param name="langCode">The new language code.</param>
-    public delegate void LanguageChangedDelegate(string langCode);
-
-    /// <summary>
-    /// Delegate for events that listen to changes to the list of active plugins.
-    /// </summary>
-    /// <param name="kind">What action caused this event to be fired.</param>
-    /// <param name="affectedThisPlugin">If this plugin was affected by the change.</param>
-    public delegate void ActivePluginsChangedDelegate(PluginListInvalidationKind kind, bool affectedThisPlugin);
 
     /// <summary>
     /// Event that gets fired when loc is changed
     /// </summary>
-    public event LanguageChangedDelegate LanguageChanged;
+    public event IDalamudPluginInterface.LanguageChangedDelegate? LanguageChanged;
 
     /// <summary>
     /// Event that is fired when the active list of plugins is changed.
     /// </summary>
-    public event ActivePluginsChangedDelegate ActivePluginsChanged;
+    public event IDalamudPluginInterface.ActivePluginsChangedDelegate? ActivePluginsChanged;
 
     /// <summary>
     /// Gets the reason this plugin was loaded.
@@ -505,21 +493,9 @@ public sealed class DalamudPluginInterface : IDisposable
 
     #endregion
 
-    /// <inheritdoc cref="Dispose"/>
-    void IDisposable.Dispose()
-    {
-    }
-
-    /// <summary>This function will do nothing. Dalamud will dispose this object on plugin unload.</summary>
-    [Obsolete("This function will do nothing. Dalamud will dispose this object on plugin unload.", true)]
-    public void Dispose()
-    {
-        // ignored
-    }
-
     /// <summary>Unregister the plugin and dispose all references.</summary>
     /// <remarks>Dalamud internal use only.</remarks>
-    internal void DisposeInternal()
+    public void Dispose()
     {
         Service<ChatGui>.Get().RemoveChatLinkHandler(this.plugin.InternalName);
         Service<Localization>.Get().LocalizationChanged -= this.OnLocalizationChanged;

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -36,6 +36,7 @@ public sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposabl
 {
     private readonly LocalPlugin plugin;
     private readonly PluginConfigurations configs;
+    private readonly UiBuilder uiBuilder;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DalamudPluginInterface"/> class.
@@ -52,7 +53,7 @@ public sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposabl
         var dataManager = Service<DataManager>.Get();
         var localization = Service<Localization>.Get();
 
-        this.UiBuilder = new(plugin, plugin.Name);
+        this.UiBuilder = this.uiBuilder = new(plugin, plugin.Name);
 
         this.configs = Service<PluginManager>.Get().PluginConfigs;
         this.Reason = reason;
@@ -80,7 +81,6 @@ public sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposabl
         localization.LocalizationChanged += this.OnLocalizationChanged;
         configuration.DalamudConfigurationSaved += this.OnDalamudConfigurationSaved;
     }
-
 
     /// <summary>
     /// Event that gets fired when loc is changed
@@ -172,7 +172,7 @@ public sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposabl
     /// <summary>
     /// Gets the <see cref="UiBuilder"/> instance which allows you to draw UI into the game via ImGui draw calls.
     /// </summary>
-    public UiBuilder UiBuilder { get; private set; }
+    public IUiBuilder UiBuilder { get; private set; }
 
     /// <summary>
     /// Gets a value indicating whether Dalamud is running in Debug mode or the /xldev menu is open. This can occur on release builds.
@@ -203,6 +203,11 @@ public sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposabl
     /// Gets a list of installed plugins along with their current state.
     /// </summary>
     public IEnumerable<InstalledPluginState> InstalledPlugins => Service<PluginManager>.Get().InstalledPlugins.Select(p => new InstalledPluginState(p.Name, p.Manifest.InternalName, p.IsLoaded, p.EffectiveVersion));
+
+    /// <summary>
+    /// Gets the <see cref="UiBuilder"/> internal implementation.
+    /// </summary>
+    internal UiBuilder LocalUiBuilder => this.uiBuilder;
 
     /// <summary>
     /// Opens the <see cref="PluginInstallerWindow"/> with the plugin name set as search target.
@@ -500,7 +505,7 @@ public sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposabl
         Service<ChatGui>.Get().RemoveChatLinkHandler(this.plugin.InternalName);
         Service<Localization>.Get().LocalizationChanged -= this.OnLocalizationChanged;
         Service<DalamudConfiguration>.Get().DalamudConfigurationSaved -= this.OnDalamudConfigurationSaved;
-        this.UiBuilder.DisposeInternal();
+        this.uiBuilder.DisposeInternal();
     }
 
     /// <summary>

--- a/Dalamud/Plugin/IDalamudPluginInterface.cs
+++ b/Dalamud/Plugin/IDalamudPluginInterface.cs
@@ -17,6 +17,9 @@ using Dalamud.Plugin.Ipc.Internal;
 
 namespace Dalamud.Plugin;
 
+/// <summary>
+/// This interface acts as an interface to various objects needed to interact with Dalamud and the game.
+/// </summary>
 public interface IDalamudPluginInterface
 {
     /// <summary>
@@ -122,7 +125,7 @@ public interface IDalamudPluginInterface
     /// <summary>
     /// Gets the <see cref="UiBuilder"/> instance which allows you to draw UI into the game via ImGui draw calls.
     /// </summary>
-    UiBuilder UiBuilder { get; }
+    IUiBuilder UiBuilder { get; }
 
     /// <summary>
     /// Gets a value indicating whether Dalamud is running in Debug mode or the /xldev menu is open. This can occur on release builds.

--- a/Dalamud/Plugin/IDalamudPluginInterface.cs
+++ b/Dalamud/Plugin/IDalamudPluginInterface.cs
@@ -1,0 +1,320 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+using Dalamud.Configuration;
+using Dalamud.Game.Text;
+using Dalamud.Game.Text.Sanitizer;
+using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Game.Text.SeStringHandling.Payloads;
+using Dalamud.Interface;
+using Dalamud.Interface.Internal.Windows.PluginInstaller;
+using Dalamud.Interface.Internal.Windows.Settings;
+using Dalamud.Plugin.Internal.Types.Manifest;
+using Dalamud.Plugin.Ipc;
+using Dalamud.Plugin.Ipc.Exceptions;
+using Dalamud.Plugin.Ipc.Internal;
+
+namespace Dalamud.Plugin;
+
+public interface IDalamudPluginInterface
+{
+    /// <summary>
+    /// Delegate for localization change with two-letter iso lang code.
+    /// </summary>
+    /// <param name="langCode">The new language code.</param>
+    public delegate void LanguageChangedDelegate(string langCode);
+
+    /// <summary>
+    /// Delegate for events that listen to changes to the list of active plugins.
+    /// </summary>
+    /// <param name="kind">What action caused this event to be fired.</param>
+    /// <param name="affectedThisPlugin">If this plugin was affected by the change.</param>
+    public delegate void ActivePluginsChangedDelegate(PluginListInvalidationKind kind, bool affectedThisPlugin);
+    
+    /// <summary>
+    /// Event that gets fired when loc is changed
+    /// </summary>
+    event LanguageChangedDelegate LanguageChanged;
+
+    /// <summary>
+    /// Event that is fired when the active list of plugins is changed.
+    /// </summary>
+    event ActivePluginsChangedDelegate ActivePluginsChanged;
+
+    /// <summary>
+    /// Gets the reason this plugin was loaded.
+    /// </summary>
+    PluginLoadReason Reason { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether or not auto-updates have already completed this session.
+    /// </summary>
+    bool IsAutoUpdateComplete { get; }
+
+    /// <summary>
+    /// Gets the repository from which this plugin was installed.
+    ///
+    /// If a plugin was installed from the official/main repository, this will return the value of
+    /// <see cref="SpecialPluginSource.MainRepo"/>. Developer plugins will return the value of
+    /// <see cref="SpecialPluginSource.DevPlugin"/>.
+    /// </summary>
+    string SourceRepository { get; }
+
+    /// <summary>
+    /// Gets the current internal plugin name.
+    /// </summary>
+    string InternalName { get; }
+
+    /// <summary>
+    /// Gets the plugin's manifest.
+    /// </summary>
+    IPluginManifest Manifest { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this is a dev plugin.
+    /// </summary>
+    bool IsDev { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this is a testing release of a plugin.
+    /// </summary>
+    /// <remarks>
+    /// Dev plugins have undefined behavior for this value, but can be expected to return <c>false</c>.
+    /// </remarks>
+    bool IsTesting { get; }
+
+    /// <summary>
+    /// Gets the time that this plugin was loaded.
+    /// </summary>
+    DateTime LoadTime { get; }
+
+    /// <summary>
+    /// Gets the UTC time that this plugin was loaded.
+    /// </summary>
+    DateTime LoadTimeUTC { get; }
+
+    /// <summary>
+    /// Gets the timespan delta from when this plugin was loaded.
+    /// </summary>
+    TimeSpan LoadTimeDelta { get; }
+
+    /// <summary>
+    /// Gets the directory Dalamud assets are stored in.
+    /// </summary>
+    DirectoryInfo DalamudAssetDirectory { get; }
+
+    /// <summary>
+    /// Gets the location of your plugin assembly.
+    /// </summary>
+    FileInfo AssemblyLocation { get; }
+
+    /// <summary>
+    /// Gets the directory your plugin configurations are stored in.
+    /// </summary>
+    DirectoryInfo ConfigDirectory { get; }
+
+    /// <summary>
+    /// Gets the config file of your plugin.
+    /// </summary>
+    FileInfo ConfigFile { get; }
+
+    /// <summary>
+    /// Gets the <see cref="UiBuilder"/> instance which allows you to draw UI into the game via ImGui draw calls.
+    /// </summary>
+    UiBuilder UiBuilder { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether Dalamud is running in Debug mode or the /xldev menu is open. This can occur on release builds.
+    /// </summary>
+    bool IsDevMenuOpen { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether a debugger is attached.
+    /// </summary>
+    bool IsDebugging { get; }
+
+    /// <summary>
+    /// Gets the current UI language in two-letter iso format.
+    /// </summary>
+    string UiLanguage { get; }
+
+    /// <summary>
+    /// Gets serializer class with functions to remove special characters from strings.
+    /// </summary>
+    ISanitizer Sanitizer { get; }
+
+    /// <summary>
+    /// Gets the chat type used by default for plugin messages.
+    /// </summary>
+    XivChatType GeneralChatType { get; }
+
+    /// <summary>
+    /// Gets a list of installed plugins along with their current state.
+    /// </summary>
+    IEnumerable<InstalledPluginState> InstalledPlugins { get; }
+
+    /// <summary>
+    /// Opens the <see cref="PluginInstallerWindow"/> with the plugin name set as search target.
+    /// </summary>
+    /// <returns>Returns false if the DalamudInterface was null.</returns>
+    bool OpenPluginInstaller();
+
+    /// <summary>
+    /// Opens the <see cref="PluginInstallerWindow"/>, with an optional search term.
+    /// </summary>
+    /// <param name="openTo">The page to open the installer to. Defaults to the "All Plugins" page.</param>
+    /// <param name="searchText">An optional search text to input in the search box.</param>
+    /// <returns>Returns false if the DalamudInterface was null.</returns>
+    bool OpenPluginInstallerTo(PluginInstallerOpenKind openTo = PluginInstallerOpenKind.AllPlugins, string searchText = null);
+
+    /// <summary>
+    /// Opens the <see cref="SettingsWindow"/>, with an optional search term.
+    /// </summary>
+    /// <param name="openTo">The tab to open the settings to. Defaults to the "General" tab.</param>
+    /// <param name="searchText">An optional search text to input in the search box.</param>
+    /// <returns>Returns false if the DalamudInterface was null.</returns>
+    bool OpenDalamudSettingsTo(SettingsOpenKind openTo = SettingsOpenKind.General, string searchText = null);
+
+    /// <summary>
+    /// Opens the dev menu bar.
+    /// </summary>
+    /// <returns>Returns false if the DalamudInterface was null.</returns>
+    bool OpenDeveloperMenu();
+
+    /// <inheritdoc cref="DataShare.GetOrCreateData{T}"/>
+    T GetOrCreateData<T>(string tag, Func<T> dataGenerator) where T : class;
+
+    /// <inheritdoc cref="DataShare.RelinquishData"/>
+    void RelinquishData(string tag);
+
+    /// <inheritdoc cref="DataShare.TryGetData{T}"/>
+    bool TryGetData<T>(string tag, [NotNullWhen(true)] out T? data) where T : class;
+
+    /// <inheritdoc cref="DataShare.GetData{T}"/>
+    T? GetData<T>(string tag) where T : class;
+
+    /// <summary>
+    /// Gets an IPC provider.
+    /// </summary>
+    /// <typeparam name="TRet">The return type for funcs. Use object if this is unused.</typeparam>
+    /// <param name="name">The name of the IPC registration.</param>
+    /// <returns>An IPC provider.</returns>
+    /// <exception cref="IpcTypeMismatchError">This is thrown when the requested types do not match the previously registered types are different.</exception>
+    ICallGateProvider<TRet> GetIpcProvider<TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateProvider{TRet}"/>
+    ICallGateProvider<T1, TRet> GetIpcProvider<T1, TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateProvider{TRet}"/>
+    ICallGateProvider<T1, T2, TRet> GetIpcProvider<T1, T2, TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateProvider{TRet}"/>
+    ICallGateProvider<T1, T2, T3, TRet> GetIpcProvider<T1, T2, T3, TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateProvider{TRet}"/>
+    ICallGateProvider<T1, T2, T3, T4, TRet> GetIpcProvider<T1, T2, T3, T4, TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateProvider{TRet}"/>
+    ICallGateProvider<T1, T2, T3, T4, T5, TRet> GetIpcProvider<T1, T2, T3, T4, T5, TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateProvider{TRet}"/>
+    ICallGateProvider<T1, T2, T3, T4, T5, T6, TRet> GetIpcProvider<T1, T2, T3, T4, T5, T6, TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateProvider{TRet}"/>
+    ICallGateProvider<T1, T2, T3, T4, T5, T6, T7, TRet> GetIpcProvider<T1, T2, T3, T4, T5, T6, T7, TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateProvider{TRet}"/>
+    ICallGateProvider<T1, T2, T3, T4, T5, T6, T7, T8, TRet> GetIpcProvider<T1, T2, T3, T4, T5, T6, T7, T8, TRet>(string name);
+
+    /// <summary>
+    /// Gets an IPC subscriber.
+    /// </summary>
+    /// <typeparam name="TRet">The return type for funcs. Use object if this is unused.</typeparam>
+    /// <param name="name">The name of the IPC registration.</param>
+    /// <returns>An IPC subscriber.</returns>
+    ICallGateSubscriber<TRet> GetIpcSubscriber<TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateSubscriber{TRet}"/>
+    ICallGateSubscriber<T1, TRet> GetIpcSubscriber<T1, TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateSubscriber{TRet}"/>
+    ICallGateSubscriber<T1, T2, TRet> GetIpcSubscriber<T1, T2, TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateSubscriber{TRet}"/>
+    ICallGateSubscriber<T1, T2, T3, TRet> GetIpcSubscriber<T1, T2, T3, TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateSubscriber{TRet}"/>
+    ICallGateSubscriber<T1, T2, T3, T4, TRet> GetIpcSubscriber<T1, T2, T3, T4, TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateSubscriber{TRet}"/>
+    ICallGateSubscriber<T1, T2, T3, T4, T5, TRet> GetIpcSubscriber<T1, T2, T3, T4, T5, TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateSubscriber{TRet}"/>
+    ICallGateSubscriber<T1, T2, T3, T4, T5, T6, TRet> GetIpcSubscriber<T1, T2, T3, T4, T5, T6, TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateSubscriber{TRet}"/>
+    ICallGateSubscriber<T1, T2, T3, T4, T5, T6, T7, TRet> GetIpcSubscriber<T1, T2, T3, T4, T5, T6, T7, TRet>(string name);
+
+    /// <inheritdoc cref="ICallGateSubscriber{TRet}"/>
+    ICallGateSubscriber<T1, T2, T3, T4, T5, T6, T7, T8, TRet> GetIpcSubscriber<T1, T2, T3, T4, T5, T6, T7, T8, TRet>(string name);
+
+    /// <summary>
+    /// Save a plugin configuration(inheriting IPluginConfiguration).
+    /// </summary>
+    /// <param name="currentConfig">The current configuration.</param>
+    void SavePluginConfig(IPluginConfiguration? currentConfig);
+
+    /// <summary>
+    /// Get a previously saved plugin configuration or null if none was saved before.
+    /// </summary>
+    /// <returns>A previously saved config or null if none was saved before.</returns>
+    IPluginConfiguration? GetPluginConfig();
+
+    /// <summary>
+    /// Get the config directory.
+    /// </summary>
+    /// <returns>directory with path of AppData/XIVLauncher/pluginConfig/PluginInternalName.</returns>
+    string GetPluginConfigDirectory();
+
+    /// <summary>
+    /// Get the loc directory.
+    /// </summary>
+    /// <returns>directory with path of AppData/XIVLauncher/pluginConfig/PluginInternalName/loc.</returns>
+    string GetPluginLocDirectory();
+
+    /// <summary>
+    /// Register a chat link handler.
+    /// </summary>
+    /// <param name="commandId">The ID of the command.</param>
+    /// <param name="commandAction">The action to be executed.</param>
+    /// <returns>Returns an SeString payload for the link.</returns>
+    DalamudLinkPayload AddChatLinkHandler(uint commandId, Action<uint, SeString> commandAction);
+
+    /// <summary>
+    /// Remove a chat link handler.
+    /// </summary>
+    /// <param name="commandId">The ID of the command.</param>
+    void RemoveChatLinkHandler(uint commandId);
+
+    /// <summary>
+    /// Removes all chat link handlers registered by the plugin.
+    /// </summary>
+    void RemoveChatLinkHandler();
+
+    /// <summary>
+    /// Create a new object of the provided type using its default constructor, then inject objects and properties.
+    /// </summary>
+    /// <param name="scopedObjects">Objects to inject additionally.</param>
+    /// <typeparam name="T">The type to create.</typeparam>
+    /// <returns>The created and initialized type.</returns>
+    T? Create<T>(params object[] scopedObjects) where T : class;
+
+    /// <summary>
+    /// Inject services into properties on the provided object instance.
+    /// </summary>
+    /// <param name="instance">The instance to inject services into.</param>
+    /// <param name="scopedObjects">Objects to inject additionally.</param>
+    /// <returns>Whether or not the injection succeeded.</returns>
+    bool Inject(object instance, params object[] scopedObjects);
+}

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -158,6 +158,8 @@ internal class PluginManager : IInternalDisposableService
     /// </summary>
     public event Action? OnAvailablePluginsChanged;
 
+    public event IDalamudPluginInterface.ActivePluginsChangedDelegate? ActivePluginsChanged;
+
     /// <summary>
     /// Gets the current Dalamud API level, used to handle breaking changes. Only plugins with this level will be loaded.
     /// As of Dalamud 9.x, this always matches the major version number of Dalamud.

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -158,8 +158,6 @@ internal class PluginManager : IInternalDisposableService
     /// </summary>
     public event Action? OnAvailablePluginsChanged;
 
-    public event IDalamudPluginInterface.ActivePluginsChangedDelegate? ActivePluginsChanged;
-
     /// <summary>
     /// Gets the current Dalamud API level, used to handle breaking changes. Only plugins with this level will be loaded.
     /// As of Dalamud 9.x, this always matches the major version number of Dalamud.

--- a/Dalamud/Plugin/Internal/PluginValidator.cs
+++ b/Dalamud/Plugin/Internal/PluginValidator.cs
@@ -64,10 +64,10 @@ internal static class PluginValidator
         if (!plugin.IsLoaded)
             throw new InvalidOperationException("Plugin must be loaded to validate.");
         
-        if (!plugin.DalamudInterface!.UiBuilder.HasConfigUi)
+        if (!plugin.DalamudInterface!.LocalUiBuilder.HasConfigUi)
             problems.Add(new NoConfigUiProblem());
         
-        if (!plugin.DalamudInterface.UiBuilder.HasMainUi)
+        if (!plugin.DalamudInterface.LocalUiBuilder.HasMainUi)
             problems.Add(new NoMainUiProblem());
 
         var cmdManager = Service<CommandManager>.Get();

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Dalamud.Configuration.Internal;
 using Dalamud.Game;
+using Dalamud.Game.Gui;
 using Dalamud.Game.Gui.Dtr;
 using Dalamud.Interface.Internal;
 using Dalamud.IoC.Internal;
@@ -242,7 +243,8 @@ internal class LocalPlugin : IDisposable
             this.instance = null;
         }
 
-        this.DalamudInterface?.DisposeInternal();
+        this.DalamudInterface?.Dispose();
+
         this.DalamudInterface = null;
 
         this.ServiceScope?.Dispose();
@@ -437,7 +439,7 @@ internal class LocalPlugin : IDisposable
             {
                 this.State = PluginState.LoadError;
                 this.UnloadAndDisposeState();
-                
+
                 Log.Error(
                     "Error while loading {PluginName}, failed to bind and call the plugin constructor", this.InternalName);
                 return;
@@ -690,13 +692,13 @@ internal class LocalPlugin : IDisposable
             throw new InvalidPluginException(this.DllFile);
         }
     }
-    
+
     private void UnloadAndDisposeState()
     {
         if (this.instance != null)
             throw new InvalidOperationException("Plugin instance should be disposed at this point");
-        
-        this.DalamudInterface?.DisposeInternal();
+
+        this.DalamudInterface?.Dispose();
         this.DalamudInterface = null;
 
         this.ServiceScope?.Dispose();


### PR DESCRIPTION
- Moves LanguageChangedDelegate and ActivePluginsChangedDelegate into the interface which will break plugins relying on them
- Adds a IDisposable but only on DalamudPluginInterface, called by LocalPlugin do unregister the events
