### PR TITLE
fix: Make MarketBoardCurrentOfferings.ItemListings accessible

### DIFF
--- a/Dalamud/Game/Network/Structures/MarketBoardCurrentOfferings.cs
+++ b/Dalamud/Game/Network/Structures/MarketBoardCurrentOfferings.cs
@@ -16,7 +16,7 @@ public class MarketBoardCurrentOfferings : IMarketBoardCurrentOfferings
     /// <summary>
     /// Gets the list of individual item listings.
     /// </summary>
-    IReadOnlyList<IMarketBoardItemListing> IMarketBoardCurrentOfferings.ItemListings => this.InternalItemListings;
+    public IReadOnlyList<IMarketBoardItemListing> ItemListings => this.InternalItemListings;
 
     /// <summary>
     /// Gets the request ID.


### PR DESCRIPTION
Not very familiar with this stuff but I am pretty sure this was supposed to be public.