### PR TITLE
Add Attestations to Dalamud CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,10 @@ concurrency:
 jobs:
   build:
     name: Build on Windows
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
     runs-on: windows-2022
     steps:
       - name: Checkout Dalamud
@@ -40,6 +44,17 @@ jobs:
         run: .\sign.ps1 .\bin\Release
       - name: Create hashlist
         run: .\CreateHashList.ps1 .\bin\Release
+      - name: Attest Build
+        if: ${{ github.repository_owner == 'goatcorp' && github.event_name == 'push' }}
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: |
+            bin/Release/hashes.json
+            bin/Release/Dalamud.dll
+            bin/Release/DalamudCrashHandler.exe
+            bin/Release/Dalamud.*.dll
+            bin/Release/Dalamud.*.exe
+            bin/Release/FFXIVClientStructs.dll
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
CI change to [enable build provenance](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) for Dalamud builds.

Per guidance, I'm only covering the essential files: all Dalamud-built DLLs and EXEs, alongside FFXIVClientStructs as we submodule-build it. For everything else, I'm also attesting our final `hashes.json`, so we have that as a canonical root to work with.