### PR TITLE
fix: Don't let a debugger crash Bink

### DIFF
--- a/Dalamud.Boot/veh.cpp
+++ b/Dalamud.Boot/veh.cpp
@@ -249,6 +249,12 @@ LONG WINAPI vectored_exception_handler(EXCEPTION_POINTERS* ex)
     {
         // pass
     }
+    else if (ex->ExceptionRecord->ExceptionCode == 0x406D1388)
+    {
+        // VS thread namer - just let these run; they aren't a problem.
+        // https://learn.microsoft.com/en-us/visualstudio/debugger/tips-for-debugging-threads
+        return EXCEPTION_CONTINUE_EXECUTION;
+    }
     else
     {
         if (!is_whitelist_exception(ex->ExceptionRecord->ExceptionCode))

--- a/Dalamud/Game/Internal/AntiDebug.cs
+++ b/Dalamud/Game/Internal/AntiDebug.cs
@@ -13,8 +13,8 @@ namespace Dalamud.Game.Internal;
 [ServiceManager.EarlyLoadedService]
 internal sealed class AntiDebug : IInternalDisposableService
 {
-    private readonly byte[] nop = new byte[] { 0x31, 0xC0, 0x90, 0x90, 0x90, 0x90 };
-    private byte[] original;
+    private readonly byte[] nop = [0x31, 0xC0, 0x90, 0x90, 0x90, 0x90];
+    private byte[]? original;
     private IntPtr debugCheckAddress;
 
     [ServiceManager.ServiceConstructor]
@@ -44,8 +44,8 @@ internal sealed class AntiDebug : IInternalDisposableService
     }
 
     /// <summary>Finalizes an instance of the <see cref="AntiDebug"/> class.</summary>
-    ~AntiDebug() => this.Disable();
-
+    ~AntiDebug() => ((IInternalDisposableService)this).DisposeService();
+    
     /// <summary>
     /// Gets a value indicating whether the anti-debugging is enabled.
     /// </summary>


### PR DESCRIPTION
Resolves a problem where attaching a debugger can cause Bink to throw an exception, crashing the game.