### PR TITLE
Fix ShowStructInternal ImGui crash

### DIFF
--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -1202,7 +1202,6 @@ public static class Util
 
             if (tree.Success)
             {
-                ImGui.PopStyleColor();
                 foreach (var f in obj.GetType()
                                      .GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.Instance))
                 {


### PR DESCRIPTION
Seems like there was a stray `PopStyleColor` left over after ImRaii changes.