### PR TITLE
Fix UIColor handling per theme

### DIFF
--- a/Dalamud/Interface/ColorHelpers.cs
+++ b/Dalamud/Interface/ColorHelpers.cs
@@ -256,6 +256,12 @@ public static class ColorHelpers
     public static uint ApplyOpacity(uint rgba, float opacity) =>
         ((uint)MathF.Round((rgba >> 24) * opacity) << 24) | (rgba & 0xFFFFFFu);
 
+    /// <summary>Swaps red and blue channels of a given color in ARGB(BB GG RR AA) and ABGR(RR GG BB AA).</summary>
+    /// <param name="x">Color to process.</param>
+    /// <returns>Swapped color.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static uint SwapRedBlue(uint x) => (x & 0xFF00FF00u) | ((x >> 16) & 0xFF) | ((x & 0xFF) << 16);
+
     /// <summary>
     /// Fade a color.
     /// </summary>

--- a/Dalamud/Interface/ImGuiSeStringRenderer/SeStringDrawParams.cs
+++ b/Dalamud/Interface/ImGuiSeStringRenderer/SeStringDrawParams.cs
@@ -56,6 +56,13 @@ public record struct SeStringDrawParams
     /// of <c>0.25f</c> that might be subject to change in the future.</value>
     public float? EdgeStrength { get; set; }
 
+    /// <summary>Gets or sets the theme that will decide the colors to use for <see cref="MacroCode.ColorType"/>
+    /// and <see cref="MacroCode.EdgeColorType"/>.</summary>
+    /// <value><c>0</c> to use colors for Dark theme, <c>1</c> to use colors for Light theme, <c>2</c> to use colors
+    /// for Classic FF theme, <c>3</c> to use colors for Clear Blue theme, or <c>null</c> to use the theme set from the
+    /// game configuration.</value>
+    public int? ThemeIndex { get; set; }
+
     /// <summary>Gets or sets the color of the rendered text.</summary>
     /// <value>Color in RGBA, or <c>null</c> to use <see cref="ImGuiCol.Text"/> (the default).</value>
     public uint? Color { get; set; }

--- a/Dalamud/Interface/ImGuiSeStringRenderer/SeStringDrawState.cs
+++ b/Dalamud/Interface/ImGuiSeStringRenderer/SeStringDrawState.cs
@@ -6,6 +6,8 @@ using System.Text;
 using Dalamud.Interface.ImGuiSeStringRenderer.Internal;
 using Dalamud.Interface.Utility;
 
+using FFXIVClientStructs.FFXIV.Component.GUI;
+
 using ImGuiNET;
 
 using Lumina.Text.Payloads;
@@ -55,6 +57,7 @@ public unsafe ref struct SeStringDrawState
         this.LinkHoverBackColor = ssdp.LinkHoverBackColor ?? ImGui.GetColorU32(ImGuiCol.ButtonHovered);
         this.LinkActiveBackColor = ssdp.LinkActiveBackColor ?? ImGui.GetColorU32(ImGuiCol.ButtonActive);
         this.ForceEdgeColor = ssdp.ForceEdgeColor;
+        this.ThemeIndex = ssdp.ThemeIndex ?? AtkStage.Instance()->AtkUIColorHolder->ActiveColorThemeType;
         this.Bold = ssdp.Bold;
         this.Italic = ssdp.Italic;
         this.Edge = ssdp.Edge;
@@ -99,6 +102,9 @@ public unsafe ref struct SeStringDrawState
 
     /// <inheritdoc cref="SeStringDrawParams.EdgeStrength"/>
     public float EdgeOpacity { get; }
+
+    /// <inheritdoc cref="SeStringDrawParams.ThemeIndex"/>
+    public int ThemeIndex { get; }
 
     /// <inheritdoc cref="SeStringDrawParams.Color"/>
     public uint Color { get; set; }

--- a/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
@@ -56,7 +56,7 @@ internal class DataWindow : Window, IDisposable
         new TaskSchedulerWidget(),
         new TexWidget(),
         new ToastWidget(),
-        new UIColorWidget(),
+        new UiColorWidget(),
     };
 
     private readonly IOrderedEnumerable<IDataWindowWidget> orderedModules;

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringRendererTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringRendererTestWidget.cs
@@ -12,6 +12,8 @@ using Dalamud.Interface.Utility;
 using Dalamud.Storage.Assets;
 using Dalamud.Utility;
 
+using FFXIVClientStructs.FFXIV.Component.GUI;
+
 using ImGuiNET;
 
 using Lumina.Excel.GeneratedSheets2;
