### PR TITLE
feat: Allow feedback to unofficial endpoints

### DIFF
--- a/Dalamud/Plugin/Internal/Types/Manifest/IPluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/Manifest/IPluginManifest.cs
@@ -16,7 +16,7 @@ public interface IPluginManifest
     /// Gets the public name of the plugin.
     /// </summary>
     public string Name { get; }
-    
+
     /// <summary>
     /// Gets a punchline of the plugins functions.
     /// </summary>
@@ -26,7 +26,7 @@ public interface IPluginManifest
     /// Gets the author/s of the plugin.
     /// </summary>
     public string Author { get; }
-    
+
     /// <summary>
     /// Gets a value indicating whether the plugin can be unloaded asynchronously.
     /// </summary>
@@ -41,17 +41,17 @@ public interface IPluginManifest
     /// Gets the assembly version of the plugin's testing variant.
     /// </summary>
     public Version? TestingAssemblyVersion { get; }
-    
+
     /// <summary>
     /// Gets the DIP17 channel name.
     /// </summary>
     public string? Dip17Channel { get; }
-    
+
     /// <summary>
     /// Gets the last time this plugin was updated.
     /// </summary>
     public long LastUpdate { get; }
-    
+
     /// <summary>
     /// Gets a changelog, null if none exists.
     /// </summary>
@@ -88,16 +88,27 @@ public interface IPluginManifest
     /// Gets an URL to the website or source code of the plugin.
     /// </summary>
     public string? RepoUrl { get; }
-    
+
     /// <summary>
     /// Gets a description of the plugins functions.
     /// </summary>
     public string? Description { get; }
 
     /// <summary>
+    /// Gets a value indicating whether this plugin accepts feedback.
+    /// </summary>
+    public bool AcceptsFeedback { get; }
+
+    /// <summary>
     /// Gets a message that is shown to users when sending feedback.
     /// </summary>
     public string? FeedbackMessage { get; }
+
+    /// <summary>
+    /// Gets the URL to submit plugin feedback to.
+    /// For mainline plugins, the WebServices API will be responsible for relaying feedback regardless of this value.
+    /// </summary>
+    public string? FeedbackWebhook { get; }
 
     /// <summary>
     /// Gets a value indicating whether the plugin is only available for testing.

--- a/Dalamud/Plugin/Internal/Types/Manifest/RemotePluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/Manifest/RemotePluginManifest.cs
@@ -16,7 +16,7 @@ internal record RemotePluginManifest : PluginManifest
     /// </summary>
     [JsonIgnore]
     public PluginRepository SourceRepo { get; set; } = null!;
-    
+
     /// <summary>
     /// Gets or sets the changelog to be shown when obtaining the testing version of the plugin.
     /// </summary>

--- a/Dalamud/Plugin/Internal/Types/PluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginManifest.cs
@@ -145,13 +145,14 @@ internal record PluginManifest : IPluginManifest
     /// <inheritdoc/>
     public string? IconUrl { get; init; }
 
-    /// <summary>
-    /// Gets a value indicating whether this plugin accepts feedback.
-    /// </summary>
+    /// <inheritdoc/>
     public bool AcceptsFeedback { get; init; } = true;
 
     /// <inheritdoc/>
     public string? FeedbackMessage { get; init; }
+
+    /// <inheritdoc/>
+    public string? FeedbackWebhook { get; init; }
 
     /// <inheritdoc/>
     [JsonProperty("_Dip17Channel")]

--- a/Dalamud/Support/BugBait.cs
+++ b/Dalamud/Support/BugBait.cs
@@ -14,7 +14,7 @@ namespace Dalamud.Support;
 /// </summary>
 internal static class BugBait
 {
-    private const string BugBaitUrl = "https://kiko.goats.dev/feedback";
+    private const string BugBaitUrl = "https://api.dalamud.dev/feedback";
 
     /// <summary>
     /// Send feedback to Discord.
@@ -25,7 +25,7 @@ internal static class BugBait
     /// <param name="reporter">The reporter name.</param>
     /// <param name="includeException">Whether or not the most recent exception to occur should be included in the report.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public static async Task SendFeedback(IPluginManifest plugin, bool isTesting, string content, string reporter, bool includeException)
+    public static async Task SendFeedback(IPluginManifest plugin, bool isTesting, bool isCustomRepo, string content, string reporter, bool includeException)
     {
         if (content.IsNullOrWhitespace())
             return;
@@ -43,11 +43,13 @@ internal static class BugBait
         {
             model.Exception = Troubleshooting.LastException == null ? "Was included, but none happened" : Troubleshooting.LastException?.ToString();
         }
-        
+
         var httpClient = Service<HappyHttpClient>.Get().SharedHttpClient;
 
+        var feedbackUrl = !isCustomRepo ? BugBaitUrl : plugin.FeedbackWebhook ?? BugBaitUrl;
+
         var postContent = new StringContent(JsonConvert.SerializeObject(model), Encoding.UTF8, "application/json");
-        var response = await httpClient.PostAsync(BugBaitUrl, postContent);
+        var response = await httpClient.PostAsync(feedbackUrl, postContent);
 
         response.EnsureSuccessStatusCode();
     }


### PR DESCRIPTION
Requires goatcorp/dalamud-bugbait#10.

As an aside, we really need to redo manifests, they're getting painful.

Intended behavior:
* Plugins that have `AcceptFeedback == false` do not display feedback buttons.
* Mainline plugins will *always* send feedback to the Bugbait endpoint.
  * Bugbait will be responsible for forwarding the feedback to the webhook URL.
* Custom plugins will accept feedback only if they have a feedback URL set.