### PR TITLE
BLM and MNK Gauge Update with CS bump

### DIFF
--- a/Dalamud/Game/ClientState/JobGauge/Enums/BeastChakra.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Enums/BeastChakra.cs
@@ -6,22 +6,22 @@ namespace Dalamud.Game.ClientState.JobGauge.Enums;
 public enum BeastChakra : byte
 {
     /// <summary>
-    /// No card.
+    /// No chakra.
     /// </summary>
     NONE = 0,
 
     /// <summary>
-    /// The Coeurl chakra.
-    /// </summary>
-    COEURL = 1,
-
-    /// <summary>
     /// The Opo-Opo chakra.
     /// </summary>
-    OPOOPO = 2,
+    OPOOPO = 1,
 
     /// <summary>
     /// The Raptor chakra.
     /// </summary>
-    RAPTOR = 3,
+    RAPTOR = 2,
+
+    /// <summary>
+    /// The Coeurl chakra.
+    /// </summary>
+    COEURL = 3,
 }

--- a/Dalamud/Game/ClientState/JobGauge/Enums/Nadi.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Enums/Nadi.cs
@@ -7,17 +7,17 @@
 public enum Nadi : byte
 {
     /// <summary>
-    /// No card.
+    /// No nadi.
     /// </summary>
     NONE = 0,
 
     /// <summary>
     /// The Lunar nadi.
     /// </summary>
-    LUNAR = 2,
+    LUNAR = 1,
 
     /// <summary>
     /// The Solar nadi.
     /// </summary>
-    SOLAR = 4,
+    SOLAR = 2,
 }

--- a/Dalamud/Game/ClientState/JobGauge/Types/BLMGauge.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Types/BLMGauge.cs
@@ -45,6 +45,11 @@ public unsafe class BLMGauge : JobGaugeBase<FFXIVClientStructs.FFXIV.Client.Game
     public byte AstralFireStacks => (byte)(this.InAstralFire ? this.Struct->ElementStance : 0);
 
     /// <summary>
+    /// Gets the amount of Astral Soul stacks.
+    /// </summary>
+    public int AstralSoulStacks => this.Struct->AstralSoulStacks;
+
+    /// <summary>
     /// Gets a value indicating whether or not the player is in Umbral Ice.
     /// </summary>
     /// <returns><c>true</c> or <c>false</c>.</returns>

--- a/Dalamud/Game/ClientState/JobGauge/Types/MNKGauge.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Types/MNKGauge.cs
@@ -37,6 +37,21 @@ public unsafe class MNKGauge : JobGaugeBase<FFXIVClientStructs.FFXIV.Client.Game
     public Nadi Nadi => (Nadi)this.Struct->Nadi;
 
     /// <summary>
+    /// Gets the amount of available Opo-opo Fury stacks.
+    /// </summary>
+    public int OpoOpoFury => this.Struct->OpoOpoStacks;
+    
+    /// <summary>
+    /// Gets the amount of available Raptor Fury stacks.
+    /// </summary>
+    public int RaptorFury => this.Struct->RaptorStacks;
+
+    /// <summary>
+    /// Gets the amount of available Coeurl Fury stacks.
+    /// </summary>
+    public int CoeurlFury => this.Struct->CoeurlStacks;
+
+    /// <summary>
     /// Gets the time remaining that Blitz is active.
     /// </summary>
     public ushort BlitzTimeRemaining => this.Struct->BlitzTimeRemaining;


### PR DESCRIPTION
breaking changes in ClientStructs are:
`UIState.IsItemActionUnlocked` argument changed from `void*` to `Item*`
`ExdModule.GetItemRowById` return type changed from `void*` to `Item*`

the rest is changing fields from void* to SheetRow*