### PR TITLE
fix: only enable ImGui asserts when adding a valid dev plugin path

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
@@ -218,6 +218,7 @@ public class DevPluginsSettingsEntry : SettingsEntry
                 "DalamudDevPluginInvalid",
                 "The entered value is not a valid path to a potential Dev Plugin.\nDid you mean to enter it as a custom plugin repository in the fields below instead?");
             Task.Delay(5000).ContinueWith(t => this.devPluginLocationAddError = string.Empty);
+            return;
         }
         else
         {


### PR DESCRIPTION
Should stop people from accidentally enabling asserts when attempting to add a custom repo into the dev plugin field