### PR TITLE
Switch INotificationManager and ITitleScreenMenu to use ISharedImmediateTexture

### DIFF
--- a/Dalamud/Interface/ImGuiNotification/IActiveNotification.cs
+++ b/Dalamud/Interface/ImGuiNotification/IActiveNotification.cs
@@ -7,6 +7,8 @@ using Dalamud.Interface.Textures.TextureWraps;
 
 namespace Dalamud.Interface.ImGuiNotification;
 
+using Textures;
+
 /// <summary>Represents an active notification.</summary>
 /// <remarks>Not to be implemented by plugins.</remarks>
 public interface IActiveNotification : INotification
@@ -52,63 +54,13 @@ public interface IActiveNotification : INotification
     /// <remarks>This does not override <see cref="INotification.HardExpiry"/>.</remarks>
     void ExtendBy(TimeSpan extension);
 
-    /// <summary>Sets the icon from <see cref="IDalamudTextureWrap"/>, overriding the icon.</summary>
-    /// <param name="textureWrap">The new texture wrap to use, or null to clear and revert back to the icon specified
+    /// <summary>Sets the icon from <see cref="texture"/>, overriding the icon.</summary>
+    /// <param name="texture">The new texture to use, or null to clear and revert back to the icon specified
     /// from <see cref="INotification.Icon"/>.</param>
     /// <remarks>
-    /// <para>The texture passed will be disposed when the notification is dismissed or a new different texture is set
-    /// via another call to this function or overwriting the property. You do not have to dispose it yourself.</para>
-    /// <para>If <see cref="DismissReason"/> is not <c>null</c>, then calling this function will simply dispose the
-    /// passed <paramref name="textureWrap"/> without actually updating the icon.</para>
+    /// <para>If you need to provide a IDalamudTextureWrap that you will be responsible for disposing of, wrap it with <see cref="ForwardingSharedImmediateTexture"/>.</para>
     /// </remarks>
-    void SetIconTexture(IDalamudTextureWrap? textureWrap);
-
-    /// <summary>Sets the icon from <see cref="IDalamudTextureWrap"/>, overriding the icon, once the given task
-    /// completes.</summary>
-    /// <param name="textureWrapTask">The task that will result in a new texture wrap to use, or null to clear and
-    /// revert back to the icon specified from <see cref="INotification.Icon"/>.</param>
-    /// <remarks>
-    /// <para>The texture resulted from the passed <see cref="Task{TResult}"/> will be disposed when the notification
-    /// is dismissed or a new different texture is set via another call to this function over overwriting the property.
-    /// You do not have to dispose the resulted instance of <see cref="IDalamudTextureWrap"/> yourself.</para>
-    /// <para>If the task fails for any reason, the exception will be silently ignored and the icon specified from
-    /// <see cref="INotification.Icon"/> will be used instead.</para>
-    /// <para>If <see cref="DismissReason"/> is not <c>null</c>, then calling this function will simply dispose the
-    /// result of the passed <paramref name="textureWrapTask"/> without actually updating the icon.</para>
-    /// </remarks>
-    void SetIconTexture(Task<IDalamudTextureWrap?>? textureWrapTask);
-
-    /// <summary>Sets the icon from <see cref="IDalamudTextureWrap"/>, overriding the icon.</summary>
-    /// <param name="textureWrap">The new texture wrap to use, or null to clear and revert back to the icon specified
-    /// from <see cref="INotification.Icon"/>.</param>
-    /// <param name="leaveOpen">Whether to keep the passed <paramref name="textureWrap"/> not disposed.</param>
-    /// <remarks>
-    /// <para>If <paramref name="leaveOpen"/> is <c>false</c>, the texture passed will be disposed when the
-    /// notification is dismissed or a new different texture is set via another call to this function. You do not have
-    /// to dispose it yourself.</para>
-    /// <para>If <see cref="DismissReason"/> is not <c>null</c> and <paramref name="leaveOpen"/> is <c>false</c>, then
-    /// calling this function will simply dispose the passed <paramref name="textureWrap"/> without actually updating
-    /// the icon.</para>
-    /// </remarks>
-    void SetIconTexture(IDalamudTextureWrap? textureWrap, bool leaveOpen);
-
-    /// <summary>Sets the icon from <see cref="IDalamudTextureWrap"/>, overriding the icon, once the given task
-    /// completes.</summary>
-    /// <param name="textureWrapTask">The task that will result in a new texture wrap to use, or null to clear and
-    /// revert back to the icon specified from <see cref="INotification.Icon"/>.</param>
-    /// <param name="leaveOpen">Whether to keep the result from the passed <paramref name="textureWrapTask"/> not
-    /// disposed.</param>
-    /// <remarks>
-    /// <para>If <paramref name="leaveOpen"/> is <c>false</c>, the texture resulted from the passed
-    /// <see cref="Task{TResult}"/> will be disposed when the notification is dismissed or a new different texture is
-    /// set via another call to this function. You do not have to dispose the resulted instance of
-    /// <see cref="IDalamudTextureWrap"/> yourself.</para>
-    /// <para>If the task fails for any reason, the exception will be silently ignored and the icon specified from
-    /// <see cref="INotification.Icon"/> will be used instead.</para>
-    /// <para>If <see cref="DismissReason"/> is not <c>null</c>, then calling this function will simply dispose the
-    /// result of the passed <paramref name="textureWrapTask"/> without actually updating the icon.</para>
-    /// </remarks>
-    void SetIconTexture(Task<IDalamudTextureWrap?>? textureWrapTask, bool leaveOpen);
+    void SetIconTexture(ISharedImmediateTexture? texture);
 
     /// <summary>Generates a new value to use for <see cref="Id"/>.</summary>
     /// <returns>The new value.</returns>

--- a/Dalamud/Interface/ImGuiNotification/IActiveNotification.cs
+++ b/Dalamud/Interface/ImGuiNotification/IActiveNotification.cs
@@ -54,14 +54,6 @@ public interface IActiveNotification : INotification
     /// <remarks>This does not override <see cref="INotification.HardExpiry"/>.</remarks>
     void ExtendBy(TimeSpan extension);
 
