### PR TITLE
[api11] Change ClientState event logic

### DIFF
--- a/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
+++ b/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
@@ -63,6 +63,11 @@ internal sealed class ClientStateAddressResolver : BaseAddressResolver
     public IntPtr SetupTerritoryType { get; private set; }
 
     /// <summary>
+    /// Gets the address of the method which sets up the player.
+    /// </summary>
+    public IntPtr ProcessPacketPlayerSetup { get; private set; }
+
+    /// <summary>
     /// Gets the address of the method which polls the gamepads for data.
     /// Called every frame, even when `Enable Gamepad` is off in the settings.
     /// </summary>
@@ -86,6 +91,8 @@ internal sealed class ClientStateAddressResolver : BaseAddressResolver
         this.JobGaugeData = sig.GetStaticAddressFromSig("48 8B 3D ?? ?? ?? ?? 33 ED") + 0x8;
 
         this.SetupTerritoryType = sig.ScanText("48 89 5C 24 ?? 48 89 6C 24 ?? 57 48 83 EC 20 0F B7 DA");
+
+        this.ProcessPacketPlayerSetup = sig.ScanText("40 53 48 83 EC 20 48 8D 0D ?? ?? ?? ?? 48 8B DA E8 ?? ?? ?? ?? 48 8B D3");
 
         // These resolve to fixed offsets only, without the base address added in, so GetStaticAddressFromSig() can't be used.
         // lea   rcx, ds:1DB9F74h[rax*4]          KeyboardState

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/LogoutEventAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/LogoutEventAgingStep.cs
@@ -50,7 +50,7 @@ internal class LogoutEventAgingStep : IAgingStep
         }
     }
 
-    private void ClientStateOnOnLogout()
+    private void ClientStateOnOnLogout(int type, int code)
     {
         this.hasPassed = true;
     }

--- a/Dalamud/Plugin/Internal/AutoUpdate/AutoUpdateManager.cs
+++ b/Dalamud/Plugin/Internal/AutoUpdate/AutoUpdateManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -89,7 +89,7 @@ internal class AutoUpdateManager : IServiceType
             t =>
             {
                 t.Result.Login += this.OnLogin;
-                t.Result.Logout += this.OnLogout;
+                t.Result.Logout += (int type, int code) => this.OnLogout();
             });
         Service<Framework>.GetAsync().ContinueWith(t => { t.Result.Update += this.OnUpdate; });
         

--- a/Dalamud/Plugin/Services/IClientState.cs
+++ b/Dalamud/Plugin/Services/IClientState.cs
@@ -23,6 +23,13 @@ public interface IClientState
     public delegate void LevelChangeDelegate(uint classJobId, uint level);
 
     /// <summary>
+    /// A delegate type used for the <see cref="Logout"/> event.
+    /// </summary>
+    /// <param name="type">The type of logout.</param>
+    /// <param name="code">The success/failure code.</param>
+    public delegate void LogoutDelegate(int type, int code);
+
+    /// <summary>
     /// Event that gets fired when the current Territory changes.
     /// </summary>
     public event Action<ushort> TerritoryChanged;
@@ -46,7 +53,7 @@ public interface IClientState
     /// <summary>
     /// Event that fires when a character is logging out.
     /// </summary>
-    public event Action Logout;
+    public event LogoutDelegate Logout;
 
     /// <summary>
     /// Event that fires when a character is entering PvP.


### PR DESCRIPTION
With this PR, ClientState now completely relies on hooks instead of the Framework.Update loop or Conditions.

For the **Login** event, `ProcessPacketPlayerSetup` is hooked.
This is where the game sets a bool `IsLoggedIn` in `AgentLobby` to `true` and sets the ContentId to UI modules.
Listeners are invoked after the original function, so that the player data is already set.

For the **Logout** event, `LogoutCallbackInterface_OnLogout` is hooked.
This is where the game sets a bool `IsLoggedIn` in `AgentLobby` to `false` and resets UI modules.
The hook provides us with a `type` and `code` of the logout, and is also called when the game gets disconnected, but is seemingly not called when the game could not connect to the lobby server (since it isn't really a logout).
I'm unsure what exactly `type` is, but from what I've seen type 2 makes the AtkDialogue box show up.
When closing the game or normally logging out, the type is 1 and code is 10000.
When losing connection, the type is 2 and code is 90002.
Listeners are invoked before the original function, so that we can handle the logout before the game does.

**EnterPvP** and **LeavePvP** invokers have been moved into the `SetupTerritoryTypeDetour`.
`GameMain.IsInPvPArea` is exactly the same thing as reading `IsPvpZone` from the TerritoryType sheet, but because the TerritoryType row isn't loaded in GameMain when the detour is called, we have to read it off the sheet ourselves.