### PR TITLE
UIDebug2 Fixes

### DIFF
--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.FieldNames.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.FieldNames.cs
@@ -16,7 +16,7 @@ public unsafe partial class AddonTree
 {
     private static readonly Dictionary<string, Type?> AddonTypeDict = [];
 
-    private static readonly Assembly? ClientStructsAssembly = typeof(Addon).Assembly;
+    private static readonly Assembly? ClientStructsAssembly = typeof(AddonAttribute).Assembly;
 
     /// <summary>
     /// Gets or sets a collection of names for field offsets that have been documented in FFXIVClientStructs.
@@ -36,7 +36,7 @@ public unsafe partial class AddonTree
             {
                 foreach (var t in from t in ClientStructsAssembly.GetTypes()
                                   where t.IsPublic
-                                  let xivAddonAttr = (Addon?)t.GetCustomAttribute(typeof(Addon), false)
+                                  let xivAddonAttr = (AddonAttribute?)t.GetCustomAttribute(typeof(AddonAttribute), false)
                                   where xivAddonAttr != null
                                   where xivAddonAttr.AddonIdentifiers.Contains(this.AddonName)
                                   select t)

--- a/Dalamud/Interface/Internal/UiDebug2/UiDebug2.Sidebar.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/UiDebug2.Sidebar.cs
@@ -49,7 +49,11 @@ internal unsafe partial class UiDebug2
     /// Gets the base address for all unit lists.
     /// </summary>
     /// <returns>The address, if found.</returns>
-    internal static AtkUnitList* GetUnitListBaseAddr() => &((UIModule*)GameGui.GetUIModule())->GetRaptureAtkModule()->RaptureAtkUnitManager.AtkUnitManager.DepthLayerOneList;
+    internal static AtkUnitList* GetUnitListBaseAddr()
+    {
+        var stage = AtkStage.Instance();
+        return &stage->RaptureAtkUnitManager->AtkUnitManager.DepthLayerOneList;
+    }
 
     private void DrawSidebar()
     {


### PR DESCRIPTION
- Quick-fix for retrieving UnitLists (switch back to using AtkStage instead of UIModule)
- Update references to AddonAttribute

These two changes got my standalone plugin version of the tool working again, so hopefully it'll work here too.