### PR TITLE
chore: Respect general chat type in plugin auto-update message

### DIFF
--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -318,6 +318,7 @@ internal class PluginManager : IInternalDisposableService
                                     new UIForegroundPayload(0),
                                     new TextPayload("]"),
                                 }),
+                            Type = this.configuration.GeneralChatType,
                         });
 
                     foreach (var metadata in updateMetadata)


### PR DESCRIPTION
Fixed a problem where the following message was printed in the debug channel.
- `The following plugins were auto-updated: [Open plugin changelogs]` (en)
- `自動アップデート:  [Open plugin changelogs]` (ja)