### PR TITLE
Implement Print methods that work with Lumina SeString/ReadOnlySeString

### DIFF
--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -112,7 +112,14 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
     /// <inheritdoc/>
     public void Print(XivChatEntry chat)
     {
-        this.chatQueue.Enqueue(new XivChatEntryRaw(chat.Name.Encode(), chat.Message.Encode(), chat.Type, chat.Timestamp, chat.Silent));
+        this.chatQueue.Enqueue(new XivChatEntryRaw
+        {
+            Type = chat.Type,
+            Timestamp = chat.Timestamp,
+            Message = chat.Message.Encode(),
+            Name = chat.Name.Encode(),
+            Silent = chat.Silent,
+        });
     }
 
     #region DalamudSeString
@@ -310,7 +317,11 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
             }
         }
 
-        this.Print(new XivChatEntryRaw(builder.Append(message).ToArray(), type: channel));
+        this.Print(new XivChatEntryRaw
+        {
+            Message = builder.Append((ReadOnlySeStringSpan)message).ToArray(),
+            Type = channel,
+        });
     }
 
     private void InventoryItemCopyDetour(InventoryItem* thisPtr, InventoryItem* otherPtr)

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -203,12 +203,12 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
                     continue;
                 }
 
-                var parts = text.Split('\u202F');
-                for (var i = 0; i < parts.Length; i++)
+                foreach (var c in text)
                 {
-                    sb.Append(parts[i]);
-                    if (i < parts.Length - 1)
+                    if (c == 0x202f)
                         sb.BeginMacro(MacroCode.NonBreakingSpace).EndMacro();
+                    else
+                        sb.Append(c);
                 }
             }
 

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -37,7 +37,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
 {
     private static readonly ModuleLog Log = new("ChatGui");
 
-    private readonly Queue<XivChatEntryReadOnly> chatQueue = new();
+    private readonly Queue<XivChatEntryRaw> chatQueue = new();
     private readonly Dictionary<(string PluginName, uint CommandId), Action<uint, SeString>> dalamudLinkHandlers = new();
 
     private readonly Hook<PrintMessageDelegate> printMessageHook;
@@ -112,7 +112,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
     /// <inheritdoc/>
     public void Print(XivChatEntry chat)
     {
-        this.chatQueue.Enqueue(new XivChatEntryReadOnly(chat.Name.Encode(), chat.Message.Encode(), chat.Type, chat.Timestamp, chat.Silent));
+        this.chatQueue.Enqueue(new XivChatEntryRaw(chat.Name.Encode(), chat.Message.Encode(), chat.Type, chat.Timestamp, chat.Silent));
     }
 
     #region DalamudSeString
@@ -146,7 +146,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
     #region LuminaSeString
 
     /// <inheritdoc/>
-    public void Print(XivChatEntryReadOnly chat)
+    public void Print(XivChatEntryRaw chat)
     {
         this.chatQueue.Enqueue(chat);
     }
@@ -310,7 +310,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
             }
         }
 
-        this.Print(new XivChatEntryReadOnly(builder.Append(message).ToArray(), type: channel));
+        this.Print(new XivChatEntryRaw(builder.Append(message).ToArray(), type: channel));
     }
 
     private void InventoryItemCopyDetour(InventoryItem* thisPtr, InventoryItem* otherPtr)
@@ -545,7 +545,7 @@ internal class ChatGuiPluginScoped : IInternalDisposableService, IChatGui
         => this.chatGuiService.PrintError(message, messageTag, tagColor);
 
     /// <inheritdoc/>
-    public void Print(XivChatEntryReadOnly chat)
+    public void Print(XivChatEntryRaw chat)
         => this.chatGuiService.Print(chat);
 
     /// <inheritdoc/>

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -12,6 +12,7 @@ using Dalamud.Hooking;
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
 using Dalamud.Logging.Internal;
+using Dalamud.Memory;
 using Dalamud.Plugin.Services;
 using Dalamud.Utility;
 
