### PR TITLE
Sort commands based on the registration order

### DIFF
--- a/Dalamud/Interface/Internal/DalamudCommands.cs
+++ b/Dalamud/Interface/Internal/DalamudCommands.cs
@@ -178,12 +178,12 @@ internal class DalamudCommands : IServiceType
         if (arguments.IsNullOrWhitespace())
         {
             chatGui.Print(Loc.Localize("DalamudCmdHelpAvailable", "Available commands:"));
-            foreach (var cmd in commandManager.Commands)
+            foreach (var cmd in commandManager.SortedCommands)
             {
-                if (!cmd.Value.ShowInHelp)
+                if (!cmd.Info.ShowInHelp)
                     continue;
 
-                chatGui.Print($"{cmd.Key}: {cmd.Value.HelpMessage}");
+                chatGui.Print($"{cmd.Command}: {cmd.Info.HelpMessage}");
             }
         }
         else

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -120,7 +120,7 @@ internal class PluginInstallerWindow : Window, IDisposable
     private List<AvailablePluginUpdate> pluginListUpdatable = new();
     private bool hasDevPlugins = false;
     private bool hasHiddenPlugins = false;
-    
+
     private string searchText = string.Empty;
     private bool isSearchTextPrefilled = false;
 
@@ -137,7 +137,7 @@ internal class PluginInstallerWindow : Window, IDisposable
     private LoadingIndicatorKind loadingIndicatorKind = LoadingIndicatorKind.Unknown;
 
     private string verifiedCheckmarkHoveredPlugin = string.Empty;
-    
+
     private string? staleDalamudNewVersion = null;
 
     /// <summary>
@@ -215,8 +215,8 @@ internal class PluginInstallerWindow : Window, IDisposable
         ProfileOrNot,
         SearchScore,
     }
-    
-    [Flags] 
+
+    [Flags]
     private enum PluginHeaderFlags
     {
         None = 0,
@@ -236,7 +236,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         Updateable,
         Dev,
     }
-    
+
     private bool AnyOperationInProgress => this.installStatus == OperationStatus.InProgress ||
                                            this.updateStatus == OperationStatus.InProgress ||
                                            this.enableDisableStatus == OperationStatus.InProgress;
@@ -304,7 +304,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             {
                 if (!t.IsCompletedSuccessfully)
                     return;
-                
+
                 var versionInfo = t.Result;
                 if (versionInfo.AssemblyVersion != Util.GetScmVersion() &&
                     versionInfo.Track != "release" &&
@@ -413,7 +413,7 @@ internal class PluginInstallerWindow : Window, IDisposable
     {
         if (!task.IsFaulted && !task.IsCanceled)
             return true;
-        
+
         var newErrorMessage = state as string;
 
         if (task.Exception != null)
@@ -438,7 +438,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 }
             }
         }
-        
+
         if (task.IsCanceled)
             Log.Error("A task was cancelled");
 
@@ -446,14 +446,14 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         return false;
     }
-    
+
     private static void EnsureHaveTestingOptIn(IPluginManifest manifest)
     {
         var configuration = Service<DalamudConfiguration>.Get();
-        
+
         if (configuration.PluginTestingOptIns.Any(x => x.InternalName == manifest.InternalName))
             return;
-        
+
         configuration.PluginTestingOptIns.Add(new PluginTestingOptIn(manifest.InternalName));
         configuration.QueueSave();
     }
@@ -490,7 +490,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 throw new ArgumentOutOfRangeException(nameof(kind), kind, null);
         }
     }
-    
+
     private void DrawProgressOverlay()
     {
         var pluginManager = Service<PluginManager>.Get();
@@ -733,7 +733,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             }
         }
     }
-    
+
     private void DrawFooter()
     {
         var configuration = Service<DalamudConfiguration>.Get();
@@ -802,7 +802,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             {
                 this.updateStatus = OperationStatus.InProgress;
                 this.loadingIndicatorKind = LoadingIndicatorKind.UpdatingAll;
-                
+
                 var toUpdate = this.pluginListUpdatable
                                    .Where(x => x.InstalledPlugin.IsWantedByAnyProfile)
                                    .ToList();
@@ -994,7 +994,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 ImGui.Text(Locs.DeletePluginConfigWarningModal_ExplainTesting());
                 ImGui.PopStyleColor();
             }
-            
+
             ImGui.Text(Locs.DeletePluginConfigWarningModal_Body(this.deletePluginConfigWarningModalPluginName));
             ImGui.Spacing();
 
@@ -1264,7 +1264,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                                                        plugin.Manifest.RepoUrl == availableManifest.RepoUrl &&
                                                        !plugin.IsDev);
 