-    /// <summary>Sets the icon from <see cref="texture"/>, overriding the icon.</summary>
-    /// <param name="texture">The new texture to use, or null to clear and revert back to the icon specified
-    /// from <see cref="INotification.Icon"/>.</param>
-    /// <remarks>
-    /// <para>If you need to provide a IDalamudTextureWrap that you will be responsible for disposing of, wrap it with <see cref="ForwardingSharedImmediateTexture"/>.</para>
-    /// </remarks>
-    void SetIconTexture(ISharedImmediateTexture? texture);
-
     /// <summary>Generates a new value to use for <see cref="Id"/>.</summary>
     /// <returns>The new value.</returns>
     internal static long CreateNewId() => Interlocked.Increment(ref idCounter);

--- a/Dalamud/Interface/ImGuiNotification/IActiveNotification.cs
+++ b/Dalamud/Interface/ImGuiNotification/IActiveNotification.cs
@@ -1,13 +1,8 @@
 using System.Threading;
-using System.Threading.Tasks;
 
 using Dalamud.Interface.ImGuiNotification.EventArgs;
-using Dalamud.Interface.Internal;
-using Dalamud.Interface.Textures.TextureWraps;
 
 namespace Dalamud.Interface.ImGuiNotification;
-
-using Textures;
 
 /// <summary>Represents an active notification.</summary>
 /// <remarks>Not to be implemented by plugins.</remarks>

--- a/Dalamud/Interface/ImGuiNotification/INotification.cs
+++ b/Dalamud/Interface/ImGuiNotification/INotification.cs
@@ -1,12 +1,6 @@
-using System.Threading.Tasks;
-
-using Dalamud.Interface.Internal;
-using Dalamud.Interface.Textures.TextureWraps;
-using Dalamud.Plugin.Services;
+using Dalamud.Interface.Textures;
 
 namespace Dalamud.Interface.ImGuiNotification;
-
-using Textures;
 
 /// <summary>Represents a notification.</summary>
 /// <remarks>Not to be implemented by plugins.</remarks>
@@ -24,7 +18,7 @@ public interface INotification
     /// <summary>Gets or sets the type of the notification.</summary>
     NotificationType Type { get; set; }
 
-    /// <summary>Gets or sets the icon source, in case <see cref="IconTextureTask"/> is not set or the task has faulted.
+    /// <summary>Gets or sets the icon source, in case <see cref="IconTexture"/> is not set.
     /// </summary>
     INotificationIcon? Icon { get; set; }
 

--- a/Dalamud/Interface/ImGuiNotification/INotification.cs
+++ b/Dalamud/Interface/ImGuiNotification/INotification.cs
@@ -28,18 +28,7 @@ public interface INotification
     /// </summary>
     INotificationIcon? Icon { get; set; }
 
-    /// <summary>Gets or sets a texture wrap that will be used in place of <see cref="Icon"/> if set.</summary>
-    /// <remarks>
-    /// <para>A texture wrap set via this property will <b>NOT</b> be disposed when the notification is dismissed.
-    /// Use <see cref="IActiveNotification.SetIconTexture(ISharedImmediateTexture?)"/> or
-    /// <see cref="IActiveNotification.SetIconTexture(Task{ISharedImmediateTexture?}?)"/> to use a texture, after calling
-    /// <see cref="INotificationManager.AddNotification"/>. Call either of those functions with <c>null</c> to revert
-    /// the effective icon back to this property.</para>
-    /// <para>This property and <see cref="IconTextureTask"/> are bound together. If the task is not <c>null</c> but
-    /// <see cref="Task.IsCompletedSuccessfully"/> is <c>false</c> (because the task is still in progress or faulted,)
-    /// the property will return <c>null</c>. Setting this property will set <see cref="IconTextureTask"/> to a new
-    /// completed <see cref="Task{TResult}"/> with the new value as its result.</para>
-    /// </remarks>
+    /// <summary>Gets or sets a texture that will be used in place of <see cref="Icon"/> if set.</summary>
     public ISharedImmediateTexture? IconTexture { get; set; }
 
     /// <summary>Gets or sets the hard expiry.</summary>

--- a/Dalamud/Interface/ImGuiNotification/INotification.cs
+++ b/Dalamud/Interface/ImGuiNotification/INotification.cs
@@ -6,6 +6,8 @@ using Dalamud.Plugin.Services;
 
 namespace Dalamud.Interface.ImGuiNotification;
 
+using Textures;
+
 /// <summary>Represents a notification.</summary>
 /// <remarks>Not to be implemented by plugins.</remarks>
 public interface INotification
@@ -29,8 +31,8 @@ public interface INotification
     /// <summary>Gets or sets a texture wrap that will be used in place of <see cref="Icon"/> if set.</summary>
     /// <remarks>
     /// <para>A texture wrap set via this property will <b>NOT</b> be disposed when the notification is dismissed.
-    /// Use <see cref="IActiveNotification.SetIconTexture(IDalamudTextureWrap?)"/> or
-    /// <see cref="IActiveNotification.SetIconTexture(Task{IDalamudTextureWrap?}?)"/> to use a texture, after calling
+    /// Use <see cref="IActiveNotification.SetIconTexture(ISharedImmediateTexture?)"/> or
+    /// <see cref="IActiveNotification.SetIconTexture(Task{ISharedImmediateTexture?}?)"/> to use a texture, after calling
     /// <see cref="INotificationManager.AddNotification"/>. Call either of those functions with <c>null</c> to revert
     /// the effective icon back to this property.</para>
     /// <para>This property and <see cref="IconTextureTask"/> are bound together. If the task is not <c>null</c> but
@@ -38,19 +40,7 @@ public interface INotification
     /// the property will return <c>null</c>. Setting this property will set <see cref="IconTextureTask"/> to a new
     /// completed <see cref="Task{TResult}"/> with the new value as its result.</para>
     /// </remarks>
