### PR TITLE
Make DtrBar more threadsafe

### DIFF
--- a/Dalamud/Game/ClientState/Objects/ObjectTable.cs
+++ b/Dalamud/Game/ClientState/Objects/ObjectTable.cs
@@ -150,7 +150,7 @@ internal sealed partial class ObjectTable : IServiceType, IObjectTable
         };
     }
 
-    [Api10ToDo("Use ThreadSafety.AssertMainThread() instead of this.")]
+    [Api11ToDo("Use ThreadSafety.AssertMainThread() instead of this.")]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool WarnMultithreadedUsage()
     {

--- a/Dalamud/Game/Gui/Dtr/DtrBar.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBar.cs
@@ -403,7 +403,7 @@ internal sealed unsafe class DtrBar : IInternalDisposableService, IDtrBar
         var additionalWidth = 0;
         AtkResNode* collisionNode = null;
 
-        foreach (var index in Enumerable.Range(0, addon->UldManager.NodeListCount))
+        for (var index = 0; index < addon->UldManager.NodeListCount; index++)
         {
             var node = addon->UldManager.NodeList[index];
             if (node->IsVisible())

--- a/Dalamud/Game/Gui/Dtr/DtrBarEntry.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBarEntry.cs
@@ -1,7 +1,6 @@
-﻿using System.Linq;
-
-using Dalamud.Configuration.Internal;
+﻿using Dalamud.Configuration.Internal;
 using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Plugin.Internal.Types;
 using Dalamud.Utility;
 
 using FFXIVClientStructs.FFXIV.Client.System.String;
@@ -86,6 +85,7 @@ public interface IDtrBarEntry : IReadOnlyDtrBarEntry
 /// <summary>
 /// Class representing an entry in the server info bar.
 /// </summary>
+[Api11ToDo(Api11ToDoAttribute.MakeInternal)]
 public sealed unsafe class DtrBarEntry : IDisposable, IDtrBarEntry
 {
     private readonly DalamudConfiguration configuration;
@@ -146,7 +146,7 @@ public sealed unsafe class DtrBarEntry : IDisposable, IDtrBarEntry
     }
 
     /// <inheritdoc/>
-    [Api10ToDo("Maybe make this config scoped to internalname?")]
+    [Api11ToDo("Maybe make this config scoped to internalname?")]
     public bool UserHidden => this.configuration.DtrIgnore?.Contains(this.Title) ?? false;
 
     /// <summary>
@@ -173,6 +173,11 @@ public sealed unsafe class DtrBarEntry : IDisposable, IDtrBarEntry
     /// Gets or sets a value indicating whether this entry has just been added.
     /// </summary>
     internal bool Added { get; set; } 
+
+    /// <summary>
+    /// Gets or sets the plugin that owns this entry.
+    /// </summary>
+    internal LocalPlugin? OwnerPlugin { get; set; }
 
     /// <inheritdoc/>
     public bool TriggerClickAction()

--- a/Dalamud/Game/Gui/Dtr/DtrBarEntry.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBarEntry.cs
@@ -160,9 +160,9 @@ public sealed unsafe class DtrBarEntry : IDisposable, IDtrBarEntry
     internal Utf8String* Storage { get; set; }
 
     /// <summary>
-    /// Gets a value indicating whether this entry should be removed.
+    /// Gets or sets a value indicating whether this entry should be removed.
     /// </summary>
-    internal bool ShouldBeRemoved { get; private set; }
+    internal bool ShouldBeRemoved { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether this entry is dirty.

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/DtrBarWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/DtrBarWidget.cs
@@ -1,4 +1,8 @@
-﻿using Dalamud.Configuration.Internal;
+﻿using System.Linq;
+using System.Threading;
+
+using Dalamud.Configuration.Internal;
+using Dalamud.Game;
 using Dalamud.Game.Gui.Dtr;
 
 using ImGuiNET;
@@ -8,17 +12,20 @@ namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
 /// <summary>
 /// Widget for displaying dtr test.
 /// </summary>
-internal class DtrBarWidget : IDataWindowWidget
+internal class DtrBarWidget : IDataWindowWidget, IDisposable
 {
     private IDtrBarEntry? dtrTest1;
     private IDtrBarEntry? dtrTest2;
     private IDtrBarEntry? dtrTest3;
-    
+
+    private Thread? loadTestThread;
+    private CancellationTokenSource? loadTestThreadCt;
+
     /// <inheritdoc/>
     public string[]? CommandShortcuts { get; init; } = { "dtr", "dtrbar" };
-    
+
     /// <inheritdoc/>
-    public string DisplayName { get; init; } = "DTR Bar"; 
+    public string DisplayName { get; init; } = "DTR Bar";
 
     /// <inheritdoc/>
     public bool Ready { get; set; }
@@ -26,31 +33,145 @@ internal class DtrBarWidget : IDataWindowWidget
     /// <inheritdoc/>
     public void Load()
     {
+        this.ClearState();
         this.Ready = true;
     }
 
     /// <inheritdoc/>
+    public void Dispose() => this.ClearState();
+
+    /// <inheritdoc/>
     public void Draw()
     {
+        if (this.loadTestThread?.IsAlive is not true)
+        {
+            if (ImGui.Button("Do multithreaded add/remove operation"))
+            {
+                var ct = this.loadTestThreadCt = new();
+                var dbar = Service<DtrBar>.Get();
+                var fw = Service<Framework>.Get();
+                var rng = new Random();
+                this.loadTestThread = new(
+                    () =>
+                    {
+                        var threads = Enumerable
+                                      .Range(0, Environment.ProcessorCount)
+                                      .Select(
+                                          i => new Thread(
+                                              (i % 4) switch
+                                              {
+                                                  0 => () =>
+                                                  {
+                                                      try
+                                                      {
+                                                          while (true)
+                                                          {
+                                                              var n = $"DtrBarWidgetTest{rng.NextInt64(8)}";
+                                                              dbar.Get(n, n[^5..]);
+                                                              fw.DelayTicks(1, ct.Token).Wait(ct.Token);
+                                                              ct.Token.ThrowIfCancellationRequested();
+                                                          }
+                                                      }
+                                                      catch (OperationCanceledException)
+                                                      {
+                                                          // ignore
+                                                      }
+                                                  },
+                                                  1 => () =>
+                                                  {
+                                                      try
+                                                      {
+                                                          while (true)
+                                                          {
+                                                              dbar.Remove($"DtrBarWidgetTest{rng.NextInt64(8)}");
+                                                              fw.DelayTicks(1, ct.Token).Wait(ct.Token);
+                                                              ct.Token.ThrowIfCancellationRequested();
+                                                          }
+                                                      }
+                                                      catch (OperationCanceledException)
+                                                      {
+                                                          // ignore
+                                                      }
+                                                  },
+                                                  2 => () =>
+                                                  {
+                                                      try
+                                                      {
+                                                          while (true)
+                                                          {
+                                                              var n = $"DtrBarWidgetTest{rng.NextInt64(8)}_";
+                                                              dbar.Get(n, n[^6..]);
+                                                              ct.Token.ThrowIfCancellationRequested();
+                                                          }
+                                                      }
+                                                      catch (OperationCanceledException)
+                                                      {
+                                                          // ignore
+                                                      }
+                                                  },
+                                                  _ => () =>
+                                                  {
+                                                      try
+                                                      {
+                                                          while (true)
+                                                          {
+                                                              dbar.Remove($"DtrBarWidgetTest{rng.NextInt64(8)}_");
+                                                              ct.Token.ThrowIfCancellationRequested();
+                                                          }
+                                                      }
+                                                      catch (OperationCanceledException)
+                                                      {
+                                                          // ignore
+                                                      }
+                                                  },
+                                              }))
+                                      .ToArray();
+                        foreach (var t in threads) t.Start();
+                        foreach (var t in threads) t.Join();
+                        for (var i = 0; i < 8; i++) dbar.Remove($"DtrBarWidgetTest{i % 8}");
+                        for (var i = 0; i < 8; i++) dbar.Remove($"DtrBarWidgetTest{i % 8}_");
+                    });
+                this.loadTestThread.Start();
+            }
+        }
+        else
+        {
+            if (ImGui.Button("Stop multithreaded add/remove operation"))
+                this.ClearState();
+        }
+
+        ImGui.Separator();
         this.DrawDtrTestEntry(ref this.dtrTest1, "DTR Test #1");
+
         ImGui.Separator();
         this.DrawDtrTestEntry(ref this.dtrTest2, "DTR Test #2");
+
         ImGui.Separator();
         this.DrawDtrTestEntry(ref this.dtrTest3, "DTR Test #3");
+
         ImGui.Separator();
+        ImGui.Text("IDtrBar.Entries:");
+        foreach (var e in Service<DtrBar>.Get().Entries)
+            ImGui.Text(e.Title);
 
         var configuration = Service<DalamudConfiguration>.Get();
         if (configuration.DtrOrder != null)
         {
             ImGui.Separator();
-
+            ImGui.Text("DtrOrder:");
             foreach (var order in configuration.DtrOrder)
-            {
                 ImGui.Text(order);
-            }
         }
     }
-    
+
+    private void ClearState()
+    {
+        this.loadTestThreadCt?.Cancel();
+        this.loadTestThread?.Join();
+        this.loadTestThread = null;
+        this.loadTestThreadCt = null;
+    }
+
     private void DrawDtrTestEntry(ref IDtrBarEntry? entry, string title)
     {
         var dtrBar = Service<DtrBar>.Get();

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabDtr.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabDtr.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Numerics;
 
 using CheapLoc;
 using Dalamud.Configuration.Internal;
@@ -45,6 +46,10 @@ public class SettingsTabDtr : SettingsTab
         }
 
         var isOrderChange = false;
+        Span<Vector2> upButtonCenters = stackalloc Vector2[order.Count];
+        Span<Vector2> downButtonCenters = stackalloc Vector2[order.Count];
+        scoped Span<Vector2> moveMouseTo = default;
+        var moveMouseToIndex = -1;
         for (var i = 0; i < order.Count; i++)
         {
             var title = order[i];
@@ -65,8 +70,12 @@ public class SettingsTabDtr : SettingsTab
                 {
                     (order[i], order[i - 1]) = (order[i - 1], order[i]);
                     isOrderChange = true;
+                    moveMouseToIndex = i - 1;
+                    moveMouseTo = upButtonCenters;
                 }
             }
+
+            upButtonCenters[i] = (ImGui.GetItemRectMin() + ImGui.GetItemRectMax()) / 2;
 
             ImGui.SameLine();
 
@@ -81,8 +90,12 @@ public class SettingsTabDtr : SettingsTab
                 {
                     (order[i], order[i + 1]) = (order[i + 1], order[i]);
                     isOrderChange = true;
+                    moveMouseToIndex = i + 1;
+                    moveMouseTo = downButtonCenters;
                 }
             }
+
+            downButtonCenters[i] = (ImGui.GetItemRectMin() + ImGui.GetItemRectMax()) / 2;
 
             ImGui.PopFont();
 
@@ -107,11 +120,17 @@ public class SettingsTabDtr : SettingsTab
             // }
         }
 
+        if (moveMouseToIndex >= 0 && moveMouseToIndex < moveMouseTo.Length)
+        {
+            ImGui.GetIO().WantSetMousePos = true;
+            ImGui.GetIO().MousePos = moveMouseTo[moveMouseToIndex];
+        }
+
         configuration.DtrOrder = order.Concat(orderLeft).ToList();
         configuration.DtrIgnore = ignore.Concat(ignoreLeft).ToList();
 
         if (isOrderChange)
-            dtrBar.ApplySort(configuration.DtrOrder);
+            dtrBar.ApplySort();
 
         ImGuiHelpers.ScaledDummy(10);
 

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabDtr.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabDtr.cs
@@ -111,7 +111,7 @@ public class SettingsTabDtr : SettingsTab
         configuration.DtrIgnore = ignore.Concat(ignoreLeft).ToList();
 
         if (isOrderChange)
-            dtrBar.ApplySort();
+            dtrBar.ApplySort(configuration.DtrOrder);
 
         ImGuiHelpers.ScaledDummy(10);
 

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -15,13 +15,11 @@ using Dalamud.Configuration;
 using Dalamud.Configuration.Internal;
 using Dalamud.Game;
 using Dalamud.Game.Gui;
-using Dalamud.Game.Gui.Dtr;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Interface;
 using Dalamud.Interface.Internal;
-using Dalamud.Interface.Internal.Windows.PluginInstaller;
 using Dalamud.IoC;
 using Dalamud.Logging.Internal;
 using Dalamud.Networking.Http;
@@ -1122,10 +1120,6 @@ internal class PluginManager : IInternalDisposableService
                 updateStatus.Status = PluginUpdateStatus.StatusKind.FailedUnload;
                 return updateStatus;
             }
-
-            // We need to handle removed DTR nodes here, as otherwise, plugins will not be able to re-add their bar entries after updates.
-            var dtr = Service<DtrBar>.Get();
-            dtr.HandleRemovedNodes();
 
             try
             {

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -6,8 +6,6 @@ using System.Threading.Tasks;
 
 using Dalamud.Configuration.Internal;
 using Dalamud.Game;
-using Dalamud.Game.Gui;
-using Dalamud.Game.Gui.Dtr;
 using Dalamud.Interface.Internal;
 using Dalamud.IoC.Internal;
 using Dalamud.Logging.Internal;
@@ -15,7 +13,6 @@ using Dalamud.Plugin.Internal.Exceptions;
 using Dalamud.Plugin.Internal.Loader;
 using Dalamud.Plugin.Internal.Profiles;
 using Dalamud.Plugin.Internal.Types.Manifest;
-using Dalamud.Utility;
 
 namespace Dalamud.Plugin.Internal.Types;
 
@@ -540,9 +537,6 @@ internal class LocalPlugin : IDisposable
         }
         finally
         {
-            // We need to handle removed DTR nodes here, as otherwise, plugins will not be able to re-add their bar entries after updates.
-            Service<DtrBar>.GetNullable()?.HandleRemovedNodes();
-
             this.pluginLoadStateLock.Release();
         }
     }

