### PR TITLE
Allow setting a DisplayOrder on commands

### DIFF
--- a/Dalamud/Game/Command/CommandInfo.cs
+++ b/Dalamud/Game/Command/CommandInfo.cs
@@ -11,7 +11,7 @@ public interface IReadOnlyCommandInfo
     /// <param name="command">The command itself.</param>
     /// <param name="arguments">The arguments supplied to the command, ready for parsing.</param>
     public delegate void HandlerDelegate(string command, string arguments);
-    
+
     /// <summary>
     /// Gets a <see cref="HandlerDelegate"/> which will be called when the command is dispatched.
     /// </summary>
@@ -26,6 +26,11 @@ public interface IReadOnlyCommandInfo
     /// Gets a value indicating whether if this command should be shown in the help output.
     /// </summary>
     bool ShowInHelp { get; }
+
+    /// <summary>
+    /// Gets the display order of this command.
+    /// </summary>
+    int DisplayOrder { get; }
 }
 
 /// <summary>
@@ -51,4 +56,7 @@ public sealed class CommandInfo : IReadOnlyCommandInfo
 
     /// <inheritdoc/>
     public bool ShowInHelp { get; set; } = true;
+
+    /// <inheritdoc/>
+    public int DisplayOrder { get; set; } = -1;
 }

--- a/Dalamud/Game/Command/CommandInfo.cs
+++ b/Dalamud/Game/Command/CommandInfo.cs
@@ -28,7 +28,7 @@ public interface IReadOnlyCommandInfo
     bool ShowInHelp { get; }
 
     /// <summary>
-    /// Gets the display order of this command.
+    /// Gets the display order of this command. Defaults to alphabetical ordering.
     /// </summary>
     int DisplayOrder { get; }
 }

--- a/Dalamud/Interface/Internal/DalamudCommands.cs
+++ b/Dalamud/Interface/Internal/DalamudCommands.cs
@@ -178,7 +178,7 @@ internal class DalamudCommands : IServiceType
         if (arguments.IsNullOrWhitespace())
         {
             chatGui.Print(Loc.Localize("DalamudCmdHelpAvailable", "Available commands:"));
-            foreach (var cmd in commandManager.Commands)
+            foreach (var cmd in commandManager.Commands.OrderBy(cInfo => cInfo.Key))
             {
                 if (!cmd.Value.ShowInHelp)
                     continue;

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -2762,14 +2762,14 @@ internal class PluginInstallerWindow : Window, IDisposable
                 var commands = commandManager.Commands
                                              .Where(cInfo =>
                                                         cInfo.Value is { ShowInHelp: true } &&
-                                                        commandManager.GetHandlerAssemblyName(cInfo.Key, cInfo.Value) == plugin.Manifest.InternalName)
-                                             .OrderBy(cInfo => cInfo.Value.DisplayOrder)
-                                             .ThenBy(cInfo => cInfo.Key);
+                                                        commandManager.GetHandlerAssemblyName(cInfo.Key, cInfo.Value) == plugin.Manifest.InternalName);
 
                 if (commands.Any())
                 {
                     ImGui.Dummy(ImGuiHelpers.ScaledVector2(10f, 10f));
-                    foreach (var command in commands)
+                    foreach (var command in commands
+                        .OrderBy(cInfo => cInfo.Value.DisplayOrder)
+                        .ThenBy(cInfo => cInfo.Key))
                     {
                         ImGuiHelpers.SafeTextWrapped($"{command.Key} → {command.Value.HelpMessage}");
                     }

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -2763,7 +2763,8 @@ internal class PluginInstallerWindow : Window, IDisposable
                                              .Where(cInfo =>
                                                         cInfo.Value is { ShowInHelp: true } &&
                                                         commandManager.GetHandlerAssemblyName(cInfo.Key, cInfo.Value) == plugin.Manifest.InternalName)
-                                             .ToArray();
+                                             .OrderBy(cInfo => cInfo.Value.DisplayOrder)
+                                             .ThenBy(cInfo => cInfo.Key);
 
                 if (commands.Any())
                 {


### PR DESCRIPTION
This adds a `DisplayOrder` field (int, default: -1) to `CommandInfo` to enable custom sorting of commands in the Plugin Installer.
Commands with the same order will be sorted alphabetically.

This also changes the commands being listed with the /xlhelp command to be sorted alphabetically (without sorting by DisplayOrder first).