### PR TITLE
Fix all warnings and breaking changes for CS on API11

### DIFF
--- a/Dalamud/Game/ClientState/Fates/Fate.cs
+++ b/Dalamud/Game/ClientState/Fates/Fate.cs
@@ -71,7 +71,13 @@ public interface IFate : IEquatable<IFate>
     /// <summary>
     /// Gets a value indicating whether or not this <see cref="Fate"/> has a EXP bonus.
     /// </summary>
+    [Obsolete("Use HasBonus instead")]
     bool HasExpBonus { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether or not this <see cref="Fate"/> has a bonus.
+    /// </summary>
+    bool HasBonus { get; }
 
     /// <summary>
     /// Gets the icon id of this <see cref="Fate"/>.
@@ -216,7 +222,11 @@ internal unsafe partial class Fate : IFate
     public byte Progress => this.Struct->Progress;
 
     /// <inheritdoc/>
+    [Obsolete("Use HasBonus instead")]
     public bool HasExpBonus => this.Struct->IsExpBonus;
+
+    /// <inheritdoc/>
+    public bool HasBonus => this.Struct->IsBonus;
 
     /// <inheritdoc/>
     public uint IconId => this.Struct->IconId;

--- a/Dalamud/Game/Gui/NamePlate/NamePlateUpdateContext.cs
+++ b/Dalamud/Game/Gui/NamePlate/NamePlateUpdateContext.cs
@@ -127,7 +127,7 @@ internal unsafe class NamePlateUpdateContext : INamePlateUpdateContext
     /// <summary>
     /// Gets a pointer to the NamePlate addon's number array entries as a struct.
     /// </summary>
-    internal AddonNamePlate.NamePlateIntArrayData* NumberStruct { get; private set; }
+    internal AddonNamePlate.AddonNamePlateNumberArray* NumberStruct { get; private set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether any handler in the current context has instantiated a part builder.
@@ -142,7 +142,7 @@ internal unsafe class NamePlateUpdateContext : INamePlateUpdateContext
     {
         this.Addon = (AddonNamePlate*)args.Addon;
         this.NumberData = ((NumberArrayData**)args.NumberArrayData)![NamePlateGui.NumberArrayIndex];
-        this.NumberStruct = (AddonNamePlate.NamePlateIntArrayData*)this.NumberData->IntArray;
+        this.NumberStruct = (AddonNamePlate.AddonNamePlateNumberArray*)this.NumberData->IntArray;
         this.StringData = ((StringArrayData**)args.StringArrayData)![NamePlateGui.StringArrayIndex];
         this.HasParts = false;
 

--- a/Dalamud/Game/Gui/NamePlate/NamePlateUpdateHandler.cs
+++ b/Dalamud/Game/Gui/NamePlate/NamePlateUpdateHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -490,7 +490,7 @@ internal unsafe class NamePlateUpdateHandler : INamePlateUpdateHandler
     private AddonNamePlate.NamePlateObject* NamePlateObject =>
         &this.context.Addon->NamePlateObjectArray[this.NamePlateIndex];
 
-    private AddonNamePlate.NamePlateIntArrayData.NamePlateObjectIntArrayData* ObjectData =>
+    private AddonNamePlate.AddonNamePlateNumberArray.NamePlateObjectIntArrayData* ObjectData =>
         this.context.NumberStruct->ObjectData.GetPointer(this.ArrayIndex);
 
     /// <inheritdoc/>

--- a/Dalamud/Game/Inventory/GameInventoryItem.cs
+++ b/Dalamud/Game/Inventory/GameInventoryItem.cs
@@ -63,7 +63,7 @@ public unsafe struct GameInventoryItem : IEquatable<GameInventoryItem>
     /// <summary>
     /// Gets the quantity of items in this item stack.
     /// </summary>
-    public uint Quantity => this.InternalItem.Quantity;
+    public int Quantity => this.InternalItem.Quantity;
 
     /// <summary>
     /// Gets the spiritbond of this item.

--- a/Dalamud/Interface/Internal/UiDebug.cs
+++ b/Dalamud/Interface/Internal/UiDebug.cs
@@ -300,7 +300,7 @@ internal unsafe class UiDebug
                         {
                             ImGui.Image(
                                 new IntPtr(kernelTexture->D3D11ShaderResourceView),
-                                new Vector2(kernelTexture->Width, kernelTexture->Height));
+                                new Vector2(kernelTexture->ActualWidth, kernelTexture->ActualHeight));
                             ImGui.TreePop();
                         }
                     }
@@ -312,8 +312,8 @@ internal unsafe class UiDebug
                             ImGui.Image(
                                 new IntPtr(textureInfo->AtkTexture.KernelTexture->D3D11ShaderResourceView),
                                 new Vector2(
-                                    textureInfo->AtkTexture.KernelTexture->Width,
-                                    textureInfo->AtkTexture.KernelTexture->Height));
+                                    textureInfo->AtkTexture.KernelTexture->ActualWidth,
+                                    textureInfo->AtkTexture.KernelTexture->ActualHeight));
                             ImGui.TreePop();
                         }
                     }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/FateTableWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/FateTableWidget.cs
