### PR TITLE
Add MarketBoard service and associated interfaces, test and data widget

### DIFF
--- a/Dalamud/Game/Marketboard/MarketBoard.cs
+++ b/Dalamud/Game/Marketboard/MarketBoard.cs
@@ -8,7 +8,7 @@ using Network.Internal;
 using Network.Structures;
 
 /// <summary>
-/// This class represents the state of the currently occupied duty.
+/// This class provides access to market board events
 /// </summary>
 [InterfaceVersion("1.0")]
 [ServiceManager.EarlyLoadedService]

--- a/Dalamud/Game/Marketboard/MarketBoard.cs
+++ b/Dalamud/Game/Marketboard/MarketBoard.cs
@@ -31,48 +31,53 @@ internal class MarketBoard : IInternalDisposableService, IMarketBoard
     }
 
     /// <inheritdoc/>
-    public event IMarketBoard.MarketBoardHistoryReceivedDelegate? MarketBoardHistoryReceived;
+    public event IMarketBoard.HistoryReceivedDelegate? HistoryReceived;
 
     /// <inheritdoc/>
-    public event IMarketBoard.MarketBoardItemPurchasedDelegate? MarketBoardItemPurchased;
+    public event IMarketBoard.ItemPurchasedDelegate? ItemPurchased;
 
     /// <inheritdoc/>
-    public event IMarketBoard.MarketBoardOfferingsReceivedDelegate? MarketBoardOfferingsReceived;
+    public event IMarketBoard.OfferingsReceivedDelegate? OfferingsReceived;
 
     /// <inheritdoc/>
-    public event IMarketBoard.MarketBoardPurchaseRequestedDelegate? MarketBoardPurchaseRequested;
+    public event IMarketBoard.PurchaseRequestedDelegate? PurchaseRequested;
 
     /// <inheritdoc/>
-    public event IMarketBoard.MarketTaxRatesReceivedDelegate? MarketTaxRatesReceived;
+    public event IMarketBoard.TaxRatesReceivedDelegate? TaxRatesReceived;
 
     /// <inheritdoc/>
     public void DisposeService()
     {
+        this.HistoryReceived = null;
+        this.ItemPurchased = null;
+        this.OfferingsReceived = null;
+        this.PurchaseRequested = null;
+        this.TaxRatesReceived = null;
     }
 
     private void OnMbHistory(MarketBoardHistory marketBoardHistory)
     {
-        this.MarketBoardHistoryReceived?.Invoke(marketBoardHistory);
+        this.HistoryReceived?.Invoke(marketBoardHistory);
     }
 
     private void OnPurchase(MarketBoardPurchase marketBoardHistory)
     {
-        this.MarketBoardItemPurchased?.Invoke(marketBoardHistory);
+        this.ItemPurchased?.Invoke(marketBoardHistory);
     }
 
     private void OnOfferings(MarketBoardCurrentOfferings currentOfferings)
     {
-        this.MarketBoardOfferingsReceived?.Invoke(currentOfferings);
+        this.OfferingsReceived?.Invoke(currentOfferings);
     }
 
     private void OnPurchaseSent(MarketBoardPurchaseHandler purchaseHandler)
     {
-        this.MarketBoardPurchaseRequested?.Invoke(purchaseHandler);
+        this.PurchaseRequested?.Invoke(purchaseHandler);
     }
 
     private void OnTaxRates(MarketTaxRates taxRates)
     {
-        this.MarketTaxRatesReceived?.Invoke(taxRates);
+        this.TaxRatesReceived?.Invoke(taxRates);
     }
 }
 
@@ -95,60 +100,60 @@ internal class MarketBoardPluginScoped : IInternalDisposableService, IMarketBoar
     /// </summary>
     internal MarketBoardPluginScoped()
     {
-        this.marketBoardService.MarketBoardHistoryReceived += this.OnMarketBoardHistoryReceived;
-        this.marketBoardService.MarketBoardItemPurchased += this.OnMarketBoardItemPurchased;
-        this.marketBoardService.MarketBoardOfferingsReceived += this.OnMarketBoardOfferingsReceived;
-        this.marketBoardService.MarketBoardPurchaseRequested += this.OnMarketBoardPurchaseRequested;
-        this.marketBoardService.MarketTaxRatesReceived += this.OnMarketTaxRatesReceived;
+        this.marketBoardService.HistoryReceived += this.OnHistoryReceived;
+        this.marketBoardService.ItemPurchased += this.OnItemPurchased;
+        this.marketBoardService.OfferingsReceived += this.OnOfferingsReceived;
+        this.marketBoardService.PurchaseRequested += this.OnPurchaseRequested;
+        this.marketBoardService.TaxRatesReceived += this.OnTaxRatesReceived;
     }
 
     /// <inheritdoc/>
-    public event IMarketBoard.MarketBoardHistoryReceivedDelegate? MarketBoardHistoryReceived;
+    public event IMarketBoard.HistoryReceivedDelegate? HistoryReceived;
 
     /// <inheritdoc/>
-    public event IMarketBoard.MarketBoardItemPurchasedDelegate? MarketBoardItemPurchased;
+    public event IMarketBoard.ItemPurchasedDelegate? ItemPurchased;
 
     /// <inheritdoc/>
-    public event IMarketBoard.MarketBoardOfferingsReceivedDelegate? MarketBoardOfferingsReceived;
+    public event IMarketBoard.OfferingsReceivedDelegate? OfferingsReceived;
 
     /// <inheritdoc/>
-    public event IMarketBoard.MarketBoardPurchaseRequestedDelegate? MarketBoardPurchaseRequested;
+    public event IMarketBoard.PurchaseRequestedDelegate? PurchaseRequested;
 
     /// <inheritdoc/>
-    public event IMarketBoard.MarketTaxRatesReceivedDelegate? MarketTaxRatesReceived;
+    public event IMarketBoard.TaxRatesReceivedDelegate? TaxRatesReceived;
 
     /// <inheritdoc/>
     void IInternalDisposableService.DisposeService()
     {
-        this.marketBoardService.MarketBoardHistoryReceived -= this.OnMarketBoardHistoryReceived;
-        this.marketBoardService.MarketBoardItemPurchased -= this.OnMarketBoardItemPurchased;
-        this.marketBoardService.MarketBoardOfferingsReceived -= this.OnMarketBoardOfferingsReceived;
-        this.marketBoardService.MarketBoardPurchaseRequested -= this.OnMarketBoardPurchaseRequested;
-        this.marketBoardService.MarketTaxRatesReceived -= this.OnMarketTaxRatesReceived;
+        this.marketBoardService.HistoryReceived -= this.OnHistoryReceived;
+        this.marketBoardService.ItemPurchased -= this.OnItemPurchased;
+        this.marketBoardService.OfferingsReceived -= this.OnOfferingsReceived;
+        this.marketBoardService.PurchaseRequested -= this.OnPurchaseRequested;
+        this.marketBoardService.TaxRatesReceived -= this.OnTaxRatesReceived;
     }
 
-    private void OnMarketBoardHistoryReceived(IMarketBoardHistory marketBoardHistory)
+    private void OnHistoryReceived(IMarketBoardHistory history)
     {
-        this.MarketBoardHistoryReceived?.Invoke(marketBoardHistory);
+        this.HistoryReceived?.Invoke(history);
     }
 
-    private void OnMarketBoardItemPurchased(IMarketBoardPurchase marketBoardPurchase)
+    private void OnItemPurchased(IMarketBoardPurchase purchase)
     {
-        this.MarketBoardItemPurchased?.Invoke(marketBoardPurchase);
+        this.ItemPurchased?.Invoke(purchase);
     }
 
-    private void OnMarketBoardOfferingsReceived(IMarketBoardCurrentOfferings marketBoardCurrentOfferings)
+    private void OnOfferingsReceived(IMarketBoardCurrentOfferings currentOfferings)
     {
-        this.MarketBoardOfferingsReceived?.Invoke(marketBoardCurrentOfferings);
+        this.OfferingsReceived?.Invoke(currentOfferings);
     }
 
-    private void OnMarketBoardPurchaseRequested(IMarketBoardPurchaseHandler marketBoardPurchaseHandler)
+    private void OnPurchaseRequested(IMarketBoardPurchaseHandler purchaseHandler)
     {
-        this.MarketBoardPurchaseRequested?.Invoke(marketBoardPurchaseHandler);
+        this.PurchaseRequested?.Invoke(purchaseHandler);
     }
 
-    private void OnMarketTaxRatesReceived(IMarketTaxRates marketTaxRates)
+    private void OnTaxRatesReceived(IMarketTaxRates taxRates)
     {
-        this.MarketTaxRatesReceived?.Invoke(marketTaxRates);
+        this.TaxRatesReceived?.Invoke(taxRates);
     }
 }

--- a/Dalamud/Game/Marketboard/MarketBoard.cs
+++ b/Dalamud/Game/Marketboard/MarketBoard.cs
@@ -130,6 +130,12 @@ internal class MarketBoardPluginScoped : IInternalDisposableService, IMarketBoar
         this.marketBoardService.OfferingsReceived -= this.OnOfferingsReceived;
         this.marketBoardService.PurchaseRequested -= this.OnPurchaseRequested;
         this.marketBoardService.TaxRatesReceived -= this.OnTaxRatesReceived;
