### PR TITLE
Fix incorrect GetMapCoordinates() within housing ward subdivisions

### DIFF
--- a/Dalamud/Utility/MapUtil.cs
+++ b/Dalamud/Utility/MapUtil.cs
@@ -155,8 +155,12 @@ public static class MapUtil
 
         return WorldToMap(
             go.Position,
-            agentMap->CurrentOffsetX,
-            agentMap->CurrentOffsetY,
+            /*
+             * https://github.com/aers/FFXIVClientStructs/issues/1029
+             * Our calculations are based on Excel's Map, but AgentMap's offset values are sign-flipped in comparison
+             */
+            -agentMap->CurrentOffsetX,
+            -agentMap->CurrentOffsetY,
             territoryTransient?.OffsetZ ?? 0,
             (uint)agentMap->CurrentMapSizeFactor,
             correctZOffset);


### PR DESCRIPTION
Closes #1916

Fixes this issue (copied description):
> Example steps to reproduce:
> 1. Visit Shirogane Subdivision (Wards 31-60) at X: 11.6, Y: 11.0
> 2. Call `ClientState.LocalPlayer?.GetMapCoordinates()`
> 3. Observe that it incorrectly returns X: -16.5, Y: -17.2

~~I believe this to be due to ClientStructs returning incorrect values (see aers/FFXIVClientStructs#1029). In the long term, it's probably better to investigate what's happening on the ClientStructs side, but until then...~~

Edit: [ClientStructs have investigated this](https://github.com/aers/FFXIVClientStructs/issues/1029#issuecomment-2220698941) and the `AgentMap` numbers appear to be correct, or at least unchanged post-Dawntrail. The issue is that they're sign-flipped in comparison to what Lumina returns via the `Map` Excel sheet. `GetMapCoordinates()` is written based on the latter.