-    public IDalamudTextureWrap? IconTexture { get; set; }
-
-    /// <summary>Gets or sets a task that results in a texture wrap that will be used in place of <see cref="Icon"/> if
-    /// available.</summary>
-    /// <remarks>
-    /// <para>A texture wrap set via this property will <b>NOT</b> be disposed when the notification is dismissed.
-    /// Use <see cref="IActiveNotification.SetIconTexture(IDalamudTextureWrap?)"/> or
-    /// <see cref="IActiveNotification.SetIconTexture(Task{IDalamudTextureWrap?}?)"/> to use a texture, after calling
-    /// <see cref="INotificationManager.AddNotification"/>. Call either of those functions with <c>null</c> to revert
-    /// the effective icon back to this property.</para>
-    /// <para>This property and <see cref="IconTexture"/> are bound together.</para>
-    /// </remarks>
-    Task<IDalamudTextureWrap?>? IconTextureTask { get; set; }
+    public ISharedImmediateTexture? IconTexture { get; set; }
 
     /// <summary>Gets or sets the hard expiry.</summary>
     /// <remarks>

--- a/Dalamud/Interface/ImGuiNotification/Internal/ActiveNotification.ImGui.cs
+++ b/Dalamud/Interface/ImGuiNotification/Internal/ActiveNotification.ImGui.cs
@@ -404,7 +404,7 @@ internal sealed partial class ActiveNotification
         var maxCoord = minCoord + size;
         var iconColor = this.Type.ToColor();
 
-        if (NotificationUtilities.DrawIconFrom(minCoord, maxCoord, this.IconTextureTask))
+        if (NotificationUtilities.DrawIconFrom(minCoord, maxCoord, this.IconTexture))
             return;
 
         if (this.Icon?.DrawIcon(minCoord, maxCoord, iconColor) is true)
@@ -499,7 +499,7 @@ internal sealed partial class ActiveNotification
 
         if (fillStartCw == 0 && fillEndCw == 0)
             return;
-       
+
         var radius = Math.Min(size.X, size.Y) / 3f;
         var ifrom = fillStartCw * MathF.PI * 2;
         var ito = fillEndCw * MathF.PI * 2;

--- a/Dalamud/Interface/ImGuiNotification/Internal/ActiveNotification.cs
+++ b/Dalamud/Interface/ImGuiNotification/Internal/ActiveNotification.cs
@@ -1,19 +1,15 @@
 using System.Runtime.Loader;
-using System.Threading.Tasks;
 
 using Dalamud.Configuration.Internal;
 using Dalamud.Interface.Animation;
 using Dalamud.Interface.Animation.EasingFunctions;
-using Dalamud.Interface.Internal;
-using Dalamud.Interface.Textures.TextureWraps;
+using Dalamud.Interface.Textures;
 using Dalamud.Plugin.Internal.Types;
 using Dalamud.Utility;
 
 using Serilog;
 
 namespace Dalamud.Interface.ImGuiNotification.Internal;
-
-using Textures;
 
 /// <summary>Represents an active notification.</summary>
 internal sealed partial class ActiveNotification : IActiveNotification

--- a/Dalamud/Interface/ImGuiNotification/Internal/ActiveNotification.cs
+++ b/Dalamud/Interface/ImGuiNotification/Internal/ActiveNotification.cs
@@ -243,12 +243,6 @@ internal sealed partial class ActiveNotification : IActiveNotification
             this.extendedExpiry = newExpiry;
     }
 
-    /// <inheritdoc/>
-    public void SetIconTexture(ISharedImmediateTexture? texture)
-    {
-        this.underlyingNotification.IconTexture = texture;
-    }
-
     /// <summary>Removes non-Dalamud invocation targets from events.</summary>
     /// <remarks>
     /// This is done to prevent references of plugins being unloaded from outliving the plugin itself.

--- a/Dalamud/Interface/ImGuiNotification/Notification.cs
+++ b/Dalamud/Interface/ImGuiNotification/Notification.cs
@@ -1,11 +1,11 @@
 using System.Threading.Tasks;
 
 using Dalamud.Interface.ImGuiNotification.Internal;
-using Dalamud.Interface.Internal;
+using Dalamud.Interface.Textures;
 using Dalamud.Interface.Textures.TextureWraps;
+using Serilog;
 
 namespace Dalamud.Interface.ImGuiNotification;
-
 /// <summary>Represents a blueprint for a notification.</summary>
 public sealed record Notification : INotification
 {
@@ -30,14 +30,7 @@ public sealed record Notification : INotification
     public INotificationIcon? Icon { get; set; }
 
     /// <inheritdoc/>
-    public IDalamudTextureWrap? IconTexture
-    {
-        get => this.IconTextureTask?.IsCompletedSuccessfully is true ? this.IconTextureTask.Result : null;
-        set => this.IconTextureTask = value is null ? null : Task.FromResult(value);
-    }
-
-    /// <inheritdoc/>
-    public Task<IDalamudTextureWrap?>? IconTextureTask { get; set; }
+    public ISharedImmediateTexture? IconTexture { get; set; }
 
     /// <inheritdoc/>
     public DateTime HardExpiry { get; set; } = DateTime.MaxValue;

--- a/Dalamud/Interface/ImGuiNotification/NotificationUtilities.cs
+++ b/Dalamud/Interface/ImGuiNotification/NotificationUtilities.cs
@@ -16,6 +16,8 @@ using ImGuiNET;
 
 namespace Dalamud.Interface.ImGuiNotification;
 
+using Textures;
+
 /// <summary>Utilities for implementing stuff under <see cref="ImGuiNotification"/>.</summary>
 public static class NotificationUtilities
 {
@@ -78,6 +80,19 @@ public static class NotificationUtilities
         return true;
     }
 
+    /// <summary>Draws an icon from an instance of <see cref="ISharedImmediateTexture"/>.</summary>
+    /// <param name="minCoord">The coordinates of the top left of the icon area.</param>
+    /// <param name="maxCoord">The coordinates of the bottom right of the icon area.</param>
+    /// <param name="texture">The texture.</param>
+    /// <returns><c>true</c> if anything has been drawn.</returns>
+    internal static bool DrawIconFrom(Vector2 minCoord, Vector2 maxCoord, ISharedImmediateTexture? texture)
+    {
+        if (texture is null)
+            return false;
+
+        return DrawIconFrom(minCoord, maxCoord, texture.GetWrapOrEmpty());
+    }
+
     /// <summary>Draws an icon from an instance of <see cref="IDalamudTextureWrap"/>.</summary>
     /// <param name="minCoord">The coordinates of the top left of the icon area.</param>
     /// <param name="maxCoord">The coordinates of the bottom right of the icon area.</param>
@@ -104,16 +119,6 @@ public static class NotificationUtilities
             return false;
         }
     }