+
+        this.HistoryReceived = null;
+        this.ItemPurchased = null;
+        this.OfferingsReceived = null;
+        this.PurchaseRequested = null;
+        this.TaxRatesReceived = null;
     }
 
     private void OnHistoryReceived(IMarketBoardHistory history)

--- a/Dalamud/Game/Marketboard/MarketBoard.cs
+++ b/Dalamud/Game/Marketboard/MarketBoard.cs
@@ -1,0 +1,154 @@
+﻿using Dalamud.IoC;
+using Dalamud.IoC.Internal;
+using Dalamud.Plugin.Services;
+
+namespace Dalamud.Game.MarketBoard;
+
+using Network.Internal;
+using Network.Structures;
+
+/// <summary>
+/// This class represents the state of the currently occupied duty.
+/// </summary>
+[InterfaceVersion("1.0")]
+[ServiceManager.EarlyLoadedService]
+internal class MarketBoard : IInternalDisposableService, IMarketBoard
+{
+    [ServiceManager.ServiceDependency]
+    private readonly NetworkHandlers networkHandlers = Service<NetworkHandlers>.Get();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MarketBoard"/> class.
+    /// </summary>
+    [ServiceManager.ServiceConstructor]
+    public MarketBoard()
+    {
+        this.networkHandlers.MbHistoryObservable.Subscribe(this.OnMbHistory);
+        this.networkHandlers.MbPurchaseObservable.Subscribe(this.OnPurchase);
+        this.networkHandlers.MbOfferingsObservable.Subscribe(this.OnOfferings);
+        this.networkHandlers.MbPurchaseSentObservable.Subscribe(this.OnPurchaseSent);
+        this.networkHandlers.MbTaxesObservable.Subscribe(this.OnTaxRates);
+    }
+
+    /// <inheritdoc/>
+    public event IMarketBoard.MarketBoardHistoryReceivedDelegate? MarketBoardHistoryReceived;
+
+    /// <inheritdoc/>
+    public event IMarketBoard.MarketBoardItemPurchasedDelegate? MarketBoardItemPurchased;
+
+    /// <inheritdoc/>
+    public event IMarketBoard.MarketBoardOfferingsReceivedDelegate? MarketBoardOfferingsReceived;
+
+    /// <inheritdoc/>
+    public event IMarketBoard.MarketBoardPurchaseRequestedDelegate? MarketBoardPurchaseRequested;
+
+    /// <inheritdoc/>
+    public event IMarketBoard.MarketTaxRatesReceivedDelegate? MarketTaxRatesReceived;
+
+    /// <inheritdoc/>
+    public void DisposeService()
+    {
+    }
+
+    private void OnMbHistory(MarketBoardHistory marketBoardHistory)
+    {
+        this.MarketBoardHistoryReceived?.Invoke(marketBoardHistory);
+    }
+
+    private void OnPurchase(MarketBoardPurchase marketBoardHistory)
+    {
+        this.MarketBoardItemPurchased?.Invoke(marketBoardHistory);
+    }
+
+    private void OnOfferings(MarketBoardCurrentOfferings currentOfferings)
+    {
+        this.MarketBoardOfferingsReceived?.Invoke(currentOfferings);
+    }
+
+    private void OnPurchaseSent(MarketBoardPurchaseHandler purchaseHandler)
+    {
+        this.MarketBoardPurchaseRequested?.Invoke(purchaseHandler);
+    }
+
+    private void OnTaxRates(MarketTaxRates taxRates)
+    {
+        this.MarketTaxRatesReceived?.Invoke(taxRates);
+    }
+}
+
+/// <summary>
+/// Plugin scoped version of MarketBoard.
+/// </summary>
+[PluginInterface]
+[InterfaceVersion("1.0")]
+[ServiceManager.ScopedService]
+#pragma warning disable SA1015
+[ResolveVia<IMarketBoard>]
+#pragma warning restore SA1015
+internal class MarketBoardPluginScoped : IInternalDisposableService, IMarketBoard
+{
+    [ServiceManager.ServiceDependency]
+    private readonly MarketBoard marketBoardService = Service<MarketBoard>.Get();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MarketBoardPluginScoped"/> class.
+    /// </summary>
+    internal MarketBoardPluginScoped()
+    {
+        this.marketBoardService.MarketBoardHistoryReceived += this.OnMarketBoardHistoryReceived;
+        this.marketBoardService.MarketBoardItemPurchased += this.OnMarketBoardItemPurchased;
+        this.marketBoardService.MarketBoardOfferingsReceived += this.OnMarketBoardOfferingsReceived;
+        this.marketBoardService.MarketBoardPurchaseRequested += this.OnMarketBoardPurchaseRequested;
+        this.marketBoardService.MarketTaxRatesReceived += this.OnMarketTaxRatesReceived;
+    }
+
+    /// <inheritdoc/>
+    public event IMarketBoard.MarketBoardHistoryReceivedDelegate? MarketBoardHistoryReceived;
+
+    /// <inheritdoc/>
+    public event IMarketBoard.MarketBoardItemPurchasedDelegate? MarketBoardItemPurchased;
+
+    /// <inheritdoc/>
+    public event IMarketBoard.MarketBoardOfferingsReceivedDelegate? MarketBoardOfferingsReceived;
+
+    /// <inheritdoc/>
+    public event IMarketBoard.MarketBoardPurchaseRequestedDelegate? MarketBoardPurchaseRequested;
+
+    /// <inheritdoc/>
+    public event IMarketBoard.MarketTaxRatesReceivedDelegate? MarketTaxRatesReceived;
+
+    /// <inheritdoc/>
+    void IInternalDisposableService.DisposeService()
+    {
+        this.marketBoardService.MarketBoardHistoryReceived -= this.OnMarketBoardHistoryReceived;
+        this.marketBoardService.MarketBoardItemPurchased -= this.OnMarketBoardItemPurchased;
+        this.marketBoardService.MarketBoardOfferingsReceived -= this.OnMarketBoardOfferingsReceived;
+        this.marketBoardService.MarketBoardPurchaseRequested -= this.OnMarketBoardPurchaseRequested;
+        this.marketBoardService.MarketTaxRatesReceived -= this.OnMarketTaxRatesReceived;
+    }
+
+    private void OnMarketBoardHistoryReceived(IMarketBoardHistory marketBoardHistory)
+    {
+        this.MarketBoardHistoryReceived?.Invoke(marketBoardHistory);
+    }
+
+    private void OnMarketBoardItemPurchased(IMarketBoardPurchase marketBoardPurchase)
+    {
+        this.MarketBoardItemPurchased?.Invoke(marketBoardPurchase);
+    }
+
+    private void OnMarketBoardOfferingsReceived(IMarketBoardCurrentOfferings marketBoardCurrentOfferings)
+    {
+        this.MarketBoardOfferingsReceived?.Invoke(marketBoardCurrentOfferings);
+    }
+
+    private void OnMarketBoardPurchaseRequested(IMarketBoardPurchaseHandler marketBoardPurchaseHandler)
+    {
+        this.MarketBoardPurchaseRequested?.Invoke(marketBoardPurchaseHandler);
+    }
+
+    private void OnMarketTaxRatesReceived(IMarketTaxRates marketTaxRates)
+    {
+        this.MarketTaxRatesReceived?.Invoke(marketTaxRates);
+    }
+}

--- a/Dalamud/Game/Network/Internal/MarketBoardUploaders/MarketBoardItemRequest.cs
+++ b/Dalamud/Game/Network/Internal/MarketBoardUploaders/MarketBoardItemRequest.cs
@@ -37,12 +37,12 @@ internal class MarketBoardItemRequest
     /// <summary>
     /// Gets the offered item listings.
     /// </summary>
-    public List<MarketBoardCurrentOfferings.MarketBoardItemListing> Listings { get; } = new();
+    public List<IMarketBoardItemListing> Listings { get; } = new();
 
     /// <summary>
     /// Gets the historical item listings.
     /// </summary>
-    public List<MarketBoardHistory.MarketBoardHistoryListing> History { get; } = new();
+    public List<IMarketBoardHistoryListing> History { get; } = new();
 
     /// <summary>
     /// Gets or sets the listing request ID.

--- a/Dalamud/Game/Network/Internal/MarketBoardUploaders/MarketBoardItemRequest.cs
+++ b/Dalamud/Game/Network/Internal/MarketBoardUploaders/MarketBoardItemRequest.cs
@@ -37,12 +37,12 @@ internal class MarketBoardItemRequest
     /// <summary>
     /// Gets the offered item listings.
     /// </summary>
-    public List<IMarketBoardItemListing> Listings { get; } = new();
+    public List<MarketBoardCurrentOfferings.MarketBoardItemListing> Listings { get; } = new();
 
     /// <summary>
     /// Gets the historical item listings.
     /// </summary>
-    public List<IMarketBoardHistoryListing> History { get; } = new();
+    public List<MarketBoardHistory.MarketBoardHistoryListing> History { get; } = new();
 
     /// <summary>
     /// Gets or sets the listing request ID.

--- a/Dalamud/Game/Network/Structures/MarketBoardCurrentOfferings.cs
+++ b/Dalamud/Game/Network/Structures/MarketBoardCurrentOfferings.cs
@@ -7,7 +7,7 @@ namespace Dalamud.Game.Network.Structures;
 /// <summary>
 /// This class represents the current market board offerings from a game network packet.
 /// </summary>
