### PR TITLE
Use object table index lookup for NamePlateGui GameObject resolution

### DIFF
--- a/Dalamud/Game/Gui/NamePlate/NamePlateUpdateHandler.cs
+++ b/Dalamud/Game/Gui/NamePlate/NamePlateUpdateHandler.cs
@@ -328,9 +328,9 @@ internal unsafe class NamePlateUpdateHandler : INamePlateUpdateHandler
     public ulong GameObjectId => this.gameObjectId ??= this.NamePlateInfo->ObjectId;
 
     /// <inheritdoc/>
-    public IGameObject? GameObject => this.gameObject ??= this.context.ObjectTable.CreateObjectReference(
-                                          (nint)this.context.Ui3DModule->NamePlateObjectInfoPointers[
-                                              this.ArrayIndex].Value->GameObject);
+    public IGameObject? GameObject => this.gameObject ??= this.context.ObjectTable[
+                                          this.context.Ui3DModule->NamePlateObjectInfoPointers[this.ArrayIndex]
+                                              .Value->GameObject->ObjectIndex];
 
     /// <inheritdoc/>
     public IBattleChara? BattleChara => this.GameObject as IBattleChara;


### PR DESCRIPTION
Sometimes, for example when exiting GPose, nameplate object info pointers may briefly end up pointing to invalidated object table entries. These objects appear valid in some ways but are not, and can have partially corrupted data/vtables. With this change, rather than wrapping the (assumed valid) object with `CreateObjectReference`, we use the object's `ObjectIndex` to look it up in `ObjectTable`. This way the object table pointer is checked for null and we correctly refuse to return an invalidated `GameObject`.

This should fix a known crash in the Player Tags plugin.