### PR TITLE
Don't allow nameplate GameObject lookup when ObjectId is invalid

### DIFF
--- a/Dalamud/Game/Gui/NamePlate/NamePlateUpdateHandler.cs
+++ b/Dalamud/Game/Gui/NamePlate/NamePlateUpdateHandler.cs
@@ -328,9 +328,22 @@ internal unsafe class NamePlateUpdateHandler : INamePlateUpdateHandler
     public ulong GameObjectId => this.gameObjectId ??= this.NamePlateInfo->ObjectId;
 
     /// <inheritdoc/>
-    public IGameObject? GameObject => this.gameObject ??= this.context.ObjectTable[
-                                          this.context.Ui3DModule->NamePlateObjectInfoPointers[this.ArrayIndex]
-                                              .Value->GameObject->ObjectIndex];
+    public IGameObject? GameObject
+    {
+        get
+        {
+            if (this.GameObjectId == 0xE0000000)
+            {
+                // Skipping Ui3DModule lookup for invalid nameplate (NamePlateInfo->ObjectId is 0xE0000000). This
+                // prevents crashes around certain Doman Reconstruction cutscenes.
+                return null;
+            }
+
+            return this.gameObject ??= this.context.ObjectTable[
+                       this.context.Ui3DModule->NamePlateObjectInfoPointers[this.ArrayIndex]
+                           .Value->GameObject->ObjectIndex];
+        }
+    }
 
     /// <inheritdoc/>
     public IBattleChara? BattleChara => this.GameObject as IBattleChara;


### PR DESCRIPTION
Skip `GameObject` lookup when `NamePlateInfo->ObjectId` is `0xE0000000`. Technically these objects can still be looked up despite the invalid `ObjectId`, but doing so and modifying plates as a result seems to result in crashes deep in font rendering code. As this is an unusual case which (to my knowledge) is not seen elsewhere, and the bad ID indicates something is invalid, it's probably correct to skip these lookups.

This should fix a crash in the FC Name Color plugin when viewing certain Doman Restoration cutscenes.