-public class MarketBoardCurrentOfferings
+public class MarketBoardCurrentOfferings : IMarketBoardCurrentOfferings
 {
     private MarketBoardCurrentOfferings()
     {
@@ -16,7 +16,7 @@ public class MarketBoardCurrentOfferings
     /// <summary>
     /// Gets the list of individual item listings.
     /// </summary>
-    public List<MarketBoardItemListing> ItemListings { get; } = new();
+    public List<IMarketBoardItemListing> ItemListings { get; } = new();
 
     /// <summary>
     /// Gets the listing end index.
@@ -105,7 +105,7 @@ public class MarketBoardCurrentOfferings
     /// <summary>
     /// This class represents the current market board offering of a single item from the <see cref="MarketBoardCurrentOfferings"/> network packet.
     /// </summary>
-    public class MarketBoardItemListing
+    public class MarketBoardItemListing : IMarketBoardItemListing
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MarketBoardItemListing"/> class.
@@ -147,7 +147,7 @@ public class MarketBoardCurrentOfferings
         /// <summary>
         /// Gets the list of materia attached to this item.
         /// </summary>
-        public List<ItemMateria> Materia { get; } = new();
+        public List<IItemMateria> Materia { get; } = new();
 
         /// <summary>
         /// Gets the amount of attached materia.
@@ -202,7 +202,7 @@ public class MarketBoardCurrentOfferings
         /// <summary>
         /// This represents the materia slotted to an <see cref="MarketBoardItemListing"/>.
         /// </summary>
-        public class ItemMateria
+        public class ItemMateria : IItemMateria
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="ItemMateria"/> class.
@@ -223,3 +223,137 @@ public class MarketBoardCurrentOfferings
         }
     }
 }
+
+/// <summary>
+/// An interface that represents the current market board offerings.
+/// </summary>
+public interface IMarketBoardCurrentOfferings
+{
+    /// <summary>
+    /// Gets the list of individual item listings.
+    /// </summary>
+    List<IMarketBoardItemListing> ItemListings { get; }
+
+    /// <summary>
+    /// Gets the listing end index.
+    /// </summary>
+    int ListingIndexEnd { get; }
+
+    /// <summary>
+    /// Gets the listing start index.
+    /// </summary>
+    int ListingIndexStart { get; }
+
+    /// <summary>
+    /// Gets the request ID.
+    /// </summary>
+    int RequestId { get; }
+}
+
+/// <summary>
+/// An interface that represents the current market board offering of a single item from the <see cref="IMarketBoardCurrentOfferings"/>.
+/// </summary>
+public interface IMarketBoardItemListing
+{
+    /// <summary>
+    /// Gets the artisan ID.
+    /// </summary>
+    ulong ArtisanId { get; }
+
+    /// <summary>
+    /// Gets the item ID.
+    /// </summary>
+    uint CatalogId { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the item is HQ.
+    /// </summary>
+    bool IsHq { get; }
+
+    /// <summary>
+    /// Gets the item quantity.
+    /// </summary>
+    uint ItemQuantity { get; }
+
+    /// <summary>
+    /// Gets the time this offering was last reviewed.
+    /// </summary>
+    DateTime LastReviewTime { get; }
+
+    /// <summary>
+    /// Gets the listing ID.
+    /// </summary>
+    ulong ListingId { get; }
+
+    /// <summary>
+    /// Gets the list of materia attached to this item.
+    /// </summary>
+    List<IItemMateria> Materia { get; }
+
+    /// <summary>
+    /// Gets the amount of attached materia.
+    /// </summary>
+    int MateriaCount { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this item is on a mannequin.
+    /// </summary>
+    bool OnMannequin { get; }
+
+    /// <summary>
+    /// Gets the player name.
+    /// </summary>
+    string PlayerName { get; }
+
+    /// <summary>
+    /// Gets the price per unit.
+    /// </summary>
+    uint PricePerUnit { get; }
+
+    /// <summary>
+    /// Gets the city ID of the retainer selling the item.
+    /// </summary>
+    int RetainerCityId { get; }
+
+    /// <summary>
+    /// Gets the ID of the retainer selling the item.
+    /// </summary>
+    ulong RetainerId { get; }
+
+    /// <summary>
+    /// Gets the name of the retainer.
+    /// </summary>
+    string RetainerName { get; }
+
+    /// <summary>
+    /// Gets the ID of the retainer's owner.
+    /// </summary>
+    ulong RetainerOwnerId { get; }
+
+    /// <summary>
+    /// Gets the stain or applied dye of the item.
+    /// </summary>
+    int StainId { get; }
+
+    /// <summary>
+    /// Gets the total tax.
+    /// </summary>
+    uint TotalTax { get; }
+}
+
+/// <summary>
+/// An interface that represents the materia slotted to an <see cref="IMarketBoardItemListing"/>.
+/// </summary>
+public interface IItemMateria
+{
+    /// <summary>
+    /// Gets the materia index.
+    /// </summary>
+    int Index { get; }
+
+    /// <summary>
+    /// Gets the materia ID.
+    /// </summary>
+    int MateriaId { get; }
+}
+

--- a/Dalamud/Game/Network/Structures/MarketBoardHistory.cs
+++ b/Dalamud/Game/Network/Structures/MarketBoardHistory.cs
@@ -7,7 +7,7 @@ namespace Dalamud.Game.Network.Structures;
 /// <summary>
 /// This class represents the market board history from a game network packet.
 /// </summary>
-public class MarketBoardHistory
+public class MarketBoardHistory : IMarketBoardHistory
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="MarketBoardHistory"/> class.
@@ -29,7 +29,7 @@ public class MarketBoardHistory
     /// <summary>
     /// Gets the list of individual item history listings.
     /// </summary>
-    public List<MarketBoardHistoryListing> HistoryListings { get; } = new();
+    public List<IMarketBoardHistoryListing> HistoryListings { get; } = new();
 
     /// <summary>
     /// Read a <see cref="MarketBoardHistory"/> object from memory.
@@ -81,7 +81,7 @@ public class MarketBoardHistory
     /// <summary>
     /// This class represents the market board history of a single item from the <see cref="MarketBoardHistory"/> network packet.
     /// </summary>
-    public class MarketBoardHistoryListing
+    public class MarketBoardHistoryListing : IMarketBoardHistoryListing
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MarketBoardHistoryListing"/> class.
@@ -125,4 +125,66 @@ public class MarketBoardHistory
         /// </summary>
         public uint SalePrice { get; internal set; }
     }
+}
+
+/// <summary>
+/// An interface that represents the market board history from the game.
+/// </summary>
+public interface IMarketBoardHistory
+{
+    /// <summary>
+    /// Gets the catalog ID.
+    /// </summary>
+    uint CatalogId { get; }
+
+    /// <summary>
+    /// Gets the second catalog ID.
+    /// </summary>
+    uint CatalogId2 { get; }
+
+    /// <summary>
+    /// Gets the list of individual item history listings.
+    /// </summary>
+    List<IMarketBoardHistoryListing> HistoryListings { get; }
+}
+
+/// <summary>
+/// An interface that represents the market board history of a single item from <see cref="IMarketBoardHistory"/>.
+/// </summary>
+public interface IMarketBoardHistoryListing
+{
+    /// <summary>
+    /// Gets the buyer's name.
+    /// </summary>
+    string BuyerName { get; }
+
+    /// <summary>
+    /// Gets the next entry's catalog ID.
+    /// </summary>
+    uint NextCatalogId { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the item is HQ.
+    /// </summary>
+    bool IsHq { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the item is on a mannequin.
+    /// </summary>
+    bool OnMannequin { get; }
+
+    /// <summary>
+    /// Gets the time of purchase.
+    /// </summary>
+    DateTime PurchaseTime { get; }
+
+    /// <summary>
+    /// Gets the quantity.
+    /// </summary>
+    uint Quantity { get; }
+
+    /// <summary>
+    /// Gets the sale price.
+    /// </summary>
+    uint SalePrice { get; }
 }

--- a/Dalamud/Game/Network/Structures/MarketBoardHistory.cs
+++ b/Dalamud/Game/Network/Structures/MarketBoardHistory.cs
@@ -26,10 +26,17 @@ public class MarketBoardHistory : IMarketBoardHistory
     /// </summary>
     public uint CatalogId2 { get; private set; }
 
+    public uint ItemId => this.CatalogId;
+
     /// <summary>
-    /// Gets the list of individual item history listings.
+    /// Gets the list of individual item listings.
     /// </summary>
-    public List<IMarketBoardHistoryListing> HistoryListings { get; } = new();
+    IReadOnlyList<IMarketBoardHistoryListing> IMarketBoardHistory.HistoryListings => this.InternalHistoryListings;
+
+    /// <summary>
+    /// Gets or sets a list of individual item listings.
+    /// </summary>
+    internal List<MarketBoardHistoryListing> InternalHistoryListings { get; set; } = new List<MarketBoardHistoryListing>();
 
     /// <summary>
     /// Read a <see cref="MarketBoardHistory"/> object from memory.
@@ -53,6 +60,7 @@ public class MarketBoardHistory : IMarketBoardHistory
             return output;
         }
 
+        var historyListings = new List<MarketBoardHistoryListing>();
         for (var i = 0; i < 20; i++)
         {
             var listingEntry = new MarketBoardHistoryListing
@@ -69,11 +77,13 @@ public class MarketBoardHistory : IMarketBoardHistory
             listingEntry.BuyerName = Encoding.UTF8.GetString(reader.ReadBytes(33)).TrimEnd('\u0000');
             listingEntry.NextCatalogId = reader.ReadUInt32();
 
-            output.HistoryListings.Add(listingEntry);
+            historyListings.Add(listingEntry);
 
             if (listingEntry.NextCatalogId == 0)
                 break;
         }
+
+        output.InternalHistoryListings = historyListings;
 
         return output;
     }