@@ -153,7 +153,7 @@ internal class FateTableWidget : IDataWindowWidget
             }
 
             ImGui.TableNextColumn(); // HasExpBonus
-            ImGui.TextUnformatted(fate.HasExpBonus.ToString());
+            ImGui.TextUnformatted(fate.HasBonus.ToString());
 
             ImGui.TableNextColumn(); // Position
             DrawCopyableText(fate.Position.ToString(), "Click to copy Position");

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/ContextMenuAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/ContextMenuAgingStep.cs
@@ -141,7 +141,7 @@ internal class ContextMenuAgingStep : IAgingStep
                         OnClicked = (IMenuItemClickedArgs a) =>
                         {
                             SeString name;
-                            uint count;
+                            int count;
                             var targetItem = (a.Target as MenuTargetInventory)!.TargetItem;
                             if (targetItem is { } item)
                             {

--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -287,7 +287,7 @@ public abstract class Window
 
                 this.IsFocused = false;
                 
-                if (doSoundEffects && !this.DisableWindowSounds) UIModule.PlaySound(this.OnCloseSfxId, 0, 0, 0);
+                if (doSoundEffects && !this.DisableWindowSounds) UIGlobals.PlaySoundEffect(this.OnCloseSfxId);
             }
 
             return;
@@ -307,7 +307,7 @@ public abstract class Window
             this.internalLastIsOpen = this.internalIsOpen;
             this.OnOpen();
 
-            if (doSoundEffects && !this.DisableWindowSounds) UIModule.PlaySound(this.OnOpenSfxId, 0, 0, 0);
+            if (doSoundEffects && !this.DisableWindowSounds) UIGlobals.PlaySoundEffect(this.OnOpenSfxId);
         }
 
         this.PreDraw();

--- a/Dalamud/Utility/StringExtensions.cs
+++ b/Dalamud/Utility/StringExtensions.cs
@@ -40,7 +40,7 @@ public static class StringExtensions
     public static bool IsValidCharacterName(this string value, bool includeLegacy = true)
     {
         if (string.IsNullOrEmpty(value)) return false;
-        if (!FFXIVClientStructs.FFXIV.Client.UI.UIModule.IsPlayerCharacterName(value)) return false;
+        if (!FFXIVClientStructs.FFXIV.Client.UI.UIGlobals.IsValidPlayerCharacterName(value)) return false;
         return includeLegacy || value.Length <= 21;
     }
 }


### PR DESCRIPTION
Removes all warnings related to changes made in CS over the last 6 months

Main thing to note is that `InventoryItem` has had a change from `uint` to `int` on its `Quantity` field due to findings of them using `-1` in some places of the game code for certain checks.