### PR TITLE
Fix IsPvPExcludingDen

### DIFF
--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -195,7 +195,6 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
             if (isPvP != this.IsPvP)
             {
                 this.IsPvP = isPvP;
-                this.IsPvPExcludingDen = this.IsPvP && this.TerritoryType != 250;
 
                 if (this.IsPvP)
                 {
@@ -208,6 +207,8 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
                     this.LeavePvP?.InvokeSafely();
                 }
             }
+
+            this.IsPvPExcludingDen = this.IsPvP && this.TerritoryType != 250;
         }
 
         this.setupTerritoryTypeHook.Original(eventFramework, territoryType);


### PR DESCRIPTION
I didn't test it, but it should be fine (famous last words).
Currently, it won't update IsPvPExcludingDen if it goes from a PvP area to another PvP area directly. So just modifying it regardless of the condition instead.