@@ -133,19 +143,14 @@ public class MarketBoardHistory : IMarketBoardHistory
 public interface IMarketBoardHistory
 {
     /// <summary>
-    /// Gets the catalog ID.
+    /// Gets the item ID.
     /// </summary>
-    uint CatalogId { get; }
-
-    /// <summary>
-    /// Gets the second catalog ID.
-    /// </summary>
-    uint CatalogId2 { get; }
+    uint ItemId { get; }
 
     /// <summary>
     /// Gets the list of individual item history listings.
     /// </summary>
-    List<IMarketBoardHistoryListing> HistoryListings { get; }
+    IReadOnlyList<IMarketBoardHistoryListing> HistoryListings { get; }
 }
 
 /// <summary>
@@ -157,11 +162,6 @@ public interface IMarketBoardHistoryListing
     /// Gets the buyer's name.
     /// </summary>
     string BuyerName { get; }
-
-    /// <summary>
-    /// Gets the next entry's catalog ID.
-    /// </summary>
-    uint NextCatalogId { get; }
 
     /// <summary>
     /// Gets a value indicating whether the item is HQ.

--- a/Dalamud/Game/Network/Structures/MarketBoardPurchase.cs
+++ b/Dalamud/Game/Network/Structures/MarketBoardPurchase.cs
@@ -6,7 +6,7 @@ namespace Dalamud.Game.Network.Structures;
 /// Represents market board purchase information. This message is received from the
 /// server when a purchase is made at a market board.
 /// </summary>
-public class MarketBoardPurchase
+public class MarketBoardPurchase : IMarketBoardPurchase
 {
     private MarketBoardPurchase()
     {
@@ -40,4 +40,21 @@ public class MarketBoardPurchase
 
         return output;
     }
+}
+
+/// <summary>
+/// An interface that represents market board purchase information. This message is received from the
+/// server when a purchase is made at a market board.
+/// </summary>
+public interface IMarketBoardPurchase
+{
+    /// <summary>
+    /// Gets the item ID of the item that was purchased.
+    /// </summary>
+    uint CatalogId { get; }
+
+    /// <summary>
+    /// Gets the quantity of the item that was purchased.
+    /// </summary>
+    uint ItemQuantity { get; }
 }

--- a/Dalamud/Game/Network/Structures/MarketBoardPurchaseHandler.cs
+++ b/Dalamud/Game/Network/Structures/MarketBoardPurchaseHandler.cs
@@ -6,7 +6,7 @@ namespace Dalamud.Game.Network.Structures;
 /// Represents market board purchase information. This message is sent from the
 /// client when a purchase is made at a market board.
 /// </summary>
-public class MarketBoardPurchaseHandler
+public class MarketBoardPurchaseHandler : IMarketBoardPurchaseHandler
 {
     private MarketBoardPurchaseHandler()
     {
@@ -58,4 +58,36 @@ public class MarketBoardPurchaseHandler
 
         return output;
     }
+}
+
+/// <summary>
+/// An interface that represents market board purchase information. This message is sent from the
+/// client when a purchase is made at a market board.
+/// </summary>
+public interface IMarketBoardPurchaseHandler
+{
+    /// <summary>
+    /// Gets the object ID of the retainer associated with the sale.
+    /// </summary>
+    ulong RetainerId { get; }
+
+    /// <summary>
+    /// Gets the object ID of the item listing.
+    /// </summary>
+    ulong ListingId { get; }
+
+    /// <summary>
+    /// Gets the item ID of the item that was purchased.
+    /// </summary>
+    uint CatalogId { get; }
+
+    /// <summary>
+    /// Gets the quantity of the item that was purchased.
+    /// </summary>
+    uint ItemQuantity { get; }
+
+    /// <summary>
+    /// Gets the unit price of the item.
+    /// </summary>
+    uint PricePerUnit { get; }
 }

--- a/Dalamud/Game/Network/Structures/MarketTaxRates.cs
+++ b/Dalamud/Game/Network/Structures/MarketTaxRates.cs
@@ -6,7 +6,7 @@ namespace Dalamud.Game.Network.Structures;
 /// This class represents the "Result Dialog" packet. This is also used e.g. for reduction results, but we only care about tax rates.
 /// We can do that by checking the "Category" field.
 /// </summary>
-public class MarketTaxRates
+public class MarketTaxRates : IMarketTaxRates
 {
     private MarketTaxRates()
     {
@@ -99,4 +99,50 @@ public class MarketTaxRates
             SharlayanTax = reader.ReadUInt32(),
         };
     }
