### PR TITLE
NRE check LinkData in HandleLinkClickDetour

### DIFF
--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -412,7 +412,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
 
     private void HandleLinkClickDetour(LogViewer* thisPtr, LinkData* linkData)
     {
-        if ((Payload.EmbeddedInfoType)(linkData->LinkType + 1) != Payload.EmbeddedInfoType.DalamudLink)
+        if (linkData == null || linkData->Payload == null || (Payload.EmbeddedInfoType)(linkData->LinkType + 1) != Payload.EmbeddedInfoType.DalamudLink)
         {
             this.handleLinkClickHook.Original(thisPtr, linkData);
             return;


### PR DESCRIPTION
Saw this crash being reported in Discord.
The original handler checks if LinkData* is null, I must have missed that.
Added an additional check for the payload itself.