### PR TITLE
Add clientstruct widget

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
@@ -27,6 +27,7 @@ internal class DataWindow : Window, IDisposable
         new AetherytesWidget(),
         new AtkArrayDataBrowserWidget(),
         new BuddyListWidget(),
+        new ClientStructWidget(),
         new CommandWidget(),
         new ConditionWidget(),
         new ConfigurationWidget(),

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ClientStructWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ClientStructWidget.cs
@@ -11,7 +11,7 @@ using ImGuiNET;
 namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
 
 /// <summary>
-/// Widget to display resolved .text sigs.
+/// Widget to display resolved CS addresses
 /// </summary>
 internal class ClientStructWidget : IDataWindowWidget
 {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ClientStructWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ClientStructWidget.cs
@@ -1,0 +1,72 @@
+﻿using System.Numerics;
+
+using Dalamud.Interface.Colors;
+using Dalamud.Interface.Utility.Raii;
+
+using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Client.UI.Info;
+
+using ImGuiNET;
+
+namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
+
+/// <summary>
+/// Widget to display resolved .text sigs.
+/// </summary>
+internal class ClientStructWidget : IDataWindowWidget
+{
+    /// <inheritdoc/>
+    public string[]? CommandShortcuts { get; init; } = ["clientstruct"];
+
+    /// <inheritdoc/>
+    public string DisplayName { get; init; } = "ClientStruct";
+
+    /// <inheritdoc/>
+    public bool Ready { get; set; }
+
+    /// <inheritdoc/>
+    public void Load()
+    {
+        this.Ready = true;
+    }
+
+    /// <inheritdoc/>
+    public unsafe void Draw()
+    {
+        ImGui.TextColored(ImGuiColors.DalamudOrange, "InfoProxies");
+        var uiModule = UIModule.Instance();
+        if (uiModule == null)
+        {
+            ImGui.TextUnformatted("Unable to load UiModule");
+            return;
+        }
+
+        var infoModule = uiModule->GetInfoModule();
+        if (infoModule == null)
+        {
+            ImGui.TextUnformatted("Unable to load InfoModule");
+            return;
+        }
+
+        using var table = ImRaii.Table("##addressTable", 2, ImGuiTableFlags.BordersInner, new Vector2(ImGui.GetWindowContentRegionMax().X / 2.5f, 0));
+        if (!table.Success)
+            return;
+
+        ImGui.TableSetupColumn("Name");
+        ImGui.TableSetupColumn("Address", ImGuiTableColumnFlags.WidthFixed);
+
+        ImGui.TableHeadersRow();
+        foreach (var proxy in Enum.GetValues<InfoProxyId>())
+        {
+            var resolvedProxy = infoModule->GetInfoProxyById(proxy);
+
+            ImGui.TableNextColumn();
+            ImGui.TextUnformatted($"{Enum.GetName(proxy)}");
+
+            var address = $"{(nint)resolvedProxy:X}";
+            ImGui.TableNextColumn();
+            if (ImGui.Selectable(address))
+                ImGui.SetClipboardText(address);
+        }
+    }
+}


### PR DESCRIPTION
A simple widget for xldata that shows all Proxy addresses currently known (addresses are Selectables)
More future updates could also show Agent addresses
![image](https://github.com/goatcorp/Dalamud/assets/22648449/68319ccd-cc54-45f0-b7b2-cb4b6d198b50)
