### PR TITLE
chore: remove [Experimental] from SeStringRenderer

### DIFF
--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Text.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Text.cs
@@ -60,9 +60,7 @@ internal unsafe partial class TextNodeTree : ResNodeTree
                 EdgeStrength = 1f,
             };
 
-#pragma warning disable SeStringRenderer
             ImGuiHelpers.SeStringWrapped(this.NodeText.AsSpan(), style);
-#pragma warning restore SeStringRenderer
         }
         catch
         {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AtkArrayDataBrowserWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AtkArrayDataBrowserWidget.cs
@@ -12,8 +12,6 @@ using Lumina.Text.ReadOnly;
 
 namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
 
-#pragma warning disable SeStringRenderer
-
 /// <summary>
 /// Widget for displaying AtkArrayData.
 /// </summary>

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/InventoryWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/InventoryWidget.cs
@@ -18,8 +18,6 @@ using Lumina.Excel.Sheets;
 
 namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
 
-#pragma warning disable SeStringRenderer
-
 /// <summary>
 /// Widget for displaying inventory data.
 /// </summary>

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringRendererTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringRendererTestWidget.cs
@@ -23,8 +23,6 @@ using Lumina.Text.ReadOnly;
 
 namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
 
-#pragma warning disable SeStringRenderer
-
 /// <summary>
 /// Widget for displaying Addon Data.
 /// </summary>

--- a/Dalamud/Interface/Utility/ImGuiHelpers.cs
+++ b/Dalamud/Interface/Utility/ImGuiHelpers.cs
@@ -212,7 +212,6 @@ public static class ImGuiHelpers
     /// <returns>Interaction result of the rendered text.</returns>
     /// <remarks>This function is experimental. Report any issues to GitHub issues or to Discord #dalamud-dev channel.
     /// The function definition is stable; only in the next API version a function may be removed.</remarks>
-    [Experimental("SeStringRenderer")]
     public static SeStringDrawResult SeStringWrapped(
         ReadOnlySpan<byte> sss,
         scoped in SeStringDrawParams style = default,
@@ -229,7 +228,6 @@ public static class ImGuiHelpers
     /// <returns>Interaction result of the rendered text.</returns>
     /// <remarks>This function is experimental. Report any issues to GitHub issues or to Discord #dalamud-dev channel.
     /// The function definition is stable; only in the next API version a function may be removed.</remarks>
-    [Experimental("SeStringRenderer")]
     public static SeStringDrawResult CompileSeStringWrapped(
         string text,
         scoped in SeStringDrawParams style = default,


### PR DESCRIPTION
It hasn't caused problem for a while (though performance probably can be better), and looks good enough to remove this attribute.