### PR TITLE
Verify conditions before killing game

### DIFF
--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -1,6 +1,8 @@
+using System.Linq;
 using System.Runtime.InteropServices;
 
 using Dalamud.Data;
+using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.Objects;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.Gui;
@@ -123,6 +125,27 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
     /// Gets client state address resolver.
     /// </summary>
     internal ClientStateAddressResolver AddressResolver => this.address;
+    
+    /// <inheritdoc/>
+    public bool IsClientIdle(out ConditionFlag blockingFlag)
+    {
+        blockingFlag = 0;
+        if (this.LocalPlayer is null) return true;
+        
+        var condition = Service<Conditions.Condition>.GetNullable();
+        
+        var blockingConditions = condition.AsReadOnlySet().Except([
+            ConditionFlag.NormalConditions, 
+            ConditionFlag.Jumping, 
+            ConditionFlag.Mounted, 
+            ConditionFlag.UsingParasol]);
+
+        blockingFlag = blockingConditions.FirstOrDefault();
+        return blockingFlag == 0;
+    }
+    
+    /// <inheritdoc/>
+    public bool IsClientIdle() => this.IsClientIdle(out _);
 
     /// <summary>
     /// Dispose of managed and unmanaged resources.
@@ -270,6 +293,12 @@ internal class ClientStatePluginScoped : IInternalDisposableService, IClientStat
 
     /// <inheritdoc/>
     public bool IsGPosing => this.clientStateService.IsGPosing;
+
+    /// <inheritdoc/>
+    public bool IsClientIdle(out ConditionFlag blockingFlag) => this.clientStateService.IsClientIdle(out blockingFlag);
+
+    /// <inheritdoc/>
+    public bool IsClientIdle() => this.clientStateService.IsClientIdle();
 
     /// <inheritdoc/>
     void IInternalDisposableService.DisposeService()

--- a/Dalamud/Game/ClientState/Conditions/Condition.cs
+++ b/Dalamud/Game/ClientState/Conditions/Condition.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
 using Dalamud.Plugin.Services;
@@ -68,6 +71,22 @@ internal sealed class Condition : IInternalDisposableService, ICondition
 
     /// <inheritdoc/>
     void IInternalDisposableService.DisposeService() => this.Dispose(true);
+    
+    /// <inheritdoc/>
+    public IReadOnlySet<ConditionFlag> AsReadOnlySet()
+    {
+        var result = new HashSet<ConditionFlag>();
+        
+        for (var i = 0; i < MaxConditionEntries; i++)
+        {
+            if (this[i])
+            {
+                result.Add((ConditionFlag)i);
+            }
+        }
+
+        return result;
+    }
 
     /// <inheritdoc/>
     public bool Any()
@@ -96,6 +115,25 @@ internal sealed class Condition : IInternalDisposableService, ICondition
         }
 
         return false;
+    }
+    
+    /// <inheritdoc/>
+    public bool AnyExcept(params ConditionFlag[] excluded)
+    {
+        return !this.AsReadOnlySet().Intersect(excluded).Any();
+    }
+
+    /// <inheritdoc/>
+    public bool OnlyAny(params ConditionFlag[] other)
+    {
+        return !this.AsReadOnlySet().Except(other).Any();
+    }
+
+    /// <inheritdoc/>
+    public bool OnlyAll(params ConditionFlag[] other)
+    {
+        var resultSet = this.AsReadOnlySet();
+        return resultSet.SetEquals(other);
     }
 
     private void Dispose(bool disposing)
@@ -175,12 +213,24 @@ internal class ConditionPluginScoped : IInternalDisposableService, ICondition
 
         this.ConditionChange = null;
     }
+    
+    /// <inheritdoc/>
+    public IReadOnlySet<ConditionFlag> AsReadOnlySet() => this.conditionService.AsReadOnlySet();
 
     /// <inheritdoc/>
     public bool Any() => this.conditionService.Any();
 
     /// <inheritdoc/>
     public bool Any(params ConditionFlag[] flags) => this.conditionService.Any(flags);
