### PR TITLE
Add events for ClassJob and Level change

### DIFF
--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -68,6 +68,7 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
         this.networkHandlers.CfPop += this.NetworkHandlersOnCfPop;
 
         this.setupTerritoryTypeHook.Enable();
+        this.uiModuleHandlePacketHook.Enable();
     }
 
     [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
@@ -163,6 +164,7 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
     void IInternalDisposableService.DisposeService()
     {
         this.setupTerritoryTypeHook.Dispose();
+        this.uiModuleHandlePacketHook.Dispose();
         this.framework.Update -= this.FrameworkOnOnUpdateEvent;
         this.networkHandlers.CfPop -= this.NetworkHandlersOnCfPop;
     }

--- a/Dalamud/Plugin/Services/IClientState.cs
+++ b/Dalamud/Plugin/Services/IClientState.cs
@@ -10,9 +10,33 @@ namespace Dalamud.Plugin.Services;
 public interface IClientState
 {
     /// <summary>
+    /// A delegate type used for the <see cref="ClassJobChanged"/> event.
+    /// </summary>
+    /// <param name="classJobId">The new ClassJob id.</param>
+    public delegate void ClassJobChangeDelegate(uint classJobId);
+
+    /// <summary>
+    /// A delegate type used for the <see cref="LevelChanged"/> event.
+    /// </summary>
+    /// <param name="classJobId">The ClassJob id.</param>
+    /// <param name="level">The level of the corresponding ClassJob.</param>
+    public delegate void LevelChangeDelegate(uint classJobId, uint level);
+
+    /// <summary>
     /// Event that gets fired when the current Territory changes.
     /// </summary>
     public event Action<ushort> TerritoryChanged;
+
+    /// <summary>
+    /// Event that fires when a characters ClassJob changed.
+    /// </summary>
+    public event ClassJobChangeDelegate? ClassJobChanged;
+
+    /// <summary>
+    /// Event that fires when a characters level changed.<br/>
+    /// This event also gets fired when the player changes jobs.
+    /// </summary>
+    public event LevelChangeDelegate? LevelChanged;
 
     /// <summary>
     /// Event that fires when a character is logging in, and the local character object is available.

--- a/Dalamud/Plugin/Services/IClientState.cs
+++ b/Dalamud/Plugin/Services/IClientState.cs
@@ -33,8 +33,8 @@ public interface IClientState
     public event ClassJobChangeDelegate? ClassJobChanged;
 
     /// <summary>
-    /// Event that fires when a characters level changed.<br/>
-    /// This event might get fired for a different ClassJob than the player is currently on (e.g. in PvP matches).
+    /// Event that fires when <em>any</em> character level changes, including levels
+    /// for a not-currently-active ClassJob (e.g. PvP matches, DoH/DoL).
     /// </summary>
     public event LevelChangeDelegate? LevelChanged;
 

--- a/Dalamud/Plugin/Services/IClientState.cs
+++ b/Dalamud/Plugin/Services/IClientState.cs
@@ -34,7 +34,7 @@ public interface IClientState
 
     /// <summary>
     /// Event that fires when a characters level changed.<br/>
-    /// This event also gets fired when the player changes jobs.
+    /// This event might get fired for a different ClassJob than the player is currently on (e.g. in PvP matches).
     /// </summary>
     public event LevelChangeDelegate? LevelChanged;
 


### PR DESCRIPTION
This PR adds 2 new events to ClientState:

- `ClassJobChanged(uint classJobId)`
- `LevelChange(uint classJobId, uint level)`

The events are fired *after* Agents are informed of the change to make sure everything is already updated appropriately.