### PR TITLE
Implement hook stacking and priorities

### DIFF
--- a/Dalamud/Hooking/HookPriority.cs
+++ b/Dalamud/Hooking/HookPriority.cs
@@ -1,0 +1,27 @@
+namespace Dalamud.Hooking;
+
+/// <summary>
+/// Defines the priorities available at hook creation.
+/// </summary>
+public enum HookPriority
+{
+    /// <summary>
+    /// Notify-only hook that runs last and cannot call its original function.
+    /// </summary>
+    AfterNotify = 0,
+
+    /// <summary>
+    /// Normal priority hook, that will run after Dalamud internal hooks.
+    /// </summary>
+    NormalPriority = 1,
+
+    /// <summary>
+    /// High Priority hook that runs before Dalamud internal and normal priority hooks.
+    /// </summary>
+    HighPriority = 2,
+
+    /// <summary>
+    /// Notify-only hook that always runs first and cannot call its original function.
+    /// </summary>
+    BeforeNotify = 3,
+}

--- a/Dalamud/Hooking/Internal/CastingHook.cs
+++ b/Dalamud/Hooking/Internal/CastingHook.cs
@@ -1,0 +1,238 @@
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Dalamud.Hooking.Internal;
+
+/// <summary>
+/// Class facilitating the casting of the delegates of an underlying hook.
+/// </summary>
+/// <typeparam name="T">Delegate of the desired hook.</typeparam>
+/// <typeparam name="TBase">Delegate of the underlying hook.</typeparam>
+internal class CastingHook<T, TBase> : Hook<T> where T : Delegate where TBase : Delegate
+{
+    private static readonly object SyncRoot = new();
+    private static int instanceCount;
+    private T originalFunction;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastingHook{T, TBase}"/> class.
+    /// </summary>
+    /// <param name="address">A memory address to install a hook.</param>
+    /// <param name="baseHook">The base hook this hook is casting its delegates to.</param>
+    /// <param name="detour">The original detour.</param>
+    public CastingHook(nint address, HollowHook<TBase> baseHook, T detour)
+        : base(address)
+    {
+        this.BaseHook = baseHook;
+        this.Detour = detour;
+
+        lock (SyncRoot)
+        {
+            this.InstanceId = instanceCount++;
+            SelfLookup[this.InstanceId] = this;
+        }
+
+        this.BaseHook.OriginalChanged += this.UpdateOriginal;
+    }
+
+    /// <inheritdoc/>
+    public override T Original => this.originalFunction;
+
+    /// <inheritdoc/>
+    public override bool IsEnabled => this.BaseHook.IsEnabled;
+
+    /// <inheritdoc/>
+    public override string BackendName => this.BaseHook.BackendName;
+
+    /// <summary>
+    /// Gets a static dictionary that allows to retrieve the correct CastingHook in a static context.
+    /// </summary>
+    internal static ConcurrentDictionary<int, IDalamudHook> SelfLookup { get; } = [];
+
+    /// <summary>
+    /// Gets the base hook this hook is casting to.
+    /// </summary>
+    internal HollowHook<TBase> BaseHook { get; }
+
+    /// <summary>
+    /// Gets the original detour.
+    /// </summary>
+    internal T Detour { get; }
+
+    private int InstanceId { get; }
+
+    private bool Thunked { get; set; }
+
+    /// <inheritdoc/>
+    public override void Dispose() 
+    {
+        this.BaseHook.OriginalChanged -= this.UpdateOriginal;
+        SelfLookup.TryRemove(this.InstanceId, out _);
+        this.BaseHook.Dispose();
+    }
+
+    /// <inheritdoc/>
+    public override void Enable()
+    {
+        this.BaseHook.Enable();
+    }
+
+    /// <inheritdoc/>
+    public override void Disable()
+    {
+        this.BaseHook.Disable();
+    }
+
+    /// <summary>
+    /// Attempts to cast a delegate as required by the base Hook type.
+    /// </summary>
+    /// <returns>Delegate of type TBase.</returns>
+    public TBase GetBaseHookDetour()
+    {
+        try
+        {
+            return DirectCastDelegateTo<TBase>((MulticastDelegate)(Delegate)this.Detour);
+        }
+        catch (ArgumentException ex)
+        {
+            HookManager.Log.Warning(ex, $"Creating IL thunk to cast incomaptible hook signatures from {typeof(T).Name} to {typeof(TBase).Name}");
+        }
+
+        this.Thunked = true;
+        this.originalFunction = this.CreateOriginalThunk();
+        return this.CreateDetourThunk();
+    }
+
+    private static TTarget DirectCastDelegateTo<TTarget>(MulticastDelegate source)
+    {
+        return (TTarget)(object)source.GetInvocationList()
+            .Select(sourceItem => Delegate.CreateDelegate(typeof(TTarget), sourceItem.Target, sourceItem.Method))
+            .Aggregate<Delegate, Delegate>(null, Delegate.Combine);
+    }
+
+    private void UpdateOriginal()
+    {
+        // Thunked base hooks do not need updating of the original delegate.
+        if (this.Thunked)
+            return;
+
+        this.originalFunction = DirectCastDelegateTo<T>((MulticastDelegate)(Delegate)this.BaseHook.Original);
+    }
+
+    private TBase CreateDetourThunk()
+    {
+        var method = typeof(TBase).GetMethod("Invoke");
+        var parameters = method.GetParameters();
+
+        var dynamicMethod = new DynamicMethod(
+            "CastingHookDetourThunk",
+            method.ReturnType,
+            Array.ConvertAll(parameters, p => p.ParameterType),
+            typeof(CastingHook<T, TBase>));
+
+        var ilGenerator = dynamicMethod.GetILGenerator();
+
+        var selfLookupGetter = typeof(CastingHook<T, TBase>).GetProperty("SelfLookup", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public).GetGetMethod(true);
+        ilGenerator.Emit(OpCodes.Call, selfLookupGetter);
+        ilGenerator.Emit(OpCodes.Ldc_I4, this.InstanceId);
+
+        var tryGetValueMethod = typeof(ConcurrentDictionary<int, IDalamudHook>).GetMethod("TryGetValue");
+        var localHook = ilGenerator.DeclareLocal(typeof(IDalamudHook));
+
+        ilGenerator.Emit(OpCodes.Ldloca_S, localHook);
+        ilGenerator.Emit(OpCodes.Callvirt, tryGetValueMethod);
+
+        var getItemLabel = ilGenerator.DefineLabel();
+        ilGenerator.Emit(OpCodes.Brtrue_S, getItemLabel);
+
+        // Case where element does not exist in the dictionary (which should never happen)
+        ilGenerator.Emit(OpCodes.Newobj, typeof(InvalidOperationException).GetConstructor(Type.EmptyTypes));
+        ilGenerator.Emit(OpCodes.Throw);
+
+        ilGenerator.MarkLabel(getItemLabel);
+        ilGenerator.Emit(OpCodes.Ldloc_S, localHook);
+        ilGenerator.Emit(OpCodes.Castclass, typeof(CastingHook<T, TBase>));
+
+        var detourGetter = typeof(CastingHook<T, TBase>).GetProperty("Detour", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public).GetGetMethod(true);
+        ilGenerator.Emit(OpCodes.Callvirt, detourGetter);
+
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            ilGenerator.Emit(OpCodes.Ldarg, i);
+        }
+
+        ilGenerator.Emit(OpCodes.Call, method);
+
+        // Handle special cases for nint to pointer types and vice versa
+        if (method.ReturnType.IsPointer)
+            ilGenerator.Emit(OpCodes.Conv_U);
+
+        if (method.ReturnType == typeof(nint))
+            ilGenerator.Emit(OpCodes.Conv_I);
+
+        ilGenerator.Emit(OpCodes.Ret);
+
+        return (TBase)dynamicMethod.CreateDelegate(typeof(TBase));
+    }
+
+    private T CreateOriginalThunk()
+    {
+        var method = typeof(T).GetMethod("Invoke");
+        var parameters = method.GetParameters();
+
+        var dynamicMethod = new DynamicMethod(
+            "CastingHookOriginalThunk",
+            method.ReturnType,
+            Array.ConvertAll(parameters, p => p.ParameterType),
+            typeof(CastingHook<T, TBase>));
+
+        var ilGenerator = dynamicMethod.GetILGenerator();
+
+        var selfLookupGetter = typeof(CastingHook<T, TBase>).GetProperty("SelfLookup", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public).GetGetMethod(true);
+        ilGenerator.Emit(OpCodes.Call, selfLookupGetter);
+        ilGenerator.Emit(OpCodes.Ldc_I4, this.InstanceId);
+
+        var tryGetValueMethod = typeof(ConcurrentDictionary<int, IDalamudHook>).GetMethod("TryGetValue");
+        var localHook = ilGenerator.DeclareLocal(typeof(IDalamudHook));
+
+        ilGenerator.Emit(OpCodes.Ldloca_S, localHook);
+        ilGenerator.Emit(OpCodes.Callvirt, tryGetValueMethod);
+
+        var getItemLabel = ilGenerator.DefineLabel();
+        ilGenerator.Emit(OpCodes.Brtrue_S, getItemLabel);
+
+        // Case where element does not exist in the dictionary (which should never happen)
+        ilGenerator.Emit(OpCodes.Newobj, typeof(InvalidOperationException).GetConstructor(Type.EmptyTypes));
+        ilGenerator.Emit(OpCodes.Throw);
+
+        ilGenerator.MarkLabel(getItemLabel);
+        ilGenerator.Emit(OpCodes.Ldloc_S, localHook);
+        ilGenerator.Emit(OpCodes.Castclass, typeof(CastingHook<T, TBase>));
+
+        var baseHookGetter = typeof(CastingHook<T, TBase>).GetProperty("BaseHook", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public).GetGetMethod(true);
+        ilGenerator.Emit(OpCodes.Callvirt, baseHookGetter);
+
+        var originalGetter = typeof(HollowHook<TBase>).GetProperty("Original", BindingFlags.Instance | BindingFlags.Public).GetGetMethod(true);
+        ilGenerator.Emit(OpCodes.Callvirt, originalGetter);
+
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            ilGenerator.Emit(OpCodes.Ldarg, i);
+        }
+
+        ilGenerator.Emit(OpCodes.Call, method);
+
+        // Handle special cases for nint to pointer types and vice versa
+        if (method.ReturnType.IsPointer)
+            ilGenerator.Emit(OpCodes.Conv_U);
+
+        if (method.ReturnType == typeof(nint))
+            ilGenerator.Emit(OpCodes.Conv_I);
+
+        ilGenerator.Emit(OpCodes.Ret);
+
+        return (T)dynamicMethod.CreateDelegate(typeof(T));
+    }
+}

