### PR TITLE
Respect null terminator in SeString.Parse(ReadOnlySpan<byte>)

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -150,7 +150,8 @@ public class SeString
     {
         fixed (byte* ptr = data)
         {
-            return Parse(ptr, data.Length);
+            var len = data.IndexOf((byte)0);
+            return Parse(ptr, len == -1 ? data.Length : len);
         }
     }
 


### PR DESCRIPTION
This pull request addresses an issue in the SeString parsing logic of a null-terminated `ReadOnlySpan<byte>` that is longer than its content. The changed code ensures that parsing stops at the null terminator if one is present.

This is necessary when using ClientStructs generated `Span<byte>` properties for string fields.
These Spans always have the length of the field, not of the content inside them.