-
-    /// <summary>Draws an icon from an instance of <see cref="Task{TResult}"/> that results in an
-    /// <see cref="IDalamudTextureWrap"/>.</summary>
-    /// <param name="minCoord">The coordinates of the top left of the icon area.</param>
-    /// <param name="maxCoord">The coordinates of the bottom right of the icon area.</param>
-    /// <param name="textureTask">The task that results in a texture.</param>
-    /// <returns><c>true</c> if anything has been drawn.</returns>
-    /// <remarks>Exceptions from the task will be treated as if no texture is provided.</remarks>
-    internal static bool DrawIconFrom(Vector2 minCoord, Vector2 maxCoord, Task<IDalamudTextureWrap?>? textureTask) =>
-        textureTask?.IsCompletedSuccessfully is true && DrawIconFrom(minCoord, maxCoord, textureTask.Result);
 
     /// <summary>Draws an icon from an instance of <see cref="LocalPlugin"/>.</summary>
     /// <param name="minCoord">The coordinates of the top left of the icon area.</param>

--- a/Dalamud/Interface/ImGuiNotification/NotificationUtilities.cs
+++ b/Dalamud/Interface/ImGuiNotification/NotificationUtilities.cs
@@ -7,6 +7,7 @@ using Dalamud.Game.Text;
 using Dalamud.Interface.Internal;
 using Dalamud.Interface.Internal.Windows;
 using Dalamud.Interface.ManagedFontAtlas;
+using Dalamud.Interface.Textures;
 using Dalamud.Interface.Textures.TextureWraps;
 using Dalamud.Interface.Utility;
 using Dalamud.Plugin.Internal.Types;
@@ -15,8 +16,6 @@ using Dalamud.Storage.Assets;
 using ImGuiNET;
 
 namespace Dalamud.Interface.ImGuiNotification;
-
-using Textures;
 
 /// <summary>Utilities for implementing stuff under <see cref="ImGuiNotification"/>.</summary>
 public static class NotificationUtilities

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -26,6 +26,7 @@ using Dalamud.Interface.Internal.Windows.Settings;
 using Dalamud.Interface.Internal.Windows.StyleEditor;
 using Dalamud.Interface.ManagedFontAtlas.Internals;
 using Dalamud.Interface.Style;
+using Dalamud.Interface.Textures;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
@@ -169,16 +170,16 @@ internal class DalamudInterface : IInternalDisposableService
             {
                 titleScreenMenu.AddEntryCore(
                     Loc.Localize("TSMDalamudPlugins", "Plugin Installer"),
-                    dalamudAssetManager.GetDalamudTextureWrap(DalamudAsset.LogoSmall),
+                    new ForwardingSharedImmediateTexture(dalamudAssetManager.GetDalamudTextureWrap(DalamudAsset.LogoSmall)),
                     this.OpenPluginInstaller);
                 titleScreenMenu.AddEntryCore(
                     Loc.Localize("TSMDalamudSettings", "Dalamud Settings"),
-                    dalamudAssetManager.GetDalamudTextureWrap(DalamudAsset.LogoSmall),
+                    new ForwardingSharedImmediateTexture(dalamudAssetManager.GetDalamudTextureWrap(DalamudAsset.LogoSmall)),
                     this.OpenSettings);
 
                 titleScreenMenu.AddEntryCore(
                     "Toggle Dev Menu",
-                    dalamudAssetManager.GetDalamudTextureWrap(DalamudAsset.LogoSmall),
+                    new ForwardingSharedImmediateTexture(dalamudAssetManager.GetDalamudTextureWrap(DalamudAsset.LogoSmall)),
                     () => Service<DalamudInterface>.GetNullable()?.ToggleDevMenu(),
                     VirtualKey.SHIFT);
 
@@ -186,7 +187,7 @@ internal class DalamudInterface : IInternalDisposableService
                 {
                     titleScreenMenu.AddEntryCore(
                         Loc.Localize("TSMDalamudDevMenu", "Developer Menu"),
-                        dalamudAssetManager.GetDalamudTextureWrap(DalamudAsset.LogoSmall),
+                        new ForwardingSharedImmediateTexture(dalamudAssetManager.GetDalamudTextureWrap(DalamudAsset.LogoSmall)),
                         () => this.isImGuiDrawDevMenu = true);
                 }
             });

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ImGuiWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ImGuiWidget.cs
@@ -219,8 +219,7 @@ internal class ImGuiWidget : IDataWindowWidget
 
                     if (textureWrap != null)
                     {
-                        n.SetIconTexture(
-                            new ForwardingSharedImmediateTexture(textureWrap));
+                        n.IconTexture = new ForwardingSharedImmediateTexture(textureWrap);
                     }
 
                     break;
@@ -229,8 +228,7 @@ internal class ImGuiWidget : IDataWindowWidget
                         tm.Shared.GetFromGame(this.notificationTemplate.IconText).GetWrapOrDefault());
                     if (textureWrap2 != null)
                     {
-                        n.SetIconTexture(
-                            new ForwardingSharedImmediateTexture(textureWrap2));
+                        n.IconTexture = new ForwardingSharedImmediateTexture(textureWrap2);
                     }
 
                     break;
