### PR TITLE
Use correct type for GameInventoryItem.Stains

### DIFF
--- a/Dalamud/Game/Inventory/GameInventoryItem.cs
+++ b/Dalamud/Game/Inventory/GameInventoryItem.cs
@@ -122,7 +122,7 @@ public unsafe struct GameInventoryItem : IEquatable<GameInventoryItem>
     /// <summary>
     /// Gets the color used for this item.
     /// </summary>
-    public ReadOnlySpan<ushort> Stains => new(Unsafe.AsPointer(ref this.InternalItem.Stains[0]), 2);
+    public ReadOnlySpan<byte> Stains => new(Unsafe.AsPointer(ref this.InternalItem.Stains[0]), 2);
 
     /// <summary>
     /// Gets the glamour id for this item.


### PR DESCRIPTION
The underlying type of [`InventoryItem.Stains`](https://github.com/aers/FFXIVClientStructs/blob/main/FFXIVClientStructs/FFXIV/Client/Game/InventoryManager.cs#L136) is byte.
Dalamud reads ushorts, resulting in invalid data:

![Screenshot](https://github.com/user-attachments/assets/f1005672-03f3-4bad-b2d0-8a21a2bf2ce1)

(This should be StainIds 7 and 0.)