### PR TITLE
Add UsedImplicitly to IDalamudPlugin

### DIFF
--- a/Dalamud/Plugin/IDalamudPlugin.cs
+++ b/Dalamud/Plugin/IDalamudPlugin.cs
@@ -5,7 +5,7 @@ namespace Dalamud.Plugin;
 /// <summary>
 /// This interface represents a basic Dalamud plugin. All plugins have to implement this interface.
 /// </summary>
-[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature,ImplicitUseTargetFlags.WithInheritors)]
+[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature, ImplicitUseTargetFlags.WithInheritors)]
 public interface IDalamudPlugin : IDisposable
 {
 }

--- a/Dalamud/Plugin/IDalamudPlugin.cs
+++ b/Dalamud/Plugin/IDalamudPlugin.cs
@@ -1,8 +1,11 @@
+﻿using JetBrains.Annotations;
+
 namespace Dalamud.Plugin;
 
 /// <summary>
 /// This interface represents a basic Dalamud plugin. All plugins have to implement this interface.
 /// </summary>
+[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature,ImplicitUseTargetFlags.WithInheritors)]
 public interface IDalamudPlugin : IDisposable
 {
 }


### PR DESCRIPTION
This adds the `UsedImplictly` Annotation to `IDalamudPlugin` to clear up warnings regarding plugin classes not being instantiated.