### PR TITLE
Add /xlcopylog command

### DIFF
--- a/Dalamud/Interface/Internal/DalamudCommands.cs
+++ b/Dalamud/Interface/Internal/DalamudCommands.cs
@@ -466,6 +466,7 @@ internal class DalamudCommands : IServiceType
             }
             else
             {
+                hGlobal.Dispose();
                 chatGui.Print(string.Format(Loc.Localize("DalamudLogCopyFailure", "Could not copy log file to clipboard."), "default"));
             }
         }

--- a/Dalamud/Interface/Internal/DalamudCommands.cs
+++ b/Dalamud/Interface/Internal/DalamudCommands.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Text;
 
 using CheapLoc;
 using Dalamud.Configuration.Internal;
@@ -11,6 +13,12 @@ using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Plugin.Internal;
 using Dalamud.Utility;
 using Serilog;
+using Windows.Win32.Foundation;
+using Windows.Win32.System.Memory;
+using Windows.Win32.System.Ole;
+using Windows.Win32.UI.Shell;
+
+using Win32_PInvoke = Windows.Win32.PInvoke;
 
 namespace Dalamud.Interface.Internal;
 
@@ -142,6 +150,13 @@ internal class DalamudCommands : IServiceType
         {
             HelpMessage = "ImGui DEBUG",
             ShowInHelp = false,
+        });
+
+        commandManager.AddHandler("/xlcopylog", new CommandInfo(this.OnCopyLogCommand)
+        {
+            HelpMessage = Loc.Localize(
+                "DalamudCopyLogHelp",
+                "Copy the dalamud.log file to your clipboard."),
         });
     }
 
@@ -405,5 +420,54 @@ internal class DalamudCommands : IServiceType
     private void OnOpenProfilerCommand(string command, string arguments)
     {
         Service<DalamudInterface>.Get().ToggleProfilerWindow();
+    }
+
+    private void OnCopyLogCommand(string command, string arguments)
+    {
+        var logPath = Path.Join(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "XIVLauncher",
+            "dalamud.log");
+        var pathBytes = Encoding.Unicode.GetBytes(logPath);
+
+        var chatGui = Service<ChatGui>.Get();
+
+        unsafe
+        {
+            var dropFilesSize = sizeof(DROPFILES);
+            var hGlobal = Win32_PInvoke.GlobalAlloc_SafeHandle(
+                GLOBAL_ALLOC_FLAGS.GHND,
+                (uint)(dropFilesSize + pathBytes.Length + 2));
+            var dropFiles = (DROPFILES*)Win32_PInvoke.GlobalLock(hGlobal);
+
+            *dropFiles = default;
+            dropFiles->fWide = true;
+            dropFiles->pFiles = (uint)dropFilesSize;
+
+            var pathLoc = (byte*)((nint)dropFiles + dropFilesSize);
+            for (var i = 0; i < pathBytes.Length; i++)
+            {
+                pathLoc![i] = pathBytes[i];
+            }
+
+            pathLoc![pathBytes.Length] = 0;
+            pathLoc[pathBytes.Length + 1] = 0;
+
+            Win32_PInvoke.GlobalUnlock(hGlobal);
+
+            if (Win32_PInvoke.OpenClipboard(HWND.Null))
+            {
+                Win32_PInvoke.SetClipboardData(
+                    (uint)CLIPBOARD_FORMAT.CF_HDROP,
+                    hGlobal);
+                Win32_PInvoke.CloseClipboard();
+
+                chatGui.Print(string.Format(Loc.Localize("DalamudLogCopySuccess", "Log file copied to clipboard."), "default"));
+            }
+            else
+            {
+                chatGui.Print(string.Format(Loc.Localize("DalamudLogCopyFailure", "Could not copy log file to clipboard."), "default"));
+            }
+        }
     }
 }

--- a/Dalamud/NativeMethods.txt
+++ b/Dalamud/NativeMethods.txt
@@ -11,3 +11,13 @@ SetActiveWindow
 HWND_TOPMOST
 HWND_NOTOPMOST
 SET_WINDOW_POS_FLAGS
+
+OpenClipboard
+SetClipboardData
+CloseClipboard
+DROPFILES
+CLIPBOARD_FORMAT
+GlobalAlloc
+GlobalLock
+GlobalUnlock
+GLOBAL_ALLOC_FLAGS


### PR DESCRIPTION
Add a command to copy the dalamud.log file to the user's clipboard, behaving the same as copying the file in an Explorer window. Sorry about the messy code.

I added this to Heliosphere recently, and it has been useful during troubleshooting. Just thought I'd toss this your way in case you might also find it useful. If not, no problem.

You may want to change it to allow copying various log files instead of *just* `dalamud.log`.

Instead of telling users to go to `%appdata%\XIVLauncher` and find the text file called `dalamud`, you can instruct them to do `/xlcopylog` if they're able to open their game.