### PR TITLE
fix: Properly handle UTF-8 characters in ImGUI paths

### DIFF
--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -604,9 +604,16 @@ internal partial class InterfaceManager : IInternalDisposableService
                 if (iniFileInfo.Length > 1200000)
                 {
                     Log.Warning("dalamudUI.ini was over 1mb, deleting");
-                    iniFileInfo.CopyTo(Path.Combine(iniFileInfo.DirectoryName!, $"dalamudUI-{DateTimeOffset.Now.ToUnixTimeSeconds()}.ini"));
+                    iniFileInfo.CopyTo(
+                        Path.Combine(
+                            iniFileInfo.DirectoryName!,
+                            $"dalamudUI-{DateTimeOffset.Now.ToUnixTimeSeconds()}.ini"));
                     iniFileInfo.Delete();
                 }
+            }
+            catch (FileNotFoundException)
+            {
+                Log.Warning("dalamudUI.ini did not exist, ImGUI will create a new one.");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
- Fixes a bug where users with special characters in their filenames would not be able to save `dalamudUI.ini`.
- Throw a special warning if `dalamudUI.ini` doesn't exist, as it's not an error case.

Fixes goatcorp/FFXIVQuickLauncher#1036.