### PR TITLE
Prevent trying to access an entry when none exist.

### DIFF
--- a/Dalamud/Interface/Internal/Windows/TitleScreenMenuWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/TitleScreenMenuWindow.cs
@@ -270,7 +270,7 @@ internal class TitleScreenMenuWindow : Window, IDisposable
 
             case State.Hide:
             {
-                if (this.DrawEntry(entries[0], true, false, true, true, false))
+                if (entries.Count > 0 && this.DrawEntry(entries[0], true, false, true, true, false))
                 {
                     this.state = State.Show;
                 }


### PR DESCRIPTION
I'm not quite sure what's the root cause, but I noticed this error gets spammed in the very first few seconds of the game launching post-injection.

> [ERR] [WindowSystem] Error during Draw(): TitleScreenMenuOverlay
> System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
>    at System.SZArrayHelper.get_Item[T](Int32 index)
>    at Dalamud.Interface.Internal.Windows.TitleScreenMenuWindow.Draw() in C:\goatsoft\companysecrets\dalamud\Interface\Internal\Windows\TitleScreenMenuWindow.cs:line 273
>    at Dalamud.Interface.Windowing.Window.DrawInternal(DalamudConfiguration configuration) in C:\goatsoft\companysecrets\dalamud\Interface\Windowing\Window.cs:line 346

It seems to be because `this.titleScreenMenu.PluginEntries` is empty, although I didn't notice a behaviour change when this was changed in #1808, so I'm unsure if it's a coincidence, or a side effect of the many changes that happened recently.