### PR TITLE
Mark DtrBar entries as dirty when added

### DIFF
--- a/Dalamud/Game/Gui/Dtr/DtrBar.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBar.cs
@@ -229,6 +229,7 @@ internal sealed unsafe class DtrBar : IInternalDisposableService, IDtrBar
             if (!data.Added)
             {
                 data.Added = this.AddNode(data.TextNode);
+                data.Dirty = true;
             }
 
             var isHide = !data.Shown || data.UserHidden;


### PR DESCRIPTION
Ensures newly added DtrBar entries are always given an opportunity to draw immediately after their nodes are attached, even if they aren't marked dirty otherwise. Resolves an issue where some nodes may be left empty after being destroyed during a visit to the aesthetician.