### PR TITLE
Small efficiency improvements for DtrBar

### DIFF
--- a/Dalamud/Game/Gui/Dtr/DtrBarEntry.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBarEntry.cs
@@ -137,14 +137,17 @@ public sealed unsafe class DtrBarEntry : IDisposable, IDtrBarEntry
         get => this.shownBacking;
         set
         {
-            this.shownBacking = value;
-            this.Dirty = true;
+            if (value != this.shownBacking)
+            {
+                this.shownBacking = value;
+                this.Dirty = true;
+            }
         }
     }
 
     /// <inheritdoc/>
     [Api10ToDo("Maybe make this config scoped to internalname?")]
-    public bool UserHidden => this.configuration.DtrIgnore?.Any(x => x == this.Title) ?? false;
+    public bool UserHidden => this.configuration.DtrIgnore?.Contains(this.Title) ?? false;
 
     /// <summary>
     /// Gets or sets the internal text node of this entry.


### PR DESCRIPTION
Make some small efficiency improvements to DtrBar. The most significant is that we don't call the native `SetText` function for hidden nodes (previously we called this every frame), and we skip setting the `Dirty` flag in the `DtrBarEntry.Shown` setter when the visibility didn't change (plugins can already do this check this but many don't since it's not intuitive, which results in a lot of re-rendering). Impact will vary but reduces my DtrBar framework time by around half.