### PR TITLE
Use RCX to resolve entrypoint

### DIFF
--- a/Dalamud.Injector/EntryPoint.cs
+++ b/Dalamud.Injector/EntryPoint.cs
@@ -828,14 +828,14 @@ namespace Dalamud.Injector
                 gamePath,
                 gameArgumentString,
                 noFixAcl,
-                p =>
+                (p, hThread) =>
                 {
                     if (!withoutDalamud && dalamudStartInfo.LoadMethod == LoadMethod.Entrypoint)
                     {
                         var startInfo = AdjustStartInfo(dalamudStartInfo, gamePath);
                         Log.Information("Using start info: {0}", JsonConvert.SerializeObject(startInfo));
                         Marshal.ThrowExceptionForHR(
-                            RewriteRemoteEntryPointW(p.Handle, gamePath, JsonConvert.SerializeObject(startInfo)));
+                            RewriteRemoteEntryPointW(p.Handle, hThread, JsonConvert.SerializeObject(startInfo)));
                         Log.Verbose("RewriteRemoteEntryPointW called!");
                     }
                 },
@@ -978,7 +978,7 @@ namespace Dalamud.Injector
         }
 
         [DllImport("Dalamud.Boot.dll")]
-        private static extern int RewriteRemoteEntryPointW(IntPtr hProcess, [MarshalAs(UnmanagedType.LPWStr)] string gamePath, [MarshalAs(UnmanagedType.LPWStr)] string loadInfoJson);
+        private static extern int RewriteRemoteEntryPointW(IntPtr hProcess, IntPtr hThread, [MarshalAs(UnmanagedType.LPWStr)] string loadInfoJson);
 
         /// <summary>
         ///     This routine appends the given argument to a command line such that

--- a/Dalamud.Injector/GameStart.cs
+++ b/Dalamud.Injector/GameStart.cs
@@ -28,7 +28,7 @@ namespace Dalamud.Injector
         /// <returns>The started process.</returns>
         /// <exception cref="Win32Exception">Thrown when a win32 error occurs.</exception>
         /// <exception cref="GameStartException">Thrown when the process did not start correctly.</exception>
-        public static Process LaunchGame(string workingDir, string exePath, string arguments, bool dontFixAcl, Action<Process> beforeResume, bool waitForGameWindow = true)
+        public static Process LaunchGame(string workingDir, string exePath, string arguments, bool dontFixAcl, Action<Process, IntPtr> beforeResume, bool waitForGameWindow = true)
         {
             Process process = null;
 
@@ -117,7 +117,7 @@ namespace Dalamud.Injector
 
                 process = new ExistingProcess(lpProcessInformation.hProcess);
 
-                beforeResume?.Invoke(process);
+                beforeResume?.Invoke(process, lpProcessInformation.hThread);
 
                 PInvoke.ResumeThread(lpProcessInformation.hThread);
 


### PR DESCRIPTION
RCX contains entry point; RDX contains PEB. While this behavior is not contractual, in reality commercial packers just assume that this is a fact, which probably means that we can rely on this behavior too.