### PR TITLE
Add new city to the universalis upload

### DIFF
--- a/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/Types/UniversalisTaxData.cs
+++ b/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/Types/UniversalisTaxData.cs
@@ -48,4 +48,10 @@ internal class UniversalisTaxData
     /// </summary>
     [JsonProperty("sharlayan")]
     public uint Sharlayan { get; set; }
+
+    /// <summary>
+    /// Gets or sets Tuliyollal's current tax rate.
+    /// </summary>
+    [JsonProperty("tuliyollal")]
+    public uint Tuliyollal { get; set; }
 }

--- a/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
+++ b/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
@@ -131,6 +131,7 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
                 Kugane = taxRates.KuganeTax,
                 Crystarium = taxRates.CrystariumTax,
                 Sharlayan = taxRates.SharlayanTax,
+                Tuliyollal = taxRates.TuliyollalTax,
             },
         };
 


### PR DESCRIPTION
Adds the new city to the actual uploaded data, which i forgot in the 7.0 patches

@karashiiro Is the JsonProperty correct for the API?

`23:04:31.890 | VRB | "/upload": "{\"uploaderID\":\"[CENSORED]\",\"worldID\":0,\"marketTaxRates\":{\"limsaLominsa\":5,\"gridania\":5,\"uldah\":5,\"ishgard\":3,\"kugane\":3,\"crystarium\":0,\"sharlayan\":3,\"tuliyollal\":3}}"
`