### PR TITLE
Update JobGauge

### DIFF
--- a/Dalamud/Game/ClientState/JobGauge/JobGauges.cs
+++ b/Dalamud/Game/ClientState/JobGauge/JobGauges.cs
@@ -35,7 +35,8 @@ internal class JobGauges : IServiceType, IJobGauges
     {
         // This is cached to mitigate the effects of using activator for instantiation.
         // Since the gauge itself reads from live memory, there isn't much downside to doing this.
-        if (!this.cache.TryGetValue(typeof(T), out var gauge))
+        // Will also recache if the address of the gauge changes to prevent corruption (this could happen if you tried to access a gauge very early on during login for example)
+        if (!this.cache.TryGetValue(typeof(T), out var gauge) || gauge.Address != this.Address)
         {
             gauge = this.cache[typeof(T)] = (T)Activator.CreateInstance(typeof(T), BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { this.Address }, null);
         }


### PR DESCRIPTION
This resolves an issue where if a gauge was to try and be cached before the memory address is properly updated would result in caching an incorrect address. Most notably would happen if something tried to access it during login.