### PR TITLE
Fix universali upload with itemId 0

### DIFF
--- a/Dalamud/Game/Network/Internal/MarketBoardUploaders/MarketBoardItemRequest.cs
+++ b/Dalamud/Game/Network/Internal/MarketBoardUploaders/MarketBoardItemRequest.cs
@@ -31,6 +31,11 @@ internal class MarketBoardItemRequest
     public uint AmountToArrive { get; private set; }
 
     /// <summary>
+    /// Gets or sets the offered catalog id used in this listing.
+    /// </summary>
+    public uint CatalogId { get; internal set; }
+
+    /// <summary>
     /// Gets the offered item listings.
     /// </summary>
     public List<MarketBoardCurrentOfferings.MarketBoardItemListing> Listings { get; } = [];

--- a/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
+++ b/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
@@ -48,7 +48,7 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
         {
             WorldId = clientState.LocalPlayer?.CurrentWorld.RowId ?? 0,
             UploaderId = uploader.ToString(),
-            ItemId = request.Listings.FirstOrDefault()?.CatalogId ?? 0,
+            ItemId = request.CatalogId,
             Listings = [],
             Sales = [],
         };
@@ -106,7 +106,7 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
 
         // ====================================================================================
 
-        Log.Verbose("Universalis data upload for item#{CatalogId} completed", request.Listings.FirstOrDefault()?.CatalogId ?? 0);
+        Log.Verbose("Universalis data upload for item#{CatalogId} completed", request.CatalogId);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Fixes #2069 

This happens because it was falsely assumed that listings would always carry the Item ID.
History always returns the Item ID, so we can use it instead to fill this field,

`22:36:07.815 | VRB | "/upload": "{\"worldID\":0,\"itemID\":44488,\"listings\":[],\"entries\":[],\"uploaderID\":\"[CENSORED]\"}"`