@@ -239,8 +237,7 @@ internal class ImGuiWidget : IDataWindowWidget
                         tm.Shared.GetFromFile(this.notificationTemplate.IconText).GetWrapOrDefault());
                     if (textureWrap3 != null)
                     {
-                        n.SetIconTexture(
-                            new ForwardingSharedImmediateTexture(textureWrap3));
+                        n.IconTexture = new ForwardingSharedImmediateTexture(textureWrap3);
                     }
 
                     break;
@@ -430,7 +427,6 @@ internal class ImGuiWidget : IDataWindowWidget
         public bool Minimized;
         public bool UserDismissable;
         public bool ActionBar;
-        public bool LeaveTexturesOpen;
         public int ProgressMode;
 
         public void Reset()
@@ -452,7 +448,6 @@ internal class ImGuiWidget : IDataWindowWidget
             this.Minimized = true;
             this.UserDismissable = true;
             this.ActionBar = true;
-            this.LeaveTexturesOpen = true;
             this.ProgressMode = 0;
             this.RespectUiHidden = true;
         }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ImGuiWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ImGuiWidget.cs
@@ -15,6 +15,8 @@ using ImGuiNET;
 
 namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
 
+using Textures;
+
 /// <summary>
 /// Widget for displaying ImGui test.
 /// </summary>
@@ -144,8 +146,6 @@ internal class ImGuiWidget : IDataWindowWidget
             "Action Bar (always on if not user dismissable for the example)",
             ref this.notificationTemplate.ActionBar);
 
-        ImGui.Checkbox("Leave Textures Open", ref this.notificationTemplate.LeaveTexturesOpen);
-
         if (ImGui.Button("Add notification"))
         {
             var text =
@@ -212,35 +212,37 @@ internal class ImGuiWidget : IDataWindowWidget
             switch (this.notificationTemplate.IconInt)
             {
                 case 5:
-                    n.SetIconTexture(
-                        DisposeLoggingTextureWrap.Wrap(
-                            dam.GetDalamudTextureWrap(
-                                Enum.Parse<DalamudAsset>(
-                                    NotificationTemplate.AssetSources[this.notificationTemplate.IconAssetInt]))),
-                        this.notificationTemplate.LeaveTexturesOpen);
-                    break;
-                case 6:
-                    n.SetIconTexture(
-                        dam.GetDalamudTextureWrapAsync(
-                               Enum.Parse<DalamudAsset>(
-                                   NotificationTemplate.AssetSources[this.notificationTemplate.IconAssetInt]))
-                           .ContinueWith(
-                               r => r.IsCompletedSuccessfully
-                                        ? Task.FromResult<IDalamudTextureWrap>(DisposeLoggingTextureWrap.Wrap(r.Result))
-                                        : r).Unwrap(),
-                        this.notificationTemplate.LeaveTexturesOpen);
+                    var textureWrap = DisposeLoggingTextureWrap.Wrap(
+                        dam.GetDalamudTextureWrap(
+                            Enum.Parse<DalamudAsset>(
+                                NotificationTemplate.AssetSources[this.notificationTemplate.IconAssetInt])));
+
+                    if (textureWrap != null)
+                    {
+                        n.SetIconTexture(
+                            new ForwardingSharedImmediateTexture(textureWrap));
+                    }
+
                     break;
                 case 7:
-                    n.SetIconTexture(
-                        DisposeLoggingTextureWrap.Wrap(
-                            tm.Shared.GetFromGame(this.notificationTemplate.IconText).GetWrapOrDefault()),
-                        this.notificationTemplate.LeaveTexturesOpen);
+                    var textureWrap2 = DisposeLoggingTextureWrap.Wrap(
+                        tm.Shared.GetFromGame(this.notificationTemplate.IconText).GetWrapOrDefault());
+                    if (textureWrap2 != null)
+                    {
+                        n.SetIconTexture(
+                            new ForwardingSharedImmediateTexture(textureWrap2));
+                    }
+
                     break;
                 case 8:
-                    n.SetIconTexture(
-                        DisposeLoggingTextureWrap.Wrap(
-                            tm.Shared.GetFromFile(this.notificationTemplate.IconText).GetWrapOrDefault()),
-                        this.notificationTemplate.LeaveTexturesOpen);
+                    var textureWrap3 = DisposeLoggingTextureWrap.Wrap(
+                        tm.Shared.GetFromFile(this.notificationTemplate.IconText).GetWrapOrDefault());
+                    if (textureWrap3 != null)
+                    {
+                        n.SetIconTexture(
+                            new ForwardingSharedImmediateTexture(textureWrap3));
+                    }
+
                     break;
             }
 
@@ -303,15 +305,15 @@ internal class ImGuiWidget : IDataWindowWidget
                 };
             }
         }
-        
+
         ImGui.SameLine();
         if (ImGui.Button("Replace images using setter"))
         {
             foreach (var n in this.notifications)
             {
                 var i = (uint)Random.Shared.NextInt64(0, 200000);
-                n.IconTexture = DisposeLoggingTextureWrap.Wrap(
-                    Service<TextureManager>.Get().Shared.GetFromGameIcon(new(i)).GetWrapOrDefault());
+
+                n.IconTexture = Service<TextureManager>.Get().Shared.GetFromGameIcon(new(i, false, false));
             }
         }
     }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ImGuiWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ImGuiWidget.cs
@@ -5,17 +5,15 @@ using System.Threading.Tasks;
 using Dalamud.Game.Text;
 using Dalamud.Interface.ImGuiNotification;
 using Dalamud.Interface.ImGuiNotification.Internal;
+using Dalamud.Interface.Textures;
 using Dalamud.Interface.Textures.Internal;
 using Dalamud.Interface.Textures.TextureWraps;
 using Dalamud.Interface.Windowing;
 using Dalamud.Storage.Assets;
-using Dalamud.Utility;
 
 using ImGuiNET;
 
 namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
-
-using Textures;
 
 /// <summary>
 /// Widget for displaying ImGui test.

--- a/Dalamud/Interface/Internal/Windows/TitleScreenMenuWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/TitleScreenMenuWindow.cs
@@ -28,11 +28,11 @@ using ImGuiNET;
 
 using Lumina.Text.ReadOnly;
 
+using Serilog;
+
 using LSeStringBuilder = Lumina.Text.SeStringBuilder;
 
 namespace Dalamud.Interface.Internal.Windows;
-
-using Serilog;
 
 /// <summary>
 /// Class responsible for drawing the main plugin window.

--- a/Dalamud/Interface/Textures/ForwardingSharedImmediateTexture.cs
+++ b/Dalamud/Interface/Textures/ForwardingSharedImmediateTexture.cs
@@ -1,0 +1,50 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+using Dalamud.Interface.Textures.TextureWraps;
+using Dalamud.Storage.Assets;
+
+namespace Dalamud.Interface.Textures;
+
+/// <summary>
+/// Wraps a dalamud texture allowing interoperability with certain services. Only use this if you need to provide a texture that has been created or rented as a ISharedImmediateTexture.
+/// </summary>
+public class ForwardingSharedImmediateTexture : ISharedImmediateTexture
+{
+    private readonly IDalamudTextureWrap textureWrap;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ForwardingSharedImmediateTexture"/> class.
+    /// </summary>
+    /// <param name="textureWrap">A textureWrap that has been created or provided by RentAsync.</param>
+    public ForwardingSharedImmediateTexture(IDalamudTextureWrap textureWrap)
+    {
+        this.textureWrap = textureWrap;
+    }
+
+    /// <inheritdoc/>
+    public IDalamudTextureWrap GetWrapOrEmpty()
+    {
+        return this.textureWrap;
+    }
+
+    /// <inheritdoc/>
+    public IDalamudTextureWrap? GetWrapOrDefault(IDalamudTextureWrap? defaultWrap = null)
+    {
+        return this.textureWrap;
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetWrap(out IDalamudTextureWrap? texture, out Exception? exception)
+    {
+        texture = this.textureWrap;
+        exception = null;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public Task<IDalamudTextureWrap> RentAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(this.textureWrap);
+    }
+}

--- a/Dalamud/Interface/TitleScreenMenu/TitleScreenMenu.cs
+++ b/Dalamud/Interface/TitleScreenMenu/TitleScreenMenu.cs
@@ -3,16 +3,13 @@ using System.Linq;
 using System.Reflection;
 
 using Dalamud.Game.ClientState.Keys;
-using Dalamud.Interface.Internal;
-using Dalamud.Interface.Textures.TextureWraps;
+using Dalamud.Interface.Textures;
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
 using Dalamud.Plugin.Services;
 using Dalamud.Utility;
 
 namespace Dalamud.Interface;
-
-using Textures;
 
 /// <summary>
 /// Class responsible for managing elements in the title screen menu.
@@ -69,7 +66,7 @@ internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
             }
         }
     }
-    
+
     /// <summary>
     /// Adds a new entry to the title screen menu.
     /// </summary>
@@ -222,7 +219,7 @@ internal class TitleScreenMenuPluginScoped : IInternalDisposableService, ITitleS
 {
     [ServiceManager.ServiceDependency]
     private readonly TitleScreenMenu titleScreenMenuService = Service<TitleScreenMenu>.Get();
-    
+
     private readonly List<IReadOnlyTitleScreenMenuEntry> pluginEntries = new();
 
     /// <inheritdoc/>
@@ -236,7 +233,7 @@ internal class TitleScreenMenuPluginScoped : IInternalDisposableService, ITitleS
             this.titleScreenMenuService.RemoveEntry(entry);
         }
     }
-    
+
     /// <inheritdoc/>
     public IReadOnlyTitleScreenMenuEntry AddEntry(string text, ISharedImmediateTexture texture, Action onTriggered)
     {
@@ -245,7 +242,7 @@ internal class TitleScreenMenuPluginScoped : IInternalDisposableService, ITitleS
 
         return entry;
     }
-    
+
     /// <inheritdoc/>
     public IReadOnlyTitleScreenMenuEntry AddEntry(ulong priority, string text, ISharedImmediateTexture texture, Action onTriggered)
     {
@@ -254,7 +251,7 @@ internal class TitleScreenMenuPluginScoped : IInternalDisposableService, ITitleS
 
         return entry;
     }
-    
+
     /// <inheritdoc/>
     public void RemoveEntry(IReadOnlyTitleScreenMenuEntry entry)
     {

--- a/Dalamud/Interface/TitleScreenMenu/TitleScreenMenu.cs
+++ b/Dalamud/Interface/TitleScreenMenu/TitleScreenMenu.cs
@@ -12,6 +12,8 @@ using Dalamud.Utility;
 
 namespace Dalamud.Interface;
 
+using Textures;
+
 /// <summary>
 /// Class responsible for managing elements in the title screen menu.
 /// </summary>
@@ -76,13 +78,8 @@ internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
     /// <param name="onTriggered">The action to execute when the option is selected.</param>
     /// <returns>A <see cref="TitleScreenMenu"/> object that can be used to manage the entry.</returns>
     /// <exception cref="ArgumentException">Thrown when the texture provided does not match the required resolution(64x64).</exception>
-    public ITitleScreenMenuEntry AddPluginEntry(string text, IDalamudTextureWrap texture, Action onTriggered)
+    public ITitleScreenMenuEntry AddPluginEntry(string text, ISharedImmediateTexture texture, Action onTriggered)
     {
-        if (texture.Height != TextureSize || texture.Width != TextureSize)
-        {
-            throw new ArgumentException("Texture must be 64x64");
-        }
-
         TitleScreenMenuEntry entry;
         lock (this.entries)
         {
@@ -103,13 +100,13 @@ internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
     }
 
     /// <inheritdoc/>
-    public IReadOnlyTitleScreenMenuEntry AddEntry(string text, IDalamudTextureWrap texture, Action onTriggered)
+    public IReadOnlyTitleScreenMenuEntry AddEntry(string text, ISharedImmediateTexture texture, Action onTriggered)
     {
         return this.AddPluginEntry(text, texture, onTriggered);
     }
 
     /// <inheritdoc/>
-    public IReadOnlyTitleScreenMenuEntry AddEntry(ulong priority, string text, IDalamudTextureWrap texture, Action onTriggered)
+    public IReadOnlyTitleScreenMenuEntry AddEntry(ulong priority, string text, ISharedImmediateTexture texture, Action onTriggered)
     {
         return this.AddPluginEntry(priority, text, texture, onTriggered);
     }
@@ -123,13 +120,8 @@ internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
     /// <param name="onTriggered">The action to execute when the option is selected.</param>
     /// <returns>A <see cref="TitleScreenMenu"/> object that can be used to manage the entry.</returns>
     /// <exception cref="ArgumentException">Thrown when the texture provided does not match the required resolution(64x64).</exception>
-    public ITitleScreenMenuEntry AddPluginEntry(ulong priority, string text, IDalamudTextureWrap texture, Action onTriggered)
+    public ITitleScreenMenuEntry AddPluginEntry(ulong priority, string text, ISharedImmediateTexture texture, Action onTriggered)
     {
-        if (texture.Height != TextureSize || texture.Width != TextureSize)
-        {
-            throw new ArgumentException("Texture must be 64x64");
-        }
-
         TitleScreenMenuEntry entry;
         lock (this.entries)
         {
@@ -166,13 +158,8 @@ internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
     /// <param name="onTriggered">The action to execute when the option is selected.</param>
     /// <returns>A <see cref="TitleScreenMenu"/> object that can be used to manage the entry.</returns>
     /// <exception cref="ArgumentException">Thrown when the texture provided does not match the required resolution(64x64).</exception>
-    internal TitleScreenMenuEntry AddEntryCore(ulong priority, string text, IDalamudTextureWrap texture, Action onTriggered)
+    internal TitleScreenMenuEntry AddEntryCore(ulong priority, string text, ISharedImmediateTexture texture, Action onTriggered)
     {
-        if (texture.Height != TextureSize || texture.Width != TextureSize)
-        {
-            throw new ArgumentException("Texture must be 64x64");
-        }
-
         TitleScreenMenuEntry entry;
         lock (this.entries)
         {
@@ -199,15 +186,10 @@ internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
     /// <exception cref="ArgumentException">Thrown when the texture provided does not match the required resolution(64x64).</exception>
     internal TitleScreenMenuEntry AddEntryCore(
         string text,
-        IDalamudTextureWrap texture,
+        ISharedImmediateTexture texture,
         Action onTriggered,
         params VirtualKey[] showConditionKeys)
     {
-        if (texture.Height != TextureSize || texture.Width != TextureSize)
-        {
-            throw new ArgumentException("Texture must be 64x64");
-        }
-
         TitleScreenMenuEntry entry;
         lock (this.entries)
         {
@@ -256,7 +238,7 @@ internal class TitleScreenMenuPluginScoped : IInternalDisposableService, ITitleS
     }
     
     /// <inheritdoc/>
-    public IReadOnlyTitleScreenMenuEntry AddEntry(string text, IDalamudTextureWrap texture, Action onTriggered)
+    public IReadOnlyTitleScreenMenuEntry AddEntry(string text, ISharedImmediateTexture texture, Action onTriggered)
     {
         var entry = this.titleScreenMenuService.AddPluginEntry(text, texture, onTriggered);
         this.pluginEntries.Add(entry);
@@ -265,7 +247,7 @@ internal class TitleScreenMenuPluginScoped : IInternalDisposableService, ITitleS
     }
     
     /// <inheritdoc/>
-    public IReadOnlyTitleScreenMenuEntry AddEntry(ulong priority, string text, IDalamudTextureWrap texture, Action onTriggered)
+    public IReadOnlyTitleScreenMenuEntry AddEntry(ulong priority, string text, ISharedImmediateTexture texture, Action onTriggered)
     {
         var entry = this.titleScreenMenuService.AddPluginEntry(priority, text, texture, onTriggered);
         this.pluginEntries.Add(entry);

--- a/Dalamud/Interface/TitleScreenMenu/TitleScreenMenuEntry.cs
+++ b/Dalamud/Interface/TitleScreenMenu/TitleScreenMenuEntry.cs
@@ -4,12 +4,9 @@ using System.Linq;
 using System.Reflection;
 
 using Dalamud.Game.ClientState.Keys;
-using Dalamud.Interface.Internal;
-using Dalamud.Interface.Textures.TextureWraps;
+using Dalamud.Interface.Textures;
 
 namespace Dalamud.Interface;
-
-using Textures;
 
 /// <summary>
 /// A interface representing an entry in the title screen menu.

--- a/Dalamud/Interface/TitleScreenMenu/TitleScreenMenuEntry.cs
+++ b/Dalamud/Interface/TitleScreenMenu/TitleScreenMenuEntry.cs
@@ -9,6 +9,8 @@ using Dalamud.Interface.Textures.TextureWraps;
 
 namespace Dalamud.Interface;
 
+using Textures;
+
 /// <summary>
 /// A interface representing an entry in the title screen menu.
 /// </summary>
@@ -64,7 +66,7 @@ public interface IReadOnlyTitleScreenMenuEntry
     /// <summary>
     /// Gets the texture of this entry.
     /// </summary>
-    IDalamudTextureWrap Texture { get; }
+    ISharedImmediateTexture Texture { get; }
 }
 
 /// <summary>
@@ -87,7 +89,7 @@ public class TitleScreenMenuEntry : ITitleScreenMenuEntry
         Assembly? callingAssembly,
         ulong priority,
         string text,
-        IDalamudTextureWrap texture,
+        ISharedImmediateTexture texture,
         Action onTriggered,
         IEnumerable<VirtualKey>? showConditionKeys = null)
     {
@@ -106,8 +108,8 @@ public class TitleScreenMenuEntry : ITitleScreenMenuEntry
     public string Name { get; set; }
 
     /// <inheritdoc/>
-    public IDalamudTextureWrap Texture { get; set; }
-        
+    public ISharedImmediateTexture Texture { get; set; }
+
     /// <inheritdoc/>
     public bool IsInternal { get; set; }
 

--- a/Dalamud/Plugin/Services/ITitleScreenMenu.cs
+++ b/Dalamud/Plugin/Services/ITitleScreenMenu.cs
@@ -6,6 +6,8 @@ using Dalamud.Interface.Textures.TextureWraps;
 
 namespace Dalamud.Plugin.Services;
 
+using Interface.Textures;
+
 /// <summary>
 /// Interface for class responsible for managing elements in the title screen menu.
 /// </summary>
@@ -20,22 +22,22 @@ public interface ITitleScreenMenu
     /// Adds a new entry to the title screen menu.
     /// </summary>
     /// <param name="text">The text to show.</param>
-    /// <param name="texture">The texture to show.</param>
+    /// <param name="texture">The texture to show. The texture must be 64x64 or the entry will not draw.</param>
     /// <param name="onTriggered">The action to execute when the option is selected.</param>
     /// <returns>A <see cref="IReadOnlyTitleScreenMenuEntry"/> object that can be reference the entry.</returns>
     /// <exception cref="ArgumentException">Thrown when the texture provided does not match the required resolution(64x64).</exception>
-    public IReadOnlyTitleScreenMenuEntry AddEntry(string text, IDalamudTextureWrap texture, Action onTriggered);
+    public IReadOnlyTitleScreenMenuEntry AddEntry(string text, ISharedImmediateTexture texture, Action onTriggered);
 
     /// <summary>
     /// Adds a new entry to the title screen menu.
     /// </summary>
     /// <param name="priority">Priority of the entry.</param>
     /// <param name="text">The text to show.</param>
-    /// <param name="texture">The texture to show.</param>
+    /// <param name="texture">The texture to show. The texture must be 64x64 or the entry will not draw.</param>
     /// <param name="onTriggered">The action to execute when the option is selected.</param>
     /// <returns>A <see cref="IReadOnlyTitleScreenMenuEntry"/> object that can be used to reference the entry.</returns>
     /// <exception cref="ArgumentException">Thrown when the texture provided does not match the required resolution(64x64).</exception>
-    public IReadOnlyTitleScreenMenuEntry AddEntry(ulong priority, string text, IDalamudTextureWrap texture, Action onTriggered);
+    public IReadOnlyTitleScreenMenuEntry AddEntry(ulong priority, string text, ISharedImmediateTexture texture, Action onTriggered);
 
     /// <summary>
     /// Remove an entry from the title screen menu.

--- a/Dalamud/Plugin/Services/ITitleScreenMenu.cs
+++ b/Dalamud/Plugin/Services/ITitleScreenMenu.cs
@@ -1,12 +1,9 @@
 ﻿using System.Collections.Generic;
 
 using Dalamud.Interface;
-using Dalamud.Interface.Internal;
-using Dalamud.Interface.Textures.TextureWraps;
+using Dalamud.Interface.Textures;
 
 namespace Dalamud.Plugin.Services;
-
-using Interface.Textures;
 
 /// <summary>
 /// Interface for class responsible for managing elements in the title screen menu.

--- a/Dalamud/Plugin/Services/ITitleScreenMenu.cs
+++ b/Dalamud/Plugin/Services/ITitleScreenMenu.cs
@@ -22,7 +22,7 @@ public interface ITitleScreenMenu
     /// Adds a new entry to the title screen menu.
     /// </summary>
     /// <param name="text">The text to show.</param>
-    /// <param name="texture">The texture to show. The texture must be 64x64 or the entry will not draw.</param>
+    /// <param name="texture">The texture to show. The texture must be 64x64 or the entry will be removed and an error will be logged.</param>
     /// <param name="onTriggered">The action to execute when the option is selected.</param>
     /// <returns>A <see cref="IReadOnlyTitleScreenMenuEntry"/> object that can be reference the entry.</returns>
     /// <exception cref="ArgumentException">Thrown when the texture provided does not match the required resolution(64x64).</exception>
@@ -33,7 +33,7 @@ public interface ITitleScreenMenu
     /// </summary>
     /// <param name="priority">Priority of the entry.</param>
     /// <param name="text">The text to show.</param>
-    /// <param name="texture">The texture to show. The texture must be 64x64 or the entry will not draw.</param>
+    /// <param name="texture">The texture to show. The texture must be 64x64 or the entry will be removed and an error will be logged.</param>
     /// <param name="onTriggered">The action to execute when the option is selected.</param>
     /// <returns>A <see cref="IReadOnlyTitleScreenMenuEntry"/> object that can be used to reference the entry.</returns>
     /// <exception cref="ArgumentException">Thrown when the texture provided does not match the required resolution(64x64).</exception>


### PR DESCRIPTION
**INotificationManager**

- Simplifies the API, can only pass in a `ISharedImmediateTexture`, if a user wants to pass in a already created texture they can use `ForwardingSharedImmediateTexture` or create their own implementation of `ISharedImmediateTexture`

- There is no longer an option to leave textures open, they can RentAsync a `ISharedImmediateTexture` or create a texture and dispose of it as they see fit

**ITitleScreenMenu**
- Users can now only pass in a `ISharedImmediateTexture` as per INotificationManager
- The icon will only be validated on draw(that it's 64x64), if it is invalid, the entry will be removed from the list and a error will be logged.

As mentioned above this PR also adds in a wrapper class for IDalamudTextureWrap if the user creates the texture wrap themselves called `ForwardingSharedImmediateTexture`