### PR TITLE
feat: Allow /xldev to disable Safe Mode

### DIFF
--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -1012,6 +1012,11 @@ internal class DalamudInterface : IInternalDisposableService
                         pluginManager.LoadBannedPlugins = !pluginManager.LoadBannedPlugins;
                     }
 
+                    if (pluginManager.SafeMode && ImGui.MenuItem("Disable Safe Mode"))
+                    {
+                        pluginManager.SafeMode = false;
+                    }
+
                     ImGui.Separator();
                     ImGui.MenuItem("API Level:" + PluginManager.DalamudApiLevel, false);
                     ImGui.MenuItem("Loaded plugins:" + pluginManager.InstalledPlugins.Count(), false);

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -48,7 +48,7 @@ internal class PluginManager : IInternalDisposableService
     /// </summary>
     public const int PluginWaitBeforeFreeDefault = 1000; // upped from 500ms, seems more stable
 
-    private static readonly ModuleLog Log = new("PLUGINM");
+    private static readonly ModuleLog Log = ModuleLog.Create<PluginManager>();
 
     private readonly object pluginListLock = new();
     private readonly DirectoryInfo pluginDirectory;
@@ -243,9 +243,9 @@ internal class PluginManager : IInternalDisposableService
     public bool ReposReady { get; private set; }
 
     /// <summary>
-    /// Gets a value indicating whether the plugin manager started in safe mode.
+    /// Gets or sets a value indicating whether the plugin manager started in safe mode.
     /// </summary>
-    public bool SafeMode { get; init; }
+    public bool SafeMode { get; set; }
 
     /// <summary>
     /// Gets the <see cref="PluginConfigurations"/> object used when initializing plugins.

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -30,7 +30,7 @@ internal class LocalPlugin : IAsyncDisposable
 #pragma warning disable SA1401
     protected LocalPluginManifest manifest;
 #pragma warning restore SA1401
-    
+
     private static readonly ModuleLog Log = new("LOCALPLUGIN");
 
     private readonly FileInfo manifestFile;
@@ -314,7 +314,7 @@ internal class LocalPlugin : IAsyncDisposable
 
             this.State = PluginState.Loading;
             Log.Information($"Loading {this.DllFile.Name}");
-            
+
             this.EnsureLoader();
 
             if (this.DllFile.DirectoryName != null &&
@@ -413,7 +413,7 @@ internal class LocalPlugin : IAsyncDisposable
             if (ex is not InvalidPluginOperationException)
                 this.State = PluginState.LoadError;
 
-            // If a precondition fails, don't record it as an error, as it isn't really. 
+            // If a precondition fails, don't record it as an error, as it isn't really.
             if (ex is PluginPreconditionFailedException)
                 Log.Warning(ex.Message);
             else
@@ -510,9 +510,6 @@ internal class LocalPlugin : IAsyncDisposable
         var startInfo = Service<Dalamud>.Get().StartInfo;
         var manager = Service<PluginManager>.Get();
 
-        if (startInfo.NoLoadPlugins)
-            return false;
-
         if (startInfo.NoLoadThirdPartyPlugins && this.manifest.IsThirdParty)
             return false;
 
@@ -556,7 +553,7 @@ internal class LocalPlugin : IAsyncDisposable
     /// </summary>
     /// <param name="reason">Why it should be saved.</param>
     protected void SaveManifest(string reason) => this.manifest.Save(this.manifestFile, reason);
-    
+
     /// <summary>
     /// Called before a plugin is reloaded.
     /// </summary>
@@ -595,7 +592,7 @@ internal class LocalPlugin : IAsyncDisposable
         // but plugins may load other versions of assemblies that Dalamud depends on.
         config.SharedAssemblies.Add((typeof(EntryPoint).Assembly.GetName(), false));
         config.SharedAssemblies.Add((typeof(Common.DalamudStartInfo).Assembly.GetName(), false));
-        
+
         // Pin Lumina since we expose it as an API surface. Before anyone removes this again, please see #1598.
         // Changes to Lumina should be upstreamed if feasible, and if there is a desire to re-add unpinned Lumina we
         // will need to put this behind some kind of feature flag somewhere.
@@ -607,7 +604,7 @@ internal class LocalPlugin : IAsyncDisposable
     {
         if (this.loader != null)
             return;
-        
+
         try
         {
             this.loader = PluginLoader.CreateFromAssemblyFile(this.DllFile.FullName, SetupLoaderConfig);


### PR DESCRIPTION
Indirectly resolves #2165 by allowing plugins to be loaded from a safe mode session.

- Adds new menu item to /xldev to disable Safe Mode, allowing users to load plugins again.
  - Safe mode cannot be re-enabled once disabled.
- Add new ModuleLog.Create<T> for eventual ILogger magic
- Make safe mode writable
- Remove redundant check in CheckPolicy