### PR TITLE
[apiX] Throw on invalid ImRaii Style type in release builds

### DIFF
--- a/Dalamud/Interface/Utility/Raii/Plot.cs
+++ b/Dalamud/Interface/Utility/Raii/Plot.cs
@@ -83,7 +83,6 @@ public static partial class ImRaii
 
         private int count;
 
-        [System.Diagnostics.Conditional("DEBUG")]
         private static void CheckStyleIdx(ImPlotStyleVar idx, Type type)
         {
             var shouldThrow = idx switch

--- a/Dalamud/Interface/Utility/Raii/Style.cs
+++ b/Dalamud/Interface/Utility/Raii/Style.cs
@@ -39,7 +39,6 @@ public static partial class ImRaii
 
         private int count;
 
-        [System.Diagnostics.Conditional("DEBUG")]
         private static void CheckStyleIdx(ImGuiStyleVar idx, Type type)
         {
             var shouldThrow = idx switch


### PR DESCRIPTION
When using `ImRaii.PushStyle` with the wrong type for an `ImGuiStyleVar`, ImGui will crash internally and stops rendering.
This is very annoying during plugin development.
A type check already exists, but is only enabled for debug builds.
This PR remove this condition, so that it will throw an error even on release builds.

Also found the same condition in PlotStyle, so I removed it there as well.