@@ -203,11 +204,11 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
                 }
             }
 
-            var output = sb.ToReadOnlySeString();
+            var output = sb.ToArray();
             LuminaSeStringBuilder.SharedPool.Return(sb);
 
-            var sender = Utf8String.FromSequence(chat.Name);
-            var message = Utf8String.FromSequence(output);
+            var sender = Utf8String.FromSequence(chat.Name.NullTerminate());
+            var message = Utf8String.FromSequence(output.NullTerminate());
 
             var targetChannel = chat.Type ?? this.configuration.GeneralChatType;
 

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -22,6 +22,8 @@ using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
+using Lumina.Text.Payloads;
+
 using LinkMacroPayloadType = Lumina.Text.Payloads.LinkMacroPayloadType;
 using LuminaSeStringBuilder = Lumina.Text.SeStringBuilder;
 using ReadOnlySePayloadType = Lumina.Text.ReadOnly.ReadOnlySePayloadType;
@@ -206,7 +208,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
                 {
                     sb.Append(parts[i]);
                     if (i < parts.Length - 1)
-                        sb.AppendMacroString("<nbsp>");
+                        sb.BeginMacro(MacroCode.NonBreakingSpace).EndMacro();
                 }
             }
 

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -195,8 +195,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
                 }
 
                 var text = Encoding.UTF8.GetString(payload.Body);
-                var index = text.IndexOf('\u202F');
-                if (index == -1)
+                if (!text.Contains('\u202F'))
                 {
                     sb.Append(payload);
                     continue;

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -201,7 +201,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
                     if (c.Value.IntValue == 0x202F)
                         sb.BeginMacro(MacroCode.NonBreakingSpace).EndMacro();
                     else
-                        sb.Append(c);
+                        sb.Append(c.EffectiveChar);
                 }
             }
 

--- a/Dalamud/Game/Text/XivChatEntry.cs
+++ b/Dalamud/Game/Text/XivChatEntry.cs
@@ -36,39 +36,30 @@ public sealed class XivChatEntry
 /// <summary>
 /// This class represents a raw chat message.
 /// </summary>
-public struct XivChatEntryRaw
+public struct XivChatEntryRaw()
 {
     /// <summary>
     /// Gets the type of entry.
     /// </summary>
-    public XivChatType? Type { get; }
+    public XivChatType? Type { get; set; }
 
     /// <summary>
     /// Gets the message timestamp.
     /// </summary>
-    public int Timestamp { get; }
+    public int Timestamp { get; set; }
 
     /// <summary>
     /// Gets the sender name.
     /// </summary>
-    public byte[] Name { get; }
+    public byte[] Name { get; set; } = [];
 
     /// <summary>
     /// Gets the message.
     /// </summary>
-    public byte[] Message { get; }
+    public byte[] Message { get; set; } = [];
 
     /// <summary>
     /// Gets a value indicating whether new message sounds should be silenced or not.
     /// </summary>
-    public bool Silent { get; }
-
-    public XivChatEntryRaw(byte[] message, byte[]? name = null, XivChatType? type = null, int timestamp = 0, bool silent = false)
-    {
-        this.Type = type;
-        this.Timestamp = timestamp;
-        this.Name = name ?? [];
-        this.Message = message;
-        this.Silent = silent;
-    }
+    public bool Silent { get; set; }
 }

--- a/Dalamud/Game/Text/XivChatEntry.cs
+++ b/Dalamud/Game/Text/XivChatEntry.cs
@@ -34,9 +34,9 @@ public sealed class XivChatEntry
 }
 
 /// <summary>
-/// This class represents a readonly chat message ready to be posted.
+/// This class represents a raw chat message.
 /// </summary>
