### PR TITLE
Fetch market board uploader info from main thread

### DIFF
--- a/Dalamud/Game/Network/Internal/MarketBoardUploaders/IMarketBoardUploader.cs
+++ b/Dalamud/Game/Network/Internal/MarketBoardUploaders/IMarketBoardUploader.cs
@@ -13,20 +13,26 @@ internal interface IMarketBoardUploader
     /// Upload data about an item.
     /// </summary>
     /// <param name="item">The item request data being uploaded.</param>
+    /// <param name="uploaderId">The uploaders ContentId.</param>
+    /// <param name="worldId">The uploaders WorldId.</param>
     /// <returns>An async task.</returns>
-    Task Upload(MarketBoardItemRequest item);
+    Task Upload(MarketBoardItemRequest item, ulong uploaderId, uint worldId);
 
     /// <summary>
     /// Upload tax rate data.
     /// </summary>
     /// <param name="taxRates">The tax rate data being uploaded.</param>
+    /// <param name="uploaderId">The uploaders ContentId.</param>
+    /// <param name="worldId">The uploaders WorldId.</param>
     /// <returns>An async task.</returns>
-    Task UploadTax(MarketTaxRates taxRates);
+    Task UploadTax(MarketTaxRates taxRates, ulong uploaderId, uint worldId);
 
     /// <summary>
     /// Upload information about a purchase this client has made.
     /// </summary>
     /// <param name="purchaseHandler">The purchase handler data associated with the sale.</param>
+    /// <param name="uploaderId">The uploaders ContentId.</param>
+    /// <param name="worldId">The uploaders WorldId.</param>
     /// <returns>An async task.</returns>
-    Task UploadPurchase(MarketBoardPurchaseHandler purchaseHandler);
+    Task UploadPurchase(MarketBoardPurchaseHandler purchaseHandler, ulong uploaderId, uint worldId);
 }

--- a/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
+++ b/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -33,21 +32,16 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
         this.httpClient = happyHttpClient.SharedHttpClient;
 
     /// <inheritdoc/>
-    public async Task Upload(MarketBoardItemRequest request)
+    public async Task Upload(MarketBoardItemRequest request, ulong uploaderId, uint worldId)
     {
-        var clientState = Service<ClientState.ClientState>.GetNullable();
-        if (clientState == null)
-            return;
-
         Log.Verbose("Starting Universalis upload");
-        var uploader = clientState.LocalContentId;
 
         // ====================================================================================
 
         var uploadObject = new UniversalisItemUploadRequest
         {
-            WorldId = clientState.LocalPlayer?.CurrentWorld.RowId ?? 0,
-            UploaderId = uploader.ToString(),
+            WorldId = worldId,
+            UploaderId = uploaderId.ToString(),
             ItemId = request.CatalogId,
             Listings = [],
             Sales = [],
@@ -117,18 +111,12 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
     }
 
     /// <inheritdoc/>
-    public async Task UploadTax(MarketTaxRates taxRates)
+    public async Task UploadTax(MarketTaxRates taxRates, ulong uploaderId, uint worldId)
     {
-        var clientState = Service<ClientState.ClientState>.GetNullable();
-        if (clientState == null)
-            return;
-
-        // ====================================================================================
-
         var taxUploadObject = new UniversalisTaxUploadRequest
         {
-            WorldId = clientState.LocalPlayer?.CurrentWorld.RowId ?? 0,
-            UploaderId = clientState.LocalContentId.ToString(),
+            WorldId = worldId,
+            UploaderId = uploaderId.ToString(),
             TaxData = new UniversalisTaxData
             {
                 LimsaLominsa = taxRates.LimsaLominsaTax,
@@ -159,14 +147,9 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
     /// to track the available listings, that is done via the listings packet. All this does is remove
     /// a listing, or delete it, when a purchase has been made.
     /// </remarks>
-    public async Task UploadPurchase(MarketBoardPurchaseHandler purchaseHandler)
+    public async Task UploadPurchase(MarketBoardPurchaseHandler purchaseHandler, ulong uploaderId, uint worldId)
     {
-        var clientState = Service<ClientState.ClientState>.GetNullable();
-        if (clientState == null)
-            return;
-
         var itemId = purchaseHandler.CatalogId;
-        var worldId = clientState.LocalPlayer?.CurrentWorld.RowId ?? 0;
 
         // ====================================================================================
 
@@ -176,7 +159,7 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
             Quantity = purchaseHandler.ItemQuantity,
             ListingId = purchaseHandler.ListingId.ToString(),
             RetainerId = purchaseHandler.RetainerId.ToString(),
-            UploaderId = clientState.LocalContentId.ToString(),
+            UploaderId = uploaderId.ToString(),
         };
 
         var deletePath = $"/api/{worldId}/{itemId}/delete";


### PR DESCRIPTION
This PR fixes `<unknown plugin> is accessing ObjectTable outside the main thread. This is deprecated.` warnings when accessing the market board.

Instead of reading the ContentId and WorldId from the local player in ClientState in the upload threads, it fetches them in via `GetUploaderInfo()` before passing them to another thread.

I took the approach the game uses in `GetCurrentWorldId` (and similar functions) by getting the WorldId from AgentLobby and falling back to the WorldId of the local player's game object. I also added a fallback for the ContentId, so it uses the one in PlayerState instead.

This is honestly the best I could do with my limited knowledge of Observers. 🙃