--- a/Dalamud/Plugin/Services/IDtrBar.cs
+++ b/Dalamud/Plugin/Services/IDtrBar.cs
@@ -2,7 +2,6 @@
 
 using Dalamud.Game.Gui.Dtr;
 using Dalamud.Game.Text.SeStringHandling;
-using Dalamud.Utility;
 
 namespace Dalamud.Plugin.Services;
 
@@ -12,10 +11,13 @@ namespace Dalamud.Plugin.Services;
 public interface IDtrBar
 {
     /// <summary>
-    /// Gets a read-only list of all DTR bar entries.
+    /// Gets a read-only copy of the list of all DTR bar entries.
     /// </summary>
-    public IReadOnlyList<IReadOnlyDtrBarEntry> Entries { get; }
-    
+    /// <remarks>If the list changes due to changes in order or insertion/removal, then this property will return a
+    /// completely new object on getter invocation. The returned object is safe to use from any thread, and will not
+    /// change.</remarks>
+    IReadOnlyList<IReadOnlyDtrBarEntry> Entries { get; }
+
     /// <summary>
     /// Get a DTR bar entry.
     /// This allows you to add your own text, and users to sort it.
@@ -24,11 +26,13 @@ public interface IDtrBar
     /// <param name="text">The text the entry shows.</param>
     /// <returns>The entry object used to update, hide and remove the entry.</returns>
     /// <exception cref="ArgumentException">Thrown when an entry with the specified title exists.</exception>
-    public IDtrBarEntry Get(string title, SeString? text = null);
+    IDtrBarEntry Get(string title, SeString? text = null);
 
     /// <summary>
     /// Removes a DTR bar entry from the system.
     /// </summary>
     /// <param name="title">Title of the entry to remove.</param>
-    public void Remove(string title);
+    /// <remarks>Remove operation is not immediate. Attempts to call <see cref="Get"/> immediately after calling this
+    /// function may fail.</remarks>
+    void Remove(string title);
 }