-public struct XivChatEntryReadOnly
+public struct XivChatEntryRaw
 {
     /// <summary>
     /// Gets the type of entry.
@@ -63,7 +63,7 @@ public struct XivChatEntryReadOnly
     /// </summary>
     public bool Silent { get; }
 
-    public XivChatEntryReadOnly(byte[] message, byte[]? name = null, XivChatType? type = null, int timestamp = 0, bool silent = false)
+    public XivChatEntryRaw(byte[] message, byte[]? name = null, XivChatType? type = null, int timestamp = 0, bool silent = false)
     {
         this.Type = type;
         this.Timestamp = timestamp;

--- a/Dalamud/Game/Text/XivChatEntry.cs
+++ b/Dalamud/Game/Text/XivChatEntry.cs
@@ -20,46 +20,33 @@ public sealed class XivChatEntry
     /// <summary>
     /// Gets or sets the sender name.
     /// </summary>
-    public SeString Name { get; set; } = string.Empty;
+    public SeString Name
+    {
+        get => SeString.Parse(this.NameBytes);
+        set => this.NameBytes = value.Encode();
+    }
 
     /// <summary>
     /// Gets or sets the message.
     /// </summary>
-    public SeString Message { get; set; } = string.Empty;
+    public SeString Message
+    {
+        get => SeString.Parse(this.MessageBytes);
+        set => this.MessageBytes = value.Encode();
+    }
+
+    /// <summary>
+    /// Gets or Sets the name payloads
+    /// </summary>
+    public byte[] NameBytes { get; set; } = [];
+
+    /// <summary>
+    /// Gets or Sets the message payloads.
+    /// </summary>
+    public byte[] MessageBytes { get; set; } = [];
 
     /// <summary>
     /// Gets or sets a value indicating whether new message sounds should be silenced or not.
-    /// </summary>
-    public bool Silent { get; set; }
-}
-
-/// <summary>
-/// This class represents a raw chat message.
-/// </summary>
-public struct XivChatEntryRaw()
-{
-    /// <summary>
-    /// Gets the type of entry.
-    /// </summary>
-    public XivChatType? Type { get; set; }
-
-    /// <summary>
-    /// Gets the message timestamp.
-    /// </summary>
-    public int Timestamp { get; set; }
-
-    /// <summary>
-    /// Gets the sender name.
-    /// </summary>
-    public byte[] Name { get; set; } = [];
-
-    /// <summary>
-    /// Gets the message.
-    /// </summary>
-    public byte[] Message { get; set; } = [];
-
-    /// <summary>
-    /// Gets a value indicating whether new message sounds should be silenced or not.
     /// </summary>
     public bool Silent { get; set; }
 }

--- a/Dalamud/Game/Text/XivChatEntry.cs
+++ b/Dalamud/Game/Text/XivChatEntry.cs
@@ -32,3 +32,43 @@ public sealed class XivChatEntry
     /// </summary>
     public bool Silent { get; set; }
 }
