### PR TITLE
fix: trim quotes from dev plugin before validation

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
@@ -206,6 +206,7 @@ public class DevPluginsSettingsEntry : SettingsEntry
 
     private void AddDevPlugin()
     {
+        this.devPluginTempLocation = this.devPluginTempLocation.Trim('"');
         if (this.devPluginLocations.Any(
                 r => string.Equals(r.Path, this.devPluginTempLocation, StringComparison.InvariantCultureIgnoreCase)))
         {
@@ -224,7 +225,7 @@ public class DevPluginsSettingsEntry : SettingsEntry
             this.devPluginLocations.Add(
                 new DevPluginLocationSettings
                 {
-                    Path = this.devPluginTempLocation.Replace("\"", string.Empty),
+                    Path = this.devPluginTempLocation,
                     IsEnabled = true,
                 });
             this.devPluginLocationsChanged = true;


### PR DESCRIPTION
Didn't make sense to edit the path after validation
Allows adding dev plugins directly from Windows' "copy as path" context menu option