+}
+
+/// <summary>
+/// An interface that represents the tax rates received by the client when interacting with a retainer vocate.
+/// </summary>
+public interface IMarketTaxRates
+{
+    /// <summary>
+    /// Gets the category of this ResultDialog packet.
+    /// </summary>
+    uint Category { get; }
+
+    /// <summary>
+    /// Gets the tax rate in Limsa Lominsa.
+    /// </summary>
+    uint LimsaLominsaTax { get; }
+
+    /// <summary>
+    /// Gets the tax rate in Gridania.
+    /// </summary>
+    uint GridaniaTax { get; }
+
+    /// <summary>
+    /// Gets the tax rate in Ul'dah.
+    /// </summary>
+    uint UldahTax { get; }
+
+    /// <summary>
+    /// Gets the tax rate in Ishgard.
+    /// </summary>
+    uint IshgardTax { get; }
+
+    /// <summary>
+    /// Gets the tax rate in Kugane.
+    /// </summary>
+    uint KuganeTax { get; }
+
+    /// <summary>
+    /// Gets the tax rate in the Crystarium.
+    /// </summary>
+    uint CrystariumTax { get; }
+
+    /// <summary>
+    /// Gets the tax rate in the Crystarium.
+    /// </summary>
+    uint SharlayanTax { get; }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
@@ -43,6 +43,7 @@ internal class DataWindow : Window, IDisposable
         new IconBrowserWidget(),
         new ImGuiWidget(),
         new KeyStateWidget(),
+        new MarketBoardWidget(),
         new NetworkMonitorWidget(),
         new ObjectTableWidget(),
         new PartyListWidget(),

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/MarketBoardWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/MarketBoardWidget.cs
@@ -1,0 +1,302 @@
+﻿using System.Collections.Concurrent;
+
+using Dalamud.Interface.Utility;
+using Dalamud.Interface.Utility.Raii;
+
+using ImGuiNET;
+
+namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
+
+using System.Globalization;
+
+using Game.MarketBoard;
+using Game.Network.Structures;
+
+/// <summary>
+/// Widget to display market board events.
+/// </summary>
+internal class MarketBoardWidget : IDataWindowWidget
+{
+    private readonly ConcurrentQueue<(IMarketBoardHistory MarketBoardHistory, IMarketBoardHistoryListing Listing)> marketBoardHistoryQueue = new();
+    private readonly ConcurrentQueue<(IMarketBoardCurrentOfferings MarketBoardCurrentOfferings, IMarketBoardItemListing Listing)> marketBoardCurrentOfferingsQueue = new();
+    private readonly ConcurrentQueue<IMarketBoardPurchase> marketBoardPurchasesQueue = new();
+    private readonly ConcurrentQueue<IMarketBoardPurchaseHandler> marketBoardPurchaseRequestsQueue = new();
+    private readonly ConcurrentQueue<IMarketTaxRates> marketTaxRatesQueue = new();
+
+    private bool trackMarketBoard;
+    private int trackedEvents;
+
+    /// <summary> Finalizes an instance of the <see cref="MarketBoardWidget"/> class. </summary>
+    ~MarketBoardWidget()
+    {
+        if (this.trackMarketBoard)
+        {
+            this.trackMarketBoard = false;
+            var marketBoard = Service<MarketBoard>.GetNullable();
+            if (marketBoard != null)
+            {
+                marketBoard.MarketBoardHistoryReceived -= this.MarketBoardHistoryReceived;
+                marketBoard.MarketBoardOfferingsReceived -= this.MarketBoardOfferingsReceived;
+                marketBoard.MarketBoardItemPurchased -= this.MarketBoardItemPurchased;
+                marketBoard.MarketBoardPurchaseRequested -= this.MarketBoardPurchaseRequested;
+                marketBoard.MarketTaxRatesReceived -= this.TaxRatesReceived;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public string[]? CommandShortcuts { get; init; } = { "marketboard" };
+
+    /// <inheritdoc/>
+    public string DisplayName { get; init; } = "Market Board";
+
+    /// <inheritdoc/>
+    public bool Ready { get; set; }
+
+    /// <inheritdoc/>
+    public void Load()
+    {
+        this.trackMarketBoard = false;
+        this.trackedEvents = 0;
+        this.marketBoardHistoryQueue.Clear();
+        this.marketBoardPurchaseRequestsQueue.Clear();
+        this.marketBoardPurchasesQueue.Clear();
+        this.marketTaxRatesQueue.Clear();
+        this.marketBoardCurrentOfferingsQueue.Clear();
+        this.Ready = true;
+    }
+
+    /// <inheritdoc/>
+    public void Draw()
+    {
+        var marketBoard = Service<MarketBoard>.Get();
+        if (ImGui.Checkbox("Track MarketBoard Events", ref this.trackMarketBoard))
+        {
+            if (this.trackMarketBoard)
+            {
+                marketBoard.MarketBoardHistoryReceived += this.MarketBoardHistoryReceived;
+                marketBoard.MarketBoardOfferingsReceived += this.MarketBoardOfferingsReceived;
+                marketBoard.MarketBoardItemPurchased += this.MarketBoardItemPurchased;
+                marketBoard.MarketBoardPurchaseRequested += this.MarketBoardPurchaseRequested;
+                marketBoard.MarketTaxRatesReceived += this.TaxRatesReceived;
+            }
+            else
+            {
+                marketBoard.MarketBoardHistoryReceived -= this.MarketBoardHistoryReceived;
+                marketBoard.MarketBoardOfferingsReceived -= this.MarketBoardOfferingsReceived;
+                marketBoard.MarketBoardItemPurchased -= this.MarketBoardItemPurchased;
+                marketBoard.MarketBoardPurchaseRequested -= this.MarketBoardPurchaseRequested;
+                marketBoard.MarketTaxRatesReceived -= this.TaxRatesReceived;
+            }
+        }
+
+        ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X / 2);
+        if (ImGui.DragInt("Stored Number of Events", ref this.trackedEvents, 0.1f, 1, 512))
+        {
+            this.trackedEvents = Math.Clamp(this.trackedEvents, 1, 512);
+        }
+
+        if (ImGui.Button("Clear Stored Events"))
+        {
+            this.marketBoardHistoryQueue.Clear();
+        }
+
+        using (var tabBar = ImRaii.TabBar("marketTabs"))
+        {
+            if (tabBar)
+            {
+                using (var tabItem = ImRaii.TabItem("History"))
+                {
+                    if (tabItem)
+                    {
+                        ImGuiTable.DrawTable(string.Empty, this.marketBoardHistoryQueue, this.DrawMarketBoardHistory, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg, "Item ID", "Quantity", "Is HQ?", "Sale Price", "Buyer Name", "Purchase Time");
+                    }
+                }
+
+                using (var tabItem = ImRaii.TabItem("Offerings"))
+                {
+                    if (tabItem)
+                    {
+                        ImGuiTable.DrawTable(string.Empty, this.marketBoardCurrentOfferingsQueue, this.DrawMarketBoardCurrentOfferings, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg, "Item ID", "Quantity", "Is HQ?", "Price Per Unit", "Buyer Name", "Retainer Name", "Last Review Time");
+                    }
+                }
+
+                using (var tabItem = ImRaii.TabItem("Purchases"))
+                {
+                    if (tabItem)
+                    {
+                        ImGuiTable.DrawTable(string.Empty, this.marketBoardPurchasesQueue, this.DrawMarketBoardPurchases, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg, "Item ID", "Quantity");
+                    }
+                }
+
+                using (var tabItem = ImRaii.TabItem("Purchase Requests"))
+                {
+                    if (tabItem)
+                    {
+                        ImGuiTable.DrawTable(string.Empty, this.marketBoardPurchaseRequestsQueue, this.DrawMarketBoardPurchaseRequests, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg, "Item ID", "Quantity", "Price Per Unit", "Listing ID", "Retainer ID");
+                    }
+                }
+
+                using (var tabItem = ImRaii.TabItem("Taxes"))
+                {
+                    if (tabItem)
+                    {
+                        ImGuiTable.DrawTable(string.Empty, this.marketTaxRatesQueue, this.DrawMarketTaxRates, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg, "Uldah", "Limsa Lominsa", "Gridania", "Ishgard", "Kugane", "Crystarium", "Sharlayan");
+                    }
+                }
+            }
+        }
+    }
+
+    private void TaxRatesReceived(IMarketTaxRates marketTaxRates)
+    {
+        this.marketTaxRatesQueue.Enqueue(marketTaxRates);
+
+        while (this.marketTaxRatesQueue.Count > this.trackedEvents)
+        {
+            this.marketTaxRatesQueue.TryDequeue(out _);
+        }
+    }
+
+    private void MarketBoardPurchaseRequested(IMarketBoardPurchaseHandler marketBoardPurchaseHandler)
+    {
+        this.marketBoardPurchaseRequestsQueue.Enqueue(marketBoardPurchaseHandler);
+
+        while (this.marketBoardPurchaseRequestsQueue.Count > this.trackedEvents)
+        {
+            this.marketBoardPurchaseRequestsQueue.TryDequeue(out _);
+        }
+    }
+
+    private void MarketBoardItemPurchased(IMarketBoardPurchase marketBoardPurchase)
+    {
+        this.marketBoardPurchasesQueue.Enqueue(marketBoardPurchase);
+
+        while (this.marketBoardPurchasesQueue.Count > this.trackedEvents)
+        {
+            this.marketBoardPurchasesQueue.TryDequeue(out _);
+        }
+    }
+
+    private void MarketBoardOfferingsReceived(IMarketBoardCurrentOfferings marketBoardCurrentOfferings)
+    {
+        foreach (var listing in marketBoardCurrentOfferings.ItemListings)
+        {
+            this.marketBoardCurrentOfferingsQueue.Enqueue((marketBoardCurrentOfferings, listing));
+        }
+
+        while (this.marketBoardCurrentOfferingsQueue.Count > this.trackedEvents)
+        {
+            this.marketBoardCurrentOfferingsQueue.TryDequeue(out _);
+        }
+    }
+
+    private void MarketBoardHistoryReceived(IMarketBoardHistory marketBoardHistory)
+    {
+        foreach (var listing in marketBoardHistory.HistoryListings)
+        {
+            this.marketBoardHistoryQueue.Enqueue((marketBoardHistory, listing));
+        }
+
+        while (this.marketBoardHistoryQueue.Count > this.trackedEvents)
+        {
+            this.marketBoardHistoryQueue.TryDequeue(out _);
+        }
+    }
+
+    private void DrawMarketBoardHistory((IMarketBoardHistory History, IMarketBoardHistoryListing Listing) data)
+    {
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.History.CatalogId.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.Listing.Quantity.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.Listing.IsHq.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.Listing.SalePrice.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.Listing.BuyerName);
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.Listing.PurchaseTime.ToString(CultureInfo.InvariantCulture));
+    }
+
+    private void DrawMarketBoardCurrentOfferings((IMarketBoardCurrentOfferings MarketBoardCurrentOfferings, IMarketBoardItemListing Listing) data)
+    {
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.Listing.CatalogId.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.Listing.ItemQuantity.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.Listing.IsHq.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.Listing.PricePerUnit.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.Listing.PlayerName);
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.Listing.RetainerName);
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.Listing.LastReviewTime.ToString(CultureInfo.InvariantCulture));
+    }
+
+    private void DrawMarketBoardPurchases(IMarketBoardPurchase data)
+    {
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.CatalogId.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.ItemQuantity.ToString());
+    }
+
+    private void DrawMarketBoardPurchaseRequests(IMarketBoardPurchaseHandler data)
+    {
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.CatalogId.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.ItemQuantity.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.PricePerUnit.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.ListingId.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.RetainerId.ToString());
+    }
+
+    private void DrawMarketTaxRates(IMarketTaxRates data)
+    {
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.UldahTax.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.LimsaLominsaTax.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.GridaniaTax.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.IshgardTax.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.KuganeTax.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.CrystariumTax.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(data.SharlayanTax.ToString());
+    }
+}

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/MarketBoardWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/MarketBoardWidget.cs
@@ -35,11 +35,11 @@ internal class MarketBoardWidget : IDataWindowWidget
             var marketBoard = Service<MarketBoard>.GetNullable();
             if (marketBoard != null)
             {
-                marketBoard.MarketBoardHistoryReceived -= this.MarketBoardHistoryReceived;
-                marketBoard.MarketBoardOfferingsReceived -= this.MarketBoardOfferingsReceived;
-                marketBoard.MarketBoardItemPurchased -= this.MarketBoardItemPurchased;
-                marketBoard.MarketBoardPurchaseRequested -= this.MarketBoardPurchaseRequested;
-                marketBoard.MarketTaxRatesReceived -= this.TaxRatesReceived;
+                marketBoard.HistoryReceived -= this.MarketBoardHistoryReceived;
+                marketBoard.OfferingsReceived -= this.MarketBoardOfferingsReceived;
+                marketBoard.ItemPurchased -= this.MarketBoardItemPurchased;
+                marketBoard.PurchaseRequested -= this.MarketBoardPurchaseRequested;
+                marketBoard.TaxRatesReceived -= this.TaxRatesReceived;
             }
         }
     }
