### PR TITLE
Return nullable on XivChatType.GetDetails

### DIFF
--- a/Dalamud/Game/Text/XivChatTypeExtensions.cs
+++ b/Dalamud/Game/Text/XivChatTypeExtensions.cs
@@ -12,7 +12,7 @@ public static class XivChatTypeExtensions
     /// </summary>
     /// <param name="chatType">The chat type.</param>
     /// <returns>The info attribute.</returns>
-    public static XivChatTypeInfoAttribute GetDetails(this XivChatType chatType)
+    public static XivChatTypeInfoAttribute? GetDetails(this XivChatType chatType)
     {
         return chatType.GetAttribute<XivChatTypeInfoAttribute>();
     }


### PR DESCRIPTION
Some `XivChatType` do not have a `XivChatTypeInfoAttribute` on them, so `XivChatType.GetDetails()` should return a nullable.