+
+    /// <inheritdoc/>
+    public bool AnyExcept(params ConditionFlag[] except) => this.conditionService.AnyExcept(except);
+    
+    /// <inheritdoc/>
+    public bool OnlyAny(params ConditionFlag[] other) => this.conditionService.OnlyAny(other);
+    
+    /// <inheritdoc/>
+    public bool OnlyAll(params ConditionFlag[] other) => this.conditionService.OnlyAll(other);
 
     private void ConditionChangedForward(ConditionFlag flag, bool value) => this.ConditionChange?.Invoke(flag, value);
 }

--- a/Dalamud/Interface/Internal/DalamudCommands.cs
+++ b/Dalamud/Interface/Internal/DalamudCommands.cs
@@ -4,13 +4,18 @@ using System.Linq;
 
 using CheapLoc;
 using Dalamud.Configuration.Internal;
+using Dalamud.Data;
 using Dalamud.Game;
+using Dalamud.Game.ClientState;
 using Dalamud.Game.Command;
 using Dalamud.Game.Gui;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Plugin.Internal;
 using Dalamud.Utility;
+
 using Serilog;
+
+using Condition = Lumina.Excel.GeneratedSheets.Condition;
 
 namespace Dalamud.Interface.Internal;
 
@@ -153,11 +158,31 @@ internal class DalamudCommands : IServiceType
 
     private void OnKillCommand(string command, string arguments)
     {
+#if RELEASE
+        var clientState = Service<ClientState>.Get();
+        if (!clientState.IsClientIdle(out var failingCondition))
+        {
+            var errCondition = Service<DataManager>.Get().GetExcelSheet<Condition>()!.GetRow((uint)failingCondition)!;
+            Service<ChatGui>.Get().PrintError(errCondition.LogMessage.Value!.Text);
+            return;
+        }
+#endif
+        
         Process.GetCurrentProcess().Kill();
     }
 
     private void OnRestartCommand(string command, string arguments)
     {
+#if RELEASE
+        var clientState = Service<ClientState>.Get();
+        if (!clientState.IsClientIdle(out var failingCondition))
+        {
+            var errCondition = Service<DataManager>.Get().GetExcelSheet<Condition>()!.GetRow((uint)failingCondition)!;
+            Service<ChatGui>.Get().PrintError(errCondition.LogMessage.Value!.Text);
+            return;
+        }
+#endif
+        
         Dalamud.RestartGame();
     }
 

--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -559,18 +559,25 @@ internal class ConsoleWindow : Window, IDisposable
             this.CopyFilteredLogEntries(false);
 
         ImGui.SameLine();
-        if (this.killGameArmed)
+        if (!Util.IsClientIdleIgnoringDebug())
         {
-            if (ImGuiComponents.IconButton(FontAwesomeIcon.ExclamationTriangle))
+            ImGuiComponents.DisabledButton(FontAwesomeIcon.Stop);
+            if (ImGui.IsItemHovered()) ImGui.SetTooltip("Kill disabled in current game state.");
+        }
+        else if (this.killGameArmed)
+        {
+            if (ImGuiComponents.IconButton(FontAwesomeIcon.ExclamationTriangle)) 
                 Process.GetCurrentProcess().Kill();
+                
+            if (ImGui.IsItemHovered()) ImGui.SetTooltip("Confirm Kill");
         }
         else
         {
             if (ImGuiComponents.IconButton(FontAwesomeIcon.Stop))
                 this.killGameArmed = true;
+            
+            if (ImGui.IsItemHovered()) ImGui.SetTooltip("Kill game");
         }
-
-        if (ImGui.IsItemHovered()) ImGui.SetTooltip("Kill game");
 
         ImGui.SameLine();
 

--- a/Dalamud/Plugin/Services/IClientState.cs
+++ b/Dalamud/Plugin/Services/IClientState.cs
@@ -1,3 +1,4 @@
+using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 
 namespace Dalamud.Plugin.Services;
@@ -81,4 +82,19 @@ public interface IClientState
     /// Gets a value indicating whether the client is currently in Group Pose (GPose) mode. 
     /// </summary>
     public bool IsGPosing { get; }