@@ -74,19 +74,19 @@ internal class MarketBoardWidget : IDataWindowWidget
         {
             if (this.trackMarketBoard)
             {
-                marketBoard.MarketBoardHistoryReceived += this.MarketBoardHistoryReceived;
-                marketBoard.MarketBoardOfferingsReceived += this.MarketBoardOfferingsReceived;
-                marketBoard.MarketBoardItemPurchased += this.MarketBoardItemPurchased;
-                marketBoard.MarketBoardPurchaseRequested += this.MarketBoardPurchaseRequested;
-                marketBoard.MarketTaxRatesReceived += this.TaxRatesReceived;
+                marketBoard.HistoryReceived += this.MarketBoardHistoryReceived;
+                marketBoard.OfferingsReceived += this.MarketBoardOfferingsReceived;
+                marketBoard.ItemPurchased += this.MarketBoardItemPurchased;
+                marketBoard.PurchaseRequested += this.MarketBoardPurchaseRequested;
+                marketBoard.TaxRatesReceived += this.TaxRatesReceived;
             }
             else
             {
-                marketBoard.MarketBoardHistoryReceived -= this.MarketBoardHistoryReceived;
-                marketBoard.MarketBoardOfferingsReceived -= this.MarketBoardOfferingsReceived;
-                marketBoard.MarketBoardItemPurchased -= this.MarketBoardItemPurchased;
-                marketBoard.MarketBoardPurchaseRequested -= this.MarketBoardPurchaseRequested;
-                marketBoard.MarketTaxRatesReceived -= this.TaxRatesReceived;
+                marketBoard.HistoryReceived -= this.MarketBoardHistoryReceived;
+                marketBoard.OfferingsReceived -= this.MarketBoardOfferingsReceived;
+                marketBoard.ItemPurchased -= this.MarketBoardItemPurchased;
+                marketBoard.PurchaseRequested -= this.MarketBoardPurchaseRequested;
+                marketBoard.TaxRatesReceived -= this.TaxRatesReceived;
             }
         }
 
@@ -207,7 +207,7 @@ internal class MarketBoardWidget : IDataWindowWidget
     private void DrawMarketBoardHistory((IMarketBoardHistory History, IMarketBoardHistoryListing Listing) data)
     {
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.History.CatalogId.ToString());
+        ImGui.TextUnformatted(data.History.ItemId.ToString());
 
         ImGui.TableNextColumn();
         ImGui.TextUnformatted(data.Listing.Quantity.ToString());
