### PR TITLE
Forcefully load stacktrace if assert UI is shown

### DIFF
--- a/Dalamud/Interface/Internal/Asserts/AssertHandler.cs
+++ b/Dalamud/Interface/Internal/Asserts/AssertHandler.cs
@@ -76,7 +76,7 @@ internal class AssertHandler : IDisposable
         if (this.ignoredAsserts.Contains(key))
             return;
 
-        Lazy<string> stackTrace = new(() => new StackTrace(3).ToString());
+        Lazy<string> stackTrace = new(() => DiagnosticUtil.GetUsefulTrace(new StackTrace()).ToString());
 
         if (!this.EnableVerboseLogging)
         {
@@ -124,6 +124,9 @@ internal class AssertHandler : IDisposable
             var fileName = file[(lastSlash + 1)..];
             return $"https://github.com/{userName}/{repoName}/blob/{branch}/{fileName}#L{line}";
         }
+
+        // grab the stack trace now that we've decided to show UI.
+        _ = stackTrace.Value;
 
         var gitHubUrl = GetRepoUrl();
         var showOnGitHubButton = new TaskDialogButton

--- a/Dalamud/Utility/DiagnosticUtil.cs
+++ b/Dalamud/Utility/DiagnosticUtil.cs
@@ -1,0 +1,32 @@
+﻿using System.Diagnostics;
+using System.Linq;
+
+namespace Dalamud.Utility;
+
+/// <summary>
+/// A set of utilities for diagnostics.
+/// </summary>
+public static class DiagnosticUtil
+{
+    private static readonly string[] IgnoredNamespaces = [
+        nameof(System),
+        nameof(ImGuiNET.ImGuiNative)
+    ];
+
+    /// <summary>
+    /// Gets a stack trace that filters out irrelevant frames.
+    /// </summary>
+    /// <param name="source">The source stacktrace to filter.</param>
+    /// <returns>Returns a stack trace with "extra" frames removed.</returns>
+    public static StackTrace GetUsefulTrace(StackTrace source)
+    {
+        var frames = source.GetFrames().SkipWhile(
+            f =>
+            {
+                var frameNs = f.GetMethod()?.DeclaringType?.Namespace;
+                return frameNs == null || IgnoredNamespaces.Any(i => frameNs.StartsWith(i, true, null));
+            });
+
+        return new StackTrace(frames);
+    }
+}


### PR DESCRIPTION
Hopefully fixes a bug where the assert UI can show a useless stack trace.