### PR TITLE
fix: always scan for dev plugins when opening the plugin installer

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -282,6 +282,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         var pluginManager = Service<PluginManager>.Get();
 
         _ = pluginManager.ReloadPluginMastersAsync();
+        Service<PluginManager>.Get().ScanDevPlugins();
 
         if (!this.isSearchTextPrefilled) this.searchText = string.Empty;
         this.sortKind = PluginSortKind.Alphabetical;

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -755,8 +755,9 @@ internal class PluginInstallerWindow : Window, IDisposable
             Service<DalamudInterface>.Get().OpenSettings();
         }
 
-        // If any dev plugins are installed, allow a shortcut for the /xldev menu item
-        if (this.hasDevPlugins)
+        // If any dev plugin locations exist, allow a shortcut for the /xldev menu item
+        var hasDevPluginLocations = configuration.DevPluginLoadLocations.Count > 0;
+        if (hasDevPluginLocations)
         {
             ImGui.SameLine();
             if (ImGui.Button(Locs.FooterButton_ScanDevPlugins))


### PR DESCRIPTION
**Reasons for change**

There exists a number of possible edge cases that don't allow the plugin installer window to detect existing dev plugins

***Scenario 1***
- Add a plugin location pointing to a DLL that may not yet exist on your filesystem
- Save
- Build your plugin, or move a DLL to this location so it does now exist
- Open Plugin Installer
- Plugins do not get reloaded, dev plugins tab does not show

***Scenario 2***
- Delete all of your installed dev plugins from the installer window
- The dev plugin locations still point to these paths, although the DLL gets deleted
- Add the plugin back
- Plugins do not get reloaded, dev plugins tab does not show

**Changes**
- Call `ScanDevPlugins` in `PluginInstallerWindow#OnOpen`. This only loads plugins not already in the installed plugin list so the overhead is minimal. The plugin repositories also get reloaded here so it seemed like a good place to stick it
- The "Scan Dev Plugins" button should appear if the dev plugins location list is not empty. This allows users to scan for plugins that may exist on the filesystem but are not yet installed