+
+    /// <summary>
+    /// Check whether the client is currently "idle". This means a player is not logged in, or is notctively in combat
+    /// or doing anything that we may not want to disrupt.
+    /// </summary>
+    /// <param name="blockingFlag">An outvar containing the first observed condition blocking the "idle" state. 0 if idle.</param>
+    /// <returns>Returns true if the client is idle, false otherwise.</returns>
+    public bool IsClientIdle(out ConditionFlag blockingFlag);
+
+    /// <summary>
+    /// Check whether the client is currently "idle". This means a player is not logged in, or is notctively in combat
+    /// or doing anything that we may not want to disrupt.
+    /// </summary>
+    /// <returns>Returns true if the client is idle, false otherwise.</returns>
+    public bool IsClientIdle() => this.IsClientIdle(out _);
 }

--- a/Dalamud/Plugin/Services/ICondition.cs
+++ b/Dalamud/Plugin/Services/ICondition.cs
@@ -1,4 +1,6 @@
-﻿using Dalamud.Game.ClientState.Conditions;
+﻿using System.Collections.Generic;
+
+using Dalamud.Game.ClientState.Conditions;
 
 namespace Dalamud.Plugin.Services;
 
@@ -38,6 +40,12 @@ public interface ICondition
     
     /// <inheritdoc cref="this[int]"/>
     public bool this[ConditionFlag flag] => this[(int)flag];
+    
+    /// <summary>
+    /// Convert the conditions array to a set of all set condition flags.
+    /// </summary>
+    /// <returns>Returns a set.</returns>
+    public IReadOnlySet<ConditionFlag> AsReadOnlySet();
 
     /// <summary>
     /// Check if any condition flags are set.
@@ -51,4 +59,26 @@ public interface ICondition
     /// <returns>Whether any single provided flag is set.</returns>
     /// <param name="flags">The condition flags to check.</param>
     public bool Any(params ConditionFlag[] flags);
+
+    /// <summary>
+    /// Check that the specified condition flags are *not* present in the current conditions.
+    /// </summary>
+    /// <param name="except">The array of flags to check.</param>
+    /// <returns>Returns false if any of the listed conditions are present, true otherwise.</returns>
+    public bool AnyExcept(params ConditionFlag[] except);
+
+    /// <summary>
+    /// Check that *only* any of the condition flags specified are set.
+    /// </summary>
+    /// <param name="other">The array of flags to check.</param>
+    /// <returns>Returns a bool.</returns>
+    public bool OnlyAny(params ConditionFlag[] other);
+
+    /// <summary>
+    /// Check that *only* the specified flags are set. Unlike <see cref="OnlyAny"/>, this method requires that all the
+    /// specified flags are set and no others are present.
+    /// </summary>
+    /// <param name="other">The array of flags to check.</param>
+    /// <returns>Returns a bool.</returns>
+    public bool OnlyAll(params ConditionFlag[] other);
 }

--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -26,6 +26,8 @@ using Serilog;
 using TerraFX.Interop.Windows;
 using Windows.Win32.Storage.FileSystem;
 
+using Dalamud.Game.ClientState;
+
 namespace Dalamud.Utility;
 
 /// <summary>
@@ -734,6 +736,19 @@ public static class Util
         {
             ImGui.SetClipboardText(actor.Address.ToInt64().ToString("X"));
         }
+    }
+
+    /// <summary>
+    /// Check if the client is idle, always returning true in debug mode. Used for UI control.
+    /// </summary>
+    /// <returns>Returns if the client is idle, or true in debug.</returns>
+    internal static bool IsClientIdleIgnoringDebug()
+    {
+#if DEBUG
+        return true;
+#endif
+
+        return Service<ClientState>.Get().IsClientIdle();
     }
 
     private static void ShowSpanProperty(ulong addr, IList<string> path, PropertyInfo p, object obj)


### PR DESCRIPTION
- Add new `ClientState#IsClientIdle` method to test if the client is currently in an "idle" state (nothing important is going on).
- Add new `Condition#AsReadOnlySet` method to receive a set of active conditions.
- Add new helper functions `Condition#OnlyAny` and `Condition#OnlyAll` to evaluate certain game conditions.
- Block kills unless the client is currently considered idle.