--- a/Dalamud/Hooking/Internal/HollowHook.cs
+++ b/Dalamud/Hooking/Internal/HollowHook.cs
@@ -1,0 +1,85 @@
+namespace Dalamud.Hooking.Internal;
+
+/// <summary>
+/// Class facilitating hooks without a backend as part of a <see cref="HookStacker{T}"/> object.
+/// </summary>
+/// <typeparam name="T">Delegate of the hook.</typeparam>
+/// <remarks>
+/// Initializes a new instance of the <see cref="HollowHook{T}"/> class.
+/// </remarks>
+/// <param name="address">A memory address to install a hook.</param>
+/// <param name="stacker">The hook stacker this hook is part of.</param>
+internal class HollowHook<T>(nint address, HookStacker<T> stacker) : Hook<T>(address) where T : Delegate
+{
+    private T originalFunction;
+    private bool isHookEnabled;
+    private HookStacker<T> stacker = stacker;
+
+    /// <summary>
+    /// Action triggered when the original function changes.
+    /// </summary>
+    internal event Action? OriginalChanged;
+
+    /// <inheritdoc/>
+    public override T Original
+    {
+        get
+        {
+            this.CheckDisposed();
+            return this.originalFunction;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override bool IsEnabled
+    {
+        get
+        {
+            this.CheckDisposed();
+            return this.isHookEnabled;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override string BackendName => this.stacker.BackendName;
+
+    /// <inheritdoc/>
+    public override void Dispose()
+    {
+        if (this.IsDisposed)
+            return;
+
+        this.Disable();
+
+        this.stacker.Remove(this);
+
+        base.Dispose();
+    }
+
+    /// <inheritdoc/>
+    public override void Enable()
+    {
+        this.CheckDisposed();
+        this.isHookEnabled = true;
+        this.stacker.UpdateDelegates();
+    }
+
+    /// <inheritdoc/>
+    public override void Disable()
+    {
+        this.CheckDisposed();
+        this.isHookEnabled = false;
+        this.stacker.UpdateDelegates();
+    }
+
+    /// <summary>
+    /// Sets the original function field.
+    /// </summary>
+    /// <param name="value">Original function. Delegate must have a same original function prototype.</param>
+    internal void SetOriginal(T value)
+    {
+        this.CheckDisposed();
+        this.originalFunction = value;
+        this.OriginalChanged?.Invoke();
+    }
+}

--- a/Dalamud/Hooking/Internal/HookInfo.cs
+++ b/Dalamud/Hooking/Internal/HookInfo.cs
@@ -16,11 +16,13 @@ internal class HookInfo
     /// <param name="hook">The tracked hook.</param>
     /// <param name="hookDelegate">The hook delegate.</param>
     /// <param name="assembly">The assembly implementing the hook.</param>
-    public HookInfo(IDalamudHook hook, Delegate hookDelegate, Assembly assembly)
+    /// <param name="priority">The priority of the hook.</param>
+    public HookInfo(IDalamudHook hook, Delegate hookDelegate, Assembly assembly, byte priority)
     {
         this.Hook = hook;
         this.Delegate = hookDelegate;
         this.Assembly = assembly;
+        this.Priority = priority;
     }
 
     /// <summary>
@@ -69,4 +71,10 @@ internal class HookInfo
     /// Gets the assembly implementing the hook.
     /// </summary>
     internal Assembly Assembly { get; }
+
+    /// <summary>
+    /// Gets the hook priority.
+    /// Higher priorities are run first; 0 and 255 are notify-only.
+    /// </summary>
+    internal byte Priority { get; }
 }

--- a/Dalamud/Hooking/Internal/HookStacker.cs
+++ b/Dalamud/Hooking/Internal/HookStacker.cs
@@ -1,0 +1,274 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Dalamud.Hooking.Internal;
+
+/// <summary>
+/// This class manages the stacking of hooks.
+/// </summary>
+/// <typeparam name="T">Delegate type to represent a function prototype. This must be the same prototype as original function.</typeparam>
+internal class HookStacker<T> : IDalamudHook where T : Delegate
+{
+    private readonly object syncRoot = new();
+    private Hook<T>? hookImpl;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HookStacker{T}"/> class.
+    /// </summary>
+    /// <param name="address">Address of this hook stacker.</param>
+    public HookStacker(nint address)
+    {
+        this.Address = address;
+        HookManager.HookStackTracker[address] = this;
+        this.BackendDelegate = this.CreateBackendDelegate();
+    }
+
+    /// <inheritdoc/>
+    public nint Address { get; }
+
+    /// <inheritdoc/>
+    public bool IsEnabled
+    {
+        get
+        {
+            lock (this.syncRoot)
+            {
+                return this.HookStack.Any(h => h.Hook.IsEnabled) ||
+                    this.BeforeNotifyHookStack.Any(h => h.Hook.IsEnabled) ||
+                    this.AfterNotifyHookStack.Any(h => h.Hook.IsEnabled);
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool IsDisposed { get; private set; }
+
+    /// <inheritdoc/>
+    public string BackendName => this.hookImpl.BackendName;
+
+    /// <summary>
+    /// Gets the first stacked delegate to be called by the underlying hook.
+    /// </summary>
+    internal T FirstStackedDelegate { get; private set; }
+
+    /// <summary>
+    /// Gets the backend delgate, which wraps the first stacked delegate so
+    /// it can be dynamically updated without recreating the underlying hook.
+    /// </summary>
+    internal T BackendDelegate { get; }
+
+    /// <summary>
+    /// Gets or sets a linked list of stacked hooks in the priority range [1,254].
+    /// The caller must hold the syncRoot hook stack lock when accessing this list.
+    /// This list is always sorted in a descending order based on hook priority.
+    /// </summary>
+    private LinkedList<HookInfo> HookStack { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the list of before-notify hooks with priority 255.
+    /// The caller must hold the syncRoot hook stack lock when accessing this list.
+    /// </summary>
+    private List<HookInfo> BeforeNotifyHookStack { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the list of after-notify hooks with priority 0.
+    /// The caller must hold the syncRoot hook stack lock when accessing this list.
+    /// </summary>
+    private List<HookInfo> AfterNotifyHookStack { get; set; } = [];
+
+    /// <inheritdoc/>
+    public virtual void Dispose()
+    {
+        if (this.IsDisposed)
+            return;
+
+        lock (this.syncRoot)
+        {
+            foreach (var hook in this.HookStack)
+                hook.Hook.Dispose();
+
+            foreach (var hook in this.BeforeNotifyHookStack)
+                hook.Hook.Dispose();
+
+            foreach (var hook in this.AfterNotifyHookStack)
+                hook.Hook.Dispose();
+
+            this.HookStack = [];
+            this.BeforeNotifyHookStack = [];
+            this.AfterNotifyHookStack = [];
+            this.hookImpl?.Dispose();
+            HookManager.HookStackTracker.TryRemove(this.Address, out _);
+        }
+
+        this.IsDisposed = true;
+    }
+
+    /// <summary>
+    /// Sets the backend hook implementation.
+    /// </summary>
+    /// <param name="hookImpl">Backend hook all other hooks are stacked on.</param>
+    internal void SetBackend(Hook<T> hookImpl)
+    {
+        this.hookImpl = hookImpl;
+        this.FirstStackedDelegate = this.hookImpl.Original;
+        this.hookImpl.Enable();
+        this.hookImpl.Disable();
+    }
+
+    /// <summary>
+    /// Rebuilds all delegates after a hook state change.
+    /// </summary>
+    internal void UpdateDelegates()
+    {
+        this.FirstStackedDelegate = this.CreateFirstStackedDelegate();
+
+        foreach (var hook in this.HookStack)
+        {
+            ((HollowHook<T>)hook.Hook).SetOriginal(this.CreateOriginalDelegate(hook));
+        }
+
+        if (this.IsEnabled) this.hookImpl.Enable();
+        else this.hookImpl.Disable();
+    }
+
+    /// <summary>
+    /// Adds a hook to the hook stack.
+    /// </summary>
+    /// <param name="hook">The hook to be added.</param>
+    public void Add(HookInfo hook)
+    {
+        lock (this.syncRoot)
+        {
+            switch (hook.Priority)
+            {
+                case byte.MaxValue:
+                    this.BeforeNotifyHookStack.Add(hook);
+                    break;
+                case byte.MinValue:
+                    this.AfterNotifyHookStack.Add(hook);
+                    break;
+                default:
+                    this.HookStack.AddFirst(hook);
+                    var sortedHooks = this.HookStack.OrderByDescending(h => h.Priority);
+                    this.HookStack = new LinkedList<HookInfo>(sortedHooks);
+                    break;
+            }
+
+            this.UpdateDelegates();
+        }
+    }
+
+    /// <summary>
+    /// Removes a hook from the hook stack.
+    /// </summary>
+    /// <param name="hook">The hook to be removed.</param>
+    internal void Remove(IDalamudHook hook)
+    {
+        lock (this.syncRoot)
+        {
+            var node = this.HookStack.FirstOrDefault(h => ReferenceEquals(h.Hook, hook));
+            this.HookStack.Remove(node);
+
+            node = this.BeforeNotifyHookStack.FirstOrDefault(h => ReferenceEquals(h.Hook, hook));
+            this.BeforeNotifyHookStack.Remove(node);
+
+            node = this.AfterNotifyHookStack.FirstOrDefault(h => ReferenceEquals(h.Hook, hook));
+            this.AfterNotifyHookStack.Remove(node);
+
+            this.UpdateDelegates();
+
+            if (this.HookStack.Count == 0 && this.BeforeNotifyHookStack.Count == 0 && this.AfterNotifyHookStack.Count == 0)
+                this.Dispose();
+        }
+    }
+
+    private T CreateBackendDelegate()
+    {
+        var method = typeof(T).GetMethod("Invoke");
+        var parameters = method.GetParameters();
+
+        var dynamicMethod = new DynamicMethod(
+            "DalamudHook",
+            method.ReturnType,
+            Array.ConvertAll(parameters, p => p.ParameterType),
+            typeof(HookStacker<T>));
+
+        var ilGenerator = dynamicMethod.GetILGenerator();
+
+        var hookStackTrackerGetter = typeof(HookManager).GetProperty("HookStackTracker", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public).GetGetMethod(true);
+        ilGenerator.Emit(OpCodes.Call, hookStackTrackerGetter);
+        ilGenerator.Emit(OpCodes.Ldc_I8, this.Address);
+        ilGenerator.Emit(OpCodes.Conv_I);
+
+        var tryGetValueMethod = typeof(ConcurrentDictionary<nint, IDalamudHook>).GetMethod("TryGetValue");
+        var localHookStacker = ilGenerator.DeclareLocal(typeof(IDalamudHook));
+
+        ilGenerator.Emit(OpCodes.Ldloca_S, localHookStacker);
+        ilGenerator.Emit(OpCodes.Callvirt, tryGetValueMethod);
+
+        var getItemLabel = ilGenerator.DefineLabel();
+        ilGenerator.Emit(OpCodes.Brtrue_S, getItemLabel);
+
+        // Case where element does not exist in the dictionary (which should never happen)
+        ilGenerator.Emit(OpCodes.Newobj, typeof(InvalidOperationException).GetConstructor(Type.EmptyTypes));
+        ilGenerator.Emit(OpCodes.Throw);
+
+        ilGenerator.MarkLabel(getItemLabel);
+        ilGenerator.Emit(OpCodes.Ldloc_S, localHookStacker);
+        ilGenerator.Emit(OpCodes.Castclass, typeof(HookStacker<T>));
+
+        var firstStackedDelegateGetter = typeof(HookStacker<T>).GetProperty("FirstStackedDelegate", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public).GetGetMethod(true);
+        ilGenerator.Emit(OpCodes.Callvirt, firstStackedDelegateGetter);
+
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            ilGenerator.Emit(OpCodes.Ldarg, i);
+        }
+
+        ilGenerator.Emit(OpCodes.Call, method);
+        ilGenerator.Emit(OpCodes.Ret);
+
+        return (T)dynamicMethod.CreateDelegate(typeof(T));
+    }
+
+    private T CreateFirstStackedDelegate()
+    {
+        lock (this.syncRoot)
+        {
+            var beforeNotify = (T)Delegate.Combine(this.BeforeNotifyHookStack.Where(h => h.Hook.IsEnabled).Select(h => h.Delegate).ToArray());
+            var node = this.HookStack.First;
+
+            while (node is not null && !node.Value.Hook.IsEnabled)
+                node = node.Next;
+
+            if (node is not null)
+                return (T)Delegate.Combine(beforeNotify, node.Value.Delegate);
+
+            var afterNotify = (T)Delegate.Combine(this.AfterNotifyHookStack.Where(h => h.Hook.IsEnabled).Select(h => h.Delegate).ToArray());
+
+            return (T)Delegate.Combine(beforeNotify, afterNotify, this.hookImpl.Original);
+        }
+    }
+
+    private T CreateOriginalDelegate(HookInfo callingHook)
+    {
+        lock (this.syncRoot)
+        {
+            var node = this.HookStack.Find(callingHook);
+            node = node.Next;
+
+            while (node is not null && !node.Value.Hook.IsEnabled)
+                node = node.Next;
+
+            if (node is not null)
+                return (T)node.Value.Delegate;
+
+            var afterNotify = (T)Delegate.Combine(this.AfterNotifyHookStack.Where(h => h.Hook.IsEnabled).Select(h => h.Delegate).ToArray());
+
+            return (T)Delegate.Combine(afterNotify, this.hookImpl.Original);
+        }
+    }
+}

--- a/Dalamud/Hooking/Internal/ReloadedHook.cs
+++ b/Dalamud/Hooking/Internal/ReloadedHook.cs
@@ -17,11 +17,10 @@ internal class ReloadedHook<T> : Hook<T> where T : Delegate
     /// </summary>
     /// <param name="address">A memory address to install a hook.</param>
     /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
-    /// <param name="callingAssembly">Calling assembly.</param>
-    internal ReloadedHook(IntPtr address, T detour, Assembly callingAssembly)
+    internal ReloadedHook(IntPtr address, T detour)
         : base(address)
     {
-        lock (HookManager.HookEnableSyncRoot)
+        lock (HookManager.HookSyncRoot)
         {
             var unhooker = HookManager.RegisterUnhooker(address);
             this.hookImpl = ReloadedHooks.Instance.CreateHook<T>(detour, address.ToInt64());
@@ -29,8 +28,6 @@ internal class ReloadedHook<T> : Hook<T> where T : Delegate
             this.hookImpl.Disable();
 
             unhooker.TrimAfterHook();
-
-            HookManager.TrackedHooks.TryAdd(Guid.NewGuid(), new HookInfo(this, detour, callingAssembly));
         }
     }
 
@@ -73,7 +70,7 @@ internal class ReloadedHook<T> : Hook<T> where T : Delegate
     {
         this.CheckDisposed();
 
-        lock (HookManager.HookEnableSyncRoot)
+        lock (HookManager.HookSyncRoot)
         {
             if (!this.hookImpl.IsHookEnabled)
                 this.hookImpl.Enable();
@@ -85,7 +82,7 @@ internal class ReloadedHook<T> : Hook<T> where T : Delegate
     {
         this.CheckDisposed();
 
-        lock (HookManager.HookEnableSyncRoot)
+        lock (HookManager.HookSyncRoot)
         {
             if (!this.hookImpl.IsHookActivated)
                 return;

--- a/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
@@ -272,7 +272,7 @@ internal class PluginStatWindow : Window
 
             if (ImGui.BeginTable(
                     "##PluginStatsHooks",
-                    4,
+                    5,
                     ImGuiTableFlags.RowBg
                     | ImGuiTableFlags.SizingStretchProp
                     | ImGuiTableFlags.Resizable
@@ -284,10 +284,11 @@ internal class PluginStatWindow : Window
                 ImGui.TableSetupColumn("Detour Method", ImGuiTableColumnFlags.None, 250);
                 ImGui.TableSetupColumn("Address", ImGuiTableColumnFlags.None, 100);
                 ImGui.TableSetupColumn("Status", ImGuiTableColumnFlags.None, 40);
+                ImGui.TableSetupColumn("Priority", ImGuiTableColumnFlags.None, 10);
                 ImGui.TableSetupColumn("Backend", ImGuiTableColumnFlags.None, 40);
                 ImGui.TableHeadersRow();
 
-                foreach (var (guid, trackedHook) in HookManager.TrackedHooks)
+                foreach (var (guid, trackedHook) in HookManager.Hooks)
                 {
                     try
                     {
@@ -343,6 +344,10 @@ internal class PluginStatWindow : Window
 
                         ImGui.TableNextColumn();
 
+                        ImGui.Text(trackedHook.Priority.ToString());
+
+                        ImGui.TableNextColumn();
+
                         ImGui.Text(trackedHook.Hook.BackendName);
                     }
                     catch (Exception ex)
@@ -359,7 +364,10 @@ internal class PluginStatWindow : Window
         {
             foreach (var guid in toRemove)
             {
-                HookManager.TrackedHooks.TryRemove(guid, out _);
+                lock (HookManager.HookSyncRoot) 
+                {
+                    HookManager.Hooks.Remove(guid, out _);
+                }
             }
         }
 

--- a/Dalamud/Plugin/Services/IGameInteropProvider.cs
+++ b/Dalamud/Plugin/Services/IGameInteropProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 using Dalamud.Hooking;
 using Dalamud.Utility.Signatures;
@@ -40,16 +40,19 @@ public interface IGameInteropProvider
     /// </summary>
     /// <param name="self">The object to initialize.</param>
     public void InitializeFromAttributes(object self);
-    
+
     /// <summary>
     /// Creates a hook by replacing the original address with an address pointing to a newly created jump to the detour.
     /// </summary>
     /// <param name="address">A memory address to install a hook.</param>
     /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
+    /// <param name="priority">Priority band of the hook.</param>
+    /// <param name="precedence">Precendence of the hook. Positive values will lead to the hook having higher effective
+    /// raw priority (called earlier), and negative values lead to lower effective raw priority (called later).</param>
     /// <returns>The hook with the supplied parameters.</returns>
     /// <typeparam name="T">Delegate of detour.</typeparam>
-    public Hook<T> HookFromFunctionPointerVariable<T>(nint address, T detour) where T : Delegate;
-    
+    public Hook<T> HookFromFunctionPointerVariable<T>(nint address, T detour, HookPriority priority = HookPriority.NormalPriority, int precedence = 0) where T : Delegate;
+
     /// <summary>
     /// Creates a hook by rewriting import table address.
     /// </summary>
@@ -58,9 +61,12 @@ public interface IGameInteropProvider
     /// <param name="functionName">Decorated name of the function.</param>
     /// <param name="hintOrOrdinal">Hint or ordinal. 0 to unspecify.</param>
     /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
+    /// <param name="priority">Priority band of the hook.</param>
+    /// <param name="precedence">Precendence of the hook. Positive values will lead to the hook having higher effective
+    /// raw priority (called earlier), and negative values lead to lower effective raw priority (called later).</param>
     /// <returns>The hook with the supplied parameters.</returns>
     /// <typeparam name="T">Delegate of detour.</typeparam>
-    public Hook<T> HookFromImport<T>(ProcessModule? module, string moduleName, string functionName, uint hintOrOrdinal, T detour) where T : Delegate;
+    public Hook<T> HookFromImport<T>(ProcessModule? module, string moduleName, string functionName, uint hintOrOrdinal, T detour, HookPriority priority = HookPriority.NormalPriority, int precedence = 0) where T : Delegate;
 
     /// <summary>
     /// Creates a hook. Hooking address is inferred by calling to GetProcAddress() function.
@@ -71,9 +77,12 @@ public interface IGameInteropProvider
     /// <param name="exportName">A name of the exported function name (e.g. send).</param>
     /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
     /// <param name="backend">Hooking library to use.</param>
+    /// <param name="priority">Priority band of the hook.</param>
+    /// <param name="precedence">Precendence of the hook. Positive values will lead to the hook having higher effective
+    /// raw priority (called earlier), and negative values lead to lower effective raw priority (called later).</param>
     /// <returns>The hook with the supplied parameters.</returns>
     /// <typeparam name="T">Delegate of detour.</typeparam>
-    Hook<T> HookFromSymbol<T>(string moduleName, string exportName, T detour, HookBackend backend = HookBackend.Automatic) where T : Delegate;
+    Hook<T> HookFromSymbol<T>(string moduleName, string exportName, T detour, HookBackend backend = HookBackend.Automatic, HookPriority priority = HookPriority.NormalPriority, int precedence = 0) where T : Delegate;
 
     /// <summary>
     /// Creates a hook. Hooking address is inferred by calling to GetProcAddress() function.
@@ -83,10 +92,13 @@ public interface IGameInteropProvider
     /// <param name="procAddress">A memory address to install a hook.</param>
     /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
     /// <param name="backend">Hooking library to use.</param>
+    /// <param name="priority">Priority band of the hook.</param>
+    /// <param name="precedence">Precendence of the hook. Positive values will lead to the hook having higher effective
+    /// raw priority (called earlier), and negative values lead to lower effective raw priority (called later).</param>
     /// <returns>The hook with the supplied parameters.</returns>
     /// <typeparam name="T">Delegate of detour.</typeparam>
-    Hook<T> HookFromAddress<T>(nint procAddress, T detour, HookBackend backend = HookBackend.Automatic) where T : Delegate;
-    
+    Hook<T> HookFromAddress<T>(nint procAddress, T detour, HookBackend backend = HookBackend.Automatic, HookPriority priority = HookPriority.NormalPriority, int precedence = 0) where T : Delegate;
+
     /// <summary>
     /// Creates a hook. Hooking address is inferred by calling to GetProcAddress() function.
     /// The hook is not activated until Enable() method is called.
@@ -95,10 +107,13 @@ public interface IGameInteropProvider
     /// <param name="procAddress">A memory address to install a hook.</param>
     /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
     /// <param name="backend">Hooking library to use.</param>
+    /// <param name="priority">Priority band of the hook.</param>
+    /// <param name="precedence">Precendence of the hook. Positive values will lead to the hook having higher effective
+    /// raw priority (called earlier), and negative values lead to lower effective raw priority (called later).</param>
     /// <returns>The hook with the supplied parameters.</returns>
     /// <typeparam name="T">Delegate of detour.</typeparam>
-    Hook<T> HookFromAddress<T>(nuint procAddress, T detour, HookBackend backend = HookBackend.Automatic) where T : Delegate;
-    
+    Hook<T> HookFromAddress<T>(nuint procAddress, T detour, HookBackend backend = HookBackend.Automatic, HookPriority priority = HookPriority.NormalPriority, int precedence = 0) where T : Delegate;
+
     /// <summary>
     /// Creates a hook. Hooking address is inferred by calling to GetProcAddress() function.
     /// The hook is not activated until Enable() method is called.
@@ -107,17 +122,23 @@ public interface IGameInteropProvider
     /// <param name="procAddress">A memory address to install a hook.</param>
     /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
     /// <param name="backend">Hooking library to use.</param>
+    /// <param name="priority">Priority band of the hook.</param>
+    /// <param name="precedence">Precendence of the hook. Positive values will lead to the hook having higher effective
+    /// raw priority (called earlier), and negative values lead to lower effective raw priority (called later).</param>
     /// <returns>The hook with the supplied parameters.</returns>
     /// <typeparam name="T">Delegate of detour.</typeparam>
-    unsafe Hook<T> HookFromAddress<T>(void* procAddress, T detour, HookBackend backend = HookBackend.Automatic) where T : Delegate;
-    
+    unsafe Hook<T> HookFromAddress<T>(void* procAddress, T detour, HookBackend backend = HookBackend.Automatic, HookPriority priority = HookPriority.NormalPriority, int precedence = 0) where T : Delegate;
+
     /// <summary>
     /// Creates a hook from a signature into the Dalamud target module.
     /// </summary>
     /// <param name="signature">Signature of function to hook.</param>
     /// <param name="detour">Callback function. Delegate must have a same original function prototype.</param>
     /// <param name="backend">Hooking library to use.</param>
+    /// <param name="priority">Priority band of the hook.</param>
+    /// <param name="precedence">Precendence of the hook. Positive values will lead to the hook having higher effective
+    /// raw priority (called earlier), and negative values lead to lower effective raw priority (called later).</param>
     /// <returns>The hook with the supplied parameters.</returns>
     /// <typeparam name="T">Delegate of detour.</typeparam>
-    Hook<T> HookFromSignature<T>(string signature, T detour, HookBackend backend = HookBackend.Automatic) where T : Delegate;
+    Hook<T> HookFromSignature<T>(string signature, T detour, HookBackend backend = HookBackend.Automatic, HookPriority priority = HookPriority.NormalPriority, int precedence = 0) where T : Delegate;
 }


### PR DESCRIPTION
Hook stacking without having multiple managed to native and native to managed transitions was the primary objective here, but priorities were relatively easy to implement on top of that.

Currently this implements the following priority bands:

* 0: After-notify only hooks (always run last)
* 1-127: Normal priority hooks
* 128-191: Dalamud internal hooks
* 192-254: High priority hooks
* 255: Before-notify only hooks (always run first)

Normal priority hooks convert to Dalamud internal ones automatically based on the calling assembly. For fine grained control inside a priority band, the optional `precedence` parameter can be used to lower or raise the effective priority.

This also makes some locking a bit stricter (like making sure jumps are followed only under the global hook lock).

There is some IL dynamically generated in 3 places (most of the time only in 1), I don't believe there is a reasonably performant alternative to that unfortunately.
When stacking hooks of incompatible signatures (like ST `private delegate void* GlobalEventDelegate(AtkUnitBase* atkUnitBase, AtkEventType eventType, uint eventParam, AtkResNode** eventData, uint* a5)` and Dalamuds `private delegate IntPtr AtkUnitBaseReceiveGlobalEvent(AtkUnitBase* thisPtr, ushort cmd, uint a3, IntPtr a4, uint* a5)`) a warning is logged and IL thunks are generated inside a `CastingHook<,>`.

`AsmHook` seem to exist a bit outside the other hooks, so these currently do not stack, but are now also under the global hook lock.

This also fixes the `callingAssembly` not resolving to the actual plugin and marking all hooks as "Dalamud Hooks".