### PR TITLE
Allow InterfaceManager fonts to be null

### DIFF
--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -128,28 +128,28 @@ internal class InterfaceManager : IInternalDisposableService
     /// <strong>Accessing this static property outside of the main thread is dangerous and not supported.</strong>
     /// </summary>
     public static ImFontPtr DefaultFont =>
-        WhenFontsReady().DefaultFontHandle!.LockUntilPostFrame().OrElse(ImGui.GetIO().FontDefault);
+        WhenFontsReady()?.DefaultFontHandle!.LockUntilPostFrame().OrElse(ImGui.GetIO().FontDefault) ?? ImGui.GetIO().FontDefault;
 
     /// <summary>
     /// Gets an included FontAwesome icon font.<br />
     /// <strong>Accessing this static property outside of the main thread is dangerous and not supported.</strong>
     /// </summary>
     public static ImFontPtr IconFont =>
-        WhenFontsReady().IconFontHandle!.LockUntilPostFrame().OrElse(ImGui.GetIO().FontDefault);
+        WhenFontsReady()?.IconFontHandle!.LockUntilPostFrame().OrElse(ImGui.GetIO().FontDefault) ?? ImGui.GetIO().FontDefault;
 
     /// <summary>
     /// Gets an included FontAwesome icon font with fixed width.
     /// <strong>Accessing this static property outside of the main thread is dangerous and not supported.</strong>
     /// </summary>
     public static ImFontPtr IconFontFixedWidth =>
-        WhenFontsReady().IconFontFixedWidthHandle!.LockUntilPostFrame().OrElse(ImGui.GetIO().FontDefault);
+        WhenFontsReady()?.IconFontFixedWidthHandle!.LockUntilPostFrame().OrElse(ImGui.GetIO().FontDefault) ?? ImGui.GetIO().FontDefault;
 
     /// <summary>
     /// Gets an included monospaced font.<br />
     /// <strong>Accessing this static property outside of the main thread is dangerous and not supported.</strong>
     /// </summary>
     public static ImFontPtr MonoFont =>
-        WhenFontsReady().MonoFontHandle!.LockUntilPostFrame().OrElse(ImGui.GetIO().FontDefault);
+        WhenFontsReady()?.MonoFontHandle!.LockUntilPostFrame().OrElse(ImGui.GetIO().FontDefault) ?? ImGui.GetIO().FontDefault;
 
     /// <summary>
     /// Gets the default font handle.
@@ -247,7 +247,7 @@ internal class InterfaceManager : IInternalDisposableService
     /// <summary>
     /// Gets the font build task.
     /// </summary>
-    public Task FontBuildTask => WhenFontsReady().dalamudAtlas!.BuildTask;
+    public Task FontBuildTask => WhenFontsReady()!.dalamudAtlas!.BuildTask;
 
     /// <summary>Gets the number of calls to <see cref="PresentDetour"/> so far.</summary>
     /// <remarks>
@@ -468,11 +468,18 @@ internal class InterfaceManager : IInternalDisposableService
                     sizeof(int))).CheckError();
     }
 
-    private static InterfaceManager WhenFontsReady()
+    private static InterfaceManager? WhenFontsReady()
     {
         var im = Service<InterfaceManager>.GetNullable();
-        if (im?.dalamudAtlas is not { } atlas)
+        if (im == null)
+        {
+            return null;
+        }
+
+        if (im.dalamudAtlas is not { } atlas)
+        {
             throw new InvalidOperationException($"Tried to access fonts before {nameof(ContinueConstruction)} call.");
+        }
 
         if (!atlas.HasBuiltAtlas)
             atlas.BuildTask.GetAwaiter().GetResult();


### PR DESCRIPTION
So this one doesn't directly fix an issue that any player would run into, however it's something I'm running into and my plan is to release a nuget package allowing for developers to boot plugins with minimal effort from within their IDE.

In respect to that, this minor change allows for calls to InterfaceManager.IconFont,etc to not explode if InterfaceManager is not available(it'll always be available when Dalamud is running otherwise something has gone massively wrong), and instead returning imgui's default font

No issues if this doesn't get merged, it really only helps me but it shouldn't hurt anyone either