-            // We "consumed" this plugin from the pile and remove it. 
+            // We "consumed" this plugin from the pile and remove it.
             if (plugin != null)
             {
                 installedPlugins.Remove(plugin);
@@ -1296,7 +1296,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 return isHidden;
             return !isHidden;
         }
-        
+
         // Filter out plugins that are not hidden
         proxies = proxies.Where(IsProxyHidden).ToList();
 
@@ -1328,14 +1328,14 @@ internal class PluginInstallerWindow : Window, IDisposable
 
             ImGui.PopID();
         }
-        
+
         // Reset the category to "All" if we're on the "Hidden" category and there are no hidden plugins (we removed the last one)
         if (i == 0 && this.categoryManager.CurrentCategoryKind == PluginCategoryManager.CategoryKind.Hidden)
         {
             this.categoryManager.CurrentCategoryKind = PluginCategoryManager.CategoryKind.All;
         }
     }
-    
+
     private void DrawInstalledPluginList(InstalledPluginListFilter filter)
     {
         var pluginList = this.pluginListInstalled;
@@ -1363,7 +1363,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         {
             if (filter == InstalledPluginListFilter.Testing && !manager.HasTestingOptIn(plugin.Manifest))
                 continue;
-            
+
             // Find applicable update and manifest, if we have them
             AvailablePluginUpdate? update = null;
             RemotePluginManifest? remoteManifest = null;
@@ -1383,11 +1383,11 @@ internal class PluginInstallerWindow : Window, IDisposable
             {
                 continue;
             }
-            
+
             this.DrawInstalledPlugin(plugin, i++, remoteManifest, update);
             drewAny = true;
         }
-        
+
         if (!drewAny)
         {
             var text = filter switch
@@ -1398,7 +1398,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 InstalledPluginListFilter.Dev => Locs.TabBody_NoPluginsDev,
                 _ => throw new ArgumentException(null, nameof(filter)),
             };
-            
+
             ImGuiHelpers.ScaledDummy(60);
 
             using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudGrey))
@@ -1490,7 +1490,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 foreach (var categoryKind in groupInfo.Categories)
                 {
                     var categoryInfo = this.categoryManager.CategoryList.First(x => x.CategoryKind == categoryKind);
-                        
+
                     switch (categoryInfo.Condition)
                     {
                         case PluginCategoryManager.CategoryInfo.AppearCondition.None:
@@ -1549,7 +1549,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             ImGui.PopFont();
             ImGui.PopStyleColor();
         }
-        
+
         void DrawLinesCentered(string text)
         {
             var lines = text.Split('\n');
@@ -1558,7 +1558,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 ImGuiHelpers.CenteredText(line);
             }
         }
-        
+
         var pm = Service<PluginManager>.Get();
         if (pm.SafeMode)
         {
@@ -1623,7 +1623,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                     case PluginCategoryManager.CategoryKind.IsTesting:
                         this.DrawInstalledPluginList(InstalledPluginListFilter.Testing);
                         break;
-                    
+
                     case PluginCategoryManager.CategoryKind.UpdateablePlugins:
                         this.DrawInstalledPluginList(InstalledPluginListFilter.Updateable);
                         break;
@@ -1631,7 +1631,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                     case PluginCategoryManager.CategoryKind.PluginProfiles:
                         this.profileManagerWidget.Draw();
                         break;
-                    
+
                     default:
                         ImGui.TextUnformatted("You found a secret category. Please feel a sense of pride and accomplishment.");
                         break;
@@ -1652,7 +1652,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                     case PluginCategoryManager.CategoryKind.PluginChangelogs:
                         this.DrawChangelogList(false, true);
                         break;
-                    
+
                     default:
                         ImGui.TextUnformatted("You found a quiet category. Please don't wake it up.");
                         break;
@@ -1979,9 +1979,9 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         var sectionSize = ImGuiHelpers.GlobalScale * 66;
         var tapeCursor = ImGui.GetCursorPos();
-        
+
         ImGui.Separator();
-        
+
         var startCursor = ImGui.GetCursorPos();
 
         if (flags.HasFlag(PluginHeaderFlags.IsTesting))
@@ -1992,9 +1992,9 @@ internal class PluginInstallerWindow : Window, IDisposable
 
                 var windowPos = ImGui.GetWindowPos();
                 var scroll = new Vector2(ImGui.GetScrollX(), ImGui.GetScrollY());
-                
+
                 var adjustedPosition = windowPos + position - scroll;
-                
+
                 var yellow = ImGui.ColorConvertFloat4ToU32(new Vector4(1.0f, 0.9f, 0.0f, 0.10f));
                 var numStripes = (int)(size.X / stripeWidth) + (int)(size.Y / skewAmount) + 1;  // +1 to cover partial stripe
 
@@ -2004,19 +2004,19 @@ internal class PluginInstallerWindow : Window, IDisposable
                     var x1 = x0 + stripeWidth;
                     var y0 = adjustedPosition.Y;
                     var y1 = y0 + size.Y;
-                    
+
                     var p0 = new Vector2(x0, y0);
                     var p1 = new Vector2(x1, y0);
                     var p2 = new Vector2(x1 - skewAmount, y1);
                     var p3 = new Vector2(x0 - skewAmount, y1);
-                    
+
                     if (i % 2 != 0)
                         continue;
-                    
+
                     wdl.AddQuadFilled(p0, p1, p2, p3, yellow);
                 }
             }
