### PR TITLE
Use MiniGame BGM scene for About tab

### DIFF
--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -260,10 +260,7 @@ internal sealed unsafe class GameGui : IInternalDisposableService, IGameGui
     /// Indicates if the game is in the lobby scene (title screen, chara select, chara make, aesthetician etc.).
     /// </summary>
     /// <returns>A value indicating whether or not the game is in the lobby scene.</returns>
-    internal bool IsInLobby()
-    {
-        return RaptureAtkModule.Instance()->CurrentUISceneString == "LobbyMain";
-    }
+    internal bool IsInLobby() => RaptureAtkModule.Instance()->CurrentUIScene.StartsWith("LobbyMain"u8);
 
     /// <summary>
     /// Sets the current background music.

--- a/Dalamud/Game/Gui/GameGuiAddressResolver.cs
+++ b/Dalamud/Game/Gui/GameGuiAddressResolver.cs
@@ -6,16 +6,6 @@ namespace Dalamud.Game.Gui;
 internal sealed class GameGuiAddressResolver : BaseAddressResolver
 {
     /// <summary>
-    /// Gets the base address of the native GuiManager class.
-    /// </summary>
-    public IntPtr BaseAddress { get; private set; }
-
-    /// <summary>
-    /// Gets the address of the native SetGlobalBgm method.
-    /// </summary>
-    public IntPtr SetGlobalBgm { get; private set; }
-
-    /// <summary>
     /// Gets the address of the native HandleImm method.
     /// </summary>
     public IntPtr HandleImm { get; private set; }
@@ -23,7 +13,6 @@ internal sealed class GameGuiAddressResolver : BaseAddressResolver
     /// <inheritdoc/>
     protected override void Setup64Bit(ISigScanner sig)
     {
-        this.SetGlobalBgm = sig.ScanText("E8 ?? ?? ?? ?? 8B 2F");                 // unnamed in CS
         this.HandleImm = sig.ScanText("E8 ?? ?? ?? ?? 84 C0 75 10 48 83 FF 09");  // unnamed in CS
     }
 }

--- a/Dalamud/Interface/Internal/DalamudCommands.cs
+++ b/Dalamud/Interface/Internal/DalamudCommands.cs
@@ -266,7 +266,7 @@ internal class DalamudCommands : IServiceType
         else
         {
             // Revert to the original BGM by specifying an invalid one
-            gameGui.SetBgm(9999);
+            gameGui.ResetBgm();
         }
     }
 

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabAbout.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabAbout.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
@@ -194,6 +194,7 @@ Contribute at: https://github.com/goatcorp/Dalamud
     private readonly IFontAtlas privateAtlas;
 
     private string creditsText;
+    private bool isBgmSet;
 
     private bool resetNow = false;
     private IDalamudTextureWrap? logoTexture;
@@ -222,10 +223,13 @@ Contribute at: https://github.com/goatcorp/Dalamud
 
         this.creditsText = string.Format(CreditsTextTempl, typeof(Dalamud).Assembly.GetName().Version, pluginCredits, Util.GetGitHashClientStructs());
 
-        var gg = Service<GameGui>.Get();
-        if (!gg.IsOnTitleScreen() && UIState.Instance() != null)
+        var gameGui = Service<GameGui>.Get();
+        var playerState = PlayerState.Instance();
+
+        if (!gameGui.IsInLobby() && playerState != null)
         {
-            gg.SetBgm((ushort)(UIState.Instance()->PlayerState.MaxExpansion > 3 ? 833 : 132));
+            gameGui.SetBgm((ushort)(playerState->MaxExpansion > 3 ? 833 : 132));
+            this.isBgmSet = true;
         }
 
         this.creditsThrottler.Restart();
@@ -242,9 +246,15 @@ Contribute at: https://github.com/goatcorp/Dalamud
     {
         this.creditsThrottler.Reset();
 
-        var gg = Service<GameGui>.Get();
-        if (!gg.IsOnTitleScreen())
-            gg.SetBgm(9999);
+        if (this.isBgmSet)
+        {
+            var gameGui = Service<GameGui>.Get();
+
+            if (!gameGui.IsInLobby())
+                gameGui.ResetBgm();
+
+            this.isBgmSet = false;
+        }
 
         Service<DalamudInterface>.Get().SetCreditsDarkeningAnimation(false);
     }


### PR DESCRIPTION
I reversed the BGMSystem a bit and now we can make proper use of the BGM scenes. 👍

This PR depends on:
- https://github.com/aers/FFXIVClientStructs/pull/1234

To elaborate further, there are 12 BGM scenes the game can use:
- 0 = Event
- 1 = Battle
- 2 = MiniGame (RhythmAction, TurnBreak)
- 3 = Content
- 4 = GFate
- 5 = Duel
- 6 = Mount
- 7 = Unknown, no xrefs
- 8 = Unknown, via packet (near PlayerState stuff)
- 9 = Wedding
- 10 = Town
- 11 = Territory

The signature for `SetGlobalBgm` resolved to the setter for the BGM scene Content, which is why the instance music doesn't come back after the About tab changed it.
I changed `GameGui.SetBgm` to default to the MiniGame scene, as it is not used very often and mini games can easily be restarted.
I also added a `GameGui.ResetBgm` function that takes care of resetting the scene for us, instead of using an invalid BGM id.
Finally, I replaced the internal `GameGui.IsOnTitleScreen` function with a `IsInLobby` function that simply checks if the `CurrentUIScene` in `AtkModule` equals to `LobbyMain`, so we don't have to check for all the possible lobby addons.

Fixes #2130