### PR TITLE
fix: Make autoupdates work again

### DIFF
--- a/Dalamud/Plugin/Internal/AutoUpdate/AutoUpdateManager.cs
+++ b/Dalamud/Plugin/Internal/AutoUpdate/AutoUpdateManager.cs
@@ -75,7 +75,6 @@ internal class AutoUpdateManager : IServiceType
     private bool hasStartedInitialUpdateThisSession;
 
     private IActiveNotification? updateNotification;
-    private bool notificationHasStartedUpdate; // Used to track if the user has started an update from the notification.
     
     private Task? autoUpdateTask;
     
@@ -191,6 +190,10 @@ internal class AutoUpdateManager : IServiceType
         {
             this.hasStartedInitialUpdateThisSession = true;
             
+            // Schedule the next update check immediately. No matter what the result of this initial update is, we'll
+            // have the next one queued up (or provide the user the ability to defer).
+            this.nextUpdateCheckTime = DateTime.Now + TimeBetweenUpdateChecks;
+            
             var currentlyUpdatablePlugins = this.GetAvailablePluginUpdates(DecideUpdateListingRestriction(behavior));
             if (currentlyUpdatablePlugins.Count == 0)
             {
@@ -209,7 +212,6 @@ internal class AutoUpdateManager : IServiceType
             }
 
             Log.Verbose("Running initial auto-update, updating {Num} plugins", currentlyUpdatablePlugins.Count);
-            this.notificationHasStartedUpdate = true;
             this.KickOffAutoUpdates(currentlyUpdatablePlugins);
             return;
         }
@@ -221,8 +223,6 @@ internal class AutoUpdateManager : IServiceType
             DateTime.Now > this.nextUpdateCheckTime &&
             this.updateNotification == null)
         {
-            this.nextUpdateCheckTime = null;
-            
             Log.Verbose("Starting periodic update check");
             this.pluginManager.ReloadPluginMastersAsync()
                 .ContinueWith(
@@ -236,6 +236,10 @@ internal class AutoUpdateManager : IServiceType
                         this.NotifyUpdatesAreAvailable(
                             this.GetAvailablePluginUpdates(
                                 DecideUpdateListingRestriction(behavior)));
+                        
+                        // Schedule the next update check opportunistically.
+                        this.nextUpdateCheckTime = DateTime.Now + TimeBetweenUpdateChecks;
+                        Log.Verbose("Scheduled next auto update check for {Time}", this.nextUpdateCheckTime);
                     });
         }
     }
@@ -245,26 +249,7 @@ internal class AutoUpdateManager : IServiceType
         if (this.updateNotification != null)
             throw new InvalidOperationException("Already showing a notification");
         
-        if (this.notificationHasStartedUpdate)
-            throw new InvalidOperationException("Lost track of notification state"); 
-        
         this.updateNotification = this.notificationManager.AddNotification(notification);
-        this.updateNotification.Dismiss += _ =>
-        {
-            this.updateNotification = null;
-
-            // If the user just clicked off the notification, we don't want to bother them again for quite a while.
-            if (this.notificationHasStartedUpdate)
-            {
-                this.nextUpdateCheckTime = DateTime.Now + TimeBetweenUpdateChecks;
-                Log.Verbose("User started update, next check at {Time}", this.nextUpdateCheckTime);
-            }
-            else
-            {
-                this.nextUpdateCheckTime = DateTime.Now + TimeBetweenUpdateChecksIfDismissed;
-                Log.Verbose("User dismissed update notification, next check at {Time}", this.nextUpdateCheckTime);
-            }
-        };
         
         return this.updateNotification!;
     }
@@ -360,8 +345,6 @@ internal class AutoUpdateManager : IServiceType
         if (updatablePlugins.Count == 0)
             return;
         
-        this.notificationHasStartedUpdate = false;
-
         var notification = this.GetBaseNotification(new Notification
         {
             Title = Locs.NotificationTitleUpdatesAvailable,
@@ -381,7 +364,6 @@ internal class AutoUpdateManager : IServiceType
             {
                 notification.DrawActions -= DrawNotificationContent;
                 this.KickOffAutoUpdates(updatablePlugins, notification);
-                this.notificationHasStartedUpdate = true;
             }
 
             ImGui.SameLine();
@@ -389,6 +371,16 @@ internal class AutoUpdateManager : IServiceType
         }
 
         notification.DrawActions += DrawNotificationContent;
+
+        // If the user dismisses the notification, we don't want to spam them with notifications. Schedule the next one
+        // relatively far out, overwriting the earlier sets.
+        notification.Dismiss += args =>
+        {
+            if (args.Reason != NotificationDismissReason.Manual) return;
+            
+            this.nextUpdateCheckTime = DateTime.Now + TimeBetweenUpdateChecksIfDismissed;
+            Log.Verbose("User dismissed update notification, next check at {Time}", this.nextUpdateCheckTime);
+        };
     }
     
     private List<AvailablePluginUpdate> GetAvailablePluginUpdates(UpdateListingRestriction restriction)


### PR DESCRIPTION
- Always opportunistically schedule a future (fast) auto-update after a check/attempt has been made.
- Track the update notification dismiss to extend this time out.

This change relies on the fact that a second auto-update won't run so long as a notification is open.