### PR TITLE
ServiceScope fixes

### DIFF
--- a/Dalamud/IoC/Internal/ServiceContainer.cs
+++ b/Dalamud/IoC/Internal/ServiceContainer.cs
@@ -145,7 +145,7 @@ internal class ServiceContainer : IServiceProvider, IServiceType
     /// <param name="publicScopes">Scoped objects to be injected.</param>
     /// <param name="scope">The scope to be used to create scoped services.</param>
     /// <returns>A <see cref="ValueTask"/> representing the operation.</returns>
-    public async ValueTask InjectProperties(object instance, object[] publicScopes, IServiceScope? scope = null)
+    public async Task InjectProperties(object instance, object[] publicScopes, IServiceScope? scope = null)
     {
         var scopeImpl = scope as ServiceScopeImpl;
         var objectType = instance.GetType();

--- a/Dalamud/IoC/Internal/ServiceScope.cs
+++ b/Dalamud/IoC/Internal/ServiceScope.cs
@@ -25,7 +25,7 @@ internal interface IServiceScope : IDisposable
     /// <param name="objectType">The type of object to create.</param>
     /// <param name="scopedObjects">Scoped objects to be included in the constructor.</param>
     /// <returns>The created object.</returns>
-    public Task<object?> CreateAsync(Type objectType, params object[] scopedObjects);
+    public Task<object> CreateAsync(Type objectType, params object[] scopedObjects);
 
     /// <summary>
     /// Inject <see cref="PluginInterfaceAttribute" /> interfaces into public or static properties on the provided object.
@@ -45,7 +45,7 @@ internal class ServiceScopeImpl : IServiceScope
     private readonly ServiceContainer container;
 
     private readonly List<object> privateScopedObjects = [];
-    private readonly ConcurrentDictionary<Type, Task<object?>> scopeCreatedObjects = new();
+    private readonly ConcurrentDictionary<Type, Task<object>> scopeCreatedObjects = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ServiceScopeImpl" /> class.
@@ -63,7 +63,7 @@ internal class ServiceScopeImpl : IServiceScope
     }
 
     /// <inheritdoc />
-    public Task<object?> CreateAsync(Type objectType, params object[] scopedObjects)
+    public Task<object> CreateAsync(Type objectType, params object[] scopedObjects)
     {
         return this.container.CreateAsync(objectType, scopedObjects, this);
     }
@@ -80,7 +80,7 @@ internal class ServiceScopeImpl : IServiceScope
     /// <param name="objectType">The type of object to create.</param>
     /// <param name="scopedObjects">Additional scoped objects.</param>
     /// <returns>The created object, or null.</returns>
-    public Task<object?> CreatePrivateScopedObject(Type objectType, params object[] scopedObjects) =>
+    public Task<object> CreatePrivateScopedObject(Type objectType, params object[] scopedObjects) =>
         this.scopeCreatedObjects.GetOrAdd(
             objectType,
             static (objectType, p) => p.Scope.container.CreateAsync(

--- a/Dalamud/IoC/Internal/ServiceScope.cs
+++ b/Dalamud/IoC/Internal/ServiceScope.cs
@@ -33,8 +33,8 @@ internal interface IServiceScope : IDisposable
     /// </summary>
     /// <param name="instance">The object instance.</param>
     /// <param name="scopedObjects">Scoped objects to be injected.</param>
-    /// <returns>Whether or not the injection was successful.</returns>
-    public Task<bool> InjectPropertiesAsync(object instance, params object[] scopedObjects);
+    /// <returns>A <see cref="ValueTask"/> representing the status of the operation.</returns>
+    public ValueTask InjectPropertiesAsync(object instance, params object[] scopedObjects);
 }
 
 /// <summary>
@@ -69,10 +69,8 @@ internal class ServiceScopeImpl : IServiceScope
     }
 
     /// <inheritdoc />
-    public Task<bool> InjectPropertiesAsync(object instance, params object[] scopedObjects)
-    {
-        return this.container.InjectProperties(instance, scopedObjects, this);
-    }
+    public ValueTask InjectPropertiesAsync(object instance, params object[] scopedObjects) =>
+        this.container.InjectProperties(instance, scopedObjects, this);
 
     /// <summary>
     /// Create a service scoped to this scope, with private scoped objects.

--- a/Dalamud/IoC/Internal/ServiceScope.cs
+++ b/Dalamud/IoC/Internal/ServiceScope.cs
@@ -17,7 +17,7 @@ internal interface IServiceScope : IDisposable
     /// but not directly to created objects.
     /// </summary>
     /// <param name="scopes">The scopes to add.</param>
-    public void RegisterPrivateScopes(params object[] scopes);
+    void RegisterPrivateScopes(params object[] scopes);
 
     /// <summary>
     /// Create an object.
@@ -25,7 +25,7 @@ internal interface IServiceScope : IDisposable
     /// <param name="objectType">The type of object to create.</param>
     /// <param name="scopedObjects">Scoped objects to be included in the constructor.</param>
     /// <returns>The created object.</returns>
-    public Task<object> CreateAsync(Type objectType, params object[] scopedObjects);
+    Task<object> CreateAsync(Type objectType, params object[] scopedObjects);
 
     /// <summary>
     /// Inject <see cref="PluginInterfaceAttribute" /> interfaces into public or static properties on the provided object.
@@ -34,7 +34,7 @@ internal interface IServiceScope : IDisposable
     /// <param name="instance">The object instance.</param>
     /// <param name="scopedObjects">Scoped objects to be injected.</param>
     /// <returns>A <see cref="ValueTask"/> representing the status of the operation.</returns>
-    public ValueTask InjectPropertiesAsync(object instance, params object[] scopedObjects);
+    Task InjectPropertiesAsync(object instance, params object[] scopedObjects);
 }
 
 /// <summary>
@@ -47,29 +47,20 @@ internal class ServiceScopeImpl : IServiceScope
     private readonly List<object> privateScopedObjects = [];
     private readonly ConcurrentDictionary<Type, Task<object>> scopeCreatedObjects = new();
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ServiceScopeImpl" /> class.
-    /// </summary>
+    /// <summary>Initializes a new instance of the <see cref="ServiceScopeImpl" /> class.</summary>
     /// <param name="container">The container this scope will use to create services.</param>
-    public ServiceScopeImpl(ServiceContainer container)
-    {
-        this.container = container;
-    }
+    public ServiceScopeImpl(ServiceContainer container) => this.container = container;
 
     /// <inheritdoc/>
-    public void RegisterPrivateScopes(params object[] scopes)
-    {
+    public void RegisterPrivateScopes(params object[] scopes) =>
         this.privateScopedObjects.AddRange(scopes);
-    }
 
     /// <inheritdoc />
-    public Task<object> CreateAsync(Type objectType, params object[] scopedObjects)
-    {
-        return this.container.CreateAsync(objectType, scopedObjects, this);
-    }
+    public Task<object> CreateAsync(Type objectType, params object[] scopedObjects) =>
+        this.container.CreateAsync(objectType, scopedObjects, this);
 
     /// <inheritdoc />
-    public ValueTask InjectPropertiesAsync(object instance, params object[] scopedObjects) =>
+    public Task InjectPropertiesAsync(object instance, params object[] scopedObjects) =>
         this.container.InjectProperties(instance, scopedObjects, this);
 
     /// <summary>

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -487,7 +487,7 @@ internal sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposa
     /// <inheritdoc/>
     public bool Inject(object instance, params object[] scopedObjects)
     {
-        var t = this.InjectAsync(instance, scopedObjects).AsTask();
+        var t = this.InjectAsync(instance, scopedObjects);
         t.Wait();
 
         if (t.Exception is { } e)
@@ -504,7 +504,7 @@ internal sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposa
     }
 
     /// <inheritdoc/>
-    public ValueTask InjectAsync(object instance, params object[] scopedObjects) =>
+    public Task InjectAsync(object instance, params object[] scopedObjects) =>
         this.plugin.ServiceScope!.InjectPropertiesAsync(instance, this.GetPublicIocScopes(scopedObjects));
 
     #endregion

--- a/Dalamud/Plugin/IDalamudPluginInterface.cs
+++ b/Dalamud/Plugin/IDalamudPluginInterface.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Threading.Tasks;
 
 using Dalamud.Configuration;
 using Dalamud.Game.Text;
@@ -304,8 +305,16 @@ public interface IDalamudPluginInterface
     /// </summary>
     /// <param name="scopedObjects">Objects to inject additionally.</param>
     /// <typeparam name="T">The type to create.</typeparam>
-    /// <returns>The created and initialized type.</returns>
+    /// <returns>The created and initialized type, or <c>null</c> on failure.</returns>
     T? Create<T>(params object[] scopedObjects) where T : class;
+
+    /// <summary>
+    /// Create a new object of the provided type using its default constructor, then inject objects and properties.
+    /// </summary>
+    /// <param name="scopedObjects">Objects to inject additionally.</param>
+    /// <typeparam name="T">The type to create.</typeparam>
+    /// <returns>A task representing the created and initialized type.</returns>
+    Task<T> CreateAsync<T>(params object[] scopedObjects) where T : class;
 
     /// <summary>
     /// Inject services into properties on the provided object instance.

--- a/Dalamud/Plugin/IDalamudPluginInterface.cs
+++ b/Dalamud/Plugin/IDalamudPluginInterface.cs
@@ -323,4 +323,12 @@ public interface IDalamudPluginInterface
     /// <param name="scopedObjects">Objects to inject additionally.</param>
     /// <returns>Whether or not the injection succeeded.</returns>
     bool Inject(object instance, params object[] scopedObjects);
+
+    /// <summary>
+    /// Inject services into properties on the provided object instance.
+    /// </summary>
+    /// <param name="instance">The instance to inject services into.</param>
+    /// <param name="scopedObjects">Objects to inject additionally.</param>
+    /// <returns>A <see cref="ValueTask"/> representing the status of the operation.</returns>
+    ValueTask InjectAsync(object instance, params object[] scopedObjects);
 }

--- a/Dalamud/Plugin/IDalamudPluginInterface.cs
+++ b/Dalamud/Plugin/IDalamudPluginInterface.cs
@@ -321,7 +321,7 @@ public interface IDalamudPluginInterface
     /// </summary>
     /// <param name="instance">The instance to inject services into.</param>
     /// <param name="scopedObjects">Objects to inject additionally.</param>
-    /// <returns>Whether or not the injection succeeded.</returns>
+    /// <returns>Whether the injection succeeded.</returns>
     bool Inject(object instance, params object[] scopedObjects);
 
     /// <summary>
@@ -330,5 +330,5 @@ public interface IDalamudPluginInterface
     /// <param name="instance">The instance to inject services into.</param>
     /// <param name="scopedObjects">Objects to inject additionally.</param>
     /// <returns>A <see cref="ValueTask"/> representing the status of the operation.</returns>
-    ValueTask InjectAsync(object instance, params object[] scopedObjects);
+    Task InjectAsync(object instance, params object[] scopedObjects);
 }


### PR DESCRIPTION
* Changed `IServiceScope.CreateAsync` to never return null, and instead store the exception in the returned Task.
* Changed `ServiceScope` to use `ConcurrentDictionary<Type, Task<object>>` to manage created objects.
* Added `IDalamudPluginInterface.CreateAsync` to offer an alternative avoiding using `.Wait`. `IDalamudPluginInterface.Create` will work as it always did; only a small note has been added that describes what happens on failure, and its actual behavior did not change.
* Added `IDalamudPluginInterface.InjectAsync` for same reasons.