### PR TITLE
Add additional warning to plugin config reset modal

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -98,6 +98,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
     private bool deletePluginConfigWarningModalDrawing = true;
     private bool deletePluginConfigWarningModalOnNextFrame = false;
+    private bool deletePluginConfigWarningModalExplainTesting = false;
     private string deletePluginConfigWarningModalPluginName = string.Empty;
     private TaskCompletionSource<bool>? deletePluginConfigWarningModalTaskCompletionSource;
 
@@ -732,7 +733,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             }
         }
     }
-
+    
     private void DrawFooter()
     {
         var configuration = Service<DalamudConfiguration>.Get();
@@ -972,10 +973,11 @@ internal class PluginInstallerWindow : Window, IDisposable
         }
     }
 
-    private Task<bool> ShowDeletePluginConfigWarningModal(string pluginName)
+    private Task<bool> ShowDeletePluginConfigWarningModal(string pluginName, bool explainTesting = false)
     {
         this.deletePluginConfigWarningModalOnNextFrame = true;
         this.deletePluginConfigWarningModalPluginName = pluginName;
+        this.deletePluginConfigWarningModalExplainTesting = explainTesting;
         this.deletePluginConfigWarningModalTaskCompletionSource = new TaskCompletionSource<bool>();
         return this.deletePluginConfigWarningModalTaskCompletionSource.Task;
     }
@@ -986,6 +988,13 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (ImGui.BeginPopupModal(modalTitle, ref this.deletePluginConfigWarningModalDrawing, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar))
         {
+            if (this.deletePluginConfigWarningModalExplainTesting)
+            {
+                ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudOrange);
+                ImGui.Text(Locs.DeletePluginConfigWarningModal_ExplainTesting());
+                ImGui.PopStyleColor();
+            }
+            
             ImGui.Text(Locs.DeletePluginConfigWarningModal_Body(this.deletePluginConfigWarningModalPluginName));
             ImGui.Spacing();
 
@@ -2898,7 +2907,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
             if (ImGui.MenuItem(Locs.PluginContext_DeletePluginConfigReload))
             {
-                this.ShowDeletePluginConfigWarningModal(plugin.Manifest.Name).ContinueWith(t =>
+                this.ShowDeletePluginConfigWarningModal(plugin.Manifest.Name, optIn != null).ContinueWith(t =>
                 {
                     var shouldDelete = t.Result;
 
@@ -4263,7 +4272,9 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         public static string DeletePluginConfigWarningModal_Title => Loc.Localize("InstallerDeletePluginConfigWarning", "Warning###InstallerDeletePluginConfigWarning");
 
-        public static string DeletePluginConfigWarningModal_Body(string pluginName) => Loc.Localize("InstallerDeletePluginConfigWarningBody", "Are you sure you want to delete all data and configuration for {0}?").Format(pluginName);
+        public static string DeletePluginConfigWarningModal_ExplainTesting() => Loc.Localize("InstallerDeletePluginConfigWarningExplainTesting", "Do not select this option if you are only trying to disable testing!");
+
+        public static string DeletePluginConfigWarningModal_Body(string pluginName) => Loc.Localize("InstallerDeletePluginConfigWarningBody", "Are you sure you want to delete all data and configuration for {0}?\nYou will lose all of your settings for this plugin.").Format(pluginName);
 
         public static string DeletePluginConfirmWarningModal_Yes => Loc.Localize("InstallerDeletePluginConfigWarningYes", "Yes");
 


### PR DESCRIPTION
Adds a little warning to the config reset modal if you are subscribed to the testing version. It also further explains that this will delete plugin settings, not something related to Dalamud's config about the plugin. Here's how it should look if you are subscribed to testing.
![image](https://github.com/user-attachments/assets/1e7642e8-41f3-4ec2-a37d-9d9ac6aeff9a)
We can't stop anyone from spreading bad info, but hopefully having an extra warning might get people to stop and ask more questions.