--- a/Dalamud/Plugin/Services/IDtrBar.cs
+++ b/Dalamud/Plugin/Services/IDtrBar.cs
@@ -32,7 +32,7 @@ public interface IDtrBar
     /// Removes a DTR bar entry from the system.
     /// </summary>
     /// <param name="title">Title of the entry to remove.</param>
-    /// <remarks>Remove operation is not immediate. Attempts to call <see cref="Get"/> immediately after calling this
-    /// function may fail.</remarks>
+    /// <remarks>Remove operation is not guaranteed to be immediately effective. Calls to <see cref="Get"/> may result
+    /// in an entry marked to be remove being revived and used again.</remarks>
     void Remove(string title);
 }

--- a/Dalamud/Utility/Api11ToDoAttribute.cs
+++ b/Dalamud/Utility/Api11ToDoAttribute.cs
@@ -1,21 +1,11 @@
 namespace Dalamud.Utility;
 
 /// <summary>
-/// Utility class for marking something to be changed for API 10, for ease of lookup.
+/// Utility class for marking something to be changed for API 11, for ease of lookup.
 /// </summary>
 [AttributeUsage(AttributeTargets.All, Inherited = false)]
 internal sealed class Api11ToDoAttribute : Attribute
 {
-    /// <summary>
-    /// Marks that this exists purely for making API 9 plugins work.
-    /// </summary>
-    public const string DeleteCompatBehavior = "Delete. This is for making API 9 plugins work.";
-
-    /// <summary>
-    /// Marks that this should be moved to another namespace.
-    /// </summary>
-    public const string MoveNamespace = "Move to another namespace.";
-
     /// <summary>
     /// Marks that this should be made internal.
     /// </summary>

--- a/Dalamud/Utility/Api11ToDoAttribute.cs
+++ b/Dalamud/Utility/Api11ToDoAttribute.cs
@@ -4,7 +4,7 @@ namespace Dalamud.Utility;
 /// Utility class for marking something to be changed for API 10, for ease of lookup.
 /// </summary>
 [AttributeUsage(AttributeTargets.All, Inherited = false)]
-internal sealed class Api10ToDoAttribute : Attribute
+internal sealed class Api11ToDoAttribute : Attribute
 {
     /// <summary>
     /// Marks that this exists purely for making API 9 plugins work.
@@ -12,16 +12,21 @@ internal sealed class Api10ToDoAttribute : Attribute
     public const string DeleteCompatBehavior = "Delete. This is for making API 9 plugins work.";
 
     /// <summary>
-    /// Marks that this should be moved to an another namespace.
+    /// Marks that this should be moved to another namespace.
     /// </summary>
     public const string MoveNamespace = "Move to another namespace.";
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="Api10ToDoAttribute"/> class.
+    /// Marks that this should be made internal.
+    /// </summary>
+    public const string MakeInternal = "Make internal.";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Api11ToDoAttribute"/> class.
     /// </summary>
     /// <param name="what">The explanation.</param>
     /// <param name="what2">The explanation 2.</param>
-    public Api10ToDoAttribute(string what, string what2 = "")
+    public Api11ToDoAttribute(string what, string what2 = "")
     {
         _ = what;
         _ = what2;


### PR DESCRIPTION
* Changed DtrBar to use ReaderWriterLockSlim so that there exists only one storage of entries, preventing possible desync.
* DtrBarEntry will now hold a reference to the LocalPlugin that created the entry, so that DtrBarPluginScoped can defer plugin related handling to the main service.
* Marked DtrBarEntry class itself to be turned internal in API 11.
* Made IDtrBar.Entries return an immutable copy of underlying list of DtrBar entries, that will be freshly created whenever the list changes.