@@ -28,10 +30,10 @@ namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
 /// </summary>
 internal unsafe class SeStringRendererTestWidget : IDataWindowWidget
 {
+    private static readonly string[] ThemeNames = ["Dark", "Light", "Classic FF", "Clear Blue"];
     private ImVectorWrapper<byte> testStringBuffer;
     private string testString = string.Empty;
     private Addon[]? addons;
-    private ReadOnlySeString? uicolor;
     private ReadOnlySeString? logkind;
     private SeStringDrawParams style;
     private bool interactable;
@@ -51,7 +53,6 @@ internal unsafe class SeStringRendererTestWidget : IDataWindowWidget
     {
         this.style = new() { GetEntity = this.GetEntity };
         this.addons = null;
-        this.uicolor = null;
         this.logkind = null;
         this.testString = string.Empty;
         this.interactable = this.useEntity = true;
@@ -118,6 +119,12 @@ internal unsafe class SeStringRendererTestWidget : IDataWindowWidget
             this.style.Shadow = t;
 
         ImGui.SameLine();
+        var t4 = this.style.ThemeIndex ?? AtkStage.Instance()->AtkUIColorHolder->ActiveColorThemeType;
+        ImGui.PushItemWidth(ImGui.CalcTextSize("WWWWWWWWWWWWWW").X);
+        if (ImGui.Combo("##theme", ref t4, ThemeNames, ThemeNames.Length))
+            this.style.ThemeIndex = t4;
+
+        ImGui.SameLine();
         t = this.style.LinkUnderlineThickness > 0f;
         if (ImGui.Checkbox("Link Underline", ref t))
             this.style.LinkUnderlineThickness = t ? 1f : 0f;
@@ -135,50 +142,6 @@ internal unsafe class SeStringRendererTestWidget : IDataWindowWidget
         t = this.useEntity;
         if (ImGui.Checkbox("Use Entity Replacements", ref t))
             this.useEntity = t;
-
-        if (ImGui.CollapsingHeader("UIColor Preview"))
-        {
-            if (this.uicolor is null)
-            {
-                var tt = new SeStringBuilder();
-                foreach (var uc in Service<DataManager>.Get().GetExcelSheet<UIColor>()!)
-                {
-                    tt.Append($"#{uc.RowId}: ")
-                      .BeginMacro(MacroCode.EdgeColorType).AppendUIntExpression(uc.RowId).EndMacro()
-                      .Append("Edge ")
-                      .BeginMacro(MacroCode.ColorType).AppendUIntExpression(uc.RowId).EndMacro()
-                      .Append("Edge+Color ")
-                      .BeginMacro(MacroCode.EdgeColorType).AppendUIntExpression(0).EndMacro()
-                      .Append("Color ")
-                      .BeginMacro(MacroCode.ColorType).AppendUIntExpression(0).EndMacro();
-                    if (uc.RowId >= 500)
-                    {
-                        if (uc.RowId % 2 == 0)
-                        {
-                            tt.BeginMacro(MacroCode.EdgeColorType).AppendUIntExpression(uc.RowId).EndMacro()
-                              .BeginMacro(MacroCode.ColorType).AppendUIntExpression(uc.RowId + 1).EndMacro()
-                              .Append($"  => color#{uc.RowId + 1} + edge#{uc.RowId}")
-                              .BeginMacro(MacroCode.EdgeColorType).AppendUIntExpression(0).EndMacro()
-                              .BeginMacro(MacroCode.ColorType).AppendUIntExpression(0).EndMacro();
-                        }
-                        else
-                        {
-                            tt.BeginMacro(MacroCode.EdgeColorType).AppendUIntExpression(uc.RowId).EndMacro()
-                              .BeginMacro(MacroCode.ColorType).AppendUIntExpression(uc.RowId - 1).EndMacro()
-                              .Append($"  => color#{uc.RowId - 1} + edge#{uc.RowId}")
-                              .BeginMacro(MacroCode.EdgeColorType).AppendUIntExpression(0).EndMacro()
-                              .BeginMacro(MacroCode.ColorType).AppendUIntExpression(0).EndMacro();
-                        }
-                    }
-
-                    tt.BeginMacro(MacroCode.NewLine).EndMacro();
-                }
-
-                this.uicolor = tt.ToReadOnlySeString();
-            }
-
-            ImGuiHelpers.SeStringWrapped(this.uicolor.Value.Data.Span, this.style);
-        }
 
         if (ImGui.CollapsingHeader("LogKind Preview"))
         {


### PR DESCRIPTION
UIColor sheet has color sets per theme. Updated `UIColorWidget` to reflect that, and added `SeStringDrawParams.ThemeIndex` to let users choose which theme color set to use while drawing SeString from Dalamud.

![image](https://github.com/user-attachments/assets/5d737a75-9fae-4a18-85da-09ed0b5f1900)

![image](https://github.com/user-attachments/assets/d818c367-3986-4f7b-a3cf-4d2bb194ad22)
Tooltips displaying the macro string to create the preview text `+E` and `+F`, which corresponds to the case where edge color or foreground color of the following row has been used.

![image](https://github.com/user-attachments/assets/7602df60-529a-4ab8-a927-f9c8d94dcc70)
Added theme selection.