+
+/// <summary>
+/// This class represents a readonly chat message ready to be posted.
+/// </summary>
+public struct XivChatEntryReadOnly
+{
+    /// <summary>
+    /// Gets the type of entry.
+    /// </summary>
+    public XivChatType? Type { get; }
+
+    /// <summary>
+    /// Gets the message timestamp.
+    /// </summary>
+    public int Timestamp { get; }
+
+    /// <summary>
+    /// Gets the sender name.
+    /// </summary>
+    public byte[] Name { get; }
+
+    /// <summary>
+    /// Gets the message.
+    /// </summary>
+    public byte[] Message { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether new message sounds should be silenced or not.
+    /// </summary>
+    public bool Silent { get; }
+
+    public XivChatEntryReadOnly(byte[] message, byte[]? name = null, XivChatType? type = null, int timestamp = 0, bool silent = false)
+    {
+        this.Type = type;
+        this.Timestamp = timestamp;
+        this.Name = name ?? [];
+        this.Message = message;
+        this.Silent = silent;
+    }
+}

--- a/Dalamud/Plugin/Services/IChatGui.cs
+++ b/Dalamud/Plugin/Services/IChatGui.cs
@@ -126,7 +126,7 @@ public interface IChatGui
     /// Queue a chat message. Dalamud will send queued messages on the next framework event.
     /// </summary>
     /// <param name="chat">A message to send.</param>
-    public void Print(XivChatEntryReadOnly chat);
+    public void Print(XivChatEntryRaw chat);
 
     /// <summary>
     /// Queue a chat message. Dalamud will send queued messages on the next framework event.

--- a/Dalamud/Plugin/Services/IChatGui.cs
+++ b/Dalamud/Plugin/Services/IChatGui.cs
@@ -125,12 +125,6 @@ public interface IChatGui
     /// <summary>
     /// Queue a chat message. Dalamud will send queued messages on the next framework event.
     /// </summary>
-    /// <param name="chat">A message to send.</param>
-    public void Print(XivChatEntryRaw chat);
-
-    /// <summary>
-    /// Queue a chat message. Dalamud will send queued messages on the next framework event.
-    /// </summary>
     /// <param name="message">A message to send.</param>
     /// <param name="messageTag">String to prepend message with "[messageTag] ".</param>
     /// <param name="tagColor">Color to display the message tag with.</param>

--- a/Dalamud/Plugin/Services/IChatGui.cs
+++ b/Dalamud/Plugin/Services/IChatGui.cs
@@ -48,7 +48,7 @@ public interface IChatGui
     /// <param name="sender">The sender name.</param>
     /// <param name="message">The message sent.</param>
     public delegate void OnMessageUnhandledDelegate(XivChatType type, int timestamp, SeString sender, SeString message);
-    
+
     /// <summary>
     /// Event that will be fired when a chat message is sent to chat by the game.
     /// </summary>
@@ -68,17 +68,17 @@ public interface IChatGui
     /// Event that will be fired when a chat message is not handled by Dalamud or a Plugin.
     /// </summary>
     public event OnMessageUnhandledDelegate ChatMessageUnhandled;
-    
+
     /// <summary>
     /// Gets the ID of the last linked item.
     /// </summary>
     public uint LastLinkedItemId { get; }
-    
+
     /// <summary>
     /// Gets the flags of the last linked item.
     /// </summary>
     public byte LastLinkedItemFlags { get; }
-    
+
     /// <summary>
     /// Gets the dictionary of Dalamud Link Handlers.
     /// </summary>
@@ -121,4 +121,26 @@ public interface IChatGui
     /// <param name="messageTag">String to prepend message with "[messageTag] ".</param>
     /// <param name="tagColor">Color to display the message tag with.</param>
     public void PrintError(SeString message, string? messageTag = null, ushort? tagColor = null);
+
+    /// <summary>
+    /// Queue a chat message. Dalamud will send queued messages on the next framework event.
+    /// </summary>
+    /// <param name="chat">A message to send.</param>
+    public void Print(XivChatEntryReadOnly chat);
+
+    /// <summary>
+    /// Queue a chat message. Dalamud will send queued messages on the next framework event.
+    /// </summary>
+    /// <param name="message">A message to send.</param>
+    /// <param name="messageTag">String to prepend message with "[messageTag] ".</param>
+    /// <param name="tagColor">Color to display the message tag with.</param>
+    public void Print(ReadOnlySpan<byte> message, string? messageTag = null, ushort? tagColor = null);
+
+    /// <summary>
+    /// Queue a chat message. Dalamud will send queued messages on the next framework event.
+    /// </summary>
+    /// <param name="message">A message to send.</param>
+    /// <param name="messageTag">String to prepend message with "[messageTag] ".</param>
+    /// <param name="tagColor">Color to display the message tag with.</param>
+    public void PrintError(ReadOnlySpan<byte> message, string? messageTag = null, ushort? tagColor = null);
 }


### PR DESCRIPTION
Adds the same functions that already exist for `string` and `Dalamud.SeString` but instead with a `ReadOnlySpan<byte>` overload which all Lumina version implicitly convert to.

The NBSP code had to be replaced with a byte[] implementation.