-            
+
             DrawCautionTape(tapeCursor + new Vector2(0, 1), new Vector2(ImGui.GetWindowWidth(), sectionSize + ImGui.GetStyle().ItemSpacing.Y), ImGuiHelpers.GlobalScale * 40, 20);
         }
 
@@ -2025,7 +2025,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         ImGui.PushStyleColor(ImGuiCol.ButtonHovered, new Vector4(0.5f, 0.5f, 0.5f, 0.2f));
         ImGui.PushStyleColor(ImGuiCol.ButtonActive, new Vector4(0.5f, 0.5f, 0.5f, 0.35f));
         ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding, 0);
-        
+
         ImGui.SetCursorPos(tapeCursor);
 
         if (ImGui.Button($"###plugin{index}CollapsibleBtn", new Vector2(ImGui.GetContentRegionAvail().X, sectionSize + ImGui.GetStyle().ItemSpacing.Y)))
@@ -2368,11 +2368,11 @@ internal class PluginInstallerWindow : Window, IDisposable
         {
             label += Locs.PluginTitleMod_TestingAvailable;
         }
-        
+
         var isThirdParty = manifest.SourceRepo.IsThirdParty;
 
         ImGui.PushID($"available{index}{manifest.InternalName}");
-        
+
         var flags = PluginHeaderFlags.None;
         if (isThirdParty)
             flags |= PluginHeaderFlags.IsThirdParty;
@@ -2382,7 +2382,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             flags |= PluginHeaderFlags.IsInstallableOutdated;
         if (useTesting || manifest.IsTestingExclusive)
             flags |= PluginHeaderFlags.IsTesting;
-        
+
         if (this.DrawPluginCollapsingHeader(label, null, manifest, flags, () => this.DrawAvailablePluginContextMenu(manifest), index))
         {
             if (!wasSeen)
@@ -2478,7 +2478,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                     EnsureHaveTestingOptIn(manifest);
                     this.StartInstall(manifest, true);
                 }
-                
+
                 ImGui.Separator();
             }
 
@@ -2676,9 +2676,9 @@ internal class PluginInstallerWindow : Window, IDisposable
                 availablePluginUpdate.UseTesting ?
                     availablePluginUpdate.UpdateManifest.TestingAssemblyVersion :
                     availablePluginUpdate.UpdateManifest.AssemblyVersion;
-            
+
             availableChangelog =
-                availablePluginUpdate.UseTesting ? 
+                availablePluginUpdate.UseTesting ?
                     availablePluginUpdate.UpdateManifest.TestingChangelog :
                     availablePluginUpdate.UpdateManifest.Changelog;
         }
@@ -2759,21 +2759,21 @@ internal class PluginInstallerWindow : Window, IDisposable
             // Available commands (if loaded)
             if (plugin.IsLoaded)
             {
-                var commands = commandManager.Commands
+                var commands = commandManager.SortedCommands
                                              .Where(cInfo =>
-                                                        cInfo.Value is { ShowInHelp: true } &&
-                                                        commandManager.GetHandlerAssemblyName(cInfo.Key, cInfo.Value) == plugin.Manifest.InternalName)
+                                                        cInfo.Info is { ShowInHelp: true } &&
+                                                        commandManager.GetHandlerAssemblyName(cInfo.Command, cInfo.Info) == plugin.Manifest.InternalName)
                                              .ToArray();
 
