### PR TITLE
Fix zero address in gauge caching

### DIFF
--- a/Dalamud/Game/ClientState/JobGauge/JobGauges.cs
+++ b/Dalamud/Game/ClientState/JobGauge/JobGauges.cs
@@ -28,7 +28,7 @@ internal class JobGauges : IServiceType, IJobGauges
     }
 
     /// <inheritdoc/>
-    public unsafe IntPtr Address => (nint)(CSJobGaugeManager.Instance()->CurrentGauge);
+    public unsafe IntPtr Address => (nint)(&CSJobGaugeManager.Instance()->EmptyGauge);
 
     /// <inheritdoc/>
     public T Get<T>() where T : JobGaugeBase


### PR DESCRIPTION
Removes the need for #2091 as this address is always the same at runtime.

`CurrentGauge` is set to nint.Zero by the game while `LocalPlayer` is null, but the gauge struct is located at the `EmptyGauge` address at all times