### PR TITLE
Add ITextureProvider.ConvertToKernelTexture

### DIFF
--- a/Dalamud/Interface/Textures/ISharedImmediateTexture.cs
+++ b/Dalamud/Interface/Textures/ISharedImmediateTexture.cs
@@ -25,7 +25,8 @@ public interface ISharedImmediateTexture
     /// <see cref="ISharedImmediateTexture"/>s may be cached, but the performance benefit will be minimal.</para>
     /// <para>Calling outside the main thread will fail.</para>
     /// <para>This function does not throw.</para>
-    /// <para><see cref="IDisposable.Dispose"/> will be ignored.</para>
+    /// <para><see cref="IDisposable.Dispose"/> will be ignored, including the cases when the returned texture wrap
+    /// is passed to a function with <c>leaveWrapOpen</c> parameter.</para>
     /// <para>If the texture is unavailable for any reason, then the returned instance of
     /// <see cref="IDalamudTextureWrap"/> will point to an empty texture instead.</para>
     /// </remarks>
@@ -42,7 +43,8 @@ public interface ISharedImmediateTexture
     /// <see cref="ISharedImmediateTexture"/>s may be cached, but the performance benefit will be minimal.</para>
     /// <para>Calling outside the main thread will fail.</para>
     /// <para>This function does not throw.</para>
-    /// <para><see cref="IDisposable.Dispose"/> will be ignored.</para>
+    /// <para><see cref="IDisposable.Dispose"/> will be ignored, including the cases when the returned texture wrap
+    /// is passed to a function with <c>leaveWrapOpen</c> parameter.</para>
     /// <para>If the texture is unavailable for any reason, then <paramref name="defaultWrap"/> will be returned.</para>
     /// </remarks>
     [return: NotNullIfNotNull(nameof(defaultWrap))]
@@ -59,7 +61,8 @@ public interface ISharedImmediateTexture
     /// <see cref="ISharedImmediateTexture"/>s may be cached, but the performance benefit will be minimal.</para>
     /// <para>Calling outside the main thread will fail.</para>
     /// <para>This function does not throw.</para>
-    /// <para><see cref="IDisposable.Dispose"/> on the returned <paramref name="texture"/> will be ignored.</para>
+    /// <para><see cref="IDisposable.Dispose"/> on the returned <paramref name="texture"/> will be ignored, including
+    /// the cases when the returned texture wrap is passed to a function with <c>leaveWrapOpen</c> parameter.</para>
     /// </remarks>
     /// <exception cref="InvalidOperationException">Thrown when called outside the UI thread.</exception>
     bool TryGetWrap([NotNullWhen(true)] out IDalamudTextureWrap? texture, out Exception? exception);

--- a/Dalamud/Interface/Textures/Internal/TextureManagerPluginScoped.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManagerPluginScoped.cs
@@ -135,6 +135,10 @@ internal sealed class TextureManagerPluginScoped
     }
 
     /// <inheritdoc/>
+    public unsafe nint ConvertToKernelTexture(IDalamudTextureWrap wrap, bool leaveWrapOpen = false) =>
+        (nint)this.ManagerOrThrow.ConvertToKernelTexture(wrap, leaveWrapOpen);
+
+    /// <inheritdoc/>
     public IDalamudTextureWrap CreateEmpty(
         RawImageSpecification specs,
         bool cpuRead,

--- a/Dalamud/Plugin/Services/ITextureProvider.cs
+++ b/Dalamud/Plugin/Services/ITextureProvider.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Dalamud.Interface.Internal;
 using Dalamud.Interface.Internal.Windows.Data.Widgets;
 using Dalamud.Interface.Textures;
 using Dalamud.Interface.Textures.TextureWraps;
@@ -281,4 +280,12 @@ public interface ITextureProvider
     /// <returns><c>true</c> if supported.</returns>
     /// <remarks><para>This function does not throw exceptions.</para></remarks>
     bool IsDxgiFormatSupportedForCreateFromExistingTextureAsync(int dxgiFormat);
+
+    /// <summary>Converts an existing <see cref="IDalamudTextureWrap"/> instance to a new instance of
+    /// <see cref="FFXIVClientStructs.FFXIV.Client.Graphics.Kernel.Texture"/>.</summary>
+    /// <param name="wrap">Instance of <see cref="IDalamudTextureWrap"/> to convert.</param>
+    /// <param name="leaveWrapOpen">Whether to leave <paramref name="wrap"/> non-disposed when the returned
+    /// <see cref="Task{TResult}"/> completes.</param>
+    /// <returns>Address of the new <see cref="FFXIVClientStructs.FFXIV.Client.Graphics.Kernel.Texture"/>.</returns>
+    nint ConvertToKernelTexture(IDalamudTextureWrap wrap, bool leaveWrapOpen = false);
 }