-                if (commands.Any())
+                if (commands.Length != 0)
                 {
-                    ImGui.Dummy(ImGuiHelpers.ScaledVector2(10f, 10f));
+                    ImGuiHelpers.ScaledDummy(10f);
                     foreach (var command in commands)
                     {
-                        ImGuiHelpers.SafeTextWrapped($"{command.Key} → {command.Value.HelpMessage}");
+                        ImGuiHelpers.SafeTextWrapped($"{command.Command} → {command.Info.HelpMessage}");
                     }
 
-                    ImGuiHelpers.ScaledDummy(3);
+                    ImGuiHelpers.ScaledDummy(3f);
                 }
             }
 
@@ -2835,7 +2835,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         {
             this.DrawInstalledPluginChangelog(applicableChangelog);
         }
-        
+
         if (this.categoryManager.CurrentCategoryKind == PluginCategoryManager.CategoryKind.UpdateablePlugins &&
             !availableChangelog.IsNullOrWhitespace() &&
             !didDrawAvailableChangelogInsideCollapsible)
@@ -3689,7 +3689,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             this.pluginListUpdatable = pluginManager.UpdatablePlugins.ToList();
             this.ResortPlugins();
         }
-        
+
         this.hasHiddenPlugins = this.pluginListAvailable.Any(x => configuration.HiddenPluginInternalName.Contains(x.InternalName));
 
         this.UpdateCategoriesOnPluginsChange();
@@ -3943,16 +3943,16 @@ internal class PluginInstallerWindow : Window, IDisposable
         public static string TabBody_DownloadFailed => Loc.Localize("InstallerDownloadFailed", "Download failed.");
 
         public static string TabBody_SafeMode => Loc.Localize("InstallerSafeMode", "Dalamud is running in Plugin Safe Mode, restart to activate plugins.");
-        
+
         public static string TabBody_NoPluginsTesting => Loc.Localize("InstallerNoPluginsTesting", "You aren't testing any plugins at the moment!\nYou can opt in to testing versions in the plugin context menu.");
-        
+
         public static string TabBody_NoPluginsInstalled =>
             string.Format(Loc.Localize("InstallerNoPluginsInstalled", "You don't have any plugins installed yet!\nYou can install them from the \"{0}\" tab."), PluginCategoryManager.Locs.Category_All);
-        
+
         public static string TabBody_NoPluginsUpdateable => Loc.Localize("InstallerNoPluginsUpdate", "No plugins have updates available at the moment.");
-        
+
         public static string TabBody_NoPluginsDev => Loc.Localize("InstallerNoPluginsDev", "You don't have any dev plugins. Add them from the settings.");
-        
+
         #endregion
 
         #region Search text
@@ -4014,11 +4014,11 @@ internal class PluginInstallerWindow : Window, IDisposable
         public static string PluginContext_TestingOptIn => Loc.Localize("InstallerTestingOptIn", "Receive plugin testing versions");
 
         public static string PluginContext_InstallTestingVersion => Loc.Localize("InstallerInstallTestingVersion", "Install testing version");
-        
+
         public static string PluginContext_MarkAllSeen => Loc.Localize("InstallerMarkAllSeen", "Mark all as seen");
 
         public static string PluginContext_HidePlugin => Loc.Localize("InstallerHidePlugin", "Hide from installer");
-        
+
         public static string PluginContext_UnhidePlugin => Loc.Localize("InstallerUnhidePlugin", "Unhide from installer");
 
         public static string PluginContext_DeletePluginConfig => Loc.Localize("InstallerDeletePluginConfig", "Reset plugin data");

--- a/Dalamud/Plugin/Services/ICommandManager.cs
+++ b/Dalamud/Plugin/Services/ICommandManager.cs
@@ -10,9 +10,14 @@ namespace Dalamud.Plugin.Services;
 public interface ICommandManager
 {
     /// <summary>
-    /// Gets a read-only list of all registered commands.
+    /// Gets a read-only dict of all registered commands.
     /// </summary>
     public ReadOnlyDictionary<string, IReadOnlyCommandInfo> Commands { get; }
+
+    /// <summary>
+    /// Gets an array of all registered commands, sorted by their registration order.
+    /// </summary>
+    public (string Command, IReadOnlyCommandInfo Info)[] SortedCommands { get; }
 
     /// <summary>
     /// Process a command in full.


### PR DESCRIPTION
- Sorts the commands in the plugin installer and command help based on that order
- Exposes the sorted list to plugins, while also keeping the old unordered list around to not break API