### PR TITLE
Avoid capturing local variables in TitleBarButton.Click closure

### DIFF
--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -351,7 +351,7 @@ public abstract class Window
             }
         }
 
-        var additionsPopupName = "WindowSystemContextActions";
+        const string additionsPopupName = "WindowSystemContextActions";
         var flagsApplicableForTitleBarIcons = !flags.HasFlag(ImGuiWindowFlags.NoDecoration) &&
                                               !flags.HasFlag(ImGuiWindowFlags.NoTitleBar);
         var showAdditions = (this.AllowPinning || this.AllowClickthrough) &&


### PR DESCRIPTION
This seemingly insignificant change is (only very slightly) less insignificant than it looks, because reading from a local variable in the `TitleBarButton.Click` closure causes a somewhat large allocation under the hood in order to provide the closure access to the method's local scope. By using a const here this allocation is optimized away.