### PR TITLE
IGameInteropProvider Additional Overloads

### DIFF
--- a/Dalamud/Hooking/Internal/GameInteropProviderPluginScoped.cs
+++ b/Dalamud/Hooking/Internal/GameInteropProviderPluginScoped.cs
@@ -47,7 +47,7 @@ internal class GameInteropProviderPluginScoped : IGameInteropProvider, IInternal
     }
 
     /// <inheritdoc/>
-    public Hook<T> HookFromFunctionPointerVariable<T>(IntPtr address, T detour) where T : Delegate
+    public Hook<T> HookFromFunctionPointerVariable<T>(nint address, T detour) where T : Delegate
     {
         var hook = Hook<T>.FromFunctionPointerVariable(address, detour);
         this.trackedHooks.Add(hook);
@@ -71,12 +71,20 @@ internal class GameInteropProviderPluginScoped : IGameInteropProvider, IInternal
     }
 
     /// <inheritdoc/>
-    public Hook<T> HookFromAddress<T>(IntPtr procAddress, T detour, IGameInteropProvider.HookBackend backend = IGameInteropProvider.HookBackend.Automatic) where T : Delegate
+    public Hook<T> HookFromAddress<T>(nint procAddress, T detour, IGameInteropProvider.HookBackend backend = IGameInteropProvider.HookBackend.Automatic) where T : Delegate
     {
         var hook = Hook<T>.FromAddress(procAddress, detour, backend == IGameInteropProvider.HookBackend.MinHook);
         this.trackedHooks.Add(hook);
         return hook;
     }
+
+    /// <inheritdoc/>
+    public Hook<T> HookFromAddress<T>(UIntPtr procAddress, T detour, IGameInteropProvider.HookBackend backend = IGameInteropProvider.HookBackend.Automatic) where T : Delegate
+        => this.HookFromAddress((nint)procAddress, detour, backend);
+
+    /// <inheritdoc/>
+    public unsafe Hook<T> HookFromAddress<T>(void* procAddress, T detour, IGameInteropProvider.HookBackend backend = IGameInteropProvider.HookBackend.Automatic) where T : Delegate
+        => this.HookFromAddress((nint)procAddress, detour, backend);
 
     /// <inheritdoc/>
     public Hook<T> HookFromSignature<T>(string signature, T detour, IGameInteropProvider.HookBackend backend = IGameInteropProvider.HookBackend.Automatic) where T : Delegate

--- a/Dalamud/Plugin/Services/IGameInteropProvider.cs
+++ b/Dalamud/Plugin/Services/IGameInteropProvider.cs
@@ -48,7 +48,7 @@ public interface IGameInteropProvider
     /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
     /// <returns>The hook with the supplied parameters.</returns>
     /// <typeparam name="T">Delegate of detour.</typeparam>
-    public Hook<T> HookFromFunctionPointerVariable<T>(IntPtr address, T detour) where T : Delegate;
+    public Hook<T> HookFromFunctionPointerVariable<T>(nint address, T detour) where T : Delegate;
     
     /// <summary>
     /// Creates a hook by rewriting import table address.
@@ -85,7 +85,31 @@ public interface IGameInteropProvider
     /// <param name="backend">Hooking library to use.</param>
     /// <returns>The hook with the supplied parameters.</returns>
     /// <typeparam name="T">Delegate of detour.</typeparam>
-    Hook<T> HookFromAddress<T>(IntPtr procAddress, T detour, HookBackend backend = HookBackend.Automatic) where T : Delegate;
+    Hook<T> HookFromAddress<T>(nint procAddress, T detour, HookBackend backend = HookBackend.Automatic) where T : Delegate;
+    
+    /// <summary>
+    /// Creates a hook. Hooking address is inferred by calling to GetProcAddress() function.
+    /// The hook is not activated until Enable() method is called.
+    /// Please do not use MinHook unless you have thoroughly troubleshot why Reloaded does not work.
+    /// </summary>
+    /// <param name="procAddress">A memory address to install a hook.</param>
+    /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
+    /// <param name="backend">Hooking library to use.</param>
+    /// <returns>The hook with the supplied parameters.</returns>
+    /// <typeparam name="T">Delegate of detour.</typeparam>
+    Hook<T> HookFromAddress<T>(nuint procAddress, T detour, HookBackend backend = HookBackend.Automatic) where T : Delegate;
+    
+    /// <summary>
+    /// Creates a hook. Hooking address is inferred by calling to GetProcAddress() function.
+    /// The hook is not activated until Enable() method is called.
+    /// Please do not use MinHook unless you have thoroughly troubleshot why Reloaded does not work.
+    /// </summary>
+    /// <param name="procAddress">A memory address to install a hook.</param>
+    /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
+    /// <param name="backend">Hooking library to use.</param>
+    /// <returns>The hook with the supplied parameters.</returns>
+    /// <typeparam name="T">Delegate of detour.</typeparam>
+    unsafe Hook<T> HookFromAddress<T>(void* procAddress, T detour, HookBackend backend = HookBackend.Automatic) where T : Delegate;
     
     /// <summary>
     /// Creates a hook from a signature into the Dalamud target module.


### PR DESCRIPTION
Also uses `nint` instead of `IntPtr`

These overloads make it easier to use these functions without requiring the user to cast to `nint` every call manually.