### PR TITLE
Update Addon Inspector for variant image node types

### DIFF
--- a/Dalamud/Interface/Internal/UiDebug.cs
+++ b/Dalamud/Interface/Internal/UiDebug.cs
@@ -189,6 +189,7 @@ internal unsafe class UiDebug
                 case NodeType.Image: Util.ShowStruct(*(AtkImageNode*)node, (ulong)node); break;
                 case NodeType.Collision: Util.ShowStruct(*(AtkCollisionNode*)node, (ulong)node); break;
                 case NodeType.NineGrid: Util.ShowStruct(*(AtkNineGridNode*)node, (ulong)node); break;
+                case NodeType.ClippingMask: Util.ShowStruct(*(AtkClippingMaskNode*)node, (ulong)node); break;
                 case NodeType.Counter: Util.ShowStruct(*(AtkCounterNode*)node, (ulong)node); break;
                 default: Util.ShowStruct(*node, (ulong)node); break;
             }
@@ -233,48 +234,15 @@ internal unsafe class UiDebug
                     break;
                 case NodeType.Image:
                     var imageNode = (AtkImageNode*)node;
-                    if (imageNode->PartsList != null)
-                    {
-                        if (imageNode->PartId > imageNode->PartsList->PartCount)
-                        {
-                            ImGui.Text("part id > part count?");
-                        }
-                        else
-                        {
-                            var textureInfo = imageNode->PartsList->Parts[imageNode->PartId].UldAsset;
-                            var texType = textureInfo->AtkTexture.TextureType;
-                            ImGui.Text($"texture type: {texType} part_id={imageNode->PartId} part_id_count={imageNode->PartsList->PartCount}");
-                            if (texType == TextureType.Resource)
-                            {
-                                var texFileNameStdString = &textureInfo->AtkTexture.Resource->TexFileResourceHandle->ResourceHandle.FileName;
-                                var texString = texFileNameStdString->Length < 16
-                                                    ? MemoryHelper.ReadSeStringAsString(out _, (nint)texFileNameStdString->Buffer)
-                                                    : MemoryHelper.ReadSeStringAsString(out _, (nint)texFileNameStdString->BufferPtr);
-
-                                ImGui.Text($"texture path: {texString}");
-                                var kernelTexture = textureInfo->AtkTexture.Resource->KernelTextureObject;
-
-                                if (ImGui.TreeNode($"Texture##{(ulong)kernelTexture->D3D11ShaderResourceView:X}"))
-                                {
-                                    ImGui.Image(new IntPtr(kernelTexture->D3D11ShaderResourceView), new Vector2(kernelTexture->Width, kernelTexture->Height));
-                                    ImGui.TreePop();
-                                }
-                            }
-                            else if (texType == TextureType.KernelTexture)
-                            {
-                                if (ImGui.TreeNode($"Texture##{(ulong)textureInfo->AtkTexture.KernelTexture->D3D11ShaderResourceView:X}"))
-                                {
-                                    ImGui.Image(new IntPtr(textureInfo->AtkTexture.KernelTexture->D3D11ShaderResourceView), new Vector2(textureInfo->AtkTexture.KernelTexture->Width, textureInfo->AtkTexture.KernelTexture->Height));
-                                    ImGui.TreePop();
-                                }
-                            }
-                        }
-                    }
-                    else
-                    {
-                        ImGui.Text("no texture loaded");
-                    }
-
+                    PrintTextureInfo(imageNode->PartsList, imageNode->PartId);
+                    break;
+                case NodeType.NineGrid:
+                    var ngNode = (AtkNineGridNode*)node;
+                    PrintTextureInfo(ngNode->PartsList, ngNode->PartId);
+                    break;
+                case NodeType.ClippingMask:
+                    var cmNode = (AtkClippingMaskNode*)node;
+                    PrintTextureInfo(cmNode->PartsList, cmNode->PartId);
                     break;
             }
 
@@ -287,7 +255,63 @@ internal unsafe class UiDebug
 
         if (isVisible && !popped)
             ImGui.PopStyleColor();
+
+        static void PrintTextureInfo(AtkUldPartsList* partsList, uint partId)
+        {
+            if (partsList != null)
+            {
+                if (partId > partsList->PartCount)
+                {
+                    ImGui.Text("part id > part count?");
+                }
+                else
+                {
+                    var textureInfo = partsList->Parts[partId].UldAsset;
+                    var texType = textureInfo->AtkTexture.TextureType;
+                    ImGui.Text(
+                        $"texture type: {texType} part_id={partId} part_id_count={partsList->PartCount}");
+                    if (texType == TextureType.Resource)
+                    {
+                        var texFileNameStdString =
+                            &textureInfo->AtkTexture.Resource->TexFileResourceHandle->ResourceHandle.FileName;
+                        var texString = texFileNameStdString->Length < 16
+                                            ? MemoryHelper.ReadSeStringAsString(out _, (nint)texFileNameStdString->Buffer)
+                                            : MemoryHelper.ReadSeStringAsString(out _, (nint)texFileNameStdString->BufferPtr);
+
+                        ImGui.Text($"texture path: {texString}");
+                        var kernelTexture = textureInfo->AtkTexture.Resource->KernelTextureObject;
+
+                        if (ImGui.TreeNode($"Texture##{(ulong)kernelTexture->D3D11ShaderResourceView:X}"))
+                        {
+                            ImGui.Image(
+                                new IntPtr(kernelTexture->D3D11ShaderResourceView),
+                                new Vector2(kernelTexture->Width, kernelTexture->Height));
+                            ImGui.TreePop();
+                        }
+                    }
+                    else if (texType == TextureType.KernelTexture)
+                    {
+                        if (ImGui.TreeNode(
+                                $"Texture##{(ulong)textureInfo->AtkTexture.KernelTexture->D3D11ShaderResourceView:X}"))
+                        {
+                            ImGui.Image(
+                                new IntPtr(textureInfo->AtkTexture.KernelTexture->D3D11ShaderResourceView),
+                                new Vector2(
+                                    textureInfo->AtkTexture.KernelTexture->Width,
+                                    textureInfo->AtkTexture.KernelTexture->Height));
+                            ImGui.TreePop();
+                        }
+                    }
+                }
+            }
+            else
+            {
+                ImGui.Text("no texture loaded");
+            }
+        }
     }
+
+    
 
     private void PrintComponentNode(AtkResNode* node, string treePrefix)
     {


### PR DESCRIPTION
Now prints texture information for `AtkNineGridNode` and `AtkClippingMaskNode`