### PR TITLE
Set style parameter of CompileSeStringWrapped to default

### DIFF
--- a/Dalamud/Interface/Utility/ImGuiHelpers.cs
+++ b/Dalamud/Interface/Utility/ImGuiHelpers.cs
@@ -208,7 +208,7 @@ public static class ImGuiHelpers
     [Experimental("SeStringRenderer")]
     public static SeStringDrawResult CompileSeStringWrapped(
         string text,
-        scoped in SeStringDrawParams style,
+        scoped in SeStringDrawParams style = default,
         ImGuiId imGuiId = default,
         ImGuiButtonFlags buttonFlags = ImGuiButtonFlags.MouseButtonDefault) =>
         Service<SeStringRenderer>.Get().CompileAndDrawWrapped(text, style, imGuiId, buttonFlags);


### PR DESCRIPTION
There are no other overloads and `ImGuiHelpers.SeStringWrapped` has it `default` too.