### PR TITLE
Limit log files to 100MB

### DIFF
--- a/Dalamud.Injector/Dalamud.Injector.csproj
+++ b/Dalamud.Injector/Dalamud.Injector.csproj
@@ -66,10 +66,10 @@
         <PackageReference Include="PeNet" Version="2.6.4" />
         <PackageReference Include="Reloaded.Memory" Version="7.0.0" />
         <PackageReference Include="Reloaded.Memory.Buffers" Version="2.0.0" />
-        <PackageReference Include="Serilog" Version="2.11.0" />
-        <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-        <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+        <PackageReference Include="Serilog" Version="4.0.0" />
+        <PackageReference Include="Serilog.Sinks.Async" Version="2.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Dalamud.Injector/EntryPoint.cs
+++ b/Dalamud.Injector/EntryPoint.cs
@@ -200,7 +200,7 @@ namespace Dalamud.Injector
 
             Log.Logger = new LoggerConfiguration()
                          .WriteTo.Console(standardErrorFromLevel: LogEventLevel.Debug)
-                         .WriteTo.File(logPath, fileSizeLimitBytes: null)
+                         .WriteTo.File(logPath, fileSizeLimitBytes: 1 * 1024 * 1024)
                          .MinimumLevel.ControlledBy(levelSwitch)
                          .CreateLogger();
 

--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -79,10 +79,10 @@
         </PackageReference>
         <PackageReference Include="MinSharp" Version="1.0.4" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Serilog" Version="2.11.0" />
-        <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-        <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+        <PackageReference Include="Serilog" Version="4.0.0" />
+        <PackageReference Include="Serilog.Sinks.Async" Version="2.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
         <PackageReference Include="sqlite-net-pcl" Version="1.8.116" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
             <PrivateAssets>all</PrivateAssets>

--- a/Dalamud/EntryPoint.cs
+++ b/Dalamud/EntryPoint.cs
@@ -109,13 +109,13 @@ public sealed class EntryPoint
 
         if (logSynchronously)
         {
-            config = config.WriteTo.File(logPath.FullName, fileSizeLimitBytes: null);
+            config = config.WriteTo.File(logPath.FullName, fileSizeLimitBytes: 100 * 1024 * 1024);
         }
         else
         {
             config = config.WriteTo.Async(a => a.File(
                                               logPath.FullName,
-                                              fileSizeLimitBytes: null,
+                                              fileSizeLimitBytes: 100 * 1024 * 1024,
                                               buffered: false,
                                               flushToDiskInterval: TimeSpan.FromSeconds(1)));
         }


### PR DESCRIPTION
This pull request aims to add a sanity limit to Dalamud's log size, currently capped to 100MB.

This value was arbitrarily chosen as it's high enough that no sane environment can ever hit it, and if it *was* hit, our concern should be to stop the bleeding rather than anything else. When this limit is hit, no new log entries will be added to the file.

There is probably room here to perform log rotations, replace the last line of the log file, print a message to chat, etc. I don't think any of these are particularly necessary for this, nor are they going to be worth the additional complication/digging into Serilog internals. This is meant to be quick and dirty, and I doubt many people are ever going to really hit this limit unless some plugin is very broken and likely spamming an exception every frame.