### PR TITLE
Cache DalamudAssetAttribute lookups

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ImGuiWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ImGuiWidget.cs
@@ -364,7 +364,7 @@ internal class ImGuiWidget : IDataWindowWidget
 
         public static readonly string[] AssetSources =
             Enum.GetValues<DalamudAsset>()
-                .Where(x => x.GetAttribute<DalamudAssetAttribute>()?.Purpose is DalamudAssetPurpose.TextureFromPng)
+                .Where(x => x.GetPurpose() is DalamudAssetPurpose.TextureFromPng)
                 .Select(Enum.GetName)
                 .ToArray();
 

--- a/Dalamud/Storage/Assets/DalamudAssetExtensions.cs
+++ b/Dalamud/Storage/Assets/DalamudAssetExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Dalamud.Utility;
+﻿using System.Collections.Frozen;
+using System.Collections.Generic;
+
+using Dalamud.Utility;
 
 namespace Dalamud.Storage.Assets;
 
@@ -7,11 +10,37 @@ namespace Dalamud.Storage.Assets;
 /// </summary>
 public static class DalamudAssetExtensions
 {
+    private static readonly FrozenDictionary<DalamudAsset, DalamudAssetAttribute> AttributeCache = CreateCache();
+
     /// <summary>
     /// Gets the purpose.
     /// </summary>
     /// <param name="asset">The asset.</param>
     /// <returns>The purpose.</returns>
-    public static DalamudAssetPurpose GetPurpose(this DalamudAsset asset) =>
-        asset.GetAttribute<DalamudAssetAttribute>()?.Purpose ?? DalamudAssetPurpose.Empty;
+    public static DalamudAssetPurpose GetPurpose(this DalamudAsset asset)
+    {
+        return GetAssetAttribute(asset)?.Purpose ?? DalamudAssetPurpose.Empty;
+    }
+
+    /// <summary>
+    /// Gets the attribute.
+    /// </summary>
+    /// <param name="asset">The asset.</param>
+    /// <returns>The attribute.</returns>
+    internal static DalamudAssetAttribute? GetAssetAttribute(this DalamudAsset asset)
+    {
+        return AttributeCache.GetValueOrDefault(asset);
+    }
+
+    private static FrozenDictionary<DalamudAsset, DalamudAssetAttribute> CreateCache()
+    {
+        var dict = new Dictionary<DalamudAsset, DalamudAssetAttribute>();
+
+        foreach (var asset in Enum.GetValues<DalamudAsset>())
+        {
+            dict.Add(asset, asset.GetAttribute<DalamudAssetAttribute>());
+        }
+
+        return dict.ToFrozenDictionary();
+    }
 }

--- a/Dalamud/Storage/Assets/DalamudAssetManager.cs
+++ b/Dalamud/Storage/Assets/DalamudAssetManager.cs
@@ -68,7 +68,7 @@ internal sealed class DalamudAssetManager : IInternalDisposableService, IDalamud
             Task.WhenAll(
                     Enum.GetValues<DalamudAsset>()
                         .Where(x => x is not DalamudAsset.Empty4X4)
-                        .Where(x => x.GetAttribute<DalamudAssetAttribute>()?.Required is true)
+                        .Where(x => x.GetAssetAttribute()?.Required is true)
                         .Select(this.CreateStreamAsync)
                         .Select(x => x.ToContentDisposedTask()))
                 .ContinueWith(
@@ -83,7 +83,7 @@ internal sealed class DalamudAssetManager : IInternalDisposableService, IDalamud
         Task.WhenAll(
                 Enum.GetValues<DalamudAsset>()
                     .Where(x => x is not DalamudAsset.Empty4X4)
-                    .Where(x => x.GetAttribute<DalamudAssetAttribute>()?.Required is false)
+                    .Where(x => x.GetAssetAttribute()?.Required is false)
                     .Select(this.CreateStreamAsync)
                     .Select(x => x.ToContentDisposedTask(true)))
             .ContinueWith(r => Log.Verbose($"Optional assets load state: {r}"));
@@ -120,7 +120,7 @@ internal sealed class DalamudAssetManager : IInternalDisposableService, IDalamud
     /// <inheritdoc/>
     [Pure]
     public bool IsStreamImmediatelyAvailable(DalamudAsset asset) =>
-        asset.GetAttribute<DalamudAssetAttribute>()?.Data is not null
+        asset.GetAssetAttribute()?.Data is not null
         || this.fileStreams[asset]?.IsCompletedSuccessfully is true;
 
     /// <inheritdoc/>
@@ -140,7 +140,7 @@ internal sealed class DalamudAssetManager : IInternalDisposableService, IDalamud
     [Pure]
     public Task<Stream> CreateStreamAsync(DalamudAsset asset)
     {
-        if (asset.GetAttribute<DalamudAssetAttribute>() is { Data: { } rawData })
+        if (asset.GetAssetAttribute() is { Data: { } rawData })
             return Task.FromResult<Stream>(new MemoryStream(rawData, false));
 
         Task<FileStream> task;


### PR DESCRIPTION
The overwhelming majority of time spent in `SharedImmediateTexture+PureImpl.GetWrapOrEmpty()` is spent in doing reflective attribute lookups. This change uses a `FrozenDictionary` to store the `DalamudAssetAttribute` for each `DalamudAsset` enum member and use that for lookups to avoid this reflective lookup.

In practice this change alone reduces the total draw time for a plugin like Wotsit by around 75%.