### PR TITLE
Add IGameInventory.GetInventoryItems

### DIFF
--- a/Dalamud/Game/Inventory/GameInventory.cs
+++ b/Dalamud/Game/Inventory/GameInventory.cs
@@ -404,6 +404,9 @@ internal class GameInventoryPluginScoped : IInternalDisposableService, IGameInve
     public event IGameInventory.InventoryChangedDelegate<InventoryItemMergedArgs>? ItemMergedExplicit;
 
     /// <inheritdoc/>
+    public ReadOnlySpan<GameInventoryItem> GetInventoryItems(GameInventoryType type) => GameInventoryItem.GetReadOnlySpanOfInventory(type);
+
+    /// <inheritdoc/>
     void IInternalDisposableService.DisposeService()
     {
         this.gameInventoryService.Unsubscribe(this);

--- a/Dalamud/Plugin/Services/IGameInventory.cs
+++ b/Dalamud/Plugin/Services/IGameInventory.cs
@@ -103,4 +103,11 @@ public interface IGameInventory
 
     /// <inheritdoc cref="ItemMerged"/>
     public event InventoryChangedDelegate<InventoryItemMergedArgs> ItemMergedExplicit;
+
+    /// <summary>
+    /// Gets all item slots of the specified inventory type.
+    /// </summary>
+    /// <param name="type">The type of inventory to get the items for.</param>
+    /// <returns>A read-only span of all items in the specified inventory type.</returns>
+    public ReadOnlySpan<GameInventoryItem> GetInventoryItems(GameInventoryType type);
 }


### PR DESCRIPTION
This PR adds a new `GetInventoryItems` function to `IGameInventory`, which returns a `ReadOnlySpan<GameInventoryItem>` of all slots in the container.

I can't think of any inventory container that ues symbolic links. My guess is that they are only used in Agents and such, so we don't have to worry about it. I even checked the containers MailEdit and HandIn, surprisingly no symbolic links.
I guess we'll hear when someone has trouble with it.

![Screenshot](https://github.com/user-attachments/assets/2dff65db-b9eb-4db0-96a6-01820c3a6b7f)