--- a/Dalamud/Plugin/Services/ITextureProvider.cs
+++ b/Dalamud/Plugin/Services/ITextureProvider.cs
@@ -282,10 +282,18 @@ public interface ITextureProvider
     bool IsDxgiFormatSupportedForCreateFromExistingTextureAsync(int dxgiFormat);
 
     /// <summary>Converts an existing <see cref="IDalamudTextureWrap"/> instance to a new instance of
-    /// <see cref="FFXIVClientStructs.FFXIV.Client.Graphics.Kernel.Texture"/>.</summary>
+    /// <see cref="FFXIVClientStructs.FFXIV.Client.Graphics.Kernel.Texture"/> which can be used to supply a custom
+    /// texture onto an in-game addon (UI element.)</summary>
     /// <param name="wrap">Instance of <see cref="IDalamudTextureWrap"/> to convert.</param>
     /// <param name="leaveWrapOpen">Whether to leave <paramref name="wrap"/> non-disposed when the returned
     /// <see cref="Task{TResult}"/> completes.</param>
     /// <returns>Address of the new <see cref="FFXIVClientStructs.FFXIV.Client.Graphics.Kernel.Texture"/>.</returns>
+    /// <example>See <c>PrintTextureInfo</c> in <see cref="Interface.Internal.UiDebug.PrintSimpleNode"/> for an example
+    /// of replacing the texture of an image node.</example>
+    /// <remarks>
+    /// <para>If the returned kernel texture is to be destroyed, call the fourth function in its vtable, by calling
+    /// <see cref="FFXIVClientStructs.FFXIV.Client.Graphics.Kernel.Texture.DecRef"/> or
+    /// <c>((delegate* unmanaged&lt;nint, void&gt;)(*(nint**)ptr)[3](ptr)</c>.</para>
+    /// </remarks>
     nint ConvertToKernelTexture(IDalamudTextureWrap wrap, bool leaveWrapOpen = false);
 }

--- a/Dalamud/Plugin/Services/ITextureReadbackProvider.cs
+++ b/Dalamud/Plugin/Services/ITextureReadbackProvider.cs
@@ -22,6 +22,9 @@ public interface ITextureReadbackProvider
     /// <remarks>
     /// <para>The length of the returned <c>RawData</c> may not match
     /// <see cref="RawImageSpecification.Height"/> * <see cref="RawImageSpecification.Pitch"/>.</para>
+    /// <para><see cref="RawImageSpecification.Pitch"/> may not be the minimal value required to represent the texture
+    /// bitmap data. For example, if a texture is 4x4 B8G8R8A8, the minimal pitch would be 32, but the function may
+    /// return 64 instead.</para>
     /// <para>This function may throw an exception.</para>
     /// </remarks>
     Task<(RawImageSpecification Specification, byte[] RawData)> GetRawImageAsync(


### PR DESCRIPTION
Lets you obtain an instance of Kernel::Texture from IDalamudTextureWrap.

Context: https://discord.com/channels/581875019861328007/653504487352303619/1270253907485921280

Displaying contents that is difficult to represent using game's native UI toolkit might be a common use case (eg. unsupported glyphs for various languages), so supporting displaying textures on them could be nice.