@@ -228,7 +228,7 @@ internal class MarketBoardWidget : IDataWindowWidget
     private void DrawMarketBoardCurrentOfferings((IMarketBoardCurrentOfferings MarketBoardCurrentOfferings, IMarketBoardItemListing Listing) data)
     {
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.Listing.CatalogId.ToString());
+        ImGui.TextUnformatted(data.Listing.ItemId.ToString());
 
         ImGui.TableNextColumn();
         ImGui.TextUnformatted(data.Listing.ItemQuantity.ToString());

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/MarketBoardAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/MarketBoardAgingStep.cs
@@ -1,0 +1,259 @@
+﻿namespace Dalamud.Interface.Internal.Windows.SelfTest.AgingSteps;
+
+using System.Globalization;
+using System.Linq;
+
+using Game.MarketBoard;
+using Game.Network.Structures;
+
+using ImGuiNET;
+
+/// <summary>
+/// Tests the various market board events
+/// </summary>
+internal class MarketBoardAgingStep : IAgingStep
+{
+    private SubStep currentSubStep;
+    private bool eventsSubscribed;
+
+    private IMarketBoardHistoryListing? historyListing;
+    private IMarketBoardItemListing? itemListing;
+    private IMarketTaxRates? marketTaxRate;
+    private IMarketBoardPurchaseHandler? marketBoardPurchaseRequest;
+    private IMarketBoardPurchase? marketBoardPurchase;
+
+    private enum SubStep
+    {
+        History,
+        Offerings,
+        PurchaseRequests,
+        Purchases,
+        Taxes,
+        Done,
+    }
+
+    /// <inheritdoc/>
+    public string Name => "Test MarketBoard";
+
+    /// <inheritdoc/>
+    public SelfTestStepResult RunStep()
+    {
+        if (!this.eventsSubscribed)
+        {
+            this.SubscribeToEvents();
+        }
+
+        ImGui.Text($"Testing: {this.currentSubStep.ToString()}");
+
+        switch (this.currentSubStep)
+        {
+            case SubStep.History:
+
+                if (this.historyListing == null)
+                {
+                    ImGui.Text("Goto a Market Board. Open any item that has historical sale listings.");
+                }
+                else
+                {
+                    ImGui.Text("Does one of the historical sales match this information?");
+                    ImGui.Separator();
+                    ImGui.Text($"Quantity: {this.historyListing.Quantity.ToString()}");
+                    ImGui.Text($"Buyer: {this.historyListing.BuyerName}");
+                    ImGui.Text($"Sale Price: {this.historyListing.SalePrice.ToString()}");
+                    ImGui.Text($"Purchase Time: {this.historyListing.PurchaseTime.ToString(CultureInfo.InvariantCulture)}");
+                    ImGui.Separator();
+                    if (ImGui.Button("Looks Correct"))
+                    {
+                        this.currentSubStep++;
+                    }
+
+                    ImGui.SameLine();
+                    if (ImGui.Button("No"))
+                    {
+                        return SelfTestStepResult.Fail;
+                    }
+                }
+
+                break;
+            case SubStep.Offerings:
+
+                if (this.itemListing == null)
+                {
+                    ImGui.Text("Goto a Market Board. Open any item that has sale listings.");
+                }
+                else
+                {
+                    ImGui.Text("Does one of the sales match this information?");
+                    ImGui.Separator();
+                    ImGui.Text($"Quantity: {this.itemListing.ItemQuantity.ToString()}");
+                    ImGui.Text($"Price Per Unit: {this.itemListing.PricePerUnit}");
+                    ImGui.Text($"Retainer Name: {this.itemListing.RetainerName}");
+                    ImGui.Text($"Is HQ?: {(this.itemListing.IsHq ? "Yes" : "No")}");
+                    ImGui.Separator();
+                    if (ImGui.Button("Looks Correct"))
+                    {
+                        this.currentSubStep++;
+                    }
+
+                    ImGui.SameLine();
+                    if (ImGui.Button("No"))
+                    {
+                        return SelfTestStepResult.Fail;
+                    }
+                }
+
+                break;
+            case SubStep.PurchaseRequests:
+                if (this.marketBoardPurchaseRequest == null)
+                {
+                    ImGui.Text("Goto a Market Board. Purchase any item, the cheapest you can find.");
+                }
+                else
+                {
+                    ImGui.Text("Does this information match the purchase you made? This is testing the request to the server.");
+                    ImGui.Separator();
+                    ImGui.Text($"Quantity: {this.marketBoardPurchaseRequest.ItemQuantity.ToString()}");
+                    ImGui.Text($"Item ID: {this.marketBoardPurchaseRequest.CatalogId}");
+                    ImGui.Text($"Price Per Unit: {this.marketBoardPurchaseRequest.PricePerUnit}");
+                    ImGui.Separator();
+                    if (ImGui.Button("Looks Correct"))
+                    {
+                        this.currentSubStep++;
+                    }
+
+                    ImGui.SameLine();
+                    if (ImGui.Button("No"))
+                    {
+                        return SelfTestStepResult.Fail;
+                    }
+                }
+
+                break;
+            case SubStep.Purchases:
+                if (this.marketBoardPurchase == null)
+                {
+                    ImGui.Text("Goto a Market Board. Purchase any item, the cheapest you can find.");
+                }
+                else
+                {
+                    ImGui.Text("Does this information match the purchase you made? This is testing the response from the server.");
+                    ImGui.Separator();
+                    ImGui.Text($"Quantity: {this.marketBoardPurchase.ItemQuantity.ToString()}");
+                    ImGui.Text($"Item ID: {this.marketBoardPurchase.CatalogId}");
+                    ImGui.Separator();
+                    if (ImGui.Button("Looks Correct"))
+                    {
+                        this.currentSubStep++;
+                    }
+
+                    ImGui.SameLine();
+                    if (ImGui.Button("No"))
+                    {
+                        return SelfTestStepResult.Fail;
+                    }
+                }
+
+                break;
+            case SubStep.Taxes:
+                if (this.marketTaxRate == null)
+                {
+                    ImGui.Text("Goto a Retainer Vocate and talk to then. Click the 'View market tax rates' menu item.");
+                }
+                else
+                {
+                    ImGui.Text("Does this market tax rate information look correct?");
+                    ImGui.Separator();
+                    ImGui.Text($"Uldah: {this.marketTaxRate.UldahTax.ToString()}");
+                    ImGui.Text($"Gridania: {this.marketTaxRate.GridaniaTax.ToString()}");
+                    ImGui.Text($"Limsa Lominsa: {this.marketTaxRate.LimsaLominsaTax.ToString()}");
+                    ImGui.Text($"Ishgard: {this.marketTaxRate.IshgardTax.ToString()}");
+                    ImGui.Text($"Kugane: {this.marketTaxRate.KuganeTax.ToString()}");
+                    ImGui.Text($"Crystarium: {this.marketTaxRate.CrystariumTax.ToString()}");
+                    ImGui.Text($"Sharlayan: {this.marketTaxRate.SharlayanTax.ToString()}");
+                    ImGui.Separator();
+                    if (ImGui.Button("Looks Correct"))
+                    {
+                        this.currentSubStep++;
+                    }
+
+                    ImGui.SameLine();
+                    if (ImGui.Button("No"))
+                    {
+                        return SelfTestStepResult.Fail;
+                    }
+                }
+                break;
+            case SubStep.Done:
+                return SelfTestStepResult.Pass;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        return SelfTestStepResult.Waiting;
+    }
+
+    /// <inheritdoc/>
+    public void CleanUp()
+    {
+        this.currentSubStep = SubStep.History;
+        this.historyListing = null;
+        this.marketTaxRate = null;
+        this.marketBoardPurchase = null;
+        this.marketBoardPurchaseRequest = null;
+        this.itemListing = null;
+        this.UnsubscribeFromEvents();
+    }
+
+    private void SubscribeToEvents()
+    {
+        var marketBoard = Service<MarketBoard>.Get();
+        marketBoard.MarketBoardHistoryReceived += this.MarketBoardOnMarketBoardHistoryReceived;
+        marketBoard.MarketBoardOfferingsReceived += this.MarketBoardOnMarketBoardOfferingsReceived;
+        marketBoard.MarketBoardItemPurchased += this.MarketBoardOnMarketBoardItemPurchased;
+        marketBoard.MarketBoardPurchaseRequested += this.MarketBoardOnMarketBoardPurchaseRequested;
+        marketBoard.MarketTaxRatesReceived += this.MarketBoardOnMarketTaxRatesReceived;
+        this.eventsSubscribed = true;
+    }
+
+    private void MarketBoardOnMarketTaxRatesReceived(IMarketTaxRates marketTaxRates)
+    {
+        this.marketTaxRate = marketTaxRates;
+    }
+
+    private void MarketBoardOnMarketBoardPurchaseRequested(IMarketBoardPurchaseHandler marketBoardPurchaseHandler)
+    {
+        this.marketBoardPurchaseRequest = marketBoardPurchaseHandler;
+    }
+
+    private void MarketBoardOnMarketBoardItemPurchased(IMarketBoardPurchase purchase)
+    {
+        this.marketBoardPurchase = purchase;
+    }
+
+    private void UnsubscribeFromEvents()
+    {
+        var marketBoard = Service<MarketBoard>.Get();
+        marketBoard.MarketBoardHistoryReceived -= this.MarketBoardOnMarketBoardHistoryReceived;
+        marketBoard.MarketBoardOfferingsReceived -= this.MarketBoardOnMarketBoardOfferingsReceived;
+        marketBoard.MarketBoardItemPurchased -= this.MarketBoardOnMarketBoardItemPurchased;
+        marketBoard.MarketBoardPurchaseRequested -= this.MarketBoardOnMarketBoardPurchaseRequested;
+        marketBoard.MarketTaxRatesReceived -= this.MarketBoardOnMarketTaxRatesReceived;
+        this.eventsSubscribed = false;
+    }
+
+    private void MarketBoardOnMarketBoardOfferingsReceived(IMarketBoardCurrentOfferings marketBoardCurrentOfferings)
+    {
+        if (marketBoardCurrentOfferings.ItemListings.Count != 0)
+        {
+            this.itemListing = marketBoardCurrentOfferings.ItemListings.First();
+        }
+    }
+
+    private void MarketBoardOnMarketBoardHistoryReceived(IMarketBoardHistory marketBoardHistory)
+    {
+        if (marketBoardHistory.HistoryListings.Count != 0)
+        {
+            this.historyListing = marketBoardHistory.HistoryListings.First();
+        }
+    }
+}

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/MarketBoardAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/MarketBoardAgingStep.cs
@@ -62,7 +62,7 @@ internal class MarketBoardAgingStep : IAgingStep
                     ImGui.Text($"Sale Price: {this.historyListing.SalePrice.ToString()}");
                     ImGui.Text($"Purchase Time: {this.historyListing.PurchaseTime.ToString(CultureInfo.InvariantCulture)}");
                     ImGui.Separator();
-                    if (ImGui.Button("Looks Correct"))
+                    if (ImGui.Button("Looks Correct / Skip"))
                     {
                         this.currentSubStep++;
                     }
@@ -90,7 +90,7 @@ internal class MarketBoardAgingStep : IAgingStep
                     ImGui.Text($"Retainer Name: {this.itemListing.RetainerName}");
                     ImGui.Text($"Is HQ?: {(this.itemListing.IsHq ? "Yes" : "No")}");
                     ImGui.Separator();
-                    if (ImGui.Button("Looks Correct"))
+                    if (ImGui.Button("Looks Correct / Skip"))
                     {
                         this.currentSubStep++;
                     }
@@ -116,7 +116,7 @@ internal class MarketBoardAgingStep : IAgingStep
                     ImGui.Text($"Item ID: {this.marketBoardPurchaseRequest.CatalogId}");
                     ImGui.Text($"Price Per Unit: {this.marketBoardPurchaseRequest.PricePerUnit}");
                     ImGui.Separator();
-                    if (ImGui.Button("Looks Correct"))
+                    if (ImGui.Button("Looks Correct / Skip"))
                     {
                         this.currentSubStep++;
                     }
@@ -141,7 +141,7 @@ internal class MarketBoardAgingStep : IAgingStep
                     ImGui.Text($"Quantity: {this.marketBoardPurchase.ItemQuantity.ToString()}");
                     ImGui.Text($"Item ID: {this.marketBoardPurchase.CatalogId}");
                     ImGui.Separator();
-                    if (ImGui.Button("Looks Correct"))
+                    if (ImGui.Button("Looks Correct / Skip"))
                     {
                         this.currentSubStep++;
                     }
@@ -171,7 +171,7 @@ internal class MarketBoardAgingStep : IAgingStep
                     ImGui.Text($"Crystarium: {this.marketTaxRate.CrystariumTax.ToString()}");
                     ImGui.Text($"Sharlayan: {this.marketTaxRate.SharlayanTax.ToString()}");
                     ImGui.Separator();
-                    if (ImGui.Button("Looks Correct"))
+                    if (ImGui.Button("Looks Correct / Skip"))
                     {
                         this.currentSubStep++;
                     }
@@ -207,41 +207,41 @@ internal class MarketBoardAgingStep : IAgingStep
     private void SubscribeToEvents()
     {
         var marketBoard = Service<MarketBoard>.Get();
-        marketBoard.MarketBoardHistoryReceived += this.MarketBoardOnMarketBoardHistoryReceived;
-        marketBoard.MarketBoardOfferingsReceived += this.MarketBoardOnMarketBoardOfferingsReceived;
-        marketBoard.MarketBoardItemPurchased += this.MarketBoardOnMarketBoardItemPurchased;
-        marketBoard.MarketBoardPurchaseRequested += this.MarketBoardOnMarketBoardPurchaseRequested;
-        marketBoard.MarketTaxRatesReceived += this.MarketBoardOnMarketTaxRatesReceived;
+        marketBoard.HistoryReceived += this.OnHistoryReceived;
+        marketBoard.OfferingsReceived += this.OnOfferingsReceived;
+        marketBoard.ItemPurchased += this.OnItemPurchased;
+        marketBoard.PurchaseRequested += this.OnPurchaseRequested;
+        marketBoard.TaxRatesReceived += this.OnTaxRatesReceived;
         this.eventsSubscribed = true;
-    }
-
-    private void MarketBoardOnMarketTaxRatesReceived(IMarketTaxRates marketTaxRates)
-    {
-        this.marketTaxRate = marketTaxRates;
-    }
-
-    private void MarketBoardOnMarketBoardPurchaseRequested(IMarketBoardPurchaseHandler marketBoardPurchaseHandler)
-    {
-        this.marketBoardPurchaseRequest = marketBoardPurchaseHandler;
-    }
-
-    private void MarketBoardOnMarketBoardItemPurchased(IMarketBoardPurchase purchase)
-    {
-        this.marketBoardPurchase = purchase;
     }
 
     private void UnsubscribeFromEvents()
     {
         var marketBoard = Service<MarketBoard>.Get();
-        marketBoard.MarketBoardHistoryReceived -= this.MarketBoardOnMarketBoardHistoryReceived;
-        marketBoard.MarketBoardOfferingsReceived -= this.MarketBoardOnMarketBoardOfferingsReceived;
-        marketBoard.MarketBoardItemPurchased -= this.MarketBoardOnMarketBoardItemPurchased;
-        marketBoard.MarketBoardPurchaseRequested -= this.MarketBoardOnMarketBoardPurchaseRequested;
-        marketBoard.MarketTaxRatesReceived -= this.MarketBoardOnMarketTaxRatesReceived;
+        marketBoard.HistoryReceived -= this.OnHistoryReceived;
+        marketBoard.OfferingsReceived -= this.OnOfferingsReceived;
+        marketBoard.ItemPurchased -= this.OnItemPurchased;
+        marketBoard.PurchaseRequested -= this.OnPurchaseRequested;
+        marketBoard.TaxRatesReceived -= this.OnTaxRatesReceived;
         this.eventsSubscribed = false;
     }
 
-    private void MarketBoardOnMarketBoardOfferingsReceived(IMarketBoardCurrentOfferings marketBoardCurrentOfferings)
+    private void OnTaxRatesReceived(IMarketTaxRates marketTaxRates)
+    {
+        this.marketTaxRate = marketTaxRates;
+    }
+
+    private void OnPurchaseRequested(IMarketBoardPurchaseHandler marketBoardPurchaseHandler)
+    {
+        this.marketBoardPurchaseRequest = marketBoardPurchaseHandler;
+    }
+
+    private void OnItemPurchased(IMarketBoardPurchase purchase)
+    {
+        this.marketBoardPurchase = purchase;
+    }
+
+    private void OnOfferingsReceived(IMarketBoardCurrentOfferings marketBoardCurrentOfferings)
     {
         if (marketBoardCurrentOfferings.ItemListings.Count != 0)
         {
@@ -249,7 +249,7 @@ internal class MarketBoardAgingStep : IAgingStep
         }
     }
 
-    private void MarketBoardOnMarketBoardHistoryReceived(IMarketBoardHistory marketBoardHistory)
+    private void OnHistoryReceived(IMarketBoardHistory marketBoardHistory)
     {
         if (marketBoardHistory.HistoryListings.Count != 0)
         {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
@@ -44,6 +44,7 @@ internal class SelfTestWindow : Window
             new HandledExceptionAgingStep(),
             new DutyStateAgingStep(),
             new GameConfigAgingStep(),
+            new MarketBoardAgingStep(),
             new LogoutEventAgingStep(),
         };
 

--- a/Dalamud/Plugin/Services/IMarketBoard.cs
+++ b/Dalamud/Plugin/Services/IMarketBoard.cs
@@ -1,0 +1,64 @@
+﻿namespace Dalamud.Plugin.Services;
+
+using Game.Network.Structures;
+
+/// <summary>
+/// Provides access to market board related events as the client receives/sends them.
+/// </summary>
+public interface IMarketBoard
+{
+    /// <summary>
+    /// A delegate type used with the <see cref="MarketBoardHistoryReceived"/> event.
+    /// </summary>
+    /// <param name="marketBoardHistory">The historical listings for a particular item on the market board.</param>
+    public delegate void MarketBoardHistoryReceivedDelegate(IMarketBoardHistory marketBoardHistory);
+
+    /// <summary>
+    /// A delegate type used with the <see cref="MarketBoardItemPurchased"/> event.
+    /// </summary>
+    /// <param name="marketBoardPurchased">The item that has been purchased.</param>
+    public delegate void MarketBoardItemPurchasedDelegate(IMarketBoardPurchase marketBoardPurchased);
+
+    /// <summary>
+    /// A delegate type used with the <see cref="MarketBoardOfferingsReceived"/> event.
+    /// </summary>
+    /// <param name="marketBoardCurrentOfferings">The current offerings for a particular item on the market board.</param>
+    public delegate void MarketBoardOfferingsReceivedDelegate(IMarketBoardCurrentOfferings marketBoardCurrentOfferings);
+
+    /// <summary>
+    /// A delegate type used with the <see cref="MarketBoardPurchaseRequested"/> event.
+    /// </summary>
+    /// <param name="marketBoardPurchaseRequested">The details about the item being purchased.</param>
+    public delegate void MarketBoardPurchaseRequestedDelegate(IMarketBoardPurchaseHandler marketBoardPurchaseRequested);
+
+    /// <summary>
+    /// A delegate type used with the <see cref="MarketBoardPurchaseRequested"/> event.
+    /// </summary>
+    /// <param name="marketTaxRates">The new tax rates.</param>
+    public delegate void MarketTaxRatesReceivedDelegate(IMarketTaxRates marketTaxRates);
+
+    /// <summary>
+    /// Event that fires when historical sale listings are received for a specific item on the market board.
+    /// </summary>
+    public event MarketBoardHistoryReceivedDelegate MarketBoardHistoryReceived;
+
+    /// <summary>
+    /// Event that fires when a item is purchased on the market board.
+    /// </summary>
+    public event MarketBoardItemPurchasedDelegate MarketBoardItemPurchased;
+
+    /// <summary>
+    /// Event that fires when current offerings are received for a specific item on the market board.
+    /// </summary>
+    public event MarketBoardOfferingsReceivedDelegate MarketBoardOfferingsReceived;
+
+    /// <summary>
+    /// Event that fires when a player requests to purchase an item from the market board.
+    /// </summary>
+    public event MarketBoardPurchaseRequestedDelegate MarketBoardPurchaseRequested;
+
+    /// <summary>
+    /// Event that fires when the client receives new tax rates. These events only occur when accessing a retainer vocate and requesting the tax rates.
+    /// </summary>
+    public event MarketTaxRatesReceivedDelegate MarketTaxRatesReceived;
+}

--- a/Dalamud/Plugin/Services/IMarketBoard.cs
+++ b/Dalamud/Plugin/Services/IMarketBoard.cs
@@ -8,57 +8,57 @@ using Game.Network.Structures;
 public interface IMarketBoard
 {
     /// <summary>
-    /// A delegate type used with the <see cref="MarketBoardHistoryReceived"/> event.
+    /// A delegate type used with the <see cref="HistoryReceived"/> event.
     /// </summary>
-    /// <param name="marketBoardHistory">The historical listings for a particular item on the market board.</param>
-    public delegate void MarketBoardHistoryReceivedDelegate(IMarketBoardHistory marketBoardHistory);
+    /// <param name="history">The historical listings for a particular item on the market board.</param>
+    public delegate void HistoryReceivedDelegate(IMarketBoardHistory history);
 
     /// <summary>
-    /// A delegate type used with the <see cref="MarketBoardItemPurchased"/> event.
+    /// A delegate type used with the <see cref="ItemPurchased"/> event.
     /// </summary>
-    /// <param name="marketBoardPurchased">The item that has been purchased.</param>
-    public delegate void MarketBoardItemPurchasedDelegate(IMarketBoardPurchase marketBoardPurchased);
+    /// <param name="purchase">The item that has been purchased.</param>
+    public delegate void ItemPurchasedDelegate(IMarketBoardPurchase purchase);
 
     /// <summary>
-    /// A delegate type used with the <see cref="MarketBoardOfferingsReceived"/> event.
+    /// A delegate type used with the <see cref="OfferingsReceived"/> event.
     /// </summary>
-    /// <param name="marketBoardCurrentOfferings">The current offerings for a particular item on the market board.</param>
-    public delegate void MarketBoardOfferingsReceivedDelegate(IMarketBoardCurrentOfferings marketBoardCurrentOfferings);
+    /// <param name="currentOfferings">The current offerings for a particular item on the market board.</param>
+    public delegate void OfferingsReceivedDelegate(IMarketBoardCurrentOfferings currentOfferings);
 
     /// <summary>
-    /// A delegate type used with the <see cref="MarketBoardPurchaseRequested"/> event.
+    /// A delegate type used with the <see cref="PurchaseRequested"/> event.
     /// </summary>
-    /// <param name="marketBoardPurchaseRequested">The details about the item being purchased.</param>
-    public delegate void MarketBoardPurchaseRequestedDelegate(IMarketBoardPurchaseHandler marketBoardPurchaseRequested);
+    /// <param name="purchaseRequested">The details about the item being purchased.</param>
+    public delegate void PurchaseRequestedDelegate(IMarketBoardPurchaseHandler purchaseRequested);
 
     /// <summary>
-    /// A delegate type used with the <see cref="MarketBoardPurchaseRequested"/> event.
+    /// A delegate type used with the <see cref="PurchaseRequested"/> event.
     /// </summary>
-    /// <param name="marketTaxRates">The new tax rates.</param>
-    public delegate void MarketTaxRatesReceivedDelegate(IMarketTaxRates marketTaxRates);
+    /// <param name="taxRates">The new tax rates.</param>
+    public delegate void TaxRatesReceivedDelegate(IMarketTaxRates taxRates);
 
     /// <summary>
     /// Event that fires when historical sale listings are received for a specific item on the market board.
     /// </summary>
-    public event MarketBoardHistoryReceivedDelegate MarketBoardHistoryReceived;
+    public event HistoryReceivedDelegate HistoryReceived;
 
     /// <summary>
     /// Event that fires when a item is purchased on the market board.
     /// </summary>
-    public event MarketBoardItemPurchasedDelegate MarketBoardItemPurchased;
+    public event ItemPurchasedDelegate ItemPurchased;
 
     /// <summary>
     /// Event that fires when current offerings are received for a specific item on the market board.
     /// </summary>
-    public event MarketBoardOfferingsReceivedDelegate MarketBoardOfferingsReceived;
+    public event OfferingsReceivedDelegate OfferingsReceived;
 
     /// <summary>
     /// Event that fires when a player requests to purchase an item from the market board.
     /// </summary>
-    public event MarketBoardPurchaseRequestedDelegate MarketBoardPurchaseRequested;
+    public event PurchaseRequestedDelegate PurchaseRequested;
 
     /// <summary>
     /// Event that fires when the client receives new tax rates. These events only occur when accessing a retainer vocate and requesting the tax rates.
     /// </summary>
-    public event MarketTaxRatesReceivedDelegate MarketTaxRatesReceived;
+    public event TaxRatesReceivedDelegate TaxRatesReceived;
 }


### PR DESCRIPTION
This PR implements a public service for accessing the market doard data dalamud collects via network hooks. I tried to avoid modifying the data that streams directly in as I believe it should be up to the plugin developer to work out how to deal with the data received.

It exposes 5 events:
MarketTaxRatesReceived
MarketBoardHistoryReceived
MarketBoardOfferingsReceived
MarketBoardItemPurchased
MarketBoardPurchaseRequested

I've added interfaces for all classes returned, added in a scoped plugin service, a self-test and a tab in the data window.

Happy to make any modifications requested.