### PR TITLE
Add WinForms back

### DIFF
--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -32,6 +32,7 @@
     </PropertyGroup>
 
     <PropertyGroup Label="Build">
+        <UseWindowsForms>true</UseWindowsForms>
         <EnableDynamicLoading>true</EnableDynamicLoading>
         <DebugSymbols>true</DebugSymbols>
         <DebugType>portable</DebugType>


### PR DESCRIPTION
This broke some third party plugins and also removed the desktop SDK from the runtime config, which is Not Good:tm:.