### PR TITLE
fix: XivChatType respects the configured chat channel if not set

### DIFF
--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -168,8 +168,10 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
 
             var sender = Utf8String.FromSequence(chat.Name.Encode());
             var message = Utf8String.FromSequence(replacedMessage.BuiltString.Encode());
+            
+            var targetChannel = chat.Type ?? this.configuration.GeneralChatType;
 
-            this.HandlePrintMessageDetour(RaptureLogModule.Instance(), chat.Type, sender, message, chat.Timestamp, (byte)(chat.Silent ? 1 : 0));
+            this.HandlePrintMessageDetour(RaptureLogModule.Instance(), targetChannel, sender, message, chat.Timestamp, (byte)(chat.Silent ? 1 : 0));
 
             sender->Dtor(true);
             message->Dtor(true);

--- a/Dalamud/Game/Text/XivChatEntry.cs
+++ b/Dalamud/Game/Text/XivChatEntry.cs
@@ -10,7 +10,7 @@ public sealed class XivChatEntry
     /// <summary>
     /// Gets or sets the type of entry.
     /// </summary>
-    public XivChatType Type { get; set; } = XivChatType.Debug;
+    public XivChatType? Type { get; set; }
 
     /// <summary>
     /// Gets or sets the message timestamp.


### PR DESCRIPTION
Fixes a bug where messages created using `new XivChatType` would always go to the `Debug` channel, regardless of what the user has set.

Behavioral change, but also patching a bug.