### PR TITLE
Safely call events in DalamudPluginInterface

### DIFF
--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -526,13 +526,40 @@ internal sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposa
     /// <param name="affectedThisPlugin">If this plugin was affected by the change.</param>
     internal void NotifyActivePluginsChanged(PluginListInvalidationKind kind, bool affectedThisPlugin)
     {
-        this.ActivePluginsChanged?.Invoke(kind, affectedThisPlugin);
+        if (this.ActivePluginsChanged is { } callback)
+        {
+            foreach (var action in callback.GetInvocationList().Cast<IDalamudPluginInterface.ActivePluginsChangedDelegate>())
+            {
+                try
+                {
+                    action(kind, affectedThisPlugin);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Exception during raise of {handler}", action.Method);
+                }
+            }
+        }
     }
 
     private void OnLocalizationChanged(string langCode)
     {
         this.UiLanguage = langCode;
-        this.LanguageChanged?.Invoke(langCode);
+
+        if (this.LanguageChanged is { } callback)
+        {
+            foreach (var action in callback.GetInvocationList().Cast<IDalamudPluginInterface.LanguageChangedDelegate>())
+            {
+                try
+                {
+                    action(langCode);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Exception during raise of {handler}", action.Method);
+                }
+            }
+        }
     }
 
     private void OnDalamudConfigurationSaved(DalamudConfiguration dalamudConfiguration)


### PR DESCRIPTION
This changes the event handler to safely call `ActivePluginsChanged` and `OnLocalizationChanged` in `DalamudPluginInterface` to prevent exceptions in plugins stopping the execution of other code.

I noticed this on the API11 branch, when I changed the language in the Dalamud Settings and it wouldn't save because one of my plugins threw an exception in its `LanguageChanged` event handler due to Lumina changes.