### PR TITLE
Remove hooks when disposed to allow plugins to GC properly

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
@@ -258,8 +258,6 @@ internal class PluginStatWindow : Window
             ImGui.EndTabItem();
         }
 
-        var toRemove = new List<Guid>();
-
         if (ImGui.BeginTabItem("Hooks"))
         {
             ImGui.Checkbox("Show Dalamud Hooks", ref this.showDalamudHooks);
@@ -291,9 +289,6 @@ internal class PluginStatWindow : Window
                 {
                     try
                     {
-                        if (trackedHook.Hook.IsDisposed)
-                            toRemove.Add(guid);
-
                         if (!this.showDalamudHooks && trackedHook.Assembly == Assembly.GetExecutingAssembly())
                             continue;
 
@@ -352,14 +347,6 @@ internal class PluginStatWindow : Window
                 }
 
                 ImGui.EndTable();
-            }
-        }
-
-        if (ImGui.IsWindowAppearing())
-        {
-            foreach (var guid in toRemove)
-            {
-                HookManager.TrackedHooks.TryRemove(guid, out _);
             }
         }
 


### PR DESCRIPTION
References to plugin are being held by HookInfo(as it stores the delegate for the hook). This does what the plugin stats screen does but in the background and on a timer. Have removed the same functionality from the plugin stats screen as it's no longer needed.
