### PR TITLE
Fix PartyFinderListing DutyCategory

### DIFF
--- a/Dalamud/Game/Gui/PartyFinder/Internal/PartyFinderPacketListing.cs
+++ b/Dalamud/Game/Gui/PartyFinder/Internal/PartyFinderPacketListing.cs
@@ -22,9 +22,9 @@ internal unsafe struct PartyFinderPacketListing
     internal ulong ContentId;
 
     private fixed byte padding4[4];
-    internal byte Category;
+    internal ushort Category;
 
-    private fixed byte padding5[3];
+    private fixed byte padding5[2];
     internal ushort Duty;
     internal byte DutyType;
 

--- a/Dalamud/Game/Gui/PartyFinder/Types/DutyCategory.cs
+++ b/Dalamud/Game/Gui/PartyFinder/Types/DutyCategory.cs
@@ -3,56 +3,85 @@ namespace Dalamud.Game.Gui.PartyFinder.Types;
 /// <summary>
 /// Category flags for the <see cref="PartyFinderGui"/> class.
 /// </summary>
-public enum DutyCategory
+public enum DutyCategory : ushort
 {
     /// <summary>
-    /// The duty category.
+    /// The none category.
     /// </summary>
-    Duty = 0,
+    None = 0,
+
+    /// <summary>
+    /// The duty roulette category.
+    /// </summary>
+    DutyRoulette = 1 << 1,
+
+    /// <summary>
+    /// The dungeons category.
+    /// </summary>
+    Dungeon = 1 << 2,
+
+    /// <summary>
+    /// The guildhests category.
+    /// </summary>
+    Guildhest = 1 << 3,
+
+    /// <summary>
+    /// The trials category.
+    /// </summary>
+    Trial = 1 << 4,
+
+    /// <summary>
+    /// The raids category.
+    /// </summary>
+    Raid = 1 << 5,
+
+    /// <summary>
+    /// The high-end duty category.
+    /// </summary>
+    HighEndDuty = 1 << 6,
+
+    /// <summary>
+    /// The pvp category.
+    /// </summary>
+    PvP = 1 << 7,
 
     /// <summary>
     /// The gold saucer category.
     /// </summary>
-    GoldSaucer = 1 << 0,
+    GoldSaucer = 1 << 8,
 
     /// <summary>
-    /// The fate category.
+    /// The fates category.
     /// </summary>
-    Fates = 1 << 1,
+    Fate = 1 << 9,
 
     /// <summary>
-    /// The treasure hunt category.
+    /// The treasure hunts category.
     /// </summary>
-    TreasureHunt = 1 << 2,
+    TreasureHunt = 1 << 10,
 
     /// <summary>
-    /// The hunt category.
+    /// The hunts category.
     /// </summary>
-    TheHunt = 1 << 3,
+    TheHunt = 1 << 11,
 
     /// <summary>
     /// The gathering forays category.
     /// </summary>
-    GatheringForays = 1 << 4,
+    GatheringForay = 1 << 12,
 
     /// <summary>
     /// The deep dungeons category.
     /// </summary>
-    DeepDungeons = 1 << 5,
-
-    /// <summary>
-    /// The adventuring forays category.
-    /// </summary>
-    [Obsolete("Adventuring Forays have been renamed to Field Operations")]
-    AdventuringForays = 1 << 6,
+    DeepDungeon = 1 << 13,
 
     /// <summary>
     /// The field operations category.
     /// </summary>
-    FieldOperations = 1 << 6,
+    FieldOperation = 1 << 14,
 
     /// <summary>
     /// The variant and criterion dungeons category.
     /// </summary>
-    VariantAndCriterionDungeons = 1 << 7,
+    VariantAndCriterionDungeon = 1 << 15,
 }

--- a/Dalamud/Game/Gui/PartyFinder/Types/DutyCategory.cs
+++ b/Dalamud/Game/Gui/PartyFinder/Types/DutyCategory.cs
@@ -51,7 +51,7 @@ public enum DutyCategory : ushort
     GoldSaucer = 1 << 8,
 
     /// <summary>
-    /// The fates category.
+    /// The FATEs category.
     /// </summary>
     Fate = 1 << 9,
 

--- a/Dalamud/Game/Gui/PartyFinder/Types/PartyFinderListing.cs
+++ b/Dalamud/Game/Gui/PartyFinder/Types/PartyFinderListing.cs
@@ -56,7 +56,7 @@ public interface IPartyFinderListing
     uint Id { get; }
 
     /// <summary>
-    /// Gets the lower bits of the player's content ID.
+    /// Gets the player's unique content ID.
     /// </summary>
     ulong ContentId { get; }
 


### PR DESCRIPTION
It was wrongly assumed that Category is a byte, it was an ushort and half of the categories were just cut off from the list

- Adjusts category to a ushort
- Rewrite DutyCategory enum to include all categories currently selectable