### PR TITLE
Use origins when calculating scaled node position

### DIFF
--- a/Dalamud/Interface/Internal/UiDebug.cs
+++ b/Dalamud/Interface/Internal/UiDebug.cs
@@ -563,11 +563,13 @@ internal unsafe class UiDebug
     private Vector2 GetNodePosition(AtkResNode* node)
     {
         var pos = new Vector2(node->X, node->Y);
+        pos -= new Vector2(node->OriginX * (node->ScaleX - 1), node->OriginY * (node->ScaleY - 1));
         var par = node->ParentNode;
         while (par != null)
         {
             pos *= new Vector2(par->ScaleX, par->ScaleY);
             pos += new Vector2(par->X, par->Y);
+            pos -= new Vector2(par->OriginX * (par->ScaleX - 1), par->OriginY * (par->ScaleY - 1));
             par = par->ParentNode;
         }
 


### PR DESCRIPTION
Changes `GetNodePosition` to consider the node's (and parent nodes') `OriginX` and `OriginY` when calculating node position. This makes `DrawOutline` draw the correct position for nodes and the children of nodes with a non-zero scale origin.

Tested with various situations including origin-scaled children of origin-scaled parent and things seemed to work fine with this logic.

I previously added this code to SimpleTweaks' UI debugging, this is just the same change for the Dalamud version.