### PR TITLE
Change ReShade related detections

### DIFF
--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -772,7 +772,7 @@ internal partial class InterfaceManager : IInternalDisposableService
             0,
             this.SetCursorDetour);
 
-        if (ReShadeAddonInterface.ReShadeHasSignature)
+        if (ReShadeAddonInterface.ReShadeIsSignedByReShade)
         {
             Log.Warning("Signed ReShade binary detected");
             Service<NotificationManager>


### PR DESCRIPTION
* Changed ReShade w/o addon support detection to compare the name of the signer to the string "ReShade", so that any false positives stemming from use of other injector do not trigger warnings.
* Changed main SwapChain detection to be done by comparing the HWND of window that the SwapChain is attached to.