### PR TITLE
Add SeStringEvaluator service

### DIFF
--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -10,7 +10,7 @@
 
     <PropertyGroup Label="Feature">
         <Description>XIV Launcher addon framework</Description>
-        <DalamudVersion>11.0.7.0</DalamudVersion>
+        <DalamudVersion>11.0.8.0</DalamudVersion>
         <AssemblyVersion>$(DalamudVersion)</AssemblyVersion>
         <Version>$(DalamudVersion)</Version>
         <FileVersion>$(DalamudVersion)</FileVersion>

--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0-windows</TargetFramework>
         <PlatformTarget>x64</PlatformTarget>
         <Platforms>x64</Platforms>
-        <LangVersion>12.0</LangVersion>
+        <LangVersion>13.0</LangVersion>
         <EnableWindowsTargeting>True</EnableWindowsTargeting>
     </PropertyGroup>
 

--- a/Dalamud/Game/ActionKind.cs
+++ b/Dalamud/Game/ActionKind.cs
@@ -1,0 +1,89 @@
+namespace Dalamud.Game;
+
+/// <summary>
+/// Enum describing possible action kinds.
+/// </summary>
+public enum ActionKind
+{
+    /// <summary>
+    /// A Trait.
+    /// </summary>
+    Trait = 0,
+
+    /// <summary>
+    /// An Action.
+    /// </summary>
+    Action = 1,
+
+    /// <summary>
+    /// A usable Item.
+    /// </summary>
+    Item = 2, // does not work?
+
+    /// <summary>
+    /// A usable EventItem.
+    /// </summary>
+    EventItem = 3, // does not work?
+
+    /// <summary>
+    /// An EventAction.
+    /// </summary>
+    EventAction = 4,
+
+    /// <summary>
+    /// A GeneralAction.
+    /// </summary>
+    GeneralAction = 5,
+
+    /// <summary>
+    /// A BuddyAction.
+    /// </summary>
+    BuddyAction = 6,
+
+    /// <summary>
+    /// A MainCommand.
+    /// </summary>
+    MainCommand = 7,
+
+    /// <summary>
+    /// A Companion.
+    /// </summary>
+    Companion = 8, // unresolved?!
+
+    /// <summary>
+    /// A CraftAction.
+    /// </summary>
+    CraftAction = 9,
+
+    /// <summary>
+    /// An Action (again).
+    /// </summary>
+    Action2 = 10, // what's the difference?
+
+    /// <summary>
+    /// A PetAction.
+    /// </summary>
+    PetAction = 11,
+
+    /// <summary>
+    /// A CompanyAction.
+    /// </summary>
+    CompanyAction = 12,
+
+    /// <summary>
+    /// A Mount.
+    /// </summary>
+    Mount = 13,
+
+    // 14-18 unused
+
+    /// <summary>
+    /// A BgcArmyAction.
+    /// </summary>
+    BgcArmyAction = 19,
+
+    /// <summary>
+    /// An Ornament.
+    /// </summary>
+    Ornament = 20,
+}

--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -323,7 +323,7 @@ internal sealed unsafe class GameGui : IInternalDisposableService, IGameGui
         return ret;
     }
 
-    private void HandleActionHoverDetour(AgentActionDetail* hoverState, ActionKind actionKind, uint actionId, int a4, byte a5)
+    private void HandleActionHoverDetour(AgentActionDetail* hoverState, FFXIVClientStructs.FFXIV.Client.UI.Agent.ActionKind actionKind, uint actionId, int a4, byte a5)
     {
         this.handleActionHoverHook.Original(hoverState, actionKind, actionId, a4, a5);
         this.HoveredAction.ActionKind = (HoverActionKind)actionKind;

--- a/Dalamud/Game/Text/Evaluator/Internal/IconWrap.cs
+++ b/Dalamud/Game/Text/Evaluator/Internal/IconWrap.cs
@@ -1,0 +1,32 @@
+using Lumina.Text;
+
+namespace Dalamud.Game.Text.Evaluator.Internal;
+
+/// <summary>
+/// Wraps payloads in an open and close icon, for example the Auto Translation open/close brackets.
+/// </summary>
+internal ref struct IconWrap : IDisposable
+{
+    private readonly ref SeStringBuilder builder;
+    private readonly uint iconClose;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IconWrap"/> struct.<br/>
+    /// Appends an icon macro with <paramref name="iconOpen"/> on creation, and an icon macro with <paramref name="iconClose"/> on disposal.
+    /// </summary>
+    /// <param name="builder">The builder to use.</param>
+    /// <param name="iconOpen">The open icon id.</param>
+    /// <param name="iconClose">The close icon id.</param>
+    public IconWrap(ref SeStringBuilder builder, uint iconOpen, uint iconClose)
+    {
+        this.builder = ref builder;
+        this.iconClose = iconClose;
+        this.builder.AppendIcon(iconOpen);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        this.builder.AppendIcon(this.iconClose);
+    }
+}

--- a/Dalamud/Game/Text/Evaluator/Internal/SeStringContext.cs
+++ b/Dalamud/Game/Text/Evaluator/Internal/SeStringContext.cs
@@ -1,0 +1,83 @@
+using System.Globalization;
+
+using Dalamud.Utility;
+
+using Lumina.Text;
+using Lumina.Text.ReadOnly;
+
+namespace Dalamud.Game.Text.Evaluator.Internal;
+
+/// <summary>
+/// A context wrapper used in <see cref="SeStringEvaluator"/>.
+/// </summary>
+internal ref struct SeStringContext
+{
+    /// <summary>
+    /// The <see cref="SeStringBuilder"/> to append text and macros to.
+    /// </summary>
+    internal ref SeStringBuilder Builder;
+
+    /// <summary>
+    /// A list of local parameters.
+    /// </summary>
+    internal Span<SeStringParameter> LocalParameters;
+
+    /// <summary>
+    /// The target language, used for sheet lookups.
+    /// </summary>
+    internal ClientLanguage Language;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SeStringContext"/> struct.
+    /// </summary>
+    /// <param name="builder">The <see cref="SeStringBuilder"/> to append text and macros to.</param>
+    /// <param name="localParameters">A list of local parameters.</param>
+    /// <param name="language">The target language, used for sheet lookups.</param>
+    internal SeStringContext(ref SeStringBuilder builder, Span<SeStringParameter> localParameters, ClientLanguage language)
+    {
+        this.Builder = ref builder;
+        this.LocalParameters = localParameters;
+        this.Language = language;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="System.Globalization.CultureInfo"/> of the current target <see cref="Language"/>.
+    /// </summary>
+    internal CultureInfo CultureInfo => Localization.GetCultureInfoFromLangCode(this.Language.ToCode());
+
+    /// <summary>
+    /// Tries to get a number from the local parameters at the specified index.
+    /// </summary>
+    /// <param name="index">The index in the <see cref="LocalParameters"/> list.</param>
+    /// <param name="value">The local parameter number.</param>
+    /// <returns><c>true</c> if the local parameters list contained a parameter at given index, <c>false</c> otherwise.</returns>
+    internal bool TryGetLNum(int index, out uint value)
+    {
+        if (index > 0 && this.LocalParameters.Length > index && this.LocalParameters[index] is SeStringParameter { } val)
+        {
+            value = val.UIntValue;
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    /// <summary>
+    /// Tries to get a string from the local parameters at the specified index.
+    /// </summary>
+    /// <param name="index">The index in the <see cref="LocalParameters"/> list.</param>
+    /// <param name="value">The local parameter string.</param>
+    /// <returns><c>true</c> if the local parameters list contained a parameter at given index, <c>false</c> otherwise.</returns>
+    internal bool TryGetLStr(int index, out ReadOnlySeString value)
+    {
+        if (index > 0 && this.LocalParameters.Length > index && this.LocalParameters[index] is SeStringParameter { } val)
+        {
+            value = val.StringValue;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/Dalamud/Game/Text/Evaluator/Internal/SeStringContext.cs
+++ b/Dalamud/Game/Text/Evaluator/Internal/SeStringContext.cs
@@ -53,7 +53,7 @@ internal ref struct SeStringContext
     /// <returns><c>true</c> if the local parameters list contained a parameter at given index, <c>false</c> otherwise.</returns>
     internal bool TryGetLNum(int index, out uint value)
     {
-        if (index > 0 && this.LocalParameters.Length > index && this.LocalParameters[index] is SeStringParameter { } val)
+        if (index >= 0 && this.LocalParameters.Length > index && this.LocalParameters[index] is SeStringParameter { } val)
         {
             value = val.UIntValue;
             return true;
@@ -71,7 +71,7 @@ internal ref struct SeStringContext
     /// <returns><c>true</c> if the local parameters list contained a parameter at given index, <c>false</c> otherwise.</returns>
     internal bool TryGetLStr(int index, out ReadOnlySeString value)
     {
-        if (index > 0 && this.LocalParameters.Length > index && this.LocalParameters[index] is SeStringParameter { } val)
+        if (index >= 0 && this.LocalParameters.Length > index && this.LocalParameters[index] is SeStringParameter { } val)
         {
             value = val.StringValue;
             return true;

--- a/Dalamud/Game/Text/Evaluator/Internal/SheetRedirectFlags.cs
+++ b/Dalamud/Game/Text/Evaluator/Internal/SheetRedirectFlags.cs
@@ -1,0 +1,49 @@
+namespace Dalamud.Game.Text.Evaluator.Internal;
+
+/// <summary>
+/// An enum providing additional information about the sheet redirect.
+/// </summary>
+[Flags]
+internal enum SheetRedirectFlags
+{
+    /// <summary>
+    /// No flags.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Resolved to a sheet related with items.
+    /// </summary>
+    Item = 1,
+
+    /// <summary>
+    /// Resolved to the EventItem sheet.
+    /// </summary>
+    EventItem = 2,
+
+    /// <summary>
+    /// Resolved to a high quality item.
+    /// </summary>
+    /// <remarks>
+    /// Append Addon#9.
+    /// </remarks>
+    HighQuality = 4,
+
+    /// <summary>
+    /// Resolved to a collectible item.
+    /// </summary>
+    /// <remarks>
+    /// Append Addon#150.
+    /// </remarks>
+    Collectible = 8,
+
+    /// <summary>
+    /// Resolved to a sheet related with actions.
+    /// </summary>
+    Action = 16,
+
+    /// <summary>
+    /// Resolved to the Action sheet.
+    /// </summary>
+    ActionSheet = 32,
+}

--- a/Dalamud/Game/Text/Evaluator/Internal/SheetRedirectResolver.cs
+++ b/Dalamud/Game/Text/Evaluator/Internal/SheetRedirectResolver.cs
@@ -102,7 +102,7 @@ internal class SheetRedirectResolver : IServiceType
                     rowId = itemId;
                 }
 
-                if (colIndex == 4 || colIndex == 5 || (colIndex - 6) <= 1)
+                if (colIndex is >= 4 and <= 7)
                     return SheetRedirectFlags.None;
 
                 break;

--- a/Dalamud/Game/Text/Evaluator/Internal/SheetRedirectResolver.cs
+++ b/Dalamud/Game/Text/Evaluator/Internal/SheetRedirectResolver.cs
@@ -1,0 +1,177 @@
+using Dalamud.Data;
+
+using Lumina.Excel.Sheets;
+using Lumina.Extensions;
+
+namespace Dalamud.Game.Text.Evaluator.Internal;
+
+/// <summary>
+/// A service to resolve sheet redirects in expressions.
+/// </summary>
+[ServiceManager.EarlyLoadedService]
+internal class SheetRedirectResolver : IServiceType
+{
+    private static readonly string[] ActStrSheetNames = [
+        "Trait",
+        "Action",
+        "Item",
+        "EventItem",
+        "EventAction",
+        "GeneralAction",
+        "BuddyAction",
+        "MainCommand",
+        "Companion",
+        "CraftAction",
+        "Action",
+        "PetAction",
+        "CompanyAction",
+        "Mount",
+        string.Empty,
+        string.Empty,
+        string.Empty,
+        string.Empty,
+        string.Empty,
+        "BgcArmyAction",
+        "Ornament",
+    ];
+
+    private static readonly string[] ObjStrSheetNames = [
+        "BNpcName",
+        "ENpcResident",
+        "Treasure",
+        "Aetheryte",
+        "GatheringPointName",
+        "EObjName",
+        "Mount",
+        "Companion",
+        string.Empty,
+        string.Empty,
+        "Item",
+    ];
+
+    [ServiceManager.ServiceDependency]
+    private readonly DataManager dataManager = Service<DataManager>.Get();
+
+    [ServiceManager.ServiceConstructor]
+    private SheetRedirectResolver()
+    {
+    }
+
+    /// <summary>
+    /// Resolves the sheet redirect, if any is present.
+    /// </summary>
+    /// <param name="sheetName">The sheet name.</param>
+    /// <param name="rowId">The row id.</param>
+    /// <param name="flags">Optional flags (currently unknown).</param>
+    internal void Resolve(ref string sheetName, ref uint rowId, ushort flags = 0xFFFF)
+    {
+        if (sheetName is "Item" or "ItemHQ" or "ItemMP") // MP means Masterpiece
+        {
+            if (rowId is > 500_000 and < 1_000_000) // Collectible
+            {
+                sheetName = "Item";
+                rowId -= 500_000;
+            }
+            else if (rowId - 2_000_000 < this.dataManager.GetExcelSheet<EventItem>().Count) // EventItem
+            {
+                sheetName = "EventItem";
+            }
+            else if (rowId >= 1_000_000) // HighQuality
+            {
+                rowId -= 1_000_000;
+            }
+            else
+            {
+                sheetName = "Item";
+            }
+        }
+        else if (sheetName == "ActStr")
+        {
+            var index = rowId / 1000000;
+
+            if (index >= 0 && index < ActStrSheetNames.Length)
+                sheetName = ActStrSheetNames[index];
+
+            rowId %= 1000000;
+        }
+        else if (sheetName == "ObjStr")
+        {
+            var index = rowId / 1000000;
+
+            if (index >= 0 && index < ObjStrSheetNames.Length)
+                sheetName = ObjStrSheetNames[index];
+
+            rowId %= 1000000;
+
+            if (index == 0) // BNpcName
+            {
+                if (rowId >= 100000)
+                    rowId += 900000;
+            }
+            else if (index == 1) // ENpcResident
+            {
+                rowId += 1000000;
+            }
+            else if (index == 2) // Treasure
+            {
+                if (this.dataManager.GetExcelSheet<Treasure>().TryGetRow(rowId, out var treasureRow) && treasureRow.Unknown0.IsEmpty)
+                    rowId = 0; // defaulting to "Treasure Coffer"
+            }
+            else if (index == 3) // Aetheryte
+            {
+                rowId = this.dataManager.GetExcelSheet<Aetheryte>().TryGetRow(rowId, out var aetheryteRow) && aetheryteRow.IsAetheryte
+                    ? 0u // "Aetheryte"
+                    : 1; // "Aethernet Shard"
+            }
+            else if (index == 5) // EObjName
+            {
+                rowId += 2000000;
+            }
+        }
+        else if (sheetName == "EObj" && (flags <= 7 || flags == 0xFFFF))
+        {
+            sheetName = "EObjName";
+        }
+        else if (sheetName == "Treasure")
+        {
+            if (this.dataManager.GetExcelSheet<Treasure>().TryGetRow(rowId, out var treasureRow) && treasureRow.Unknown0.IsEmpty)
+                rowId = 0; // defaulting to "Treasure Coffer"
+        }
+        else if (sheetName == "WeatherPlaceName")
+        {
+            sheetName = "PlaceName";
+
+            var placeNameSubId = rowId;
+            if (this.dataManager.GetExcelSheet<WeatherReportReplace>().TryGetFirst(row => row.PlaceNameSub.RowId == placeNameSubId, out var row))
+                rowId = row.PlaceNameParent.RowId;
+        }
+        else if (sheetName == "InstanceContent" && flags == 3)
+        {
+            sheetName = "ContentFinderCondition";
+
+            if (this.dataManager.GetExcelSheet<InstanceContent>().TryGetRow(rowId, out var row))
+                rowId = row.Order;
+        }
+        else if (sheetName == "PartyContent" && flags == 2)
+        {
+            sheetName = "ContentFinderCondition";
+
+            if (this.dataManager.GetExcelSheet<PartyContent>().TryGetRow(rowId, out var row))
+                rowId = row.ContentFinderCondition.RowId;
+        }
+        else if (sheetName == "PublicContent" && flags == 3)
+        {
+            sheetName = "ContentFinderCondition";
+
+            if (this.dataManager.GetExcelSheet<PublicContent>().TryGetRow(rowId, out var row))
+                rowId = row.ContentFinderCondition.RowId;
+        }
+        else if (sheetName == "AkatsukiNote")
+        {
+            sheetName = "AkatsukiNoteString";
+
+            if (this.dataManager.Excel.GetSubrowSheet<AkatsukiNote>().TryGetRow(rowId, out var row))
+                rowId = (uint)row[0].Unknown2;
+        }
+    }
+}

--- a/Dalamud/Game/Text/Evaluator/Internal/SheetRedirectResolver.cs
+++ b/Dalamud/Game/Text/Evaluator/Internal/SheetRedirectResolver.cs
@@ -76,7 +76,7 @@ internal class SheetRedirectResolver : IServiceType
             {
                 var (itemId, kind) = ItemPayload.GetAdjustedId(rowId);
                 if (kind == ItemKind.EventItem &&
-                    rowId - 2_000_000 < this.dataManager.GetExcelSheet<LSheets.EventItem>().Count)
+                    rowId - 2_000_000 <= this.dataManager.GetExcelSheet<LSheets.EventItem>().Count)
                 {
                     sheetName = nameof(LSheets.EventItem);
                 }

--- a/Dalamud/Game/Text/Evaluator/Internal/SheetRedirectResolver.cs
+++ b/Dalamud/Game/Text/Evaluator/Internal/SheetRedirectResolver.cs
@@ -1,4 +1,6 @@
 using Dalamud.Data;
+using Dalamud.Utility;
+
 using Lumina.Extensions;
 
 using ItemKind = Dalamud.Game.Text.SeStringHandling.Payloads.ItemPayload.ItemKind;
@@ -74,7 +76,7 @@ internal class SheetRedirectResolver : IServiceType
             // MP means Masterpiece
             case "Item" or "ItemHQ" or "ItemMP":
             {
-                var (itemId, kind) = ItemPayload.GetAdjustedId(rowId);
+                var (itemId, kind) = ItemUtil.GetBaseId(rowId);
                 if (kind == ItemKind.EventItem &&
                     rowId - 2_000_000 <= this.dataManager.GetExcelSheet<LSheets.EventItem>().Count)
                 {

--- a/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
@@ -83,10 +83,11 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
             return new(str);
 
         var builder = SeStringBuilder.SharedPool.Get();
+        var lang = language ?? this.dalamudConfiguration.EffectiveLanguage.ToClientLanguage();
 
         try
         {
-            var context = new SeStringContext(ref builder, localParameters, language ?? this.dalamudConfiguration.EffectiveLanguage.ToClientLanguage());
+            var context = new SeStringContext(ref builder, localParameters, lang);
 
             foreach (var payload in str)
             {
@@ -107,28 +108,34 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
     /// <inheritdoc/>
     public ReadOnlySeString EvaluateFromAddon(uint addonId, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null)
     {
-        if (!this.dataManager.GetExcelSheet<AddonSheet>(language).TryGetRow(addonId, out var addonRow))
+        var lang = language ?? this.dalamudConfiguration.EffectiveLanguage.ToClientLanguage();
+
+        if (!this.dataManager.GetExcelSheet<AddonSheet>(lang).TryGetRow(addonId, out var addonRow))
             return default;
 
-        return this.Evaluate(addonRow.Text.AsSpan(), localParameters, language);
+        return this.Evaluate(addonRow.Text.AsSpan(), localParameters, lang);
     }
 
     /// <inheritdoc/>
     public ReadOnlySeString EvaluateFromLobby(uint lobbyId, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null)
     {
-        if (!this.dataManager.GetExcelSheet<Lobby>(language).TryGetRow(lobbyId, out var lobbyRow))
+        var lang = language ?? this.dalamudConfiguration.EffectiveLanguage.ToClientLanguage();
+
+        if (!this.dataManager.GetExcelSheet<Lobby>(lang).TryGetRow(lobbyId, out var lobbyRow))
             return default;
 
-        return this.Evaluate(lobbyRow.Text.AsSpan(), localParameters, language);
+        return this.Evaluate(lobbyRow.Text.AsSpan(), localParameters, lang);
     }
 
     /// <inheritdoc/>
     public ReadOnlySeString EvaluateFromLogMessage(uint logMessageId, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null)
     {
-        if (!this.dataManager.GetExcelSheet<LogMessage>(language).TryGetRow(logMessageId, out var logMessageRow))
+        var lang = language ?? this.dalamudConfiguration.EffectiveLanguage.ToClientLanguage();
+
+        if (!this.dataManager.GetExcelSheet<LogMessage>(lang).TryGetRow(logMessageId, out var logMessageRow))
             return default;
 
-        return this.Evaluate(logMessageRow.Text.AsSpan(), localParameters, language);
+        return this.Evaluate(logMessageRow.Text.AsSpan(), localParameters, lang);
     }
 
     /// <inheritdoc/>

--- a/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
@@ -1034,15 +1034,9 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
             var mapPosX = ConvertRawToMapPosX(mapRow, rawX / 1000f);
             var mapPosY = ConvertRawToMapPosY(mapRow, rawY / 1000f);
 
-            ReadOnlySeString linkText;
-            if (rawZ == -30000)
-            {
-                linkText = this.EvaluateFromAddon(1635, [placeNameWithInstance, mapPosX, mapPosY], context.Language);
-            }
-            else
-            {
-                linkText = this.EvaluateFromAddon(1636, [placeNameWithInstance, mapPosX, mapPosY, rawZ / (rawZ >= 0 ? 10 : -10), rawZ], context.Language);
-            }
+            var linkText = rawZ == -30000
+                ? this.EvaluateFromAddon(1635, [placeNameWithInstance, mapPosX, mapPosY], context.Language)
+                : this.EvaluateFromAddon(1636, [placeNameWithInstance, mapPosX, mapPosY, rawZ / (rawZ >= 0 ? 10 : -10), rawZ], context.Language);
 
             context.Builder.PushLinkMapPosition(territoryTypeId, mapId, rawX, rawY);
             context.Builder.Append(this.EvaluateFromAddon(371, [linkText], context.Language));
@@ -1189,13 +1183,15 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
 
         var sb = SeStringBuilder.SharedPool.Get();
 
-        if (statusRow.StatusCategory == 1)
+        switch (statusRow.StatusCategory)
         {
-            sb.Append(this.EvaluateFromAddon(376, null, context.Language));
-        }
-        else if (statusRow.StatusCategory == 2)
-        {
-            sb.Append(this.EvaluateFromAddon(377, null, context.Language));
+            case 1:
+                sb.Append(this.EvaluateFromAddon(376, default, context.Language));
+                break;
+
+            case 2:
+                sb.Append(this.EvaluateFromAddon(377, default, context.Language));
+                break;
         }
 
         sb.Append(statusName);

--- a/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
@@ -1,0 +1,1894 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+using Dalamud.Configuration.Internal;
+using Dalamud.Data;
+using Dalamud.Game.ClientState.Objects.Enums;
+using Dalamud.Game.Config;
+using Dalamud.Game.Text.Evaluator.Internal;
+using Dalamud.Game.Text.Noun;
+using Dalamud.Logging.Internal;
+using Dalamud.Plugin.Services;
+using Dalamud.Utility;
+
+using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+using FFXIVClientStructs.FFXIV.Client.UI.Info;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+using FFXIVClientStructs.FFXIV.Component.Text;
+
+using Lumina.Excel;
+using Lumina.Excel.Sheets;
+using Lumina.Extensions;
+using Lumina.Text;
+using Lumina.Text.Expressions;
+using Lumina.Text.Payloads;
+using Lumina.Text.ReadOnly;
+
+using AddonSheet = Lumina.Excel.Sheets.Addon;
+
+namespace Dalamud.Game.Text.Evaluator;
+
+#pragma warning disable SeStringEvaluator
+
+/// <summary>
+/// Evaluator for SeStrings.
+/// </summary>
+[ServiceManager.EarlyLoadedService]
+internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
+{
+    private static readonly ModuleLog Log = new("SeStringEvaluator");
+
+    [ServiceManager.ServiceDependency]
+    private readonly ClientState.ClientState clientState = Service<ClientState.ClientState>.Get();
+
+    [ServiceManager.ServiceDependency]
+    private readonly DataManager dataManager = Service<DataManager>.Get();
+
+    [ServiceManager.ServiceDependency]
+    private readonly GameConfig gameConfig = Service<GameConfig>.Get();
+
+    [ServiceManager.ServiceDependency]
+    private readonly DalamudConfiguration dalamudConfiguration = Service<DalamudConfiguration>.Get();
+
+    [ServiceManager.ServiceDependency]
+    private readonly NounProcessor nounProcessor = Service<NounProcessor>.Get();
+
+    [ServiceManager.ServiceDependency]
+    private readonly SheetRedirectResolver sheetRedirectResolver = Service<SheetRedirectResolver>.Get();
+
+    private Dictionary<(ActionKind ActionKind, uint Id, ClientLanguage Language), string> actStrCache = [];
+    private Dictionary<(ObjectKind ObjectKind, uint Id, ClientLanguage Language), string> objStrCache = [];
+
+    [ServiceManager.ServiceConstructor]
+    private SeStringEvaluator()
+    {
+    }
+
+    /// <inheritdoc/>
+    public ReadOnlySeString Evaluate(ReadOnlySeString str, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null)
+    {
+        return this.Evaluate(str.AsSpan(), localParameters, language);
+    }
+
+    /// <inheritdoc/>
+    public ReadOnlySeString Evaluate(ReadOnlySeStringSpan str, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null)
+    {
+        if (str.IsTextOnly())
+            return new(str);
+
+        var builder = SeStringBuilder.SharedPool.Get();
+
+        try
+        {
+            var context = new SeStringContext(ref builder, localParameters, language ?? this.dalamudConfiguration.EffectiveLanguage.ToClientLanguage());
+
+            foreach (var payload in str)
+            {
+                if (!this.ResolvePayload(ref context, payload))
+                {
+                    context.Builder.Append(payload);
+                }
+            }
+
+            return builder.ToReadOnlySeString();
+        }
+        finally
+        {
+            SeStringBuilder.SharedPool.Return(builder);
+        }
+    }
+
+    /// <inheritdoc/>
+    public ReadOnlySeString EvaluateFromAddon(uint addonId, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null)
+    {
+        if (!this.dataManager.GetExcelSheet<AddonSheet>(language).TryGetRow(addonId, out var addonRow))
+            return default;
+
+        return this.Evaluate(addonRow.Text.AsSpan(), localParameters, language);
+    }
+
+    /// <inheritdoc/>
+    public ReadOnlySeString EvaluateFromLobby(uint lobbyId, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null)
+    {
+        if (!this.dataManager.GetExcelSheet<Lobby>(language).TryGetRow(lobbyId, out var lobbyRow))
+            return default;
+
+        return this.Evaluate(lobbyRow.Text.AsSpan(), localParameters, language);
+    }
+
+    /// <inheritdoc/>
+    public ReadOnlySeString EvaluateFromLogMessage(uint logMessageId, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null)
+    {
+        if (!this.dataManager.GetExcelSheet<LogMessage>(language).TryGetRow(logMessageId, out var logMessageRow))
+            return default;
+
+        return this.Evaluate(logMessageRow.Text.AsSpan(), localParameters, language);
+    }
+
+    /// <inheritdoc/>
+    public string EvaluateActStr(ActionKind actionKind, uint id, ClientLanguage? language = null)
+    {
+        var lang = language ?? this.dalamudConfiguration.EffectiveLanguage.ToClientLanguage();
+        var key = (actionKind, id, lang);
+
+        if (this.actStrCache.TryGetValue(key, out var text))
+            return text;
+
+        text = string.Intern(this.EvaluateFromAddon(2026, [actionKind.GetActStrId(id)], lang).ExtractText().StripSoftHypen());
+        this.actStrCache.Add(key, text);
+        return text;
+    }
+
+    /// <inheritdoc/>
+    public string EvaluateObjStr(ObjectKind objectKind, uint id, ClientLanguage? language = null)
+    {
+        var lang = language ?? this.dalamudConfiguration.EffectiveLanguage.ToClientLanguage();
+        var key = (objectKind, id, lang);
+
+        if (this.objStrCache.TryGetValue(key, out var text))
+            return text;
+
+        text = string.Intern(this.EvaluateFromAddon(2025, [objectKind.GetObjStrId(id)], lang).ExtractText().StripSoftHypen());
+        this.objStrCache.Add(key, text);
+        return text;
+    }
+
+    // TODO: move this to MapUtil?
+    private static uint ConvertRawToMapPos(Lumina.Excel.Sheets.Map map, short offset, float value)
+    {
+        var scale = map.SizeFactor / 100.0f;
+        return (uint)(10 - (int)(((value + offset) * scale + 1024f) * -0.2f / scale));
+    }
+
+    private static uint ConvertRawToMapPosX(Lumina.Excel.Sheets.Map map, float x)
+        => ConvertRawToMapPos(map, map.OffsetX, x);
+
+    private static uint ConvertRawToMapPosY(Lumina.Excel.Sheets.Map map, float y)
+        => ConvertRawToMapPos(map, map.OffsetY, y);
+
+    private bool ResolvePayload(ref SeStringContext context, ReadOnlySePayloadSpan payload)
+    {
+        if (payload.Type != ReadOnlySePayloadType.Macro)
+            return false;
+
+        // if (context.HandlePayload(payload, ref context))
+        //    return true;
+
+        switch (payload.MacroCode)
+        {
+            case MacroCode.SetResetTime:
+                return this.TryResolveSetResetTime(ref context, payload);
+
+            case MacroCode.SetTime:
+                return this.TryResolveSetTime(ref context, payload);
+
+            case MacroCode.If:
+                return this.TryResolveIf(ref context, payload);
+
+            case MacroCode.Switch:
+                return this.TryResolveSwitch(ref context, payload);
+
+            case MacroCode.PcName:
+                return this.TryResolvePcName(ref context, payload);
+
+            case MacroCode.IfPcGender:
+                return this.TryResolveIfPcGender(ref context, payload);
+
+            case MacroCode.IfPcName:
+                return this.TryResolveIfPcName(ref context, payload);
+
+            // case MacroCode.Josa:
+            // case MacroCode.Josaro:
+
+            case MacroCode.IfSelf:
+                return this.TryResolveIfSelf(ref context, payload);
+
+            // case MacroCode.NewLine: // pass through
+            // case MacroCode.Wait: // pass through
+            // case MacroCode.Icon: // pass through
+
+            case MacroCode.Color:
+                return this.TryResolveColor(ref context, payload);
+
+            case MacroCode.EdgeColor:
+                return this.TryResolveEdgeColor(ref context, payload);
+
+            case MacroCode.ShadowColor:
+                return this.TryResolveShadowColor(ref context, payload);
+
+            // case MacroCode.SoftHyphen: // pass through
+            // case MacroCode.Key:
+            // case MacroCode.Scale:
+
+            case MacroCode.Bold:
+                return this.TryResolveBold(ref context, payload);
+
+            case MacroCode.Italic:
+                return this.TryResolveItalic(ref context, payload);
+
+            // case MacroCode.Edge:
+            // case MacroCode.Shadow:
+            // case MacroCode.NonBreakingSpace: // pass through
+            // case MacroCode.Icon2: // pass through
+            // case MacroCode.Hyphen: // pass through
+
+            case MacroCode.Num:
+                return this.TryResolveNum(ref context, payload);
+
+            case MacroCode.Hex:
+                return this.TryResolveHex(ref context, payload);
+
+            case MacroCode.Kilo:
+                return this.TryResolveKilo(ref context, payload);
+
+            // case MacroCode.Byte:
+
+            case MacroCode.Sec:
+                return this.TryResolveSec(ref context, payload);
+
+            // case MacroCode.Time:
+
+            case MacroCode.Float:
+                return this.TryResolveFloat(ref context, payload);
+
+            // case MacroCode.Link: // pass through
+
+            case MacroCode.Sheet:
+                return this.TryResolveSheet(ref context, payload);
+
+            case MacroCode.String:
+                return this.TryResolveString(ref context, payload);
+
+            case MacroCode.Caps:
+                return this.TryResolveCaps(ref context, payload);
+
+            case MacroCode.Head:
+                return this.TryResolveHead(ref context, payload);
+
+            case MacroCode.Split:
+                return this.TryResolveSplit(ref context, payload);
+
+            case MacroCode.HeadAll:
+                return this.TryResolveHeadAll(ref context, payload);
+
+            case MacroCode.Fixed:
+                return this.TryResolveFixed(ref context, payload);
+
+            case MacroCode.Lower:
+                return this.TryResolveLower(ref context, payload);
+
+            case MacroCode.JaNoun:
+                return this.TryResolveNoun(ClientLanguage.Japanese, ref context, payload);
+
+            case MacroCode.EnNoun:
+                return this.TryResolveNoun(ClientLanguage.English, ref context, payload);
+
+            case MacroCode.DeNoun:
+                return this.TryResolveNoun(ClientLanguage.German, ref context, payload);
+
+            case MacroCode.FrNoun:
+                return this.TryResolveNoun(ClientLanguage.French, ref context, payload);
+
+            // case MacroCode.ChNoun:
+
+            case MacroCode.LowerHead:
+                return this.TryResolveLowerHead(ref context, payload);
+
+            case MacroCode.ColorType:
+                return this.TryResolveColorType(ref context, payload);
+
+            case MacroCode.EdgeColorType:
+                return this.TryResolveEdgeColorType(ref context, payload);
+
+            // case MacroCode.Ruby:
+
+            case MacroCode.Digit:
+                return this.TryResolveDigit(ref context, payload);
+
+            case MacroCode.Ordinal:
+                return this.TryResolveOrdinal(ref context, payload);
+
+            // case MacroCode.Sound: // pass through
+
+            case MacroCode.LevelPos:
+                return this.TryResolveLevelPos(ref context, payload);
+
+            default:
+                return false;
+        }
+    }
+
+    private unsafe bool TryResolveSetResetTime(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        DateTime date;
+
+        if (payload.TryGetExpression(out var eHour, out var eWeekday)
+            && this.TryResolveInt(ref context, eHour, out var eHourVal)
+            && this.TryResolveInt(ref context, eWeekday, out var eWeekdayVal))
+        {
+            var t = DateTime.UtcNow.AddDays((eWeekdayVal - (int)DateTime.UtcNow.DayOfWeek + 7) % 7);
+            date = new DateTime(t.Year, t.Month, t.Day, eHourVal, 0, 0, DateTimeKind.Utc).ToLocalTime();
+        }
+        else if (payload.TryGetExpression(out eHour)
+                 && this.TryResolveInt(ref context, eHour, out eHourVal))
+        {
+            var t = DateTime.UtcNow;
+            date = new DateTime(t.Year, t.Month, t.Day, eHourVal, 0, 0, DateTimeKind.Utc).ToLocalTime();
+        }
+        else
+        {
+            return false;
+        }
+
+        MacroDecoder.GetMacroTime()->SetTime(date);
+
+        return true;
+    }
+
+    private unsafe bool TryResolveSetTime(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eTime) || !this.TryResolveUInt(ref context, eTime, out var eTimeVal))
+            return false;
+
+        var date = DateTimeOffset.FromUnixTimeSeconds(eTimeVal).LocalDateTime;
+        MacroDecoder.GetMacroTime()->SetTime(date);
+
+        return true;
+    }
+
+    private bool TryResolveIf(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        return
+            payload.TryGetExpression(out var eCond, out var eTrue, out var eFalse)
+            && this.ResolveStringExpression(
+                ref context,
+                this.TryResolveBool(ref context, eCond, out var eCondVal) && eCondVal
+                    ? eTrue
+                    : eFalse);
+    }
+
+    private bool TryResolveSwitch(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        var cond = -1;
+        foreach (var e in payload)
+        {
+            switch (cond)
+            {
+                case -1:
+                    cond = this.TryResolveUInt(ref context, e, out var eVal) ? (int)eVal : 0;
+                    break;
+                case > 1:
+                    cond--;
+                    break;
+                default:
+                    return this.ResolveStringExpression(ref context, e);
+            }
+        }
+
+        return false;
+    }
+
+    private unsafe bool TryResolvePcName(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eEntityId))
+            return false;
+
+        if (!this.TryResolveUInt(ref context, eEntityId, out var entityId))
+            return false;
+
+        // TODO: handle LogNameType
+
+        NameCache.CharacterInfo characterInfo = default;
+        if (NameCache.Instance()->TryGetCharacterInfoByEntityId(entityId, &characterInfo))
+        {
+            context.Builder.Append((ReadOnlySeStringSpan)characterInfo.Name.AsSpan());
+
+            if (characterInfo.HomeWorldId != AgentLobby.Instance()->LobbyData.HomeWorldId &&
+                WorldHelper.Instance()->AllWorlds.TryGetValue((ushort)characterInfo.HomeWorldId, out var world, false))
+            {
+                context.Builder.AppendIcon(88);
+
+                if (this.gameConfig.UiConfig.TryGetUInt("LogCrossWorldName", out var logCrossWorldName) && logCrossWorldName == 1)
+                    context.Builder.Append((ReadOnlySeStringSpan)world.Name);
+            }
+
+            return true;
+        }
+
+        // TODO: lookup via InstanceContentCrystallineConflictDirector
+        // TODO: lookup via MJIManager
+
+        return false;
+    }
+
+    private unsafe bool TryResolveIfPcGender(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eEntityId, out var eMale, out var eFemale))
+            return false;
+
+        if (!this.TryResolveUInt(ref context, eEntityId, out var entityId))
+            return false;
+
+        NameCache.CharacterInfo characterInfo = default;
+        if (NameCache.Instance()->TryGetCharacterInfoByEntityId(entityId, &characterInfo))
+            return this.ResolveStringExpression(ref context, characterInfo.Sex == 0 ? eMale : eFemale);
+
+        // TODO: lookup via InstanceContentCrystallineConflictDirector
+
+        return false;
+    }
+
+    private unsafe bool TryResolveIfPcName(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eEntityId, out var eName, out var eTrue, out var eFalse))
+            return false;
+
+        if (!this.TryResolveUInt(ref context, eEntityId, out var entityId) || !eName.TryGetString(out var name))
+            return false;
+
+        name = this.Evaluate(name, context.LocalParameters, context.Language).AsSpan();
+
+        NameCache.CharacterInfo characterInfo = default;
+        return NameCache.Instance()->TryGetCharacterInfoByEntityId(entityId, &characterInfo) &&
+            this.ResolveStringExpression(ref context, name.Equals((ReadOnlySeStringSpan)characterInfo.Name.AsSpan())
+                ? eTrue
+                : eFalse);
+    }
+
+    private unsafe bool TryResolveIfSelf(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eEntityId, out var eTrue, out var eFalse))
+            return false;
+
+        if (!this.TryResolveUInt(ref context, eEntityId, out var entityId))
+            return false;
+
+        // the game uses LocalPlayer here, but using PlayerState seems more safe..
+        return this.ResolveStringExpression(ref context, PlayerState.Instance()->EntityId == entityId ? eTrue : eFalse);
+    }
+
+    private bool TryResolveColor(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eColor))
+            return false;
+
+        if (eColor.TryGetPlaceholderExpression(out var ph) && ph == (int)ExpressionType.StackColor)
+            context.Builder.PopColor();
+        else if (this.TryResolveUInt(ref context, eColor, out var eColorVal))
+            context.Builder.PushColorBgra(eColorVal);
+
+        return true;
+    }
+
+    private bool TryResolveEdgeColor(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eColor))
+            return false;
+
+        if (eColor.TryGetPlaceholderExpression(out var ph) && ph == (int)ExpressionType.StackColor)
+            context.Builder.PopEdgeColor();
+        else if (this.TryResolveUInt(ref context, eColor, out var eColorVal))
+            context.Builder.PushEdgeColorBgra(eColorVal);
+
+        return true;
+    }
+
+    private bool TryResolveShadowColor(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eColor))
+            return false;
+
+        if (eColor.TryGetPlaceholderExpression(out var ph) && ph == (int)ExpressionType.StackColor)
+            context.Builder.PopShadowColor();
+        else if (this.TryResolveUInt(ref context, eColor, out var eColorVal))
+            context.Builder.PushShadowColorBgra(eColorVal);
+
+        return true;
+    }
+
+    private bool TryResolveBold(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eEnable) || !this.TryResolveBool(ref context, eEnable, out var eEnableVal))
+            return false;
+
+        context.Builder.AppendSetBold(eEnableVal);
+
+        return true;
+    }
+
+    private bool TryResolveItalic(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eEnable) || !this.TryResolveBool(ref context, eEnable, out var eEnableVal))
+            return false;
+
+        context.Builder.AppendSetItalic(eEnableVal);
+
+        return true;
+    }
+
+    private bool TryResolveNum(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eInt) || !this.TryResolveInt(ref context, eInt, out var eIntVal))
+        {
+            context.Builder.Append('0');
+            return true;
+        }
+
+        context.Builder.Append(eIntVal.ToString());
+
+        return true;
+    }
+
+    private bool TryResolveHex(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eUInt) || !this.TryResolveUInt(ref context, eUInt, out var eUIntVal))
+        {
+            // TODO: throw?
+            // ERROR: mismatch parameter type ('' is not numeric)
+            return false;
+        }
+
+        context.Builder.Append("0x{0:X08}".Format(eUIntVal));
+
+        return true;
+    }
+
+    private bool TryResolveKilo(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eInt, out var eSep) || !this.TryResolveInt(ref context, eInt, out var eIntVal))
+        {
+            context.Builder.Append('0');
+            return true;
+        }
+
+        if (eIntVal == int.MinValue)
+        {
+            // -2147483648
+            context.Builder.Append("-2"u8);
+            this.ResolveStringExpression(ref context, eSep);
+            context.Builder.Append("147"u8);
+            this.ResolveStringExpression(ref context, eSep);
+            context.Builder.Append("483"u8);
+            this.ResolveStringExpression(ref context, eSep);
+            context.Builder.Append("648"u8);
+            return true;
+        }
+
+        if (eIntVal < 0)
+        {
+            context.Builder.Append('-');
+            eIntVal = -eIntVal;
+        }
+
+        if (eIntVal == 0)
+        {
+            context.Builder.Append('0');
+            return true;
+        }
+
+        var anyDigitPrinted = false;
+        for (var i = 1_000_000_000; i > 0; i /= 10)
+        {
+            var digit = eIntVal / i % 10;
+            switch (anyDigitPrinted)
+            {
+                case false when digit == 0:
+                    continue;
+                case true when i % 3 == 0:
+                    this.ResolveStringExpression(ref context, eSep);
+                    break;
+            }
+
+            anyDigitPrinted = true;
+            context.Builder.Append((char)('0' + digit));
+        }
+
+        return true;
+    }
+
+    private bool TryResolveSec(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eInt) || !this.TryResolveUInt(ref context, eInt, out var eIntVal))
+        {
+            // TODO: throw?
+            // ERROR: mismatch parameter type ('' is not numeric)
+            return false;
+        }
+
+        context.Builder.Append("{0:00}".Format(eIntVal));
+        return true;
+    }
+
+    private bool TryResolveFloat(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eValue, out var eRadix, out var eSeparator)
+            || !this.TryResolveInt(ref context, eValue, out var eValueVal)
+            || !this.TryResolveInt(ref context, eRadix, out var eRadixVal))
+        {
+            return false;
+        }
+
+        var (integerPart, fractionalPart) = int.DivRem(eValueVal, eRadixVal);
+        if (fractionalPart < 0)
+        {
+            integerPart--;
+            fractionalPart += eRadixVal;
+        }
+
+        context.Builder.Append(integerPart.ToString());
+        this.ResolveStringExpression(ref context, eSeparator);
+
+        // brain fried code
+        Span<byte> fractionalDigits = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        var pos = fractionalDigits.Length - 1;
+        for (var r = eRadixVal; r > 1; r /= 10)
+        {
+            fractionalDigits[pos--] = (byte)('0' + fractionalPart % 10);
+            fractionalPart /= 10;
+        }
+
+        context.Builder.Append(fractionalDigits[(pos + 1)..]);
+
+        return true;
+    }
+
+    private bool TryResolveSheet(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        var enu = payload.GetEnumerator();
+
+        if (!enu.MoveNext() || !enu.Current.TryGetString(out var eSheetNameStr))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var eRowIdValue))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var eColIndexValue))
+            return false;
+
+        var eColParamValue = 0u;
+        if (enu.MoveNext())
+            this.TryResolveUInt(ref context, enu.Current, out eColParamValue);
+
+        var resolvedSheetName = this.Evaluate(eSheetNameStr, context.LocalParameters, context.Language).ExtractText();
+
+        this.sheetRedirectResolver.Resolve(ref resolvedSheetName, ref eRowIdValue);
+
+        if (string.IsNullOrEmpty(resolvedSheetName))
+            return false;
+
+        if (!this.dataManager.Excel.SheetNames.Contains(resolvedSheetName))
+            return false;
+
+        if (!this.dataManager.GetExcelSheet<RawRow>(context.Language, resolvedSheetName).TryGetRow(eRowIdValue, out var row))
+            return false;
+
+        var column = row.ReadColumn((int)eColIndexValue);
+        if (column == null)
+            return false;
+
+        switch (column)
+        {
+            case ReadOnlySeString val:
+                context.Builder.Append(this.Evaluate(val, [eColParamValue], context.Language));
+                return true;
+
+            case bool val:
+                context.Builder.Append((val ? 1u : 0).ToString("D", CultureInfo.InvariantCulture));
+                return true;
+
+            case sbyte val:
+                context.Builder.Append(val.ToString("D", CultureInfo.InvariantCulture));
+                return true;
+
+            case byte val:
+                context.Builder.Append(val.ToString("D", CultureInfo.InvariantCulture));
+                return true;
+
+            case short val:
+                context.Builder.Append(val.ToString("D", CultureInfo.InvariantCulture));
+                return true;
+
+            case ushort val:
+                context.Builder.Append(val.ToString("D", CultureInfo.InvariantCulture));
+                return true;
+
+            case int val:
+                context.Builder.Append(val.ToString("D", CultureInfo.InvariantCulture));
+                return true;
+
+            case uint val:
+                context.Builder.Append(val.ToString("D", CultureInfo.InvariantCulture));
+                return true;
+
+            case { } val:
+                context.Builder.Append(val.ToString());
+                return true;
+        }
+
+        return false;
+    }
+
+    private bool TryResolveString(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        return payload.TryGetExpression(out var eStr) && this.ResolveStringExpression(ref context, eStr);
+    }
+
+    private bool TryResolveCaps(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eStr))
+            return false;
+
+        var builder = SeStringBuilder.SharedPool.Get();
+
+        try
+        {
+            var headContext = new SeStringContext(ref builder, context.LocalParameters, context.Language);
+
+            if (!this.ResolveStringExpression(ref headContext, eStr))
+                return false;
+
+            var str = builder.ToReadOnlySeString();
+            var pIdx = 0;
+
+            foreach (var p in str)
+            {
+                pIdx++;
+
+                if (p.Type == ReadOnlySePayloadType.Invalid)
+                    continue;
+
+                if (pIdx == 1 && p.Type == ReadOnlySePayloadType.Text)
+                {
+                    context.Builder.Append(Encoding.UTF8.GetString(p.Body.ToArray()).ToUpper(context.CultureInfo));
+                    continue;
+                }
+
+                context.Builder.Append(p);
+            }
+
+            return true;
+        }
+        finally
+        {
+            SeStringBuilder.SharedPool.Return(builder);
+        }
+    }
+
+    private bool TryResolveHead(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eStr))
+            return false;
+
+        var builder = SeStringBuilder.SharedPool.Get();
+
+        try
+        {
+            var headContext = new SeStringContext(ref builder, context.LocalParameters, context.Language);
+
+            if (!this.ResolveStringExpression(ref headContext, eStr))
+                return false;
+
+            var str = builder.ToReadOnlySeString();
+            var pIdx = 0;
+
+            foreach (var p in str)
+            {
+                pIdx++;
+
+                if (p.Type == ReadOnlySePayloadType.Invalid)
+                    continue;
+
+                if (pIdx == 1 && p.Type == ReadOnlySePayloadType.Text)
+                {
+                    context.Builder.Append(Encoding.UTF8.GetString(p.Body.ToArray()).FirstCharToUpper());
+                    continue;
+                }
+
+                context.Builder.Append(p);
+            }
+
+            return true;
+        }
+        finally
+        {
+            SeStringBuilder.SharedPool.Return(builder);
+        }
+    }
+
+    private bool TryResolveSplit(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eText, out var eSeparator, out var eIndex))
+            return false;
+
+        if (!eSeparator.TryGetString(out var eSeparatorVal) || !eIndex.TryGetUInt(out var eIndexVal) || eIndexVal <= 0)
+            return false;
+
+        var builder = SeStringBuilder.SharedPool.Get();
+
+        try
+        {
+            var headContext = new SeStringContext(ref builder, context.LocalParameters, context.Language);
+
+            if (!this.ResolveStringExpression(ref headContext, eText))
+                return false;
+
+            var separator = eSeparatorVal.ExtractText();
+            if (separator.Length < 1)
+                return false;
+
+            var splitted = builder.ToReadOnlySeString().ExtractText().Split(separator[0]);
+            if (eIndexVal <= splitted.Length)
+            {
+                context.Builder.Append(splitted[eIndexVal - 1]);
+                return true;
+            }
+
+            return false;
+        }
+        finally
+        {
+            SeStringBuilder.SharedPool.Return(builder);
+        }
+    }
+
+    private bool TryResolveHeadAll(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eStr))
+            return false;
+
+        var builder = SeStringBuilder.SharedPool.Get();
+
+        try
+        {
+            var headContext = new SeStringContext(ref builder, context.LocalParameters, context.Language);
+
+            if (!this.ResolveStringExpression(ref headContext, eStr))
+                return false;
+
+            var str = builder.ToReadOnlySeString();
+
+            foreach (var p in str)
+            {
+                if (p.Type == ReadOnlySePayloadType.Invalid)
+                    continue;
+
+                if (p.Type == ReadOnlySePayloadType.Text)
+                {
+                    context.Builder.Append(context.CultureInfo.TextInfo.ToTitleCase(Encoding.UTF8.GetString(p.Body.ToArray())));
+
+                    continue;
+                }
+
+                context.Builder.Append(p);
+            }
+
+            return true;
+        }
+        finally
+        {
+            SeStringBuilder.SharedPool.Return(builder);
+        }
+    }
+
+    private bool TryResolveFixed(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        // This is handled by the second function in Client::UI::Misc::PronounModule_ProcessString
+
+        var enu = payload.GetEnumerator();
+
+        if (!enu.MoveNext() || !this.TryResolveInt(ref context, enu.Current, out var e0Val))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveInt(ref context, enu.Current, out var e1Val))
+            return false;
+
+        return e0Val switch
+        {
+            100 or 200 => e1Val switch
+            {
+                1 => this.TryResolveFixedPlayerLink(ref context, ref enu),
+                2 => this.TryResolveFixedClassJobLevel(ref context, ref enu),
+                3 => this.TryResolveFixedMapLink(ref context, ref enu),
+                4 => this.TryResolveFixedItemLink(ref context, ref enu),
+                5 => this.TryResolveFixedChatSoundEffect(ref context, ref enu),
+                6 => this.TryResolveFixedObjStr(ref context, ref enu),
+                7 => this.TryResolveFixedString(ref context, ref enu),
+                8 => this.TryResolveFixedTimeRemaining(ref context, ref enu),
+                // Reads a uint and saves it to PronounModule+0x3AC
+                // TODO: handle this? looks like it's for the mentor/beginner icon of the player link in novice network
+                // see "FF 50 50 8B B0"
+                9 => true,
+                10 => this.TryResolveFixedStatusLink(ref context, ref enu),
+                11 => this.TryResolveFixedPartyFinderLink(ref context, ref enu),
+                12 => this.TryResolveFixedQuestLink(ref context, ref enu),
+                _ => false,
+            },
+            _ => this.TryResolveFixedAutoTranslation(ref context, payload, e0Val, e1Val),
+        };
+    }
+
+    private unsafe bool TryResolveFixedPlayerLink(ref SeStringContext context, ref ReadOnlySePayloadSpan.Enumerator enu)
+    {
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var worldId))
+            return false;
+
+        if (!enu.MoveNext() || !enu.Current.TryGetString(out var playerName))
+            return false;
+
+        if (UIGlobals.IsValidPlayerCharacterName(playerName.ExtractText()))
+        {
+            var flags = 0u;
+            if (InfoModule.Instance()->IsInCrossWorldDuty())
+                flags |= 0x10;
+
+            context.Builder.PushLink(LinkMacroPayloadType.Character, flags, worldId, 0u, playerName);
+            context.Builder.Append(playerName);
+            context.Builder.PopLink();
+        }
+        else
+        {
+            context.Builder.Append(playerName);
+        }
+
+        if (worldId == AgentLobby.Instance()->LobbyData.HomeWorldId)
+            return true;
+
+        if (!this.dataManager.GetExcelSheet<World>(context.Language).TryGetRow(worldId, out var worldRow))
+            return false;
+
+        context.Builder.AppendIcon(88);
+        context.Builder.Append(worldRow.Name);
+
+        return true;
+    }
+
+    private bool TryResolveFixedClassJobLevel(ref SeStringContext context, ref ReadOnlySePayloadSpan.Enumerator enu)
+    {
+        if (!enu.MoveNext() || !this.TryResolveInt(ref context, enu.Current, out var classJobId) || classJobId <= 0)
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveInt(ref context, enu.Current, out var level))
+            return false;
+
+        if (!this.dataManager.GetExcelSheet<ClassJob>(context.Language).TryGetRow((uint)classJobId, out var classJobRow))
+            return false;
+
+        context.Builder.Append(classJobRow.Name);
+
+        if (level != 0)
+        {
+            context.Builder.Append('(');
+            context.Builder.Append(level.ToString("D", CultureInfo.InvariantCulture));
+            context.Builder.Append(')');
+        }
+
+        return true;
+    }
+
+    private bool TryResolveFixedMapLink(ref SeStringContext context, ref ReadOnlySePayloadSpan.Enumerator enu)
+    {
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var territoryTypeId))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var packedIds))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveInt(ref context, enu.Current, out var rawX))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveInt(ref context, enu.Current, out var rawY))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveInt(ref context, enu.Current, out var rawZ))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var placeNameIdInt))
+            return false;
+
+        var instance = packedIds >> 0x10;
+        var mapId = packedIds & 0xFF;
+
+        if (this.dataManager.GetExcelSheet<TerritoryType>(context.Language).TryGetRow(territoryTypeId, out var territoryTypeRow))
+        {
+            if (!this.dataManager.GetExcelSheet<PlaceName>(context.Language).TryGetRow(placeNameIdInt == 0 ? territoryTypeRow.PlaceName.RowId : placeNameIdInt, out var placeNameRow))
+                return false;
+
+            if (!this.dataManager.GetExcelSheet<Lumina.Excel.Sheets.Map>().TryGetRow(mapId, out var mapRow))
+                return false;
+
+            var sb = SeStringBuilder.SharedPool.Get();
+
+            sb.Append(placeNameRow.Name);
+            if (instance > 0 && instance <= 9)
+                sb.Append((char)((char)0xE0B0 + (char)instance));
+
+            var placeNameWithInstance = sb.ToReadOnlySeString();
+            SeStringBuilder.SharedPool.Return(sb);
+
+            var mapPosX = ConvertRawToMapPosX(mapRow, rawX / 1000f);
+            var mapPosY = ConvertRawToMapPosY(mapRow, rawY / 1000f);
+
+            ReadOnlySeString linkText;
+            if (rawZ == -30000)
+            {
+                linkText = this.EvaluateFromAddon(1635, [placeNameWithInstance, mapPosX, mapPosY], context.Language);
+            }
+            else
+            {
+                linkText = this.EvaluateFromAddon(1636, [placeNameWithInstance, mapPosX, mapPosY, rawZ / (rawZ >= 0 ? 10 : -10), rawZ], context.Language);
+            }
+
+            context.Builder.PushLinkMapPosition(territoryTypeId, mapId, rawX, rawY);
+            context.Builder.Append(this.EvaluateFromAddon(371, [linkText], context.Language));
+            context.Builder.PopLink();
+
+            return true;
+        }
+        else if (mapId == 0)
+        {
+            if (this.dataManager.GetExcelSheet<AddonSheet>(context.Language).TryGetRow(875, out var addonRow)) // "(No location set for map link)"
+                context.Builder.Append(addonRow.Text);
+
+            return true;
+        }
+        else if (mapId == 1)
+        {
+            if (this.dataManager.GetExcelSheet<AddonSheet>(context.Language).TryGetRow(874, out var addonRow)) // "(Map link unavailable in this area)"
+                context.Builder.Append(addonRow.Text);
+
+            return true;
+        }
+        else if (mapId == 2)
+        {
+            if (this.dataManager.GetExcelSheet<AddonSheet>(context.Language).TryGetRow(13743, out var addonRow)) // "(Unable to set map link)"
+                context.Builder.Append(addonRow.Text);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryResolveFixedItemLink(ref SeStringContext context, ref ReadOnlySePayloadSpan.Enumerator enu)
+    {
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var itemId))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var rarity))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveInt(ref context, enu.Current, out var unk2))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveInt(ref context, enu.Current, out var unk3))
+            return false;
+
+        if (!enu.MoveNext() || !enu.Current.TryGetString(out var itemName)) // TODO: unescape??
+            return false;
+
+        // rarity color start
+        context.Builder.Append(this.EvaluateFromAddon(6, [rarity], context.Language));
+
+        var v2 = (ushort)((unk2 & 0xFF) + (unk3 << 0x10)); // TODO: find out what this does
+
+        context.Builder.PushLink(LinkMacroPayloadType.Item, itemId, rarity, v2);
+
+        // arrow and item name
+        context.Builder.Append(this.EvaluateFromAddon(371, [itemName], context.Language));
+
+        context.Builder.PopLink();
+        context.Builder.PopColor();
+
+        return true;
+    }
+
+    private bool TryResolveFixedChatSoundEffect(ref SeStringContext context, ref ReadOnlySePayloadSpan.Enumerator enu)
+    {
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var soundEffectId))
+            return false;
+
+        context.Builder.Append($"<se.{soundEffectId + 1}>");
+
+        // the game would play it here
+
+        return true;
+    }
+
+    private bool TryResolveFixedObjStr(ref SeStringContext context, ref ReadOnlySePayloadSpan.Enumerator enu)
+    {
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var objStrId))
+            return false;
+
+        context.Builder.Append(this.EvaluateFromAddon(2025, [objStrId], context.Language));
+
+        return true;
+    }
+
+    private bool TryResolveFixedString(ref SeStringContext context, ref ReadOnlySePayloadSpan.Enumerator enu)
+    {
+        if (!enu.MoveNext() || !enu.Current.TryGetString(out var text))
+            return false;
+
+        // formats it through vsprintf using "%s"??
+        context.Builder.Append(text.ExtractText());
+
+        return true;
+    }
+
+    private bool TryResolveFixedTimeRemaining(ref SeStringContext context, ref ReadOnlySePayloadSpan.Enumerator enu)
+    {
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var seconds))
+            return false;
+
+        if (seconds != 0)
+        {
+            context.Builder.Append(this.EvaluateFromAddon(33, [seconds / 60, seconds % 60], context.Language));
+        }
+        else
+        {
+            if (this.dataManager.GetExcelSheet<AddonSheet>(context.Language).TryGetRow(48, out var addonRow))
+                context.Builder.Append(addonRow.Text);
+        }
+
+        return true;
+    }
+
+    private bool TryResolveFixedStatusLink(ref SeStringContext context, ref ReadOnlySePayloadSpan.Enumerator enu)
+    {
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var statusId))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveBool(ref context, enu.Current, out var hasOverride))
+            return false;
+
+        if (!this.dataManager.GetExcelSheet<Lumina.Excel.Sheets.Status>(context.Language).TryGetRow(statusId, out var statusRow))
+            return false;
+
+        ReadOnlySeStringSpan statusName;
+        ReadOnlySeStringSpan statusDescription;
+
+        if (hasOverride)
+        {
+            if (!enu.MoveNext() || !enu.Current.TryGetString(out statusName))
+                return false;
+
+            if (!enu.MoveNext() || !enu.Current.TryGetString(out statusDescription))
+                return false;
+        }
+        else
+        {
+            statusName = statusRow.Name.AsSpan();
+            statusDescription = statusRow.Description.AsSpan();
+        }
+
+        var sb = SeStringBuilder.SharedPool.Get();
+
+        if (statusRow.StatusCategory == 1)
+        {
+            sb.Append(this.EvaluateFromAddon(376, null, context.Language));
+        }
+        else if (statusRow.StatusCategory == 2)
+        {
+            sb.Append(this.EvaluateFromAddon(377, null, context.Language));
+        }
+
+        sb.Append(statusName);
+
+        var linkText = sb.ToReadOnlySeString();
+        SeStringBuilder.SharedPool.Return(sb);
+
+        context.Builder
+           .BeginMacro(MacroCode.Link)
+            .AppendUIntExpression((uint)LinkMacroPayloadType.Status)
+            .AppendUIntExpression(statusId)
+            .AppendUIntExpression(0)
+            .AppendUIntExpression(0)
+            .AppendStringExpression(statusName)
+            .AppendStringExpression(statusDescription)
+            .EndMacro();
+
+        context.Builder.Append(this.EvaluateFromAddon(371, [linkText], context.Language));
+
+        context.Builder.PopLink();
+
+        return true;
+    }
+
+    private bool TryResolveFixedPartyFinderLink(ref SeStringContext context, ref ReadOnlySePayloadSpan.Enumerator enu)
+    {
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var listingId))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var unk1))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var worldId))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveInt(ref context, enu.Current, out var crossWorldFlag)) // 0 = cross world, 1 = not cross world
+            return false;
+
+        if (!enu.MoveNext() || !enu.Current.TryGetString(out var playerName))
+            return false;
+
+        context.Builder
+           .BeginMacro(MacroCode.Link)
+            .AppendUIntExpression((uint)LinkMacroPayloadType.PartyFinder)
+            .AppendUIntExpression(listingId)
+            .AppendUIntExpression(unk1)
+            .AppendUIntExpression((uint)(crossWorldFlag << 0x10) + worldId)
+            .EndMacro();
+
+        context.Builder.Append(this.EvaluateFromAddon(371, [this.EvaluateFromAddon(2265, [playerName, crossWorldFlag], context.Language)], context.Language));
+
+        context.Builder.PopLink();
+
+        return true;
+    }
+
+    private bool TryResolveFixedQuestLink(ref SeStringContext context, ref ReadOnlySePayloadSpan.Enumerator enu)
+    {
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var questId))
+            return false;
+
+        if (!enu.MoveNext() || !enu.MoveNext() || !enu.MoveNext()) // unused
+            return false;
+
+        if (!enu.MoveNext() || !enu.Current.TryGetString(out var questName))
+            return false;
+
+        /* TODO: hide incomplete, repeatable special event quest names
+        if (!QuestManager.IsQuestComplete(questId) && !QuestManager.Instance()->IsQuestAccepted(questId))
+        {
+            var questRecompleteManager = QuestRecompleteManager.Instance();
+            if (questRecompleteManager == null || !questRecompleteManager->"E8 ?? ?? ?? ?? 0F B6 57 FF"(questId)) {
+                if (_excelService.TryGetRow<AddonSheet>(5497, context.Language, out var addonRow))
+                    questName = addonRow.Text.AsSpan();
+            }
+        }
+        */
+
+        context.Builder
+           .BeginMacro(MacroCode.Link)
+            .AppendUIntExpression((uint)LinkMacroPayloadType.Quest)
+            .AppendUIntExpression(questId)
+            .AppendUIntExpression(0)
+            .AppendUIntExpression(0)
+            .EndMacro();
+
+        context.Builder.Append(this.EvaluateFromAddon(371, [questName], context.Language));
+
+        context.Builder.PopLink();
+
+        return true;
+    }
+
+    private bool TryResolveFixedAutoTranslation(ref SeStringContext context, in ReadOnlySePayloadSpan payload, int e0Val, int e1Val)
+    {
+        // Auto-Translation / Completion
+        var group = (uint)(e0Val + 1);
+        var rowId = (uint)e1Val;
+
+        using var icons = new IconWrap(ref context.Builder, 54, 55);
+
+        if (!this.dataManager.GetExcelSheet<Completion>(context.Language).TryGetFirst(row => row.Group == group && !row.LookupTable.IsEmpty, out var groupRow))
+            return false;
+
+        var lookupTable = (
+            groupRow.LookupTable.IsTextOnly()
+                ? groupRow.LookupTable
+                : this.Evaluate(groupRow.LookupTable.AsSpan(), context.LocalParameters, context.Language)).ExtractText();
+
+        // Completion sheet
+        if (lookupTable.Equals("@"))
+        {
+            if (this.dataManager.GetExcelSheet<Completion>(context.Language).TryGetRow(rowId, out var completionRow))
+            {
+                context.Builder.Append(completionRow.Text);
+            }
+
+            return true;
+        }
+
+        // CategoryDataCache
+        else if (lookupTable.Equals("#"))
+        {
+            // couldn't find any, so we don't handle them :p
+            context.Builder.Append(payload);
+            return false;
+        }
+
+        // All other sheets
+        var rangesStart = lookupTable.IndexOf('[');
+        RawRow row = default;
+        if (rangesStart == -1) // Sheet without ranges
+        {
+            if (this.dataManager.GetExcelSheet<RawRow>(context.Language, lookupTable).TryGetRow(rowId, out row))
+            {
+                context.Builder.Append(row.ReadStringColumn(0));
+                return true;
+            }
+        }
+
+        var sheetName = lookupTable[..rangesStart];
+        var ranges = lookupTable[(rangesStart + 1)..(lookupTable.Length - 1)];
+        if (ranges.Length == 0)
+            return true;
+
+        var isNoun = false;
+        var col = 0;
+
+        if (ranges.StartsWith("noun"))
+        {
+            isNoun = true;
+        }
+        else if (ranges.StartsWith("col"))
+        {
+            var colRangeEnd = ranges.IndexOf(',');
+            if (colRangeEnd == -1)
+                colRangeEnd = ranges.Length;
+
+            col = int.Parse(ranges[4..colRangeEnd]);
+        }
+        else if (ranges.StartsWith("tail"))
+        {
+            // couldn't find any, so we don't handle them :p
+            context.Builder.Append(payload);
+            return false;
+        }
+
+        if (isNoun && context.Language == ClientLanguage.German && sheetName == "Companion")
+        {
+            context.Builder.Append(this.nounProcessor.ProcessNoun(sheetName, rowId, ClientLanguage.German, 1, 5));
+        }
+        else if (this.dataManager.GetExcelSheet<RawRow>(context.Language, sheetName).TryGetRow(rowId, out row))
+        {
+            context.Builder.Append(row.ReadStringColumn(col));
+        }
+
+        return true;
+    }
+
+    private bool TryResolveLower(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eStr))
+            return false;
+
+        var builder = SeStringBuilder.SharedPool.Get();
+
+        try
+        {
+            var headContext = new SeStringContext(ref builder, context.LocalParameters, context.Language);
+
+            if (!this.ResolveStringExpression(ref headContext, eStr))
+                return false;
+
+            var str = builder.ToReadOnlySeString();
+
+            foreach (var p in str)
+            {
+                if (p.Type == ReadOnlySePayloadType.Invalid)
+                    continue;
+
+                if (p.Type == ReadOnlySePayloadType.Text)
+                {
+                    context.Builder.Append(Encoding.UTF8.GetString(p.Body.ToArray()).ToLower(context.CultureInfo));
+
+                    continue;
+                }
+
+                context.Builder.Append(p);
+            }
+
+            return true;
+        }
+        finally
+        {
+            SeStringBuilder.SharedPool.Return(builder);
+        }
+    }
+
+    private bool TryResolveNoun(ClientLanguage language, ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        var eAmountVal = 1;
+        var eCaseVal = 1;
+
+        var enu = payload.GetEnumerator();
+
+        if (!enu.MoveNext() || !enu.Current.TryGetString(out var eSheetNameStr))
+            return false;
+
+        var sheetName = this.Evaluate(eSheetNameStr, context.LocalParameters, context.Language).ExtractText();
+
+        if (!enu.MoveNext() || !this.TryResolveInt(ref context, enu.Current, out var eArticleTypeVal))
+            return false;
+
+        if (!enu.MoveNext() || !this.TryResolveUInt(ref context, enu.Current, out var eRowIdVal))
+            return false;
+
+        this.sheetRedirectResolver.Resolve(ref sheetName, ref eRowIdVal);
+
+        if (string.IsNullOrEmpty(sheetName))
+            return false;
+
+        // optional arguments
+        if (enu.MoveNext())
+        {
+            if (!this.TryResolveInt(ref context, enu.Current, out eAmountVal))
+                return false;
+
+            if (enu.MoveNext())
+            {
+                if (!this.TryResolveInt(ref context, enu.Current, out eCaseVal))
+                    return false;
+
+                // For Chinese texts?
+                /*
+                if (enu.MoveNext())
+                {
+                    var eUnkInt5 = enu.Current;
+                    if (!TryResolveInt(ref context, eUnkInt5, out eUnkInt5Val))
+                        return false;
+                }
+                */
+            }
+        }
+
+        context.Builder.Append(this.nounProcessor.ProcessNoun(sheetName, eRowIdVal, language, eAmountVal, eArticleTypeVal, eCaseVal - 1));
+
+        return true;
+    }
+
+    private bool TryResolveLowerHead(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eStr))
+            return false;
+
+        var builder = SeStringBuilder.SharedPool.Get();
+
+        try
+        {
+            var headContext = new SeStringContext(ref builder, context.LocalParameters, context.Language);
+
+            if (!this.ResolveStringExpression(ref headContext, eStr))
+                return false;
+
+            var str = builder.ToReadOnlySeString();
+            var pIdx = 0;
+
+            foreach (var p in str)
+            {
+                pIdx++;
+
+                if (p.Type == ReadOnlySePayloadType.Invalid)
+                    continue;
+
+                if (pIdx == 1 && p.Type == ReadOnlySePayloadType.Text)
+                {
+                    context.Builder.Append(Encoding.UTF8.GetString(p.Body.ToArray()).FirstCharToLower());
+                    continue;
+                }
+
+                context.Builder.Append(p);
+            }
+
+            return true;
+        }
+        finally
+        {
+            SeStringBuilder.SharedPool.Return(builder);
+        }
+    }
+
+    private bool TryResolveColorType(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eColorType) || !this.TryResolveUInt(ref context, eColorType, out var eColorTypeVal))
+            return false;
+
+        if (eColorTypeVal == 0)
+            context.Builder.PopColor();
+        else if (this.dataManager.GetExcelSheet<UIColor>().TryGetRow(eColorTypeVal, out var row))
+            context.Builder.PushColorBgra(row.UIForeground >> 8 | row.UIForeground << 24);
+
+        return true;
+    }
+
+    private bool TryResolveEdgeColorType(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eColorType) || !this.TryResolveUInt(ref context, eColorType, out var eColorTypeVal))
+            return false;
+
+        if (eColorTypeVal == 0)
+            context.Builder.PopEdgeColor();
+        else if (this.dataManager.GetExcelSheet<UIColor>().TryGetRow(eColorTypeVal, out var row))
+            context.Builder.PushEdgeColorBgra(row.UIForeground >> 8 | row.UIForeground << 24);
+
+        return true;
+    }
+
+    private bool TryResolveDigit(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eValue, out var eTargetLength))
+            return false;
+
+        if (!this.TryResolveInt(ref context, eValue, out var eValueVal))
+            return false;
+
+        if (!this.TryResolveInt(ref context, eTargetLength, out var eTargetLengthVal))
+            return false;
+
+        context.Builder.Append(eValueVal.ToString(new string('0', eTargetLengthVal)));
+
+        return true;
+    }
+
+    private bool TryResolveOrdinal(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eValue) || !this.TryResolveUInt(ref context, eValue, out var eValueVal))
+            return false;
+
+        if (MathF.Floor(eValueVal / 10f) % 10 == 1)
+        {
+            context.Builder.Append($"{eValueVal}th");
+            return true;
+        }
+
+        context.Builder.Append($"{eValueVal}{(eValueVal % 10) switch
+        {
+            1 => "st",
+            2 => "nd",
+            3 => "rd",
+            _ => "th",
+        }}");
+        return true;
+    }
+
+    private bool TryResolveLevelPos(ref SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var eLevel) || !this.TryResolveUInt(ref context, eLevel, out var eLevelVal))
+            return false;
+
+        if (!this.dataManager.GetExcelSheet<Level>(context.Language).TryGetRow(eLevelVal, out var level) || !level.Map.IsValid)
+            return false;
+
+        if (!this.dataManager.GetExcelSheet<PlaceName>(context.Language).TryGetRow(level.Map.Value.PlaceName.RowId, out var placeName))
+            return false;
+
+        var mapPosX = ConvertRawToMapPosX(level.Map.Value, level.X);
+        var mapPosY = ConvertRawToMapPosY(level.Map.Value, level.Z); // Z is [sic]
+
+        context.Builder.Append(
+            this.EvaluateFromAddon(
+                1637,
+                [placeName.Name, mapPosX, mapPosY],
+                context.Language));
+
+        return true;
+    }
+
+    private unsafe bool TryGetGNumDefault(uint parameterIndex, out uint value)
+    {
+        value = 0u;
+
+        var rtm = RaptureTextModule.Instance();
+        if (rtm is null)
+            return false;
+
+        if (!ThreadSafety.IsMainThread)
+        {
+            Log.Error("Global parameters may only be used from the main thread.");
+            return false;
+        }
+
+        ref var gp = ref rtm->TextModule.MacroDecoder.GlobalParameters;
+        if (parameterIndex >= gp.MySize)
+            return false;
+
+        var p = rtm->TextModule.MacroDecoder.GlobalParameters[parameterIndex];
+        switch (p.Type)
+        {
+            case TextParameterType.Integer:
+                value = (uint)p.IntValue;
+                return true;
+
+            case TextParameterType.ReferencedUtf8String:
+                Log.Error("Requested a number; Utf8String global parameter at {parameterIndex}.", parameterIndex);
+                return false;
+
+            case TextParameterType.String:
+                Log.Error("Requested a number; string global parameter at {parameterIndex}.", parameterIndex);
+                return false;
+
+            case TextParameterType.Uninitialized:
+                Log.Error("Requested a number; uninitialized global parameter at {parameterIndex}.", parameterIndex);
+                return false;
+
+            default:
+                return false;
+        }
+    }
+
+    private unsafe bool TryProduceGStrDefault(ref SeStringBuilder builder, ClientLanguage language, uint parameterIndex)
+    {
+        var rtm = RaptureTextModule.Instance();
+        if (rtm is null)
+            return false;
+
+        ref var gp = ref rtm->TextModule.MacroDecoder.GlobalParameters;
+        if (parameterIndex >= gp.MySize)
+            return false;
+
+        if (!ThreadSafety.IsMainThread)
+        {
+            Log.Error("Global parameters may only be used from the main thread.");
+            return false;
+        }
+
+        var p = rtm->TextModule.MacroDecoder.GlobalParameters[parameterIndex];
+        switch (p.Type)
+        {
+            case TextParameterType.Integer:
+                builder.Append(p.IntValue.ToString());
+                return true;
+
+            case TextParameterType.ReferencedUtf8String:
+                builder.Append(this.Evaluate(new ReadOnlySeStringSpan(p.ReferencedUtf8StringValue->Utf8String.AsSpan()), null, language));
+                return false;
+
+            case TextParameterType.String:
+                builder.Append(this.Evaluate(new ReadOnlySeStringSpan(p.StringValue), null, language));
+                return false;
+
+            case TextParameterType.Uninitialized:
+            default:
+                return false;
+        }
+    }
+
+    private unsafe bool TryResolveUInt(ref SeStringContext context, in ReadOnlySeExpressionSpan expression, out uint value)
+    {
+        if (expression.TryGetUInt(out value))
+            return true;
+
+        if (expression.TryGetPlaceholderExpression(out var exprType))
+        {
+            // if (context.TryGetPlaceholderNum(exprType, out value))
+            //     return true;
+
+            switch ((ExpressionType)exprType)
+            {
+                case ExpressionType.Millisecond:
+                    value = (uint)DateTime.Now.Millisecond;
+                    return true;
+                case ExpressionType.Second:
+                    value = (uint)MacroDecoder.GetMacroTime()->tm_sec;
+                    return true;
+                case ExpressionType.Minute:
+                    value = (uint)MacroDecoder.GetMacroTime()->tm_min;
+                    return true;
+                case ExpressionType.Hour:
+                    value = (uint)MacroDecoder.GetMacroTime()->tm_hour;
+                    return true;
+                case ExpressionType.Day:
+                    value = (uint)MacroDecoder.GetMacroTime()->tm_mday;
+                    return true;
+                case ExpressionType.Weekday:
+                    value = (uint)MacroDecoder.GetMacroTime()->tm_wday;
+                    return true;
+                case ExpressionType.Month:
+                    value = (uint)MacroDecoder.GetMacroTime()->tm_mon + 1;
+                    return true;
+                case ExpressionType.Year:
+                    value = (uint)MacroDecoder.GetMacroTime()->tm_year + 1900;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        if (expression.TryGetParameterExpression(out exprType, out var operand1))
+        {
+            if (!this.TryResolveUInt(ref context, operand1, out var paramIndex))
+                return false;
+            if (paramIndex == 0)
+                return false;
+            paramIndex--;
+            return (ExpressionType)exprType switch
+            {
+                ExpressionType.LocalNumber => context.TryGetLNum((int)paramIndex, out value), // lnum
+                ExpressionType.GlobalNumber => this.TryGetGNumDefault(paramIndex, out value), // gnum
+                _ => false, // gstr, lstr
+            };
+        }
+
+        if (expression.TryGetBinaryExpression(out exprType, out operand1, out var operand2))
+        {
+            switch ((ExpressionType)exprType)
+            {
+                case ExpressionType.GreaterThanOrEqualTo:
+                case ExpressionType.GreaterThan:
+                case ExpressionType.LessThanOrEqualTo:
+                case ExpressionType.LessThan:
+                    if (!this.TryResolveInt(ref context, operand1, out var value1)
+                        || !this.TryResolveInt(ref context, operand2, out var value2))
+                    {
+                        return false;
+                    }
+
+                    value = (ExpressionType)exprType switch
+                    {
+                        ExpressionType.GreaterThanOrEqualTo => value1 >= value2 ? 1u : 0u,
+                        ExpressionType.GreaterThan => value1 > value2 ? 1u : 0u,
+                        ExpressionType.LessThanOrEqualTo => value1 <= value2 ? 1u : 0u,
+                        ExpressionType.LessThan => value1 < value2 ? 1u : 0u,
+                        _ => 0u,
+                    };
+                    return true;
+
+                case ExpressionType.Equal:
+                case ExpressionType.NotEqual:
+                    if (this.TryResolveInt(ref context, operand1, out value1) && this.TryResolveInt(ref context, operand2, out value2))
+                    {
+                        if ((ExpressionType)exprType == ExpressionType.Equal)
+                            value = value1 == value2 ? 1u : 0u;
+                        else
+                            value = value1 == value2 ? 0u : 1u;
+                        return true;
+                    }
+
+                    if (operand1.TryGetString(out var strval1) && operand2.TryGetString(out var strval2))
+                    {
+                        var resolvedStr1 = this.Evaluate(strval1, context.LocalParameters, context.Language);
+                        var resolvedStr2 = this.Evaluate(strval2, context.LocalParameters, context.Language);
+                        var equals = resolvedStr1.Equals(resolvedStr2);
+
+                        if ((ExpressionType)exprType == ExpressionType.Equal)
+                            value = equals ? 1u : 0u;
+                        else
+                            value = equals ? 0u : 1u;
+                        return true;
+                    }
+
+                    // compare int with string, string with int??
+
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        if (expression.TryGetString(out var str))
+        {
+            var evaluatedStr = this.Evaluate(str, context.LocalParameters, context.Language);
+
+            foreach (var payload in evaluatedStr)
+            {
+                if (!payload.TryGetExpression(out var expr))
+                    return false;
+
+                return this.TryResolveUInt(ref context, expr, out value);
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryResolveInt(ref SeStringContext context, in ReadOnlySeExpressionSpan expression, out int value)
+    {
+        if (this.TryResolveUInt(ref context, expression, out var u32))
+        {
+            value = (int)u32;
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryResolveBool(ref SeStringContext context, in ReadOnlySeExpressionSpan expression, out bool value)
+    {
+        if (this.TryResolveUInt(ref context, expression, out var u32))
+        {
+            value = u32 != 0;
+            return true;
+        }
+
+        value = false;
+        return false;
+    }
+
+    private bool ResolveStringExpression(ref SeStringContext context, in ReadOnlySeExpressionSpan expression)
+    {
+        uint u32;
+
+        if (expression.TryGetString(out var innerString))
+        {
+            context.Builder.Append(this.Evaluate(innerString, context.LocalParameters, context.Language));
+            return true;
+        }
+
+        /*
+        if (expression.TryGetPlaceholderExpression(out var exprType))
+        {
+            if (context.TryProducePlaceholder(ref context, exprType))
+                return true;
+        }
+        */
+
+        if (expression.TryGetParameterExpression(out var exprType, out var operand1))
+        {
+            if (!this.TryResolveUInt(ref context, operand1, out var paramIndex))
+                return false;
+            if (paramIndex == 0)
+                return false;
+            paramIndex--;
+            switch ((ExpressionType)exprType)
+            {
+                case ExpressionType.LocalNumber: // lnum
+                    if (!context.TryGetLNum((int)paramIndex, out u32))
+                        return false;
+
+                    context.Builder.Append(unchecked((int)u32).ToString());
+                    return true;
+
+                case ExpressionType.LocalString: // lstr
+                    if (!context.TryGetLStr((int)paramIndex, out var str))
+                        return false;
+
+                    context.Builder.Append(str);
+                    return true;
+
+                case ExpressionType.GlobalNumber: // gnum
+                    if (!this.TryGetGNumDefault(paramIndex, out u32))
+                        return false;
+
+                    context.Builder.Append(unchecked((int)u32).ToString());
+                    return true;
+
+                case ExpressionType.GlobalString: // gstr
+                    return this.TryProduceGStrDefault(ref context.Builder, context.Language, paramIndex);
+
+                default:
+                    return false;
+            }
+        }
+
+        // Handles UInt and Binary expressions
+        if (!this.TryResolveUInt(ref context, expression, out u32))
+            return false;
+
+        context.Builder.Append(((int)u32).ToString());
+        return true;
+    }
+}

--- a/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
@@ -726,62 +726,61 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
         switch (column.Type)
         {
             case ExcelColumnDataType.String:
-                context.Builder.Append(
-                    $"{this.Evaluate(row.ReadString(column.Offset), [eColParamValue], context.Language)}");
+                context.Builder.Append(this.Evaluate(row.ReadString(column.Offset), [eColParamValue], context.Language));
                 return true;
             case ExcelColumnDataType.Bool:
-                context.Builder.Append($"{(row.ReadBool(column.Offset) ? 1u : 0):D}");
+                context.Builder.Append((row.ReadBool(column.Offset) ? 1u : 0).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.Int8:
-                context.Builder.Append($"{row.ReadInt8(column.Offset):D}");
+                context.Builder.Append(row.ReadInt8(column.Offset).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.UInt8:
-                context.Builder.Append($"{row.ReadUInt8(column.Offset):D}");
+                context.Builder.Append(row.ReadUInt8(column.Offset).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.Int16:
-                context.Builder.Append($"{row.ReadInt16(column.Offset):D}");
+                context.Builder.Append(row.ReadInt16(column.Offset).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.UInt16:
-                context.Builder.Append($"{row.ReadUInt16(column.Offset):D}");
+                context.Builder.Append(row.ReadUInt16(column.Offset).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.Int32:
-                context.Builder.Append($"{row.ReadInt32(column.Offset):D}");
+                context.Builder.Append(row.ReadInt32(column.Offset).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.UInt32:
-                context.Builder.Append($"{row.ReadUInt32(column.Offset):D}");
+                context.Builder.Append(row.ReadUInt32(column.Offset).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.Float32:
-                context.Builder.Append($"{row.ReadFloat32(column.Offset):D}");
+                context.Builder.Append(row.ReadFloat32(column.Offset).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.Int64:
-                context.Builder.Append($"{row.ReadInt64(column.Offset):D}");
+                context.Builder.Append(row.ReadInt64(column.Offset).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.UInt64:
-                context.Builder.Append($"{row.ReadUInt64(column.Offset):D}");
+                context.Builder.Append(row.ReadUInt64(column.Offset).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.PackedBool0:
-                context.Builder.Append($"{(row.ReadPackedBool(column.Offset, 0) ? 1u : 0):D}");
+                context.Builder.Append((row.ReadPackedBool(column.Offset, 0) ? 1u : 0).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.PackedBool1:
-                context.Builder.Append($"{(row.ReadPackedBool(column.Offset, 1) ? 1u : 0):D}");
+                context.Builder.Append((row.ReadPackedBool(column.Offset, 1) ? 1u : 0).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.PackedBool2:
-                context.Builder.Append($"{(row.ReadPackedBool(column.Offset, 2) ? 1u : 0):D}");
+                context.Builder.Append((row.ReadPackedBool(column.Offset, 2) ? 1u : 0).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.PackedBool3:
-                context.Builder.Append($"{(row.ReadPackedBool(column.Offset, 3) ? 1u : 0):D}");
+                context.Builder.Append((row.ReadPackedBool(column.Offset, 3) ? 1u : 0).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.PackedBool4:
-                context.Builder.Append($"{(row.ReadPackedBool(column.Offset, 4) ? 1u : 0):D}");
+                context.Builder.Append((row.ReadPackedBool(column.Offset, 4) ? 1u : 0).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.PackedBool5:
-                context.Builder.Append($"{(row.ReadPackedBool(column.Offset, 5) ? 1u : 0):D}");
+                context.Builder.Append((row.ReadPackedBool(column.Offset, 5) ? 1u : 0).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.PackedBool6:
-                context.Builder.Append($"{(row.ReadPackedBool(column.Offset, 6) ? 1u : 0):D}");
+                context.Builder.Append((row.ReadPackedBool(column.Offset, 6) ? 1u : 0).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             case ExcelColumnDataType.PackedBool7:
-                context.Builder.Append($"{(row.ReadPackedBool(column.Offset, 7) ? 1u : 0):D}");
+                context.Builder.Append((row.ReadPackedBool(column.Offset, 7) ? 1u : 0).ToString("D", CultureInfo.InvariantCulture));
                 return true;
             default:
                 return false;

--- a/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
@@ -1539,7 +1539,7 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
                 Quantity = eAmountVal,
                 ArticleType = eArticleTypeVal,
                 GrammaticalCase = eCaseVal - 1,
-                IsItemSheet = flags.HasFlag(SheetRedirectFlags.Item),
+                IsActionSheet = flags.HasFlag(SheetRedirectFlags.Action),
             }));
 
         return true;

--- a/Dalamud/Game/Text/Evaluator/SeStringParameter.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringParameter.cs
@@ -50,7 +50,7 @@ public readonly struct SeStringParameter
     /// <summary>
     /// Gets a numeric value.
     /// </summary>
-    public uint UIntValue => this.IsString ? uint.TryParse(this.str.ExtractText(), out var value) ? value : 0 : this.num;
+    public uint UIntValue => this.IsString ? (uint.TryParse(this.str.ExtractText(), out var value) ? value : 0) : this.num;
 
     /// <summary>
     /// Gets a string value.

--- a/Dalamud/Game/Text/Evaluator/SeStringParameter.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringParameter.cs
@@ -1,0 +1,73 @@
+using Lumina.Text.ReadOnly;
+
+using DSeString = Dalamud.Game.Text.SeStringHandling.SeString;
+using LSeString = Lumina.Text.SeString;
+
+namespace Dalamud.Game.Text.Evaluator;
+
+/// <summary>
+/// A wrapper for a local parameter, holding either a number or a string.
+/// </summary>
+public readonly struct SeStringParameter
+{
+    private readonly uint num;
+    private readonly ReadOnlySeString str;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SeStringParameter"/> struct for a number parameter.
+    /// </summary>
+    /// <param name="value">The number value.</param>
+    public SeStringParameter(uint value)
+    {
+        this.num = value;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SeStringParameter"/> struct for a string parameter.
+    /// </summary>
+    /// <param name="value">The string value.</param>
+    public SeStringParameter(ReadOnlySeString value)
+    {
+        this.str = value;
+        this.IsString = true;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SeStringParameter"/> struct for a string parameter.
+    /// </summary>
+    /// <param name="value">The string value.</param>
+    public SeStringParameter(string value)
+    {
+        this.str = new ReadOnlySeString(value);
+        this.IsString = true;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the backing type of this parameter is a string.
+    /// </summary>
+    public bool IsString { get; }
+
+    /// <summary>
+    /// Gets a numeric value.
+    /// </summary>
+    public uint UIntValue => this.IsString ? uint.TryParse(this.str.ExtractText(), out var value) ? value : 0 : this.num;
+
+    /// <summary>
+    /// Gets a string value.
+    /// </summary>
+    public ReadOnlySeString StringValue => this.IsString ? this.str : new ReadOnlySeString(this.num.ToString());
+
+    public static implicit operator SeStringParameter(int value) => new((uint)value);
+
+    public static implicit operator SeStringParameter(uint value) => new(value);
+
+    public static implicit operator SeStringParameter(ReadOnlySeString value) => new(value);
+
+    public static implicit operator SeStringParameter(ReadOnlySeStringSpan value) => new(new ReadOnlySeString(value));
+
+    public static implicit operator SeStringParameter(LSeString value) => new(new ReadOnlySeString(value.RawData));
+
+    public static implicit operator SeStringParameter(DSeString value) => new(new ReadOnlySeString(value.Encode()));
+
+    public static implicit operator SeStringParameter(string value) => new(value);
+}

--- a/Dalamud/Game/Text/Noun/Enums/EnglishArticleType.cs
+++ b/Dalamud/Game/Text/Noun/Enums/EnglishArticleType.cs
@@ -1,0 +1,17 @@
+namespace Dalamud.Game.Text.Noun.Enums;
+
+/// <summary>
+/// Article types for <see cref="ClientLanguage.English"/>.
+/// </summary>
+public enum EnglishArticleType
+{
+    /// <summary>
+    /// Indefinite article (a, an).
+    /// </summary>
+    Indefinite = 1,
+
+    /// <summary>
+    /// Definite article (the).
+    /// </summary>
+    Definite = 2,
+}

--- a/Dalamud/Game/Text/Noun/Enums/FrenchArticleType.cs
+++ b/Dalamud/Game/Text/Noun/Enums/FrenchArticleType.cs
@@ -1,0 +1,32 @@
+namespace Dalamud.Game.Text.Noun.Enums;
+
+/// <summary>
+/// Article types for <see cref="ClientLanguage.French"/>.
+/// </summary>
+public enum FrenchArticleType
+{
+    /// <summary>
+    /// Indefinite article (une, des).
+    /// </summary>
+    Indefinite = 1,
+
+    /// <summary>
+    /// Definite article (le, la, les).
+    /// </summary>
+    Definite = 2,
+
+    /// <summary>
+    /// Possessive article (mon, mes).
+    /// </summary>
+    PossessiveFirstPerson = 3,
+
+    /// <summary>
+    /// Possessive article (ton, tes).
+    /// </summary>
+    PossessiveSecondPerson = 4,
+
+    /// <summary>
+    /// Possessive article (son, ses).
+    /// </summary>
+    PossessiveThirdPerson = 5,
+}

--- a/Dalamud/Game/Text/Noun/Enums/GermanArticleType.cs
+++ b/Dalamud/Game/Text/Noun/Enums/GermanArticleType.cs
@@ -1,0 +1,37 @@
+namespace Dalamud.Game.Text.Noun.Enums;
+
+/// <summary>
+/// Article types for <see cref="ClientLanguage.German"/>.
+/// </summary>
+public enum GermanArticleType
+{
+    /// <summary>
+    /// Unbestimmter Artikel (ein, eine, etc.).
+    /// </summary>
+    Indefinite = 1,
+
+    /// <summary>
+    /// Bestimmter Artikel (der, die, das, etc.).
+    /// </summary>
+    Definite = 2,
+
+    /// <summary>
+    /// Possessivartikel "dein" (dein, deine, etc.).
+    /// </summary>
+    Possessive = 3,
+
+    /// <summary>
+    /// Negativartikel "kein" (kein, keine, etc.).
+    /// </summary>
+    Negative = 4,
+
+    /// <summary>
+    /// Nullartikel.
+    /// </summary>
+    ZeroArticle = 5,
+
+    /// <summary>
+    /// Demonstrativpronomen "dieser" (dieser, diese, etc.).
+    /// </summary>
+    Demonstrative = 6,
+}

--- a/Dalamud/Game/Text/Noun/Enums/JapaneseArticleType.cs
+++ b/Dalamud/Game/Text/Noun/Enums/JapaneseArticleType.cs
@@ -1,0 +1,17 @@
+namespace Dalamud.Game.Text.Noun.Enums;
+
+/// <summary>
+/// Article types for <see cref="ClientLanguage.Japanese"/>.
+/// </summary>
+public enum JapaneseArticleType
+{
+    /// <summary>
+    /// Near listener (それら).
+    /// </summary>
+    NearListener = 1,
+
+    /// <summary>
+    /// Distant from both speaker and listener (あれら).
+    /// </summary>
+    Distant = 2,
+}

--- a/Dalamud/Game/Text/Noun/NounParams.cs
+++ b/Dalamud/Game/Text/Noun/NounParams.cs
@@ -1,0 +1,69 @@
+using Dalamud.Game.Text.Noun.Enums;
+
+using Lumina.Text.ReadOnly;
+
+using LSheets = Lumina.Excel.Sheets;
+
+namespace Dalamud.Game.Text.Noun;
+
+/// <summary>
+/// Parameters for noun processing.
+/// </summary>
+internal record struct NounParams()
+{
+    /// <summary>
+    /// The language of the sheet to be processed. If null, the effective Dalamud UI language is used.
+    /// </summary>
+    public required ClientLanguage Language;
+
+    /// <summary>The name of the sheet containing the row to process.
+    /// </summary>
+    public required string SheetName = string.Empty;
+
+    /// <summary>
+    /// The row id within the sheet to process.
+    /// </summary>
+    public required uint RowId;
+
+    /// <summary>
+    /// The quantity of the entity (default is 1). Used to determine grammatical number (e.g., singular or plural).
+    /// </summary>
+    public int Quantity = 1;
+
+    /// <summary>
+    /// The article type. Depending on the <see cref="Language"/>, this has different meanings. See <see cref="JapaneseArticleType"/>, <see cref="GermanArticleType"/>, <see cref="FrenchArticleType"/>, <see cref="EnglishArticleType"/>.
+    /// </summary>
+    public int ArticleType = 1;
+
+    /// <summary>
+    /// The grammatical case (e.g., Nominative, Genitive, Dative, Accusative) used for German texts (default is 0).
+    /// </summary>
+    public int GrammaticalCase = 0;
+
+    /// <summary>
+    /// An optional string that is placed in front of the text that should be linked, such as item names (default is an empty string; the game uses "//").
+    /// </summary>
+    public ReadOnlySeString LinkMarker = default;
+
+    /// <summary>
+    /// An indicator that this noun will be processed from an Item sheet.
+    /// </summary>
+    public bool IsItemSheet;
+
+    /// <summary>
+    /// Gets the column offset.
+    /// </summary>
+    public readonly int ColumnOffset => this.SheetName switch
+    {
+        // See "E8 ?? ?? ?? ?? 44 8B 6B 08"
+        nameof(LSheets.BeastTribe) => 10,
+        nameof(LSheets.DeepDungeonItem) => 1,
+        nameof(LSheets.DeepDungeonEquipment) => 1,
+        nameof(LSheets.DeepDungeonMagicStone) => 1,
+        nameof(LSheets.DeepDungeonDemiclone) => 1,
+        nameof(LSheets.Glasses) => 4,
+        nameof(LSheets.GlassesStyle) => 15,
+        nameof(LSheets.Ornament) => 8, // not part of that function, but still shifted
+        _ => 0,
+    };
+}

--- a/Dalamud/Game/Text/Noun/NounParams.cs
+++ b/Dalamud/Game/Text/Noun/NounParams.cs
@@ -12,11 +12,12 @@ namespace Dalamud.Game.Text.Noun;
 internal record struct NounParams()
 {
     /// <summary>
-    /// The language of the sheet to be processed. If null, the effective Dalamud UI language is used.
+    /// The language of the sheet to be processed.
     /// </summary>
     public required ClientLanguage Language;
 
-    /// <summary>The name of the sheet containing the row to process.
+    /// <summary>
+    /// The name of the sheet containing the row to process.
     /// </summary>
     public required string SheetName = string.Empty;
 
@@ -31,8 +32,12 @@ internal record struct NounParams()
     public int Quantity = 1;
 
     /// <summary>
-    /// The article type. Depending on the <see cref="Language"/>, this has different meanings. See <see cref="JapaneseArticleType"/>, <see cref="GermanArticleType"/>, <see cref="FrenchArticleType"/>, <see cref="EnglishArticleType"/>.
+    /// The article type.
     /// </summary>
+    /// <remarks>
+    /// Depending on the <see cref="Language"/>, this has different meanings.<br/>
+    /// See <see cref="JapaneseArticleType"/>, <see cref="GermanArticleType"/>, <see cref="FrenchArticleType"/>, <see cref="EnglishArticleType"/>.
+    /// </remarks>
     public int ArticleType = 1;
 
     /// <summary>
@@ -46,9 +51,9 @@ internal record struct NounParams()
     public ReadOnlySeString LinkMarker = default;
 
     /// <summary>
-    /// An indicator that this noun will be processed from an Item sheet.
+    /// An indicator that this noun will be processed from an Action sheet. Only used for German texts.
     /// </summary>
-    public bool IsItemSheet;
+    public bool IsActionSheet;
 
     /// <summary>
     /// Gets the column offset.

--- a/Dalamud/Game/Text/Noun/NounParams.cs
+++ b/Dalamud/Game/Text/Noun/NounParams.cs
@@ -68,7 +68,6 @@ internal record struct NounParams()
         nameof(LSheets.DeepDungeonDemiclone) => 1,
         nameof(LSheets.Glasses) => 4,
         nameof(LSheets.GlassesStyle) => 15,
-        nameof(LSheets.Ornament) => 8, // not part of that function, but still shifted
         _ => 0,
     };
 }

--- a/Dalamud/Game/Text/Noun/NounProcessor.cs
+++ b/Dalamud/Game/Text/Noun/NounProcessor.cs
@@ -1,0 +1,519 @@
+using System.Collections.Concurrent;
+
+using Dalamud.Configuration.Internal;
+using Dalamud.Data;
+using Dalamud.Game.Text.Noun.Enums;
+using Dalamud.Logging.Internal;
+using Dalamud.Plugin.Services;
+using Dalamud.Utility;
+
+using Lumina.Excel;
+using Lumina.Text.ReadOnly;
+
+using LSeStringBuilder = Lumina.Text.SeStringBuilder;
+
+namespace Dalamud.Game.Text.Noun;
+
+/*
+Attributive sheet:
+  Japanese:
+    Unknown0 = Singular Demonstrative
+    Unknown1 = Plural Demonstrative
+  English:
+    Unknown2 = Article before a singular noun beginning with a consonant sound
+    Unknown3 = Article before a generic noun beginning with a consonant sound
+    Unknown4 = N/A
+    Unknown5 = Article before a singular noun beginning with a vowel sound
+    Unknown6 = Article before a generic noun beginning with a vowel sound
+    Unknown7 = N/A
+  German:
+    Unknown8 = Nominative Masculine
+    Unknown9 = Nominative Feminine
+    Unknown10 = Nominative Neutral
+    Unknown11 = Nominative Plural
+    Unknown12 = Genitive Masculine
+    Unknown13 = Genitive Feminine
+    Unknown14 = Genitive Neutral
+    Unknown15 = Genitive Plural
+    Unknown16 = Dative Masculine
+    Unknown17 = Dative Feminine
+    Unknown18 = Dative Neutral
+    Unknown19 = Dative Plural
+    Unknown20 = Accusative Masculine
+    Unknown21 = Accusative Feminine
+    Unknown22 = Accusative Neutral
+    Unknown23 = Accusative Plural
+  French (unsure):
+    Unknown24 = Singular Article
+    Unknown25 = Singular Masculine Article
+    Unknown26 = Plural Masculine Article
+    Unknown27 = ?
+    Unknown28 = ?
+    Unknown29 = Singular Masculine/Feminine Article, before a noun beginning in a vowel or an h
+    Unknown30 = Plural Masculine/Feminine Article, before a noun beginning in a vowel or an h
+    Unknown31 = ?
+    Unknown32 = ?
+    Unknown33 = Singular Feminine Article
+    Unknown34 = Plural Feminine Article
+    Unknown35 = ?
+    Unknown36 = ?
+    Unknown37 = Singular Masculine/Feminine Article, before a noun beginning in a vowel or an h
+    Unknown38 = Plural Masculine/Feminine Article, before a noun beginning in a vowel or an h
+    Unknown39 = ?
+    Unknown40 = ?
+*/
+
+/// <summary>
+/// Provides functionality to process texts from sheets containing grammatical placeholders.
+/// </summary>
+[ServiceManager.EarlyLoadedService]
+internal class NounProcessor : IServiceType
+{
+    // column names from ExdSchema, most likely incorrect
+    private const int SingularColumnIdx = 0;
+    private const int AdjectiveColumnIdx = 1;
+    private const int PluralColumnIdx = 2;
+    private const int PossessivePronounColumnIdx = 3;
+    private const int StartsWithVowelColumnIdx = 4;
+    private const int Unknown5ColumnIdx = 5; // probably used in Chinese texts
+    private const int PronounColumnIdx = 6;
+    private const int ArticleColumnIdx = 7;
+
+    private static readonly ModuleLog Log = new("NounProcessor");
+
+    [ServiceManager.ServiceDependency]
+    private readonly DataManager dataManager = Service<DataManager>.Get();
+
+    [ServiceManager.ServiceDependency]
+    private readonly DalamudConfiguration dalamudConfiguration = Service<DalamudConfiguration>.Get();
+
+    private readonly ConcurrentDictionary<(
+        ClientLanguage Language,
+        string SheetName,
+        uint RowId,
+        int Quantity,
+        int ArticleType,
+        int GrammaticalCase), ReadOnlySeString> cache = [];
+
+    [ServiceManager.ServiceConstructor]
+    private NounProcessor()
+    {
+    }
+
+    // Placeholders:
+    // [t] = article or grammatical gender (EN: the, DE: der, die, das)
+    // [n] = amount (number)
+    // [a] = declension
+    // [p] = plural
+    // [pa] = ?
+
+    /// <summary>
+    /// Processes a specific row from a sheet and generates a formatted string based on grammatical and language-specific rules.
+    /// </summary>
+    /// <param name="sheetName">The name of the sheet containing the row to process.</param>
+    /// <param name="rowId">The row id within the sheet to process.</param>
+    /// <param name="language">The language of the sheet to be processed. If null, the effective Dalamud UI language is used.</param>
+    /// <param name="quantity">The quantity of the entity (default is 1). Used to determine grammatical number (e.g., singular or plural).</param>
+    /// <param name="articleType">The article type. Depending on the <paramref name="language"/>, this has different meanings. See <see cref="JapaneseArticleType"/>, <see cref="GermanArticleType"/>, <see cref="FrenchArticleType"/>, <see cref="EnglishArticleType"/>.</param>
+    /// <param name="grammaticalCase">The grammatical case (e.g., Nominative, Genitive, Dative, Accusative) used for German texts (default is 0).</param>
+    /// <param name="linkMarker">An optional string that is placed in front of the text that should be linked, such as item names (default is an empty string; the game uses "//").</param>
+    /// <returns>A ReadOnlySeString representing the processed text.</returns>
+    public ReadOnlySeString ProcessNoun(
+        string sheetName,
+        uint rowId,
+        ClientLanguage? language = null,
+        int quantity = 1,
+        int articleType = 1,
+        int grammaticalCase = 0,
+        ReadOnlySeString linkMarker = default)
+    {
+        var lang = language ?? this.dalamudConfiguration.EffectiveLanguage.ToClientLanguage();
+
+        if (this.cache.TryGetValue((lang, sheetName, rowId, quantity, articleType, grammaticalCase), out var value))
+            return value;
+
+        var sheet = this.dataManager.Excel.GetSheet<RawRow>(lang.ToLumina(), sheetName);
+        if (sheet == null)
+        {
+            Log.Warning("Sheet {SheetName} not found", sheetName);
+            return default;
+        }
+
+        if (!sheet.HasRow(rowId))
+        {
+            Log.Warning("Sheet {SheetName} does not contain row #{RowId}", sheetName, rowId);
+            return default;
+        }
+
+        var row = sheet.GetRow(rowId);
+
+        // see "E8 ?? ?? ?? ?? 44 8B 6B 08"
+        var columnOffset = sheetName switch
+        {
+            "BeastTribe" => 10,
+            "DeepDungeonItem" or "DeepDungeonEquipment" or "DeepDungeonMagicStone" or "DeepDungeonDemiclone" => 1,
+            "Glasses" => 4,
+            "GlassesStyle" => 15,
+            "Ornament" => 8, // not part of that function, but still shifted
+            _ => 0,
+        };
+
+        return this.ProcessNoun(sheetName, row, lang, columnOffset, quantity, articleType, grammaticalCase, linkMarker);
+    }
+
+    /// <summary>
+    /// Processes a specific row and generates a formatted string based on grammatical and language-specific rules.
+    /// </summary>
+    /// <param name="sheetName">The name of the sheet containing the row to process. Used for caching.</param>
+    /// <param name="row">The row to process.</param>
+    /// <param name="language">The language of the row to be processed. If null, the effective Dalamud UI language is used.</param>
+    /// <param name="columnOffset">The starting position offset for the text-related columns within the row.</param>
+    /// <param name="quantity">The quantity of the entity, used to determine grammatical number (e.g., singular or plural; default is 1).</param>
+    /// <param name="articleType">The article type. Depending on the <paramref name="language"/>, this has different meanings. See <see cref="JapaneseArticleType"/>, <see cref="GermanArticleType"/>, <see cref="FrenchArticleType"/>, <see cref="EnglishArticleType"/>.</param>
+    /// <param name="grammaticalCase">The grammatical case (e.g., Nominative, Genitive, Dative, Accusative) used for German texts (default is 0).</param>
+    /// <param name="linkMarker">An optional string that is placed in front of the text that should be linked, such as item names (default is an empty string; the game uses "//").</param>
+    /// <returns>A ReadOnlySeString representing the processed text.</returns>
+    public ReadOnlySeString ProcessNoun(
+        string sheetName,
+        RawRow row,
+        ClientLanguage? language = null,
+        int columnOffset = 0,
+        int quantity = 1,
+        int articleType = 1,
+        int grammaticalCase = 0,
+        ReadOnlySeString linkMarker = default)
+    {
+        var lang = language ?? this.dalamudConfiguration.EffectiveLanguage.ToClientLanguage();
+
+        if ((short)grammaticalCase < 0 || (short)grammaticalCase > 5)
+            return default;
+
+        var key = (lang, sheetName, row.RowId, quantity, articleType, grammaticalCase);
+
+        if (this.cache.TryGetValue(key, out var value))
+            return value;
+
+        var attributiveSheet = this.dataManager.Excel.GetSheet<RawRow>(lang.ToLumina(), "Attributive");
+        if (attributiveSheet == null)
+        {
+            Log.Warning("Sheet Attributive not found");
+            return default;
+        }
+
+        var output = lang switch
+        {
+            ClientLanguage.Japanese => ResolveNounJa(row, quantity, (JapaneseArticleType)articleType, attributiveSheet, linkMarker, columnOffset),
+            ClientLanguage.English => ResolveNounEn(row, quantity, (EnglishArticleType)articleType, attributiveSheet, linkMarker, columnOffset),
+            ClientLanguage.German => ResolveNounDe(row, quantity, (GermanArticleType)articleType, attributiveSheet, linkMarker, columnOffset, (ushort)grammaticalCase),
+            ClientLanguage.French => ResolveNounFr(row, quantity, (FrenchArticleType)articleType, attributiveSheet, linkMarker, columnOffset),
+            _ => default,
+        };
+
+        this.cache.TryAdd(key, output);
+
+        return output;
+    }
+
+    /// <summary>
+    /// Resolves noun placeholders in Japanese text.
+    /// </summary>
+    /// <param name="row">The row containing the unprocessed text.</param>
+    /// <param name="quantity">The grammatical number representing the quantity.</param>
+    /// <param name="articleType">The article type.</param>
+    /// <param name="attributiveSheet">The sheet containing the data used for resolving the noun.</param>
+    /// <param name="linkMarker">An optional prefix string for linked text, such as item names.</param>
+    /// <param name="columnOffset">The starting position offset for the text-related columns within the row.</param>
+    /// <returns>A ReadOnlySeString representing the processed text.</returns>
+    /// <remarks>
+    /// This is a C# implementation of Component::Text::Localize::NounJa.Resolve.
+    /// </remarks>
+    private static ReadOnlySeString ResolveNounJa(RawRow row, int quantity, JapaneseArticleType articleType, ExcelSheet<RawRow> attributiveSheet, ReadOnlySeString linkMarker, int columnOffset)
+    {
+        var builder = LSeStringBuilder.SharedPool.Get();
+
+        // Ko-So-A-Do
+        var ksad = attributiveSheet.GetRow((uint)articleType).ReadStringColumn(quantity > 1 ? 1 : 0);
+        if (!ksad.IsEmpty)
+        {
+            builder.Append(ksad);
+
+            if (quantity > 1)
+            {
+                builder.ReplaceText("[n]"u8, ReadOnlySeString.FromText(quantity.ToString()));
+            }
+        }
+
+        if (!linkMarker.IsEmpty)
+            builder.Append(linkMarker);
+
+        var text = row.ReadStringColumn(columnOffset);
+        if (!text.IsEmpty)
+            builder.Append(text);
+
+        var ross = builder.ToReadOnlySeString();
+        LSeStringBuilder.SharedPool.Return(builder);
+        return ross;
+    }
+
+    /// <summary>
+    /// Resolves noun placeholders in English text.
+    /// </summary>
+    /// <param name="row">The row containing the unprocessed text.</param>
+    /// <param name="quantity">The grammatical number representing the quantity.</param>
+    /// <param name="articleType">The article type.</param>
+    /// <param name="attributiveSheet">The sheet containing the data used for resolving the noun.</param>
+    /// <param name="linkMarker">An optional prefix string for linked text, such as item names.</param>
+    /// <param name="columnOffset">The starting position offset for the text-related columns within the row.</param>
+    /// <returns>A ReadOnlySeString representing the processed text.</returns>
+    /// <remarks>
+    /// This is a C# implementation of Component::Text::Localize::NounEn.Resolve.
+    /// </remarks>
+    private static ReadOnlySeString ResolveNounEn(RawRow row, int quantity, EnglishArticleType articleType, ExcelSheet<RawRow> attributiveSheet, ReadOnlySeString linkMarker, int columnOffset)
+    {
+        /*
+          a1->Offsets[0] = SingularColumnIdx
+          a1->Offsets[1] = PluralColumnIdx
+          a1->Offsets[2] = StartsWithVowelColumnIdx
+          a1->Offsets[3] = PossessivePronounColumnIdx
+          a1->Offsets[4] = ArticleColumnIdx
+        */
+
+        var builder = LSeStringBuilder.SharedPool.Get();
+
+        var isProperNounColumn = columnOffset + ArticleColumnIdx;
+        var isProperNoun = isProperNounColumn >= 0 ? row.ReadInt8Column(isProperNounColumn) : ~isProperNounColumn;
+        if (isProperNoun == 0)
+        {
+            var startsWithVowelColumn = columnOffset + StartsWithVowelColumnIdx;
+            var startsWithVowel = startsWithVowelColumn >= 0 ? row.ReadInt8Column(startsWithVowelColumn) : ~startsWithVowelColumn;
+
+            var articleColumn = startsWithVowel + 2 * (startsWithVowel + 1);
+            var grammaticalNumberColumnOffset = quantity == 1 ? SingularColumnIdx : PluralColumnIdx;
+            var article = attributiveSheet.GetRow((uint)articleType).ReadStringColumn(articleColumn + grammaticalNumberColumnOffset);
+            if (!article.IsEmpty)
+                builder.Append(article);
+
+            if (!linkMarker.IsEmpty)
+                builder.Append(linkMarker);
+        }
+
+        var text = row.ReadStringColumn(columnOffset + (quantity == 1 ? SingularColumnIdx : PluralColumnIdx));
+        if (!text.IsEmpty)
+            builder.Append(text);
+
+        builder.ReplaceText("[n]"u8, ReadOnlySeString.FromText(quantity.ToString()));
+
+        var ross = builder.ToReadOnlySeString();
+        LSeStringBuilder.SharedPool.Return(builder);
+        return ross;
+    }
+
+    /// <summary>
+    /// Resolves noun placeholders in German text.
+    /// </summary>
+    /// <param name="row">The row containing the unprocessed text.</param>
+    /// <param name="quantity">The grammatical number representing the quantity.</param>
+    /// <param name="articleType">The article type.</param>
+    /// <param name="attributiveSheet">The sheet containing the data used for resolving the noun.</param>
+    /// <param name="linkMarker">An optional prefix string for linked text, such as item names.</param>
+    /// <param name="columnOffset">The starting position offset for the text-related columns within the row.</param>
+    /// <param name="grammaticalCase">The grammatical case (e.g., Nominative, Genitive, Dative, Accusative; default is 0).</param>
+    /// <returns>A ReadOnlySeString representing the processed text.</returns>
+    /// <remarks>
+    /// This is a C# implementation of Component::Text::Localize::NounDe.Resolve.
+    /// </remarks>
+    private static ReadOnlySeString ResolveNounDe(RawRow row, int quantity, GermanArticleType articleType, ExcelSheet<RawRow> attributiveSheet, ReadOnlySeString linkMarker, int columnOffset, ushort grammaticalCase)
+    {
+        /*
+             a1->Offsets[0] = SingularColumnIdx
+             a1->Offsets[1] = PluralColumnIdx
+             a1->Offsets[2] = PronounColumnIdx
+             a1->Offsets[3] = AdjectiveColumnIdx
+             a1->Offsets[4] = PossessivePronounColumnIdx
+             a1->Offsets[5] = Unknown5ColumnIdx
+             a1->Offsets[6] = ArticleColumnIdx
+         */
+
+        var builder = LSeStringBuilder.SharedPool.Get();
+        ReadOnlySeString ross;
+
+        var readColumnDirectly = (byte)(grammaticalCase >> 8 & 0xFF) & 1; // BYTE2(Case) & 1
+
+        if ((grammaticalCase & 0x10000) != 0)
+            grammaticalCase = 0;
+
+        if (readColumnDirectly != 0)
+        {
+            builder.Append(row.ReadStringColumn(grammaticalCase - 0x10000));
+            builder.ReplaceText("[n]"u8, ReadOnlySeString.FromText(quantity.ToString()));
+
+            ross = builder.ToReadOnlySeString();
+            LSeStringBuilder.SharedPool.Return(builder);
+            return ross;
+        }
+
+        var genderIndexColumn = columnOffset + PronounColumnIdx;
+        var genderIndex = genderIndexColumn >= 0 ? row.ReadInt8Column(genderIndexColumn) : ~genderIndexColumn;
+
+        var articleIndexColumn = columnOffset + ArticleColumnIdx;
+        var articleIndex = articleIndexColumn >= 0 ? row.ReadInt8Column(articleIndexColumn) : ~articleIndexColumn;
+
+        var caseColumnOffset = 4 * grammaticalCase + 8;
+
+        var caseRowOffsetColumn = columnOffset + (quantity == 1 ? AdjectiveColumnIdx : PossessivePronounColumnIdx);
+        var caseRowOffset = caseRowOffsetColumn >= 0 ? row.ReadInt8Column(caseRowOffsetColumn) : (sbyte)~caseRowOffsetColumn;
+
+        if (quantity != 1)
+            genderIndex = 3;
+
+        var has_t = false;
+        var text = row.ReadStringColumn(columnOffset + (quantity == 1 ? SingularColumnIdx : PluralColumnIdx));
+        if (!text.IsEmpty)
+        {
+            has_t = text.ContainsText("[t]"u8);
+
+            if (articleIndex == 0 && !has_t)
+            {
+                var grammaticalGender = attributiveSheet.GetRow((uint)articleType).ReadStringColumn(caseColumnOffset + genderIndex); // Genus
+                if (!grammaticalGender.IsEmpty)
+                    builder.Append(grammaticalGender);
+            }
+
+            if (!linkMarker.IsEmpty)
+                builder.Append(linkMarker);
+
+            builder.Append(text);
+
+            var plural = attributiveSheet.GetRow((uint)(caseRowOffset + 26)).ReadStringColumn(caseColumnOffset + genderIndex);
+            if (builder.ContainsText("[p]"u8))
+                builder.ReplaceText("[p]"u8, plural);
+            else
+                builder.Append(plural);
+
+            if (has_t)
+            {
+                var article = attributiveSheet.GetRow(39).ReadStringColumn(caseColumnOffset + genderIndex); // Definiter Artikel
+                builder.ReplaceText("[t]"u8, article);
+            }
+        }
+
+        var pa = attributiveSheet.GetRow(24).ReadStringColumn(caseColumnOffset + genderIndex);
+        builder.ReplaceText("[pa]"u8, pa);
+
+        RawRow declensionRow;
+
+        if (articleType is GermanArticleType.Possessive or GermanArticleType.Demonstrative || has_t)
+            declensionRow = attributiveSheet.GetRow(25); // Schwache Flexion eines Adjektivs?!
+        else if (articleType == GermanArticleType.ZeroArticle)
+            declensionRow = attributiveSheet.GetRow(38); // Starke Deklination
+        else if (articleType == GermanArticleType.Definite)
+            declensionRow = attributiveSheet.GetRow(37); // Gemischte Deklination
+        else
+            declensionRow = attributiveSheet.GetRow(26); // Starke Flexion eines Artikels?!
+
+        var declension = declensionRow.ReadStringColumn(caseColumnOffset + genderIndex);
+        builder.ReplaceText("[a]"u8, declension);
+
+        builder.ReplaceText("[n]"u8, ReadOnlySeString.FromText(quantity.ToString()));
+
+        ross = builder.ToReadOnlySeString();
+        LSeStringBuilder.SharedPool.Return(builder);
+        return ross;
+    }
+
+    /// <summary>
+    /// Resolves noun placeholders in French text.
+    /// </summary>
+    /// <param name="row">The row containing the unprocessed text.</param>
+    /// <param name="quantity">The grammatical number representing the quantity.</param>
+    /// <param name="articleType">The article type.</param>
+    /// <param name="attributiveSheet">The sheet containing the data used for resolving the noun.</param>
+    /// <param name="linkMarker">An optional prefix string for linked text, such as item names.</param>
+    /// <param name="columnOffset">The starting position offset for the text-related columns within the row.</param>
+    /// <returns>A ReadOnlySeString representing the processed text.</returns>
+    /// <remarks>
+    /// This is a C# implementation of Component::Text::Localize::NounFr.Resolve.
+    /// </remarks>
+    private static ReadOnlySeString ResolveNounFr(RawRow row, int quantity, FrenchArticleType articleType, ExcelSheet<RawRow> attributiveSheet, ReadOnlySeString linkMarker, int columnOffset)
+    {
+        /*
+            a1->Offsets[0] = SingularColumnIdx
+            a1->Offsets[1] = PluralColumnIdx
+            a1->Offsets[2] = StartsWithVowelColumnIdx
+            a1->Offsets[3] = PronounColumnIdx
+            a1->Offsets[4] = Unknown5ColumnIdx
+            a1->Offsets[5] = ArticleColumnIdx
+        */
+
+        var builder = LSeStringBuilder.SharedPool.Get();
+        ReadOnlySeString ross;
+
+        var startsWithVowelColumn = columnOffset + StartsWithVowelColumnIdx;
+        var startsWithVowel = startsWithVowelColumn >= 0 ? row.ReadInt8Column(startsWithVowelColumn) : ~startsWithVowelColumn;
+
+        var pronounColumn = columnOffset + PronounColumnIdx;
+        var pronoun = pronounColumn >= 0 ? row.ReadInt8Column(pronounColumn) : ~pronounColumn;
+
+        var articleColumn = columnOffset + ArticleColumnIdx;
+        var article = articleColumn >= 0 ? row.ReadInt8Column(articleColumn) : ~articleColumn;
+
+        var v20 = 4 * (startsWithVowel + 6 + 2 * pronoun);
+
+        if (article != 0)
+        {
+            var v21 = attributiveSheet.GetRow((uint)articleType).ReadStringColumn(v20);
+            if (!v21.IsEmpty)
+                builder.Append(v21);
+
+            if (!linkMarker.IsEmpty)
+                builder.Append(linkMarker);
+
+            var text = row.ReadStringColumn(columnOffset + (quantity <= 1 ? SingularColumnIdx : PluralColumnIdx));
+            if (!text.IsEmpty)
+                builder.Append(text);
+
+            if (quantity <= 1)
+                builder.ReplaceText("[n]"u8, ReadOnlySeString.FromText(quantity.ToString()));
+
+            ross = builder.ToReadOnlySeString();
+            LSeStringBuilder.SharedPool.Return(builder);
+            return ross;
+        }
+
+        var v17 = row.ReadInt8Column(columnOffset + Unknown5ColumnIdx);
+        if (v17 != 0 && (quantity > 1 || v17 == 2))
+        {
+            var v29 = attributiveSheet.GetRow((uint)articleType).ReadStringColumn(v20 + 2);
+            if (!v29.IsEmpty)
+            {
+                builder.Append(v29);
+
+                if (!linkMarker.IsEmpty)
+                    builder.Append(linkMarker);
+
+                var text = row.ReadStringColumn(columnOffset + PluralColumnIdx);
+                if (!text.IsEmpty)
+                    builder.Append(text);
+            }
+        }
+        else
+        {
+            var v27 = attributiveSheet.GetRow((uint)articleType).ReadStringColumn(v20 + (v17 != 0 ? 1 : 3));
+            if (!v27.IsEmpty)
+                builder.Append(v27);
+
+            if (!linkMarker.IsEmpty)
+                builder.Append(linkMarker);
+
+            var text = row.ReadStringColumn(columnOffset + SingularColumnIdx);
+            if (!text.IsEmpty)
+                builder.Append(text);
+        }
+
+        builder.ReplaceText("[n]"u8, ReadOnlySeString.FromText(quantity.ToString()));
+
+        ross = builder.ToReadOnlySeString();
+        LSeStringBuilder.SharedPool.Return(builder);
+        return ross;
+    }
+}

--- a/Dalamud/Game/Text/Noun/NounProcessor.cs
+++ b/Dalamud/Game/Text/Noun/NounProcessor.cs
@@ -61,6 +61,13 @@ Attributive sheet:
     Unknown38 = Plural Masculine/Feminine Article, before a noun beginning in a vowel or an h
     Unknown39 = ?
     Unknown40 = ?
+
+Placeholders:
+    [t] = article or grammatical gender (EN: the, DE: der, die, das)
+    [n] = amount (number)
+    [a] = declension
+    [p] = plural
+    [pa] = ?
 */
 
 /// <summary>
@@ -99,13 +106,6 @@ internal class NounProcessor : IServiceType
     private NounProcessor()
     {
     }
-
-    // Placeholders:
-    // [t] = article or grammatical gender (EN: the, DE: der, die, das)
-    // [n] = amount (number)
-    // [a] = declension
-    // [p] = plural
-    // [pa] = ?
 
     /// <summary>
     /// Processes a specific row from a sheet and generates a formatted string based on grammatical and language-specific rules.

--- a/Dalamud/Game/Text/Noun/NounProcessor.cs
+++ b/Dalamud/Game/Text/Noun/NounProcessor.cs
@@ -265,7 +265,7 @@ internal class NounProcessor : IServiceType
         var builder = LSeStringBuilder.SharedPool.Get();
         ReadOnlySeString ross;
 
-        if (nounParams.IsItemSheet)
+        if (nounParams.IsActionSheet)
         {
             builder.Append(row.ReadStringColumn(nounParams.GrammaticalCase));
             builder.ReplaceText("[n]"u8, ReadOnlySeString.FromText(nounParams.Quantity.ToString()));

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/ItemPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/ItemPayload.cs
@@ -179,9 +179,9 @@ public class ItemPayload : Payload
     {
         return rawItemId switch
         {
-            > 500_000 and < 1_000_000 => (rawItemId - 500_000, ItemKind.Collectible),
-            > 1_000_000 and < 2_000_000 => (rawItemId - 1_000_000, ItemKind.Hq),
-            > 2_000_000 => (rawItemId, ItemKind.EventItem), // EventItem IDs are NOT adjusted
+            >= 500_000 and < 1_000_000 => (rawItemId - 500_000, ItemKind.Collectible),
+            >= 1_000_000 and < 2_000_000 => (rawItemId - 1_000_000, ItemKind.Hq),
+            >= 2_000_000 => (rawItemId, ItemKind.EventItem), // EventItem IDs are NOT adjusted
             _ => (rawItemId, ItemKind.Normal),
         };
     }

--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -5,10 +5,15 @@ using System.Runtime.InteropServices;
 using System.Text;
 
 using Dalamud.Data;
+using Dalamud.Game.Text.Evaluator;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Utility;
+
 using Lumina.Excel.Sheets;
+
 using Newtonsoft.Json;
+
+using LSeStringBuilder = Lumina.Text.SeStringBuilder;
 
 namespace Dalamud.Game.Text.SeStringHandling;
 
@@ -187,57 +192,32 @@ public class SeString
     /// <returns>An SeString containing all the payloads necessary to display an item link in the chat log.</returns>
     public static SeString CreateItemLink(uint itemId, ItemPayload.ItemKind kind = ItemPayload.ItemKind.Normal, string? displayNameOverride = null)
     {
-        var data = Service<DataManager>.Get();
+        var clientState = Service<ClientState.ClientState>.Get();
+        var seStringEvaluator = Service<SeStringEvaluator>.Get();
 
-        var displayName = displayNameOverride;
-        var rarity = 1; // default: white
-        if (displayName == null)
-        {
-            switch (kind)
-            {
-                case ItemPayload.ItemKind.Normal:
-                case ItemPayload.ItemKind.Collectible:
-                case ItemPayload.ItemKind.Hq:
-                    var item = data.GetExcelSheet<Item>()?.GetRowOrDefault(itemId);
-                    displayName = item?.Name.ExtractText();
-                    rarity = item?.Rarity ?? 1;
-                    break;
-                case ItemPayload.ItemKind.EventItem:
-                    displayName = data.GetExcelSheet<EventItem>()?.GetRowOrDefault(itemId)?.Name.ExtractText();
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(kind), kind, null);
-            }
-        }
+        var rawId = ItemUtil.GetRawId(itemId, kind);
 
-        if (displayName == null)
-        {
+        var displayName = displayNameOverride ?? ItemUtil.GetItemName(rawId);
+        if (displayName.IsEmpty)
             throw new Exception("Invalid item ID specified, could not determine item name.");
-        }
 
-        if (kind == ItemPayload.ItemKind.Hq)
-        {
-            displayName += $" {(char)SeIconChar.HighQuality}";
-        }
-        else if (kind == ItemPayload.ItemKind.Collectible)
-        {
-            displayName += $" {(char)SeIconChar.Collectible}";
-        }
+        var copyName = ItemUtil.GetItemName(rawId, false).ExtractText();
+        var textColor = ItemUtil.GetItemRarityColorType(rawId);
+        var textEdgeColor = textColor + 1u;
 
-        var textColor = (ushort)(549 + ((rarity - 1) * 2));
-        var textGlowColor = (ushort)(textColor + 1);
+        var sb = LSeStringBuilder.SharedPool.Get();
+        var itemLink = sb
+            .PushColorType(textColor)
+            .PushEdgeColorType(textEdgeColor)
+            .PushLinkItem(rawId, copyName)
+            .Append(displayName)
+            .PopLink()
+            .PopEdgeColorType()
+            .PopColorType()
+            .ToReadOnlySeString();
+        LSeStringBuilder.SharedPool.Return(sb);
 
-        // Note: `SeStringBuilder.AddItemLink` uses this function, so don't call it here!
-        return new SeStringBuilder()
-            .AddUiForeground(textColor)
-            .AddUiGlow(textGlowColor)
-            .Add(new ItemPayload(itemId, kind))
-            .Append(TextArrowPayloads)
-            .AddText(displayName)
-            .AddUiGlowOff()
-            .AddUiForegroundOff()
-            .Add(RawPayload.LinkTerminator)
-            .Build();
+        return SeString.Parse(seStringEvaluator.EvaluateFromAddon(371, [itemLink], clientState.ClientLanguage));
     }
 
     /// <summary>
@@ -301,7 +281,7 @@ public class SeString
     public static SeString CreateMapLink(
         uint territoryId, uint mapId, float xCoord, float yCoord, float fudgeFactor = 0.05f) =>
         CreateMapLinkWithInstance(territoryId, mapId, null, xCoord, yCoord, fudgeFactor);
-    
+
     /// <summary>
     /// Creates an SeString representing an entire Payload chain that can be used to link a map position in the chat log.
     /// </summary>
@@ -340,7 +320,7 @@ public class SeString
     /// <returns>An SeString containing all of the payloads necessary to display a map link in the chat log.</returns>
     public static SeString? CreateMapLink(string placeName, float xCoord, float yCoord, float fudgeFactor = 0.05f) =>
         CreateMapLinkWithInstance(placeName, null, xCoord, yCoord, fudgeFactor);
-    
+
     /// <summary>
     /// Creates an SeString representing an entire Payload chain that can be used to link a map position in the chat log, matching a specified zone name.
     /// Returns null if no corresponding PlaceName was found.
@@ -511,7 +491,7 @@ public class SeString
         {
             messageBytes.AddRange(p.Encode());
         }
-        
+
         // Add Null Terminator
         messageBytes.Add(0);
 
@@ -526,7 +506,7 @@ public class SeString
     {
         return this.TextValue;
     }
-    
+
     private static string GetMapLinkNameString(string placeName, int? instance, string coordinateString)
     {
         var instanceString = string.Empty;
@@ -534,7 +514,7 @@ public class SeString
         {
             instanceString = (SeIconChar.Instance1 + instance.Value - 1).ToIconString();
         }
-        
+
         return $"{placeName}{instanceString} {coordinateString}";
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
@@ -53,7 +53,7 @@ internal class DataWindow : Window, IDisposable
         new PluginIpcWidget(),
         new SeFontTestWidget(),
         new ServicesWidget(),
-        new SeStringCreator(),
+        new SeStringCreatorWidget(),
         new SeStringRendererTestWidget(),
         new StartInfoWidget(),
         new TargetWidget(),

--- a/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
@@ -47,6 +47,7 @@ internal class DataWindow : Window, IDisposable
         new KeyStateWidget(),
         new MarketBoardWidget(),
         new NetworkMonitorWidget(),
+        new NounProcessorWidget(),
         new ObjectTableWidget(),
         new PartyListWidget(),
         new PluginIpcWidget(),

--- a/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
@@ -70,6 +70,7 @@ internal class DataWindow : Window, IDisposable
     private bool isExcept;
     private bool selectionCollapsed;
     private IDataWindowWidget currentWidget;
+    private bool isLoaded;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DataWindow"/> class.
@@ -83,8 +84,6 @@ internal class DataWindow : Window, IDisposable
         this.RespectCloseHotkey = false;
         this.orderedModules = this.modules.OrderBy(module => module.DisplayName);
         this.currentWidget = this.orderedModules.First();
-
-        this.Load();
     }
 
     /// <inheritdoc/>
@@ -93,6 +92,7 @@ internal class DataWindow : Window, IDisposable
     /// <inheritdoc/>
     public override void OnOpen()
     {
+        this.Load();
     }
 
     /// <inheritdoc/>
@@ -185,6 +185,7 @@ internal class DataWindow : Window, IDisposable
 
             if (ImGuiComponents.IconButton("forceReload", FontAwesomeIcon.Sync))
             {
+                this.isLoaded = false;
                 this.Load();
             }
 
@@ -238,6 +239,11 @@ internal class DataWindow : Window, IDisposable
 
     private void Load()
     {
+        if (this.isLoaded)
+            return;
+
+        this.isLoaded = true;
+
         foreach (var widget in this.modules)
         {
             widget.Load();

--- a/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
@@ -53,6 +53,7 @@ internal class DataWindow : Window, IDisposable
         new PluginIpcWidget(),
         new SeFontTestWidget(),
         new ServicesWidget(),
+        new SeStringCreator(),
         new SeStringRendererTestWidget(),
         new StartInfoWidget(),
         new TargetWidget(),

--- a/Dalamud/Interface/Internal/Windows/Data/WidgetUtil.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/WidgetUtil.cs
@@ -1,0 +1,34 @@
+using Dalamud.Interface.Utility;
+
+using ImGuiNET;
+
+namespace Dalamud.Interface.Internal.Windows.Data;
+
+/// <summary>
+/// Common utilities used in Widgets.
+/// </summary>
+internal class WidgetUtil
+{
+    /// <summary>
+    /// Draws text that can be copied on click.
+    /// </summary>
+    /// <param name="text">The text shown and to be copied.</param>
+    /// <param name="tooltipText">The text in the tooltip.</param>
+    internal static void DrawCopyableText(string text, string tooltipText = "Copy")
+    {
+        ImGuiHelpers.SafeTextWrapped(text);
+
+        if (ImGui.IsItemHovered())
+        {
+            ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
+            ImGui.BeginTooltip();
+            ImGui.TextUnformatted(tooltipText);
+            ImGui.EndTooltip();
+        }
+
+        if (ImGui.IsItemClicked())
+        {
+            ImGui.SetClipboardText(text);
+        }
+    }
+}

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AtkArrayDataBrowserWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AtkArrayDataBrowserWidget.cs
@@ -57,24 +57,6 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
         this.DrawExtendArrayTab();
     }
 
-    private static void DrawCopyableText(string text, string tooltipText)
-    {
-        ImGuiHelpers.SafeTextWrapped(text);
-
-        if (ImGui.IsItemHovered())
-        {
-            ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
-            ImGui.BeginTooltip();
-            ImGui.TextUnformatted(tooltipText);
-            ImGui.EndTooltip();
-        }
-
-        if (ImGui.IsItemClicked())
-        {
-            ImGui.SetClipboardText(text);
-        }
-    }
-
     private void DrawArrayList(Type? arrayType, int arrayCount, short* arrayKeys, AtkArrayData** arrays, ref int selectedIndex)
     {
         using var table = ImRaii.Table("ArkArrayTable", 3, ImGuiTableFlags.ScrollY | ImGuiTableFlags.Borders, new Vector2(300, -1));
@@ -162,7 +144,7 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
         ImGui.SameLine();
         ImGui.TextUnformatted("Address: ");
         ImGui.SameLine(0, 0);
-        DrawCopyableText($"0x{(nint)array:X}", "Copy address");
+        WidgetUtil.DrawCopyableText($"0x{(nint)array:X}", "Copy address");
 
         if (array->SubscribedAddonsCount > 0)
         {
@@ -238,22 +220,22 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
             var ptr = &array->IntArray[i];
 
             ImGui.TableNextColumn(); // Address
-            DrawCopyableText($"0x{(nint)ptr:X}", "Copy entry address");
+            WidgetUtil.DrawCopyableText($"0x{(nint)ptr:X}", "Copy entry address");
 
             ImGui.TableNextColumn(); // Integer
-            DrawCopyableText((*ptr).ToString(), "Copy value");
+            WidgetUtil.DrawCopyableText((*ptr).ToString(), "Copy value");
 
             ImGui.TableNextColumn(); // Short
-            DrawCopyableText((*(short*)ptr).ToString(), "Copy as short");
+            WidgetUtil.DrawCopyableText((*(short*)ptr).ToString(), "Copy as short");
 
             ImGui.TableNextColumn(); // Byte
-            DrawCopyableText((*(byte*)ptr).ToString(), "Copy as byte");
+            WidgetUtil.DrawCopyableText((*(byte*)ptr).ToString(), "Copy as byte");
 
             ImGui.TableNextColumn(); // Float
-            DrawCopyableText((*(float*)ptr).ToString(), "Copy as float");
+            WidgetUtil.DrawCopyableText((*(float*)ptr).ToString(), "Copy as float");
 
             ImGui.TableNextColumn(); // Hex
-            DrawCopyableText($"0x{array->IntArray[i]:X2}", "Copy Hex");
+            WidgetUtil.DrawCopyableText($"0x{array->IntArray[i]:X2}", "Copy Hex");
         }
     }
 
@@ -333,11 +315,11 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
             if (this.showTextAddress)
             {
                 if (!isNull)
-                    DrawCopyableText($"0x{(nint)array->StringArray[i]:X}", "Copy text address");
+                    WidgetUtil.DrawCopyableText($"0x{(nint)array->StringArray[i]:X}", "Copy text address");
             }
             else
             {
-                DrawCopyableText($"0x{(nint)(&array->StringArray[i]):X}", "Copy entry address");
+                WidgetUtil.DrawCopyableText($"0x{(nint)(&array->StringArray[i]):X}", "Copy entry address");
             }
 
             ImGui.TableNextColumn(); // Managed
@@ -351,7 +333,7 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
             {
                 if (this.showMacroString)
                 {
-                    DrawCopyableText(new ReadOnlySeStringSpan(array->StringArray[i]).ToString(), "Copy text");
+                    WidgetUtil.DrawCopyableText(new ReadOnlySeStringSpan(array->StringArray[i]).ToString(), "Copy text");
                 }
                 else
                 {
@@ -408,11 +390,11 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
             ImGui.TextUnformatted($"#{i}");
 
             ImGui.TableNextColumn(); // Address
-            DrawCopyableText($"0x{(nint)(&array->DataArray[i]):X}", "Copy entry address");
+            WidgetUtil.DrawCopyableText($"0x{(nint)(&array->DataArray[i]):X}", "Copy entry address");
 
             ImGui.TableNextColumn(); // Pointer
             if (!isNull)
-                DrawCopyableText($"0x{(nint)array->DataArray[i]:X}", "Copy address");
+                WidgetUtil.DrawCopyableText($"0x{(nint)array->DataArray[i]:X}", "Copy address");
         }
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/FateTableWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/FateTableWidget.cs
@@ -69,10 +69,10 @@ internal class FateTableWidget : IDataWindowWidget
             ImGui.TextUnformatted($"#{i}");
 
             ImGui.TableNextColumn(); // Address
-            DrawCopyableText($"0x{fate.Address:X}", "Click to copy Address");
+            WidgetUtil.DrawCopyableText($"0x{fate.Address:X}", "Click to copy Address");
 
             ImGui.TableNextColumn(); // FateId
-            DrawCopyableText(fate.FateId.ToString(), "Click to copy FateId (RowId of Fate sheet)");
+            WidgetUtil.DrawCopyableText(fate.FateId.ToString(), "Click to copy FateId (RowId of Fate sheet)");
 
             ImGui.TableNextColumn(); // State
             ImGui.TextUnformatted(fate.State.ToString());
@@ -140,7 +140,7 @@ internal class FateTableWidget : IDataWindowWidget
 
             ImGui.TableNextColumn(); // Name
 
-            DrawCopyableText(fate.Name.ToString(), "Click to copy Name");
+            WidgetUtil.DrawCopyableText(fate.Name.ToString(), "Click to copy Name");
 
             ImGui.TableNextColumn(); // Progress
             ImGui.TextUnformatted($"{fate.Progress}%");
@@ -156,28 +156,10 @@ internal class FateTableWidget : IDataWindowWidget
             ImGui.TextUnformatted(fate.HasBonus.ToString());
 
             ImGui.TableNextColumn(); // Position
-            DrawCopyableText(fate.Position.ToString(), "Click to copy Position");
+            WidgetUtil.DrawCopyableText(fate.Position.ToString(), "Click to copy Position");
 
             ImGui.TableNextColumn(); // Radius
-            DrawCopyableText(fate.Radius.ToString(), "Click to copy Radius");
-        }
-    }
-
-    private static void DrawCopyableText(string text, string tooltipText)
-    {
-        ImGuiHelpers.SafeTextWrapped(text);
-
-        if (ImGui.IsItemHovered())
-        {
-            ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
-            ImGui.BeginTooltip();
-            ImGui.TextUnformatted(tooltipText);
-            ImGui.EndTooltip();
-        }
-
-        if (ImGui.IsItemClicked())
-        {
-            ImGui.SetClipboardText(text);
+            WidgetUtil.DrawCopyableText(fate.Radius.ToString(), "Click to copy Radius");
         }
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/NounProcessorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/NounProcessorWidget.cs
@@ -146,7 +146,16 @@ internal class NounProcessorWidget : IDataWindowWidget
             {
                 for (var grammaticalCase = 0; grammaticalCase < numCases; grammaticalCase++)
                 {
-                    var output = nounProcessor.ProcessNoun(sheetType.Name, (uint)this.rowId, language, this.amount, (int)articleType, grammaticalCase).ExtractText().Replace("\"", "\\\"");
+                    var nounParams = new NounParams()
+                    {
+                        SheetName = sheetType.Name,
+                        RowId = (uint)this.rowId,
+                        Language = language,
+                        Quantity = this.amount,
+                        ArticleType = (int)articleType,
+                        GrammaticalCase = grammaticalCase,
+                    };
+                    var output = nounProcessor.ProcessNoun(nounParams).ExtractText().Replace("\"", "\\\"");
                     var caseParam = language == ClientLanguage.German ? $"(int)GermanCases.{GermanCases[grammaticalCase]}" : "1";
                     sb.AppendLine($"new(nameof(LSheets.{sheetType.Name}), {this.rowId}, ClientLanguage.{language}, {this.amount}, (int){articleTypeEnumType.Name}.{Enum.GetName(articleTypeEnumType, articleType)}, {caseParam}, \"{output}\"),");
                 }
@@ -177,7 +186,16 @@ internal class NounProcessorWidget : IDataWindowWidget
 
                 try
                 {
-                    ImGui.TextUnformatted(nounProcessor.ProcessNoun(sheetType.Name, (uint)this.rowId, language, this.amount, (int)articleType, currentCase).ExtractText());
+                    var nounParams = new NounParams()
+                    {
+                        SheetName = sheetType.Name,
+                        RowId = (uint)this.rowId,
+                        Language = language,
+                        Quantity = this.amount,
+                        ArticleType = (int)articleType,
+                        GrammaticalCase = currentCase,
+                    };
+                    ImGui.TextUnformatted(nounProcessor.ProcessNoun(nounParams).ExtractText());
                 }
                 catch (Exception ex)
                 {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/NounProcessorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/NounProcessorWidget.cs
@@ -20,7 +20,8 @@ namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
 /// </summary>
 internal class NounProcessorWidget : IDataWindowWidget
 {
-    private static readonly string[] GermanCases = ["Nominative", "Genitive", "Dative", "Accusative"];
+    /// <summary>A list of German grammatical cases.</summary>
+    internal static readonly string[] GermanCases = ["Nominative", "Genitive", "Dative", "Accusative"];
 
     private static readonly Type[] NounSheets = [
         typeof(Aetheryte),

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreator.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreator.cs
@@ -1,0 +1,941 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+
+using Dalamud.Configuration.Internal;
+using Dalamud.Game;
+using Dalamud.Game.Text.Evaluator;
+using Dalamud.Game.Text.Noun.Enums;
+using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Interface.ImGuiSeStringRenderer;
+using Dalamud.Interface.Utility;
+using Dalamud.Interface.Utility.Raii;
+using Dalamud.Utility;
+
+using FFXIVClientStructs.FFXIV.Client.System.String;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+
+using ImGuiNET;
+
+using Lumina.Excel.Sheets;
+using Lumina.Text.Expressions;
+using Lumina.Text.Payloads;
+using Lumina.Text.ReadOnly;
+
+using LSeStringBuilder = Lumina.Text.SeStringBuilder;
+
+namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
+
+/// <summary>
+/// Widget to create SeStrings.
+/// </summary>
+internal class SeStringCreator : IDataWindowWidget
+{
+    private const LinkMacroPayloadType DalamudLinkType = (LinkMacroPayloadType)Payload.EmbeddedInfoType.DalamudLink - 1;
+
+    private readonly Dictionary<MacroCode, string[]> expressionNames = new()
+    {
+        { MacroCode.SetResetTime, ["Hour", "WeekDay"] },
+        { MacroCode.SetTime, ["Time"] },
+        { MacroCode.If, ["Condition", "StatementTrue", "StatementFalse"] },
+        { MacroCode.Switch, ["Condition"] },
+        { MacroCode.PcName, ["EntityId"] },
+        { MacroCode.IfPcGender, ["EntityId", "CaseMale", "CaseFemale"] },
+        { MacroCode.IfPcName, ["EntityId", "CaseTrue", "CaseFalse"] },
+        // { MacroCode.Josa, [] },
+        // { MacroCode.Josaro, [] },
+        { MacroCode.IfSelf, ["EntityId", "CaseTrue", "CaseFalse"] },
+        // { MacroCode.NewLine, [] },
+        { MacroCode.Wait, ["Seconds"] },
+        { MacroCode.Icon, ["IconId"] },
+        { MacroCode.Color, ["Color"] },
+        { MacroCode.EdgeColor, ["Color"] },
+        { MacroCode.ShadowColor, ["Color"] },
+        // { MacroCode.SoftHyphen, [] },
+        // { MacroCode.Key, [] },
+        // { MacroCode.Scale, [] },
+        { MacroCode.Bold, ["Enabled"] },
+        { MacroCode.Italic, ["Enabled"] },
+        // { MacroCode.Edge, [] },
+        // { MacroCode.Shadow, [] },
+        // { MacroCode.NonBreakingSpace, [] },
+        { MacroCode.Icon2, ["IconId"] },
+        // { MacroCode.Hyphen, [] },
+        // { MacroCode.Num, [] },
+        { MacroCode.Hex, ["Value"] },
+        { MacroCode.Kilo, ["Value", "Separator"] },
+        { MacroCode.Byte, ["Value"] },
+        { MacroCode.Sec, ["Time"] },
+        { MacroCode.Time, ["Value"] },
+        { MacroCode.Float, ["Value", "Radix", "Separator"] },
+        { MacroCode.Link, ["Type"] },
+        { MacroCode.Sheet, ["SheetName", "RowId", "ColumnIndex", "ColumnParam"] },
+        // { MacroCode.String, [] },
+        // { MacroCode.Caps, [] },
+        { MacroCode.Head, ["String"] },
+        // { MacroCode.Split, [] },
+        { MacroCode.HeadAll, ["String"] },
+        // { MacroCode.Fixed, [] },
+        { MacroCode.Lower, ["String"] },
+        { MacroCode.JaNoun, ["SheetName", "ArticleType", "RowId", "Amount", "Case", "UnkInt5"] },
+        { MacroCode.EnNoun, ["SheetName", "ArticleType", "RowId", "Amount", "Case", "UnkInt5"] },
+        { MacroCode.DeNoun, ["SheetName", "ArticleType", "RowId", "Amount", "Case", "UnkInt5"] },
+        { MacroCode.FrNoun, ["SheetName", "ArticleType", "RowId", "Amount", "Case", "UnkInt5"] },
+        { MacroCode.ChNoun, ["SheetName", "ArticleType", "RowId", "Amount", "Case", "UnkInt5"] },
+        { MacroCode.LowerHead, ["String"] },
+        { MacroCode.ColorType, ["ColorType"] },
+        { MacroCode.EdgeColorType, ["ColorType"] },
+        { MacroCode.Digit, ["Value", "TargetLength"] },
+        { MacroCode.Ordinal, ["Value"] },
+        { MacroCode.Sound, ["IsJingle", "SoundId"] },
+        // { MacroCode.LevelPos, [] },
+    };
+
+    private readonly Dictionary<LinkMacroPayloadType, string[]> linkExpressionNames = new()
+    {
+        { LinkMacroPayloadType.Character, ["Flags", "WorldId"] },
+        { LinkMacroPayloadType.Item, ["ItemId", "Rarity"] },
+        { LinkMacroPayloadType.MapPosition, ["TerritoryType/MapId", "RawX", "RawY"] },
+        { LinkMacroPayloadType.Quest, ["QuestId"] },
+        { LinkMacroPayloadType.Achievement, ["AchievementId"] },
+        { LinkMacroPayloadType.HowTo, ["HowToId"] },
+        // PartyFinderNotification
+        { LinkMacroPayloadType.Status, ["StatusId"] },
+        { LinkMacroPayloadType.PartyFinder, ["ListingId", string.Empty, "WorldId"] },
+        { LinkMacroPayloadType.AkatsukiNote, ["AkatsukiNoteId"] },
+        { DalamudLinkType, ["CommandId", "Extra1", "Extra2", "ExtraString"] },
+    };
+
+    private readonly Dictionary<uint, string[]> fixedExpressionNames = new()
+    {
+        { 1, ["Type0", "Type1", "WorldId"] },
+        { 2, ["Type0", "Type1", "ClassJobId", "Level"] },
+        { 3, ["Type0", "Type1", "TerritoryTypeId", "Instance & MapId", "RawX", "RawY", "RawZ", "PlaceNameIdOverride"] },
+        { 4, ["Type0", "Type1", "ItemId", "Rarity", string.Empty, string.Empty, "Item Name"] },
+        { 5, ["Type0", "Type1", "Sound Effect Id"] },
+        { 6, ["Type0", "Type1", "ObjStrId"] },
+        { 7, ["Type0", "Type1", "Text"] },
+        { 8, ["Type0", "Type1", "Seconds"] },
+        { 9, ["Type0", "Type1", string.Empty] },
+        { 10, ["Type0", "Type1", "StatusId", "HasOverride", "NameOverride", "DescriptionOverride"] },
+        { 11, ["Type0", "Type1", "ListingId", string.Empty, "WorldId", "CrossWorldFlag"] },
+        { 12, ["Type0", "Type1", "QuestId", string.Empty, string.Empty, string.Empty, "QuestName"] },
+    };
+
+    private readonly List<TextEntry> entries = [
+        new TextEntry(TextEntryType.String, "Test1 "),
+        new TextEntry(TextEntryType.Macro, "<color(0xFF9000)>"),
+        new TextEntry(TextEntryType.String, "Test2 "),
+        new TextEntry(TextEntryType.Macro, "<color(0)>"),
+        new TextEntry(TextEntryType.String, "Test3 "),
+        new TextEntry(TextEntryType.Macro, "<color(stackcolor)>"),
+        new TextEntry(TextEntryType.String, "Test 4 "),
+        new TextEntry(TextEntryType.Macro, "<color(stackcolor)>"),
+        new TextEntry(TextEntryType.String, "Test 5"),
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Fixed, "<fixed(200,1,1,Some Player)>"),
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Fixed, "<fixed(200,2,28,100,0,0,ClassJob)>"),
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Fixed, "<fixed(200,3,156,65561,65035,-696153,63,0)>"),
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Fixed, "<fixed(200,3,156,65561,65035,-696153,-63,0)>"),
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Fixed, "<fixed(200,4,39246,1,0,0,Phoenix Riser Suit)>"),
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Fixed, "<fixed(200,5,4)>"),
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Fixed, "<fixed(200,6,1031195)>"),
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Fixed, "<fixed(200,6,1031197)>"),
+        // 7 formats a string??
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Fixed, "<fixed(200,8,190)>"),
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Fixed, "<fixed(200,8,0)>"),
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        // 9 writes a uint to PronounModule
+        new TextEntry(TextEntryType.Fixed, "<fixed(200,10,3,0)>"),
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Fixed, "<fixed(200,10,3,1,Title,Description)>"),
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Fixed, "<fixed(200,11,12345,0,65536,0,Player Name)>"),
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Fixed, "<fixed(200,12,70058,0,0,0,The Ultimate Weapon)>"),
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Macro, "<fixed(48,209)>"), // Mount
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Macro, "<fixed(49,28)>"), // ClassJob
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Macro, "<fixed(50,2957)>"), // PlaceName
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Macro, "<fixed(51,4)>"), // Race
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Macro, "<fixed(52,7)>"), // Tribe
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Macro, "<fixed(64,13)>"), // Companion
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Macro, "<fixed(60,21)>"), // MainCommand
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Macro, "<ordinal(501)>"), // 501st
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Macro, "<split(Hello World, ,1)>"), // Hello
+        new TextEntry(TextEntryType.Macro, "<br>"),
+        new TextEntry(TextEntryType.Macro, "<split(Hello World, ,2)>"), // World
+    ];
+
+    private SeStringParameter[]? localParameters = null;
+    private ReadOnlySeString input;
+    private ClientLanguage? language;
+
+    private enum TextEntryType
+    {
+        String,
+        Macro,
+        Fixed,
+    }
+
+    /// <inheritdoc/>
+    public string[]? CommandShortcuts { get; init; } = [];
+
+    /// <inheritdoc/>
+    public string DisplayName { get; init; } = "SeString Creator";
+
+    /// <inheritdoc/>
+    public bool Ready { get; set; }
+
+    /// <inheritdoc/>
+    public void Load()
+    {
+        this.Ready = true;
+    }
+
+    /// <inheritdoc/>
+    public void Draw()
+    {
+        // Init
+        if (this.language == null)
+        {
+            this.language = Service<DalamudConfiguration>.Get().EffectiveLanguage.ToClientLanguage();
+            this.UpdateInputString();
+        }
+
+        this.DrawControls();
+        ImGui.Spacing();
+        this.DrawInputs();
+
+        this.localParameters ??= this.GetLocalParameters(this.input.AsSpan(), []);
+
+        var evaluated = Service<SeStringEvaluator>.Get().Evaluate(this.input.AsSpan(), this.localParameters, this.language);
+
+        ImGui.SameLine();
+        using var child = ImRaii.Child("Preview", new Vector2(ImGui.GetContentRegionAvail().X, -1));
+        if (!child) return;
+
+        this.DrawPreview(evaluated);
+
+        if (this.localParameters!.Length != 0)
+        {
+            ImGui.Spacing();
+            this.DrawParameters();
+        }
+
+        ImGui.Spacing();
+        this.DrawPayloads(evaluated);
+    }
+
+    private unsafe void DrawControls()
+    {
+        if (ImGui.Button("Add entry"))
+        {
+            this.entries.Add(new(TextEntryType.String, string.Empty));
+        }
+
+        ImGui.SameLine();
+
+        if (ImGui.Button("PrintString"))
+        {
+            var output = Utf8String.CreateEmpty();
+            var temp = Utf8String.CreateEmpty();
+            var temp2 = Utf8String.CreateEmpty();
+
+            foreach (var entry in this.entries)
+            {
+                switch (entry.Type)
+                {
+                    case TextEntryType.String:
+                        output->ConcatCStr(entry.Message);
+                        break;
+
+                    case TextEntryType.Macro:
+                        temp->Clear();
+                        RaptureTextModule.Instance()->MacroEncoder.EncodeString(temp, entry.Message);
+                        output->Append(temp);
+                        break;
+
+                    case TextEntryType.Fixed:
+                        temp->SetString(entry.Message);
+                        temp2->Clear();
+
+                        RaptureTextModule.Instance()->TextModule.ProcessMacroCode(temp2, temp->StringPtr);
+                        var out1 = PronounModule.Instance()->ProcessString(temp2, true);
+                        var out2 = PronounModule.Instance()->ProcessString(out1, false);
+
+                        output->Append(out2);
+                        break;
+                }
+            }
+
+            RaptureLogModule.Instance()->PrintString(output->StringPtr);
+            temp2->Dtor(true);
+            temp->Dtor(true);
+            output->Dtor(true);
+        }
+
+        ImGui.SameLine();
+
+        if (ImGui.Button("Print Evaluated"))
+        {
+            var sb = new LSeStringBuilder();
+
+            foreach (var entry in this.entries)
+            {
+                switch (entry.Type)
+                {
+                    case TextEntryType.String:
+                        sb.Append(entry.Message);
+                        break;
+
+                    case TextEntryType.Macro:
+                    case TextEntryType.Fixed:
+                        sb.AppendMacroString(entry.Message);
+                        break;
+                }
+            }
+
+            RaptureLogModule.Instance()->PrintString(Service<SeStringEvaluator>.Get().Evaluate(sb.ToReadOnlySeString()));
+        }
+
+        if (this.entries.Count != 0)
+        {
+            ImGui.SameLine();
+
+            if (ImGui.Button("Clear entries"))
+            {
+                this.entries.Clear();
+                this.UpdateInputString();
+            }
+        }
+
+        var raptureTextModule = RaptureTextModule.Instance();
+        if (!raptureTextModule->MacroEncoder.EncoderError.IsEmpty)
+        {
+            ImGui.SameLine();
+            ImGui.TextUnformatted(raptureTextModule->MacroEncoder.EncoderError.ToString()); // TODO: EncoderError doesn't clear
+        }
+
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(90 * ImGuiHelpers.GlobalScale);
+        using (var dropdown = ImRaii.Combo("##Language", this.language.ToString() ?? "Language..."))
+        {
+            if (dropdown)
+            {
+                var values = Enum.GetValues<ClientLanguage>().OrderBy((ClientLanguage lang) => lang.ToString());
+                foreach (var value in values)
+                {
+                    if (ImGui.Selectable(Enum.GetName(value), value == this.language))
+                    {
+                        this.language = value;
+                        this.UpdateInputString();
+                    }
+                }
+            }
+        }
+    }
+
+    private unsafe void DrawInputs()
+    {
+        using var child = ImRaii.Child("Inputs", new Vector2(ImGui.GetContentRegionAvail().X / 2, -1));
+        if (!child) return;
+
+        using var table = ImRaii.Table("StringMakerTable", 3, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY | ImGuiTableFlags.NoSavedSettings);
+        if (!table) return;
+
+        ImGui.TableSetupColumn("Type", ImGuiTableColumnFlags.WidthFixed, 100);
+        ImGui.TableSetupColumn("Text", ImGuiTableColumnFlags.WidthStretch);
+        ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthFixed, 80);
+        ImGui.TableSetupScrollFreeze(3, 1);
+        ImGui.TableHeadersRow();
+
+        var arrowUpButtonSize = this.GetIconButtonSize(FontAwesomeIcon.ArrowUp);
+        var arrowDownButtonSize = this.GetIconButtonSize(FontAwesomeIcon.ArrowDown);
+        var trashButtonSize = this.GetIconButtonSize(FontAwesomeIcon.Trash);
+        var terminalButtonSize = this.GetIconButtonSize(FontAwesomeIcon.Terminal);
+
+        var entryToRemove = -1;
+        var entryToMoveUp = -1;
+        var entryToMoveDown = -1;
+        var updateString = false;
+
+        for (var i = 0; i < this.entries.Count; i++)
+        {
+            var key = $"##Entry{i}";
+            var entry = this.entries[i];
+
+            ImGui.TableNextRow();
+
+            ImGui.TableNextColumn(); // Type
+            var type = (int)entry.Type;
+            ImGui.SetNextItemWidth(-1);
+            if (ImGui.Combo($"##Type{i}", ref type, ["String", "Macro", "Fixed"], 3))
+            {
+                entry.Type = (TextEntryType)type;
+                updateString |= true;
+            }
+
+            ImGui.TableNextColumn(); // Text
+            var message = entry.Message;
+            ImGui.SetNextItemWidth(-1);
+            if (ImGui.InputText($"##{i}_Message", ref message, 255))
+            {
+                entry.Message = message;
+                updateString |= true;
+            }
+
+            ImGui.TableNextColumn(); // Actions
+
+            if (i > 0)
+            {
+                if (this.IconButton(key + "_Up", FontAwesomeIcon.ArrowUp, "Move up"))
+                {
+                    entryToMoveUp = i;
+                }
+            }
+            else
+            {
+                ImGui.Dummy(arrowUpButtonSize);
+            }
+
+            ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
+
+            if (i < this.entries.Count - 1)
+            {
+                if (this.IconButton(key + "_Down", FontAwesomeIcon.ArrowDown, "Move down"))
+                {
+                    entryToMoveDown = i;
+                }
+            }
+            else
+            {
+                ImGui.Dummy(arrowDownButtonSize);
+            }
+
+            ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
+
+            if (ImGui.IsKeyDown(ImGuiKey.LeftShift) || ImGui.IsKeyDown(ImGuiKey.RightShift))
+            {
+                if (this.IconButton(key + "_Delete", FontAwesomeIcon.Trash, "Delete"))
+                {
+                    entryToRemove = i;
+                }
+            }
+            else
+            {
+                this.IconButton(
+                    key + "_Delete",
+                    FontAwesomeIcon.Trash,
+                    "Delete with shift",
+                    disabled: true);
+            }
+        }
+
+        table.Dispose();
+
+        if (entryToMoveUp != -1)
+        {
+            var removedItem = this.entries[entryToMoveUp];
+            this.entries.RemoveAt(entryToMoveUp);
+            this.entries.Insert(entryToMoveUp - 1, removedItem);
+            updateString |= true;
+        }
+
+        if (entryToMoveDown != -1)
+        {
+            var removedItem = this.entries[entryToMoveDown];
+            this.entries.RemoveAt(entryToMoveDown);
+            this.entries.Insert(entryToMoveDown + 1, removedItem);
+            updateString |= true;
+        }
+
+        if (entryToRemove != -1)
+        {
+            this.entries.RemoveAt(entryToRemove);
+            updateString |= true;
+        }
+
+        if (updateString)
+        {
+            this.UpdateInputString();
+        }
+    }
+
+    private unsafe void UpdateInputString()
+    {
+        var sb = new LSeStringBuilder();
+
+        foreach (var entry in this.entries)
+        {
+            switch (entry.Type)
+            {
+                case TextEntryType.String:
+                    sb.Append(entry.Message);
+                    break;
+
+                case TextEntryType.Macro:
+                case TextEntryType.Fixed:
+                    sb.AppendMacroString(entry.Message);
+                    break;
+            }
+        }
+
+        this.input = sb.ToReadOnlySeString();
+        this.localParameters = null;
+    }
+
+    private void DrawPreview(ReadOnlySeString evaluated)
+    {
+        using var nodeColor = ImRaii.PushColor(ImGuiCol.Text, 0xFF00FF00);
+        using var node = ImRaii.TreeNode("Preview", ImGuiTreeNodeFlags.DefaultOpen);
+        nodeColor.Pop();
+        if (!node) return;
+
+        ImGui.Dummy(new Vector2(0, ImGui.GetTextLineHeight()));
+        ImGui.SameLine(0, 0);
+        ImGuiHelpers.SeStringWrapped(evaluated, new SeStringDrawParams()
+        {
+            ForceEdgeColor = true,
+        });
+    }
+
+    private void DrawParameters()
+    {
+        using var nodeColor = ImRaii.PushColor(ImGuiCol.Text, 0xFF00FF00);
+        using var node = ImRaii.TreeNode("Parameters", ImGuiTreeNodeFlags.DefaultOpen);
+        nodeColor.Pop();
+        if (!node) return;
+
+        for (var i = 0; i < this.localParameters!.Length; i++)
+        {
+            if (this.localParameters[i].IsString)
+            {
+                var str = this.localParameters[i].StringValue.ExtractText();
+                if (ImGui.InputText($"lstr({i + 1})", ref str, 255))
+                {
+                    this.localParameters[i] = new(str);
+                }
+            }
+            else
+            {
+                var num = (int)this.localParameters[i].UIntValue;
+                if (ImGui.InputInt($"lnum({i + 1})", ref num))
+                {
+                    this.localParameters[i] = new((uint)num);
+                }
+            }
+        }
+    }
+
+    private void DrawPayloads(ReadOnlySeString evaluated)
+    {
+        using (var nodeColor = ImRaii.PushColor(ImGuiCol.Text, 0xFF00FF00))
+        using (var node = ImRaii.TreeNode("Payloads", ImGuiTreeNodeFlags.DefaultOpen | ImGuiTreeNodeFlags.SpanAvailWidth))
+        {
+            nodeColor.Pop();
+            if (node) this.DrawSeString("payloads", this.input.AsSpan(), treeNodeFlags: ImGuiTreeNodeFlags.DefaultOpen | ImGuiTreeNodeFlags.SpanAvailWidth);
+        }
+
+        if (this.input.Equals(evaluated))
+            return;
+
+        using (var nodeColor = ImRaii.PushColor(ImGuiCol.Text, 0xFF00FF00))
+        using (var node = ImRaii.TreeNode("Payloads (Evaluated)", ImGuiTreeNodeFlags.DefaultOpen | ImGuiTreeNodeFlags.SpanAvailWidth))
+        {
+            nodeColor.Pop();
+            if (node) this.DrawSeString("payloads-evaluated", evaluated.AsSpan(), treeNodeFlags: ImGuiTreeNodeFlags.DefaultOpen | ImGuiTreeNodeFlags.SpanAvailWidth);
+        }
+    }
+
+    private void DrawSeString(string id, ReadOnlySeStringSpan rosss, bool asTreeNode = false, bool renderSeString = false, int depth = 0, ImGuiTreeNodeFlags treeNodeFlags = ImGuiTreeNodeFlags.None)
+    {
+        using var seStringId = ImRaii.PushId(id);
+
+        if (rosss.PayloadCount == 0)
+        {
+            ImGui.Dummy(Vector2.Zero);
+            return;
+        }
+
+        using var node = asTreeNode ? this.SeStringTreeNode(id, rosss) : null;
+        if (asTreeNode && !node!) return;
+
+        if (!asTreeNode && renderSeString)
+        {
+            ImGuiHelpers.SeStringWrapped(rosss, new()
+            {
+                ForceEdgeColor = true,
+            });
+        }
+
+        var payloadIdx = -1;
+        foreach (var payload in rosss)
+        {
+            payloadIdx++;
+            using var payloadId = ImRaii.PushId(payloadIdx);
+
+            var preview = payload.Type.ToString();
+            if (payload.Type == ReadOnlySePayloadType.Macro)
+                preview += $": {payload.MacroCode}";
+
+            using var nodeColor = ImRaii.PushColor(ImGuiCol.Text, 0xFF00FFFF);
+            using var payloadNode = ImRaii.TreeNode($"[{payloadIdx}] {preview}", ImGuiTreeNodeFlags.DefaultOpen | ImGuiTreeNodeFlags.SpanAvailWidth);
+            nodeColor.Pop();
+            if (!payloadNode) continue;
+
+            using var table = ImRaii.Table($"##Payload{payloadIdx}Table", 2);
+            if (!table) return;
+
+            ImGui.TableSetupColumn("Label", ImGuiTableColumnFlags.WidthFixed, 120);
+            ImGui.TableSetupColumn("Tree", ImGuiTableColumnFlags.WidthStretch);
+
+            ImGui.TableNextRow();
+            ImGui.TableNextColumn();
+            ImGui.TextUnformatted(payload.Type == ReadOnlySePayloadType.Text ? "Text" : "ToString()");
+            ImGui.TableNextColumn();
+            var text = payload.ToString();
+            WidgetUtil.DrawCopyableText($"\"{text}\"", text);
+
+            if (payload.Type != ReadOnlySePayloadType.Macro)
+                continue;
+
+            if (payload.ExpressionCount > 0)
+            {
+                var exprIdx = 0;
+                uint? subType = null;
+                uint? fixedType = null;
+
+                if (payload.MacroCode == MacroCode.Link && payload.TryGetExpression(out var linkExpr1) && linkExpr1.TryGetUInt(out var linkExpr1Val))
+                {
+                    subType = linkExpr1Val;
+                }
+                else if (payload.MacroCode == MacroCode.Fixed && payload.TryGetExpression(out var fixedTypeExpr, out var linkExpr2) && fixedTypeExpr.TryGetUInt(out var fixedTypeVal) && linkExpr2.TryGetUInt(out var linkExpr2Val))
+                {
+                    subType = linkExpr2Val;
+                    fixedType = fixedTypeVal;
+                }
+
+                foreach (var expr in payload)
+                {
+                    using var exprId = ImRaii.PushId(exprIdx);
+
+                    this.DrawExpression(payload.MacroCode, subType, fixedType, exprIdx++, expr);
+                }
+            }
+        }
+    }
+
+    private unsafe void DrawExpression(MacroCode macroCode, uint? subType, uint? fixedType, int exprIdx, ReadOnlySeExpressionSpan expr)
+    {
+        ImGui.TableNextRow();
+
+        ImGui.TableNextColumn();
+        var expressionName = this.GetExpressionName(macroCode, subType, exprIdx, expr);
+        ImGui.TextUnformatted($"[{exprIdx}] " + (string.IsNullOrEmpty(expressionName) ? $"Expr {exprIdx}" : expressionName));
+
+        ImGui.TableNextColumn();
+
+        if (expr.Body.IsEmpty)
+        {
+            ImGui.TextUnformatted("(?)");
+            return;
+        }
+
+        if (expr.TryGetUInt(out var u32))
+        {
+            if (macroCode is MacroCode.Icon or MacroCode.Icon2 && exprIdx == 0)
+            {
+                var iconId = u32;
+
+                if (macroCode == MacroCode.Icon2)
+                {
+                    var iconMapping = RaptureAtkModule.Instance()->AtkFontManager.Icon2RemapTable;
+                    for (var i = 0; i < 30; i++)
+                    {
+                        if (iconMapping[i].IconId == iconId)
+                        {
+                            iconId = iconMapping[i].RemappedIconId;
+                            break;
+                        }
+                    }
+                }
+
+                var builder = LSeStringBuilder.SharedPool.Get();
+                builder.AppendIcon(iconId);
+                ImGuiHelpers.SeStringWrapped(builder.ToArray());
+                LSeStringBuilder.SharedPool.Return(builder);
+
+                ImGui.SameLine();
+            }
+
+            WidgetUtil.DrawCopyableText(u32.ToString());
+            ImGui.SameLine();
+            WidgetUtil.DrawCopyableText($"0x{u32:X}");
+
+            if (macroCode == MacroCode.Link && exprIdx == 0)
+            {
+                var name = subType != null && (LinkMacroPayloadType)subType == DalamudLinkType
+                    ? "Dalamud"
+                    : Enum.GetName((LinkMacroPayloadType)u32);
+
+                if (!string.IsNullOrEmpty(name))
+                {
+                    ImGui.SameLine();
+                    ImGui.TextUnformatted(name);
+                }
+            }
+
+            if (macroCode is MacroCode.JaNoun or MacroCode.EnNoun or MacroCode.DeNoun or MacroCode.FrNoun && exprIdx == 1)
+            {
+                var language = macroCode switch
+                {
+                    MacroCode.JaNoun => ClientLanguage.Japanese,
+                    MacroCode.DeNoun => ClientLanguage.German,
+                    MacroCode.FrNoun => ClientLanguage.French,
+                    _ => ClientLanguage.English,
+                };
+                var articleTypeEnumType = language switch
+                {
+                    ClientLanguage.Japanese => typeof(JapaneseArticleType),
+                    ClientLanguage.German => typeof(GermanArticleType),
+                    ClientLanguage.French => typeof(FrenchArticleType),
+                    _ => typeof(EnglishArticleType),
+                };
+                ImGui.SameLine();
+                ImGui.TextUnformatted(Enum.GetName(articleTypeEnumType, u32));
+            }
+
+            if (macroCode is MacroCode.Fixed && subType != null && fixedType != null && fixedType is 100 or 200 && subType == 5 && exprIdx == 2)
+            {
+                ImGui.SameLine();
+                if (ImGui.SmallButton("Play"))
+                {
+                    UIGlobals.PlayChatSoundEffect(u32 + 1);
+                }
+            }
+
+            return;
+        }
+
+        if (expr.TryGetString(out var s))
+        {
+            this.DrawSeString("Preview", s, treeNodeFlags: ImGuiTreeNodeFlags.DefaultOpen);
+            return;
+        }
+
+        if (expr.TryGetPlaceholderExpression(out var exprType))
+        {
+            if (((ExpressionType)exprType).GetNativeName() is { } nativeName)
+            {
+                ImGui.TextUnformatted(nativeName);
+                return;
+            }
+
+            ImGui.TextUnformatted($"?x{exprType:X02}");
+            return;
+        }
+
+        if (expr.TryGetParameterExpression(out exprType, out var e1))
+        {
+            if (((ExpressionType)exprType).GetNativeName() is { } nativeName)
+            {
+                ImGui.TextUnformatted($"{nativeName}({e1.ToString()})");
+                return;
+            }
+
+            throw new InvalidOperationException("All native names must be defined for unary expressions.");
+        }
+
+        if (expr.TryGetBinaryExpression(out exprType, out e1, out var e2))
+        {
+            if (((ExpressionType)exprType).GetNativeName() is { } nativeName)
+            {
+                ImGui.TextUnformatted($"{e1.ToString()} {nativeName} {e2.ToString()}");
+                return;
+            }
+
+            throw new InvalidOperationException("All native names must be defined for binary expressions.");
+        }
+
+        var sb = new StringBuilder();
+        sb.EnsureCapacity(1 + 3 * expr.Body.Length);
+        sb.Append($"({expr.Body[0]:X02}");
+        for (var i = 1; i < expr.Body.Length; i++)
+            sb.Append($" {expr.Body[i]:X02}");
+        sb.Append(')');
+        ImGui.TextUnformatted(sb.ToString());
+    }
+
+    private string GetExpressionName(MacroCode macroCode, uint? subType, int idx, ReadOnlySeExpressionSpan expr)
+    {
+        if (this.expressionNames.TryGetValue(macroCode, out var names) && idx < names.Length)
+            return names[idx];
+
+        if (macroCode == MacroCode.Switch)
+            return $"Case {idx - 1}";
+
+        if (macroCode == MacroCode.Link && subType != null && this.linkExpressionNames.TryGetValue((LinkMacroPayloadType)subType, out var linkNames) && idx - 1 < linkNames.Length)
+            return linkNames[idx - 1];
+
+        if (macroCode == MacroCode.Fixed && subType != null && this.fixedExpressionNames.TryGetValue((uint)subType, out var fixedNames) && idx < fixedNames.Length)
+            return fixedNames[idx];
+
+        if (macroCode == MacroCode.Link && idx == 4)
+            return "Copy String";
+
+        return string.Empty;
+    }
+
+    private SeStringParameter[] GetLocalParameters(ReadOnlySeStringSpan rosss, Dictionary<uint, SeStringParameter>? parameters)
+    {
+        parameters ??= [];
+
+        void ProcessString(ReadOnlySeStringSpan rosss)
+        {
+            foreach (var payload in rosss)
+            {
+                foreach (var expression in payload)
+                {
+                    ProcessExpression(expression);
+                }
+            }
+        }
+
+        void ProcessExpression(ReadOnlySeExpressionSpan expression)
+        {
+            if (expression.TryGetString(out var exprString))
+            {
+                ProcessString(exprString);
+                return;
+            }
+
+            if (expression.TryGetBinaryExpression(out var expressionType, out var operand1, out var operand2))
+            {
+                ProcessExpression(operand1);
+                ProcessExpression(operand2);
+                return;
+            }
+
+            if (expression.TryGetParameterExpression(out expressionType, out var operand))
+            {
+                if (!operand.TryGetUInt(out var index))
+                    return;
+
+                if (parameters.ContainsKey(index))
+                    return;
+
+                if (expressionType == (int)ExpressionType.LocalNumber)
+                {
+                    parameters[index] = new SeStringParameter(0);
+                    return;
+                }
+                else if (expressionType == (int)ExpressionType.LocalString)
+                {
+                    parameters[index] = new SeStringParameter(string.Empty);
+                    return;
+                }
+            }
+        }
+
+        ProcessString(rosss);
+
+        if (parameters.Count > 0)
+        {
+            var last = parameters.OrderBy(x => x.Key).Last();
+
+            if (parameters.Count != last.Key)
+            {
+                // fill missing local parameter slots, so we can go off the array index in SeStringContext
+
+                for (var i = 1u; i <= last.Key; i++)
+                {
+                    if (!parameters.ContainsKey(i))
+                        parameters[i] = new SeStringParameter(0);
+                }
+            }
+        }
+
+        return parameters.OrderBy(x => x.Key).Select(x => x.Value).ToArray();
+    }
+
+    private ImRaii.IEndObject SeStringTreeNode(string id, ReadOnlySeStringSpan previewText, uint color = 0xFF00FFFF, ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags.None)
+    {
+        using var titleColor = ImRaii.PushColor(ImGuiCol.Text, color);
+        var node = ImRaii.TreeNode("##" + id, flags);
+        ImGui.SameLine();
+        ImGuiHelpers.SeStringWrapped(previewText, new()
+        {
+            ForceEdgeColor = true,
+            WrapWidth = 9999,
+        });
+        return node;
+    }
+
+    private bool IconButton(string key, FontAwesomeIcon icon, string tooltip, Vector2 size = default, bool disabled = false, bool active = false)
+    {
+        using var iconFont = ImRaii.PushFont(UiBuilder.IconFont);
+        if (!key.StartsWith("##")) key = "##" + key;
+
+        var disposables = new List<IDisposable>();
+
+        if (disabled)
+        {
+            disposables.Add(ImRaii.PushColor(ImGuiCol.Text, ImGui.GetStyle().Colors[(int)ImGuiCol.TextDisabled]));
+            disposables.Add(ImRaii.PushColor(ImGuiCol.ButtonActive, ImGui.GetStyle().Colors[(int)ImGuiCol.Button]));
+            disposables.Add(ImRaii.PushColor(ImGuiCol.ButtonHovered, ImGui.GetStyle().Colors[(int)ImGuiCol.Button]));
+        }
+        else if (active)
+        {
+            disposables.Add(ImRaii.PushColor(ImGuiCol.Button, ImGui.GetStyle().Colors[(int)ImGuiCol.ButtonActive]));
+        }
+
+        var pressed = ImGui.Button(icon.ToIconString() + key, size);
+
+        foreach (var disposable in disposables)
+            disposable.Dispose();
+
+        iconFont?.Dispose();
+
+        if (ImGui.IsItemHovered())
+        {
+            ImGui.BeginTooltip();
+            ImGui.TextUnformatted(tooltip);
+            ImGui.EndTooltip();
+        }
+
+        return pressed;
+    }
+
+    private Vector2 GetIconButtonSize(FontAwesomeIcon icon)
+    {
+        using var iconFont = ImRaii.PushFont(UiBuilder.IconFont);
+        return ImGui.CalcTextSize(icon.ToIconString()) + ImGui.GetStyle().FramePadding * 2;
+    }
+
+    private class TextEntry(TextEntryType type, string text)
+    {
+        public string Message { get; set; } = text;
+
+        public TextEntryType Type { get; set; } = type;
+    }
+}

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreator.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreator.cs
@@ -19,7 +19,6 @@ using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 
 using ImGuiNET;
 
-using Lumina.Excel.Sheets;
 using Lumina.Text.Expressions;
 using Lumina.Text.Payloads;
 using Lumina.Text.ReadOnly;

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreator.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreator.cs
@@ -62,7 +62,7 @@ internal class SeStringCreator : IDataWindowWidget
         // { MacroCode.NonBreakingSpace, [] },
         { MacroCode.Icon2, ["IconId"] },
         // { MacroCode.Hyphen, [] },
-        // { MacroCode.Num, [] },
+        { MacroCode.Num, ["Value"] },
         { MacroCode.Hex, ["Value"] },
         { MacroCode.Kilo, ["Value", "Separator"] },
         { MacroCode.Byte, ["Value"] },
@@ -71,10 +71,10 @@ internal class SeStringCreator : IDataWindowWidget
         { MacroCode.Float, ["Value", "Radix", "Separator"] },
         { MacroCode.Link, ["Type"] },
         { MacroCode.Sheet, ["SheetName", "RowId", "ColumnIndex", "ColumnParam"] },
-        // { MacroCode.String, [] },
-        // { MacroCode.Caps, [] },
+        { MacroCode.String, ["String"] },
+        { MacroCode.Caps, ["String"] },
         { MacroCode.Head, ["String"] },
-        // { MacroCode.Split, [] },
+        { MacroCode.Split, ["String", "Separator"] },
         { MacroCode.HeadAll, ["String"] },
         // { MacroCode.Fixed, [] },
         { MacroCode.Lower, ["String"] },
@@ -89,7 +89,7 @@ internal class SeStringCreator : IDataWindowWidget
         { MacroCode.Digit, ["Value", "TargetLength"] },
         { MacroCode.Ordinal, ["Value"] },
         { MacroCode.Sound, ["IsJingle", "SoundId"] },
-        // { MacroCode.LevelPos, [] },
+        { MacroCode.LevelPos, ["LevelId"] },
     };
 
     private readonly Dictionary<LinkMacroPayloadType, string[]> linkExpressionNames = new()
@@ -254,7 +254,7 @@ internal class SeStringCreator : IDataWindowWidget
 
         ImGui.SameLine();
 
-        if (ImGui.Button("PrintString"))
+        if (ImGui.Button("Print"))
         {
             var output = Utf8String.CreateEmpty();
             var temp = Utf8String.CreateEmpty();

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
@@ -25,6 +25,7 @@ using Lumina.Data;
 using Lumina.Data.Files.Excel;
 using Lumina.Data.Structs.Excel;
 using Lumina.Excel;
+using Lumina.Excel.Sheets;
 using Lumina.Text.Expressions;
 using Lumina.Text.Payloads;
 using Lumina.Text.ReadOnly;
@@ -1025,6 +1026,46 @@ internal class SeStringCreatorWidget : IDataWindowWidget
                 if (ImGui.SmallButton("Play"))
                 {
                     UIGlobals.PlayChatSoundEffect(u32 + 1);
+                }
+            }
+
+            if (macroCode is MacroCode.Link && subType != null && exprIdx == 1)
+            {
+                var dataManager = Service<DataManager>.Get();
+
+                switch ((LinkMacroPayloadType)subType)
+                {
+                    case LinkMacroPayloadType.Item when dataManager.GetExcelSheet<Item>(this.language).TryGetRow(u32, out var itemRow):
+                        ImGui.SameLine();
+                        ImGui.TextUnformatted(itemRow.Name.ExtractText());
+                        break;
+
+                    case LinkMacroPayloadType.Quest when dataManager.GetExcelSheet<Quest>(this.language).TryGetRow(u32, out var questRow):
+                        ImGui.SameLine();
+                        ImGui.TextUnformatted(questRow.Name.ExtractText());
+                        break;
+
+                    case LinkMacroPayloadType.Achievement when dataManager.GetExcelSheet<Achievement>(this.language).TryGetRow(u32, out var achievementRow):
+                        ImGui.SameLine();
+                        ImGui.TextUnformatted(achievementRow.Name.ExtractText());
+                        break;
+
+                    case LinkMacroPayloadType.HowTo when dataManager.GetExcelSheet<HowTo>(this.language).TryGetRow(u32, out var howToRow):
+                        ImGui.SameLine();
+                        ImGui.TextUnformatted(howToRow.Name.ExtractText());
+                        break;
+
+                    case LinkMacroPayloadType.Status when dataManager.GetExcelSheet<Status>(this.language).TryGetRow(u32, out var statusRow):
+                        ImGui.SameLine();
+                        ImGui.TextUnformatted(statusRow.Name.ExtractText());
+                        break;
+
+                    case LinkMacroPayloadType.AkatsukiNote when
+                        dataManager.GetSubrowExcelSheet<AkatsukiNote>(this.language).TryGetRow(u32, out var akatsukiNoteRow) &&
+                        dataManager.GetExcelSheet<AkatsukiNoteString>(this.language).TryGetRow((uint)akatsukiNoteRow[0].Unknown2, out var akatsukiNoteStringRow):
+                        ImGui.SameLine();
+                        ImGui.TextUnformatted(akatsukiNoteStringRow.Unknown0.ExtractText());
+                        break;
                 }
             }
 

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
@@ -30,7 +30,7 @@ namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
 /// <summary>
 /// Widget to create SeStrings.
 /// </summary>
-internal class SeStringCreator : IDataWindowWidget
+internal class SeStringCreatorWidget : IDataWindowWidget
 {
     private const LinkMacroPayloadType DalamudLinkType = (LinkMacroPayloadType)Payload.EmbeddedInfoType.DalamudLink - 1;
 

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/NounProcessorAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/NounProcessorAgingStep.cs
@@ -1,0 +1,248 @@
+using Dalamud.Game;
+using Dalamud.Game.Text.Noun;
+using Dalamud.Game.Text.Noun.Enums;
+
+using ImGuiNET;
+
+using LSheets = Lumina.Excel.Sheets;
+
+namespace Dalamud.Interface.Internal.Windows.SelfTest.AgingSteps;
+
+/// <summary>
+/// Test setup for NounProcessor.
+/// </summary>
+internal class NounProcessorAgingStep : IAgingStep
+{
+    private NounTestEntry[] tests =
+    [
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.Japanese, 1, (int)JapaneseArticleType.NearListener, 1, "その蜂蜜酒の運び人"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.Japanese, 1, (int)JapaneseArticleType.Distant, 1, "蜂蜜酒の運び人"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.Japanese, 2, (int)JapaneseArticleType.NearListener, 1, "それらの蜂蜜酒の運び人"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.Japanese, 2, (int)JapaneseArticleType.Distant, 1, "あれらの蜂蜜酒の運び人"),
+
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.English, 1, (int)EnglishArticleType.Indefinite, 1, "a mead-porting Midlander"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.English, 1, (int)EnglishArticleType.Definite, 1, "the mead-porting Midlander"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.English, 2, (int)EnglishArticleType.Indefinite, 1, "mead-porting Midlanders"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.English, 2, (int)EnglishArticleType.Definite, 1, "mead-porting Midlanders"),
+
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Indefinite, (int)GermanCases.Nominative, "ein Met schleppender Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Indefinite, (int)GermanCases.Genitive, "eines Met schleppenden Wiesländers"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Indefinite, (int)GermanCases.Dative, "einem Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Indefinite, (int)GermanCases.Accusative, "einen Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Definite, (int)GermanCases.Nominative, "der Met schleppender Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Definite, (int)GermanCases.Genitive, "des Met schleppenden Wiesländers"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Definite, (int)GermanCases.Dative, "dem Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Definite, (int)GermanCases.Accusative, "den Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Possessive, (int)GermanCases.Nominative, "dein Met schleppende Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Possessive, (int)GermanCases.Genitive, "deines Met schleppenden Wiesländers"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Possessive, (int)GermanCases.Dative, "deinem Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Possessive, (int)GermanCases.Accusative, "deinen Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Negative, (int)GermanCases.Nominative, "kein Met schleppender Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Negative, (int)GermanCases.Genitive, "keines Met schleppenden Wiesländers"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Negative, (int)GermanCases.Dative, "keinem Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Negative, (int)GermanCases.Accusative, "keinen Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Nominative, "Met schleppender Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Genitive, "Met schleppenden Wiesländers"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Dative, "Met schleppendem Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Accusative, "Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Demonstrative, (int)GermanCases.Nominative, "dieser Met schleppende Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Demonstrative, (int)GermanCases.Genitive, "dieses Met schleppenden Wiesländers"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Demonstrative, (int)GermanCases.Dative, "diesem Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 1, (int)GermanArticleType.Demonstrative, (int)GermanCases.Accusative, "diesen Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Indefinite, (int)GermanCases.Nominative, "2 Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Indefinite, (int)GermanCases.Genitive, "2 Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Indefinite, (int)GermanCases.Dative, "2 Met schleppenden Wiesländern"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Indefinite, (int)GermanCases.Accusative, "2 Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Definite, (int)GermanCases.Nominative, "die Met schleppende Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Definite, (int)GermanCases.Genitive, "der Met schleppender Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Definite, (int)GermanCases.Dative, "den Met schleppenden Wiesländern"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Definite, (int)GermanCases.Accusative, "die Met schleppende Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Possessive, (int)GermanCases.Nominative, "deine Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Possessive, (int)GermanCases.Genitive, "deiner Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Possessive, (int)GermanCases.Dative, "deinen Met schleppenden Wiesländern"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Possessive, (int)GermanCases.Accusative, "deine Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Negative, (int)GermanCases.Nominative, "keine Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Negative, (int)GermanCases.Genitive, "keiner Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Negative, (int)GermanCases.Dative, "keinen Met schleppenden Wiesländern"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Negative, (int)GermanCases.Accusative, "keine Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Nominative, "Met schleppende Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Genitive, "Met schleppender Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Dative, "Met schleppenden Wiesländern"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Accusative, "Met schleppende Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Demonstrative, (int)GermanCases.Nominative, "diese Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Demonstrative, (int)GermanCases.Genitive, "dieser Met schleppenden Wiesländer"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Demonstrative, (int)GermanCases.Dative, "diesen Met schleppenden Wiesländern"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.German, 2, (int)GermanArticleType.Demonstrative, (int)GermanCases.Accusative, "diese Met schleppenden Wiesländer"),
+
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.French, 1, (int)FrenchArticleType.Indefinite, 1, "un livreur d'hydromel"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.French, 1, (int)FrenchArticleType.Definite, 1, "le livreur d'hydromel"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.French, 1, (int)FrenchArticleType.PossessiveFirstPerson, 1, "mon livreur d'hydromel"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.French, 1, (int)FrenchArticleType.PossessiveSecondPerson, 1, "ton livreur d'hydromel"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.French, 1, (int)FrenchArticleType.PossessiveThirdPerson, 1, "son livreur d'hydromel"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.French, 2, (int)FrenchArticleType.Indefinite, 1, "des livreurs d'hydromel"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.French, 2, (int)FrenchArticleType.Definite, 1, "les livreurs d'hydromel"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.French, 2, (int)FrenchArticleType.PossessiveFirstPerson, 1, "mes livreurs d'hydromel"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.French, 2, (int)FrenchArticleType.PossessiveSecondPerson, 1, "tes livreurs d'hydromel"),
+        new(nameof(LSheets.BNpcName), 1330, ClientLanguage.French, 2, (int)FrenchArticleType.PossessiveThirdPerson, 1, "ses livreurs d'hydromel"),
+
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.Japanese, 1, (int)JapaneseArticleType.NearListener, 1, "その酔いどれのネル"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.Japanese, 1, (int)JapaneseArticleType.Distant, 1, "酔いどれのネル"),
+
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.English, 1, (int)EnglishArticleType.Indefinite, 1, "Nell Half-full"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.English, 1, (int)EnglishArticleType.Definite, 1, "Nell Half-full"),
+
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Indefinite, (int)GermanCases.Nominative, "Nell die Beschwipste"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Indefinite, (int)GermanCases.Genitive, "Nell der Beschwipsten"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Indefinite, (int)GermanCases.Dative, "Nell der Beschwipsten"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Indefinite, (int)GermanCases.Accusative, "Nell die Beschwipste"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Definite, (int)GermanCases.Nominative, "Nell die Beschwipste"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Definite, (int)GermanCases.Genitive, "Nell der Beschwipsten"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Definite, (int)GermanCases.Dative, "Nell der Beschwipsten"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Definite, (int)GermanCases.Accusative, "Nell die Beschwipste"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Possessive, (int)GermanCases.Nominative, "Nell die Beschwipste"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Possessive, (int)GermanCases.Genitive, "Nell der Beschwipsten"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Possessive, (int)GermanCases.Dative, "Nell der Beschwipsten"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Possessive, (int)GermanCases.Accusative, "Nell die Beschwipste"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Negative, (int)GermanCases.Nominative, "Nell die Beschwipste"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Negative, (int)GermanCases.Genitive, "Nell der Beschwipsten"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Negative, (int)GermanCases.Dative, "Nell der Beschwipsten"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Negative, (int)GermanCases.Accusative, "Nell die Beschwipste"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Nominative, "Nell die Beschwipste"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Genitive, "Nell der Beschwipsten"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Dative, "Nell der Beschwipsten"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Accusative, "Nell die Beschwipste"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Demonstrative, (int)GermanCases.Nominative, "Nell die Beschwipste"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Demonstrative, (int)GermanCases.Genitive, "Nell der Beschwipsten"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Demonstrative, (int)GermanCases.Dative, "Nell der Beschwipsten"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.German, 1, (int)GermanArticleType.Demonstrative, (int)GermanCases.Accusative, "Nell die Beschwipste"),
+
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.French, 1, (int)FrenchArticleType.Indefinite, 1, "Nell la Boit-sans-soif"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.French, 1, (int)FrenchArticleType.Definite, 1, "Nell la Boit-sans-soif"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.French, 1, (int)FrenchArticleType.PossessiveFirstPerson, 1, "ma Nell la Boit-sans-soif"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.French, 1, (int)FrenchArticleType.PossessiveSecondPerson, 1, "ta Nell la Boit-sans-soif"),
+        new(nameof(LSheets.ENpcResident), 1031947, ClientLanguage.French, 1, (int)FrenchArticleType.PossessiveThirdPerson, 1, "sa Nell la Boit-sans-soif"),
+
+        new(nameof(LSheets.Item), 44348, ClientLanguage.Japanese, 1, (int)JapaneseArticleType.NearListener, 1, "その希少トームストーン:幻想"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.Japanese, 1, (int)JapaneseArticleType.Distant, 1, "希少トームストーン:幻想"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.Japanese, 2, (int)JapaneseArticleType.NearListener, 1, "それらの希少トームストーン:幻想"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.Japanese, 2, (int)JapaneseArticleType.Distant, 1, "あれらの希少トームストーン:幻想"),
+
+        new(nameof(LSheets.Item), 44348, ClientLanguage.English, 1, (int)EnglishArticleType.Indefinite, 1, "an irregular tomestone of phantasmagoria"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.English, 1, (int)EnglishArticleType.Definite, 1, "the irregular tomestone of phantasmagoria"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.English, 2, (int)EnglishArticleType.Indefinite, 1, "irregular tomestones of phantasmagoria"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.English, 2, (int)EnglishArticleType.Definite, 1, "irregular tomestones of phantasmagoria"),
+
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Indefinite, (int)GermanCases.Nominative, "ein ungewöhnlicher Allagischer Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Indefinite, (int)GermanCases.Genitive, "eines ungewöhnlichen Allagischen Steins der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Indefinite, (int)GermanCases.Dative, "einem ungewöhnlichen Allagischen Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Indefinite, (int)GermanCases.Accusative, "einen ungewöhnlichen Allagischen Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Definite, (int)GermanCases.Nominative, "der ungewöhnlicher Allagischer Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Definite, (int)GermanCases.Genitive, "des ungewöhnlichen Allagischen Steins der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Definite, (int)GermanCases.Dative, "dem ungewöhnlichen Allagischen Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Definite, (int)GermanCases.Accusative, "den ungewöhnlichen Allagischen Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Possessive, (int)GermanCases.Nominative, "dein ungewöhnliche Allagische Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Possessive, (int)GermanCases.Genitive, "deines ungewöhnlichen Allagischen Steins der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Possessive, (int)GermanCases.Dative, "deinem ungewöhnlichen Allagischen Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Possessive, (int)GermanCases.Accusative, "deinen ungewöhnlichen Allagischen Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Negative, (int)GermanCases.Nominative, "kein ungewöhnlicher Allagischer Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Negative, (int)GermanCases.Genitive, "keines ungewöhnlichen Allagischen Steins der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Negative, (int)GermanCases.Dative, "keinem ungewöhnlichen Allagischen Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Negative, (int)GermanCases.Accusative, "keinen ungewöhnlichen Allagischen Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Nominative, "ungewöhnlicher Allagischer Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Genitive, "ungewöhnlichen Allagischen Steins der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Dative, "ungewöhnlichem Allagischem Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Accusative, "ungewöhnlichen Allagischen Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Demonstrative, (int)GermanCases.Nominative, "dieser ungewöhnliche Allagische Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Demonstrative, (int)GermanCases.Genitive, "dieses ungewöhnlichen Allagischen Steins der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Demonstrative, (int)GermanCases.Dative, "diesem ungewöhnlichen Allagischen Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 1, (int)GermanArticleType.Demonstrative, (int)GermanCases.Accusative, "diesen ungewöhnlichen Allagischen Stein der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Indefinite, (int)GermanCases.Nominative, "2 ungewöhnlichen Allagischen Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Indefinite, (int)GermanCases.Genitive, "2 ungewöhnlichen Allagischen Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Indefinite, (int)GermanCases.Dative, "2 ungewöhnlichen Allagischen Steinen der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Indefinite, (int)GermanCases.Accusative, "2 ungewöhnlichen Allagischen Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Definite, (int)GermanCases.Nominative, "die ungewöhnliche Allagische Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Definite, (int)GermanCases.Genitive, "der ungewöhnlicher Allagischer Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Definite, (int)GermanCases.Dative, "den ungewöhnlichen Allagischen Steinen der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Definite, (int)GermanCases.Accusative, "die ungewöhnliche Allagische Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Possessive, (int)GermanCases.Nominative, "deine ungewöhnlichen Allagischen Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Possessive, (int)GermanCases.Genitive, "deiner ungewöhnlichen Allagischen Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Possessive, (int)GermanCases.Dative, "deinen ungewöhnlichen Allagischen Steinen der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Possessive, (int)GermanCases.Accusative, "deine ungewöhnlichen Allagischen Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Negative, (int)GermanCases.Nominative, "keine ungewöhnlichen Allagischen Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Negative, (int)GermanCases.Genitive, "keiner ungewöhnlichen Allagischen Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Negative, (int)GermanCases.Dative, "keinen ungewöhnlichen Allagischen Steinen der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Negative, (int)GermanCases.Accusative, "keine ungewöhnlichen Allagischen Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Nominative, "ungewöhnliche Allagische Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Genitive, "ungewöhnlicher Allagischer Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Dative, "ungewöhnlichen Allagischen Steinen der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.ZeroArticle, (int)GermanCases.Accusative, "ungewöhnliche Allagische Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Demonstrative, (int)GermanCases.Nominative, "diese ungewöhnlichen Allagischen Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Demonstrative, (int)GermanCases.Genitive, "dieser ungewöhnlichen Allagischen Steine der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Demonstrative, (int)GermanCases.Dative, "diesen ungewöhnlichen Allagischen Steinen der Phantasmagorie"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.German, 2, (int)GermanArticleType.Demonstrative, (int)GermanCases.Accusative, "diese ungewöhnlichen Allagischen Steine der Phantasmagorie"),
+
+        new(nameof(LSheets.Item), 44348, ClientLanguage.French, 1, (int)FrenchArticleType.Indefinite, 1, "un mémoquartz inhabituel fantasmagorique"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.French, 1, (int)FrenchArticleType.Definite, 1, "le mémoquartz inhabituel fantasmagorique"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.French, 1, (int)FrenchArticleType.PossessiveFirstPerson, 1, "mon mémoquartz inhabituel fantasmagorique"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.French, 1, (int)FrenchArticleType.PossessiveSecondPerson, 1, "ton mémoquartz inhabituel fantasmagorique"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.French, 1, (int)FrenchArticleType.PossessiveThirdPerson, 1, "son mémoquartz inhabituel fantasmagorique"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.French, 2, (int)FrenchArticleType.Indefinite, 1, "des mémoquartz inhabituels fantasmagoriques"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.French, 2, (int)FrenchArticleType.Definite, 1, "les mémoquartz inhabituels fantasmagoriques"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.French, 2, (int)FrenchArticleType.PossessiveFirstPerson, 1, "mes mémoquartz inhabituels fantasmagoriques"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.French, 2, (int)FrenchArticleType.PossessiveSecondPerson, 1, "tes mémoquartz inhabituels fantasmagoriques"),
+        new(nameof(LSheets.Item), 44348, ClientLanguage.French, 2, (int)FrenchArticleType.PossessiveThirdPerson, 1, "ses mémoquartz inhabituels fantasmagoriques"),
+    ];
+
+    private enum GermanCases
+    {
+        Nominative,
+        Genitive,
+        Dative,
+        Accusative,
+    }
+
+    /// <inheritdoc/>
+    public string Name => "Test NounProcessor";
+
+    /// <inheritdoc/>
+    public unsafe SelfTestStepResult RunStep()
+    {
+        var nounProcessor = Service<NounProcessor>.Get();
+
+        for (var i = 0; i < this.tests.Length; i++)
+        {
+            var e = this.tests[i];
+
+            var output = nounProcessor.ProcessNoun(e.SheetName, e.RowId, e.Language, e.Quantity, e.ArticleType, e.GrammaticalCase);
+
+            if (e.ExpectedResult != output)
+            {
+                ImGui.TextUnformatted($"Mismatch detected (Test #{i}):");
+                ImGui.TextUnformatted($"Got: {output}");
+                ImGui.TextUnformatted($"Expected: {e.ExpectedResult}");
+
+                if (ImGui.Button("Continue"))
+                    return SelfTestStepResult.Fail;
+
+                return SelfTestStepResult.Waiting;
+            }
+        }
+
+        return SelfTestStepResult.Pass;
+    }
+
+    /// <inheritdoc/>
+    public void CleanUp()
+    {
+        // ignored
+    }
+
+    private record struct NounTestEntry(
+        string SheetName,
+        uint RowId,
+        ClientLanguage Language,
+        int Quantity,
+        int ArticleType,
+        int GrammaticalCase,
+        string ExpectedResult);
+}

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/NounProcessorAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/NounProcessorAgingStep.cs
@@ -212,8 +212,17 @@ internal class NounProcessorAgingStep : IAgingStep
         for (var i = 0; i < this.tests.Length; i++)
         {
             var e = this.tests[i];
-
-            var output = nounProcessor.ProcessNoun(e.SheetName, e.RowId, e.Language, e.Quantity, e.ArticleType, e.GrammaticalCase);
+            
+            var nounParams = new NounParams()
+            {
+                SheetName = e.SheetName,
+                RowId = e.RowId,
+                Language = e.Language,
+                Quantity = e.Quantity,
+                ArticleType = e.ArticleType,
+                GrammaticalCase = e.GrammaticalCase,
+            };
+            var output = nounProcessor.ProcessNoun(nounParams);
 
             if (e.ExpectedResult != output)
             {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/NounProcessorAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/NounProcessorAgingStep.cs
@@ -191,6 +191,8 @@ internal class NounProcessorAgingStep : IAgingStep
         new(nameof(LSheets.Item), 44348, ClientLanguage.French, 2, (int)FrenchArticleType.PossessiveFirstPerson, 1, "mes mémoquartz inhabituels fantasmagoriques"),
         new(nameof(LSheets.Item), 44348, ClientLanguage.French, 2, (int)FrenchArticleType.PossessiveSecondPerson, 1, "tes mémoquartz inhabituels fantasmagoriques"),
         new(nameof(LSheets.Item), 44348, ClientLanguage.French, 2, (int)FrenchArticleType.PossessiveThirdPerson, 1, "ses mémoquartz inhabituels fantasmagoriques"),
+
+        new(nameof(LSheets.Action), 45, ClientLanguage.German, 1, (int)FrenchArticleType.Indefinite, 1, "Blumenflüsterer IV"),
     ];
 
     private enum GermanCases

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/SeStringEvaluatorAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/SeStringEvaluatorAgingStep.cs
@@ -8,7 +8,7 @@ using Lumina.Text.ReadOnly;
 namespace Dalamud.Interface.Internal.Windows.SelfTest.AgingSteps;
 
 /// <summary>
-/// Test setup for targets.
+/// Test setup for SeStringEvaluator.
 /// </summary>
 internal class SeStringEvaluatorAgingStep : IAgingStep
 {
@@ -27,7 +27,8 @@ internal class SeStringEvaluatorAgingStep : IAgingStep
             case 0:
                 ImGui.TextUnformatted("Is this the current time, and is it ticking?");
 
-                // This checks that MacroDecoder.GetMacroTime()->SetTime() has been called
+                // This checks that EvaluateFromAddon fetches the correct Addon row,
+                // that MacroDecoder.GetMacroTime()->SetTime() has been called
                 // and that local and global parameters have been read correctly.
 
                 ImGui.TextUnformatted(seStringEvaluator.EvaluateFromAddon(31, [(uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds()]).ExtractText());
@@ -60,21 +61,18 @@ internal class SeStringEvaluatorAgingStep : IAgingStep
                 var evaluatedPlayerName = seStringEvaluator.Evaluate(ReadOnlySeString.FromMacroString("<pcname(lnum1)>"), [localPlayer.EntityId]).ExtractText();
                 var localPlayerName = localPlayer.Name.TextValue;
 
-                if (evaluatedPlayerName == localPlayerName)
-                {
-                    this.step++;
-                }
-                else
+                if (evaluatedPlayerName != localPlayerName)
                 {
                     ImGui.TextUnformatted("The player name doesn't match:");
                     ImGui.TextUnformatted($"Evaluated Player Name (got): {evaluatedPlayerName}");
                     ImGui.TextUnformatted($"Local Player Name (expected): {localPlayerName}");
-                    return SelfTestStepResult.Fail;
+
+                    if (ImGui.Button("Continue"))
+                        return SelfTestStepResult.Fail;
+
+                    return SelfTestStepResult.Waiting;
                 }
 
-                break;
-
-            case 2:
                 return SelfTestStepResult.Pass;
         }
 

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/SeStringEvaluatorAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/SeStringEvaluatorAgingStep.cs
@@ -55,6 +55,10 @@ internal class SeStringEvaluatorAgingStep : IAgingStep
                 if (localPlayer is null)
                 {
                     ImGui.TextUnformatted("You need to be logged in for this step.");
+
+                    if (ImGui.Button("Skip"))
+                        return SelfTestStepResult.NotRan;
+
                     return SelfTestStepResult.Waiting;
                 }
 

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/SeStringEvaluatorAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/SeStringEvaluatorAgingStep.cs
@@ -1,0 +1,90 @@
+using Dalamud.Game.ClientState;
+using Dalamud.Game.Text.Evaluator;
+
+using ImGuiNET;
+
+using Lumina.Text.ReadOnly;
+
+namespace Dalamud.Interface.Internal.Windows.SelfTest.AgingSteps;
+
+/// <summary>
+/// Test setup for targets.
+/// </summary>
+internal class SeStringEvaluatorAgingStep : IAgingStep
+{
+    private int step = 0;
+
+    /// <inheritdoc/>
+    public string Name => "Test SeStringEvaluator";
+
+    /// <inheritdoc/>
+    public SelfTestStepResult RunStep()
+    {
+        var seStringEvaluator = Service<SeStringEvaluator>.Get();
+
+        switch (this.step)
+        {
+            case 0:
+                ImGui.TextUnformatted("Is this the current time, and is it ticking?");
+
+                // This checks that MacroDecoder.GetMacroTime()->SetTime() has been called
+                // and that local and global parameters have been read correctly.
+
+                ImGui.TextUnformatted(seStringEvaluator.EvaluateFromAddon(31, [(uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds()]).ExtractText());
+
+                if (ImGui.Button("Yes"))
+                    this.step++;
+
+                ImGui.SameLine();
+
+                if (ImGui.Button("No"))
+                    return SelfTestStepResult.Fail;
+
+                break;
+
+            case 1:
+                ImGui.TextUnformatted("Checking pcname macro using the local player name...");
+
+                // This makes sure that NameCache.Instance()->TryGetCharacterInfoByEntityId() has been called,
+                // that it returned the local players name by using its EntityId,
+                // and that it didn't include the world name by checking the HomeWorldId against AgentLobby.Instance()->LobbyData.HomeWorldId.
+
+                var clientState = Service<ClientState>.Get();
+                var localPlayer = clientState.LocalPlayer;
+                if (localPlayer is null)
+                {
+                    ImGui.TextUnformatted("You need to be logged in for this step.");
+                    return SelfTestStepResult.Waiting;
+                }
+
+                var evaluatedPlayerName = seStringEvaluator.Evaluate(ReadOnlySeString.FromMacroString("<pcname(lnum1)>"), [localPlayer.EntityId]).ExtractText();
+                var localPlayerName = localPlayer.Name.TextValue;
+
+                if (evaluatedPlayerName == localPlayerName)
+                {
+                    this.step++;
+                }
+                else
+                {
+                    ImGui.TextUnformatted("The player name doesn't match:");
+                    ImGui.TextUnformatted($"Evaluated Player Name (got): {evaluatedPlayerName}");
+                    ImGui.TextUnformatted($"Local Player Name (expected): {localPlayerName}");
+                    return SelfTestStepResult.Fail;
+                }
+
+                break;
+
+            case 2:
+                return SelfTestStepResult.Pass;
+        }
+
+        return SelfTestStepResult.Waiting;
+    }
+
+    /// <inheritdoc/>
+    public void CleanUp()
+    {
+        // ignored
+        this.step = 0;
+    }
+}

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/SheetRedirectResolverAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/SheetRedirectResolverAgingStep.cs
@@ -1,0 +1,133 @@
+using System.Runtime.InteropServices;
+
+using Dalamud.Game;
+using Dalamud.Game.Text.Evaluator.Internal;
+
+using FFXIVClientStructs.FFXIV.Client.System.String;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+
+using ImGuiNET;
+
+namespace Dalamud.Interface.Internal.Windows.SelfTest.AgingSteps;
+
+/// <summary>
+/// Test setup for SheetRedirectResolver.
+/// </summary>
+internal class SheetRedirectResolverAgingStep : IAgingStep
+{
+    private int step = 0;
+    private RedirectEntry[] redirects =
+    [
+        new("Item", 10),
+        new("ItemHQ", 10),
+        new("ItemMP", 10),
+        new("Item", 35588),
+        new("Item", 1035588),
+        new("Item", 2000217),
+        new("ActStr", 10),       // Trait
+        new("ActStr", 1000010),  // Action
+        new("ActStr", 2000010),  // Item
+        new("ActStr", 3000010),  // EventItem
+        new("ActStr", 4000010),  // EventAction
+        new("ActStr", 5000010),  // GeneralAction
+        new("ActStr", 6000010),  // BuddyAction
+        new("ActStr", 7000010),  // MainCommand
+        new("ActStr", 8000010),  // Companion
+        new("ActStr", 9000010),  // CraftAction
+        new("ActStr", 10000010), // Action
+        new("ActStr", 11000010), // PetAction
+        new("ActStr", 12000010), // CompanyAction
+        new("ActStr", 13000010), // Mount
+        // new("ActStr", 14000010),
+        // new("ActStr", 15000010),
+        // new("ActStr", 16000010),
+        // new("ActStr", 17000010),
+        // new("ActStr", 18000010),
+        new("ActStr", 19000010), // BgcArmyAction
+        new("ActStr", 20000010), // Ornament
+        new("ObjStr", 10),       // BNpcName
+        new("ObjStr", 1000010),  // ENpcResident
+        new("ObjStr", 2000010),  // Treasure
+        new("ObjStr", 3000010),  // Aetheryte
+        new("ObjStr", 4000010),  // GatheringPointName
+        new("ObjStr", 5000010),  // EObjName
+        new("ObjStr", 6000010),  // Mount
+        new("ObjStr", 7000010),  // Companion
+        // new("ObjStr", 8000010),
+        // new("ObjStr", 9000010),
+        new("ObjStr", 10000010), // Item
+        new("EObj", 2003479), // EObj => EObjName
+        new("Treasure", 1473), // Treasure (without name, falls back to rowId 0)
+        new("Treasure", 1474), // Treasure (with name)
+        new("WeatherPlaceName", 0),
+        new("WeatherPlaceName", 28),
+        new("WeatherPlaceName", 40),
+        new("WeatherPlaceName", 52),
+        new("WeatherPlaceName", 2300),
+    ];
+
+    private unsafe delegate uint ResolveSheetRedirect(RaptureTextModule* thisPtr, Utf8String* sheetName, uint* rowId, ushort* flags);
+
+    /// <inheritdoc/>
+    public string Name => "Test SheetRedirectResolver";
+
+    /// <inheritdoc/>
+    public unsafe SelfTestStepResult RunStep()
+    {
+        var sigScanner = Service<TargetSigScanner>.Get();
+        var sheetRedirectResolver = Service<SheetRedirectResolver>.Get();
+
+        if (!sigScanner.TryScanText("E8 ?? ?? ?? ?? 44 8B E8 A8 10", out var addr))
+            return SelfTestStepResult.Fail;
+
+        var resolveSheetRedirect = Marshal.GetDelegateForFunctionPointer<ResolveSheetRedirect>(addr);
+
+        var utf8SheetName = Utf8String.CreateEmpty();
+
+        var i = 0;
+        try
+        {
+            foreach (var redirect in this.redirects)
+            {
+                utf8SheetName->SetString(redirect.SheetName);
+
+                var rowId1 = redirect.RowId;
+                ushort flags = 0xFFFF;
+                resolveSheetRedirect(RaptureTextModule.Instance(), utf8SheetName, &rowId1, &flags);
+
+                var sheetName2 = redirect.SheetName;
+                var rowId2 = redirect.RowId;
+                sheetRedirectResolver.Resolve(ref sheetName2, ref rowId2);
+
+                if (utf8SheetName->ToString() != sheetName2 || rowId1 != rowId2)
+                {
+                    ImGui.TextUnformatted($"Mismatch detected (Test #{i}):");
+                    ImGui.TextUnformatted($"Input: {redirect.SheetName}#{redirect.RowId}");
+                    ImGui.TextUnformatted($"Game: {utf8SheetName->ToString()}#{rowId1}");
+                    ImGui.TextUnformatted($"Evaluated: {sheetName2}#{rowId2}");
+
+                    if (ImGui.Button("Continue"))
+                        return SelfTestStepResult.Fail;
+
+                    return SelfTestStepResult.Waiting;
+                }
+
+                i++;
+            }
+
+            return SelfTestStepResult.Pass;
+        }
+        finally
+        {
+            utf8SheetName->Dtor(true);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void CleanUp()
+    {
+        // ignored
+    }
+
+    private record struct RedirectEntry(string SheetName, uint RowId);
+}

--- a/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
@@ -50,6 +50,7 @@ internal class SelfTestWindow : Window
             new DutyStateAgingStep(),
             new GameConfigAgingStep(),
             new MarketBoardAgingStep(),
+            new SheetRedirectResolverAgingStep(),
             new SeStringEvaluatorAgingStep(),
             new LogoutEventAgingStep(),
         };

--- a/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
@@ -51,6 +51,7 @@ internal class SelfTestWindow : Window
             new GameConfigAgingStep(),
             new MarketBoardAgingStep(),
             new SheetRedirectResolverAgingStep(),
+            new NounProcessorAgingStep(),
             new SeStringEvaluatorAgingStep(),
             new LogoutEventAgingStep(),
         };

--- a/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
@@ -50,6 +50,7 @@ internal class SelfTestWindow : Window
             new DutyStateAgingStep(),
             new GameConfigAgingStep(),
             new MarketBoardAgingStep(),
+            new SeStringEvaluatorAgingStep(),
             new LogoutEventAgingStep(),
         };
 

--- a/Dalamud/Interface/Utility/ImGuiHelpers.cs
+++ b/Dalamud/Interface/Utility/ImGuiHelpers.cs
@@ -210,8 +210,6 @@ public static class ImGuiHelpers
     /// <param name="imGuiId">ImGui ID, if link functionality is desired.</param>
     /// <param name="buttonFlags">Button flags to use on link interaction.</param>
     /// <returns>Interaction result of the rendered text.</returns>
-    /// <remarks>This function is experimental. Report any issues to GitHub issues or to Discord #dalamud-dev channel.
-    /// The function definition is stable; only in the next API version a function may be removed.</remarks>
     public static SeStringDrawResult SeStringWrapped(
         ReadOnlySpan<byte> sss,
         scoped in SeStringDrawParams style = default,
@@ -226,8 +224,6 @@ public static class ImGuiHelpers
     /// <param name="imGuiId">ImGui ID, if link functionality is desired.</param>
     /// <param name="buttonFlags">Button flags to use on link interaction.</param>
     /// <returns>Interaction result of the rendered text.</returns>
-    /// <remarks>This function is experimental. Report any issues to GitHub issues or to Discord #dalamud-dev channel.
-    /// The function definition is stable; only in the next API version a function may be removed.</remarks>
     public static SeStringDrawResult CompileSeStringWrapped(
         string text,
         scoped in SeStringDrawParams style = default,

--- a/Dalamud/Plugin/Services/ISeStringEvaluator.cs
+++ b/Dalamud/Plugin/Services/ISeStringEvaluator.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics.CodeAnalysis;
+
+using Dalamud.Game;
+using Dalamud.Game.ClientState.Objects.Enums;
+using Dalamud.Game.Text.Evaluator;
+
+using Lumina.Text.ReadOnly;
+
+namespace Dalamud.Plugin.Services;
+
+/// <summary>
+/// Defines a service for retrieving localized text for various in-game entities.
+/// </summary>
+[Experimental("SeStringEvaluator")]
+public interface ISeStringEvaluator
+{
+    /// <summary>
+    /// Evaluates macros in a <see cref="ReadOnlySeString"/>.
+    /// </summary>
+    /// <param name="str">The string containing macros.</param>
+    /// <param name="localParameters">An optional list of local parameters.</param>
+    /// <param name="language">An optional language override.</param>
+    /// <returns>An evaluated <see cref="ReadOnlySeString"/>.</returns>
+    ReadOnlySeString Evaluate(ReadOnlySeString str, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null);
+
+    /// <summary>
+    /// Evaluates macros in a <see cref="ReadOnlySeStringSpan"/>.
+    /// </summary>
+    /// <param name="str">The string containing macros.</param>
+    /// <param name="localParameters">An optional list of local parameters.</param>
+    /// <param name="language">An optional language override.</param>
+    /// <returns>An evaluated <see cref="ReadOnlySeString"/>.</returns>
+    ReadOnlySeString Evaluate(ReadOnlySeStringSpan str, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null);
+
+    /// <summary>
+    /// Evaluates macros in text from the Addon sheet.
+    /// </summary>
+    /// <param name="addonId">The row id of the Addon sheet.</param>
+    /// <param name="localParameters">An optional list of local parameters.</param>
+    /// <param name="language">An optional language override.</param>
+    /// <returns>An evaluated <see cref="ReadOnlySeString"/>.</returns>
+    ReadOnlySeString EvaluateFromAddon(uint addonId, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null);
+
+    /// <summary>
+    /// Evaluates macros in text from the Lobby sheet.
+    /// </summary>
+    /// <param name="lobbyId">The row id of the Lobby sheet.</param>
+    /// <param name="localParameters">An optional list of local parameters.</param>
+    /// <param name="language">An optional language override.</param>
+    /// <returns>An evaluated <see cref="ReadOnlySeString"/>.</returns>
+    ReadOnlySeString EvaluateFromLobby(uint lobbyId, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null);
+
+    /// <summary>
+    /// Evaluates macros in text from the LogMessage sheet.
+    /// </summary>
+    /// <param name="logMessageId">The row id of the LogMessage sheet.</param>
+    /// <param name="localParameters">An optional list of local parameters.</param>
+    /// <param name="language">An optional language override.</param>
+    /// <returns>An evaluated <see cref="ReadOnlySeString"/>.</returns>
+    ReadOnlySeString EvaluateFromLogMessage(uint logMessageId, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null);
+
+    /// <summary>
+    /// Evaluates ActStr from the given ActionKind and id.
+    /// </summary>
+    /// <param name="actionKind">The ActionKind.</param>
+    /// <param name="id">The action id.</param>
+    /// <param name="language">An optional language override.</param>
+    /// <returns>The name of the action.</returns>
+    string EvaluateActStr(ActionKind actionKind, uint id, ClientLanguage? language = null);
+
+    /// <summary>
+    /// Evaluates ObjStr from the given ObjectKind and id.
+    /// </summary>
+    /// <param name="objectKind">The ObjectKind.</param>
+    /// <param name="id">The object id.</param>
+    /// <param name="language">An optional language override.</param>
+    /// <returns>The singular name of the object.</returns>
+    string EvaluateObjStr(ObjectKind objectKind, uint id, ClientLanguage? language = null);
+}

--- a/Dalamud/Utility/ActionKindExtensions.cs
+++ b/Dalamud/Utility/ActionKindExtensions.cs
@@ -1,0 +1,26 @@
+using Dalamud.Game;
+
+namespace Dalamud.Utility;
+
+/// <summary>
+/// Extension methods for the <see cref="ActionKind"/> enum.
+/// </summary>
+public static class ActionKindExtensions
+{
+    /// <summary>
+    /// Converts the id of an ActionKind to the id used in the ActStr sheet redirect.
+    /// </summary>
+    /// <param name="actionKind">The ActionKind this id is for.</param>
+    /// <param name="id">The id.</param>
+    /// <returns>An id that can be used in the ActStr sheet redirect.</returns>
+    public static uint GetActStrId(this ActionKind actionKind, uint id)
+    {
+        // See "83 F9 0D 76 0B"
+        var idx = (uint)actionKind;
+
+        if (idx is <= 13 or 19 or 20)
+            return id + (1000000 * idx);
+
+        return 0;
+    }
+}

--- a/Dalamud/Utility/ClientLanguageExtensions.cs
+++ b/Dalamud/Utility/ClientLanguageExtensions.cs
@@ -23,4 +23,40 @@ public static class ClientLanguageExtensions
             _ => throw new ArgumentOutOfRangeException(nameof(language)),
         };
     }
+
+    /// <summary>
+    /// Gets the language code from a ClientLanguage.
+    /// </summary>
+    /// <param name="value">The ClientLanguage to convert.</param>
+    /// <returns>The language code (ja, en, de, fr).</returns>
+    /// <exception cref="ArgumentOutOfRangeException">An exception that is thrown when no valid ClientLanguage was given.</exception>
+    public static string ToCode(this ClientLanguage value)
+    {
+        return value switch
+        {
+            ClientLanguage.Japanese => "ja",
+            ClientLanguage.English => "en",
+            ClientLanguage.German => "de",
+            ClientLanguage.French => "fr",
+            _ => throw new ArgumentOutOfRangeException(nameof(value)),
+        };
+    }
+
+    /// <summary>
+    /// Gets the ClientLanguage from a language code.
+    /// </summary>
+    /// <param name="value">The language code to convert (ja, en, de, fr).</param>
+    /// <returns>The ClientLanguage.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">An exception that is thrown when no valid language code was given.</exception>
+    public static ClientLanguage ToClientLanguage(this string value)
+    {
+        return value switch
+        {
+            "ja" => ClientLanguage.Japanese,
+            "en" => ClientLanguage.English,
+            "de" => ClientLanguage.German,
+            "fr" => ClientLanguage.French,
+            _ => throw new ArgumentOutOfRangeException(nameof(value)),
+        };
+    }
 }

--- a/Dalamud/Utility/ItemUtil.cs
+++ b/Dalamud/Utility/ItemUtil.cs
@@ -1,0 +1,159 @@
+using System.Runtime.CompilerServices;
+
+using Dalamud.Data;
+using Dalamud.Game;
+using Dalamud.Game.Text.SeStringHandling.Payloads;
+using Dalamud.Game.Text;
+
+using Lumina.Excel.Sheets;
+using Lumina.Text.ReadOnly;
+
+using static Dalamud.Game.Text.SeStringHandling.Payloads.ItemPayload;
+using Lumina.Text;
+
+namespace Dalamud.Utility;
+
+/// <summary>
+/// Utilities related to Items.
+/// </summary>
+internal static class ItemUtil
+{
+    private static int? eventItemRowCount;
+
+    /// <summary>Converts raw item ID to item ID with its classification.</summary>
+    /// <param name="rawItemId">Raw item ID.</param>
+    /// <returns>Item ID and its classification.</returns>
+    internal static (uint ItemId, ItemKind Kind) GetBaseId(uint rawItemId)
+    {
+        if (IsEventItem(rawItemId)) return (rawItemId, ItemKind.EventItem); // EventItem IDs are NOT adjusted
+        if (IsHighQuality(rawItemId)) return (rawItemId - 1_000_000, ItemKind.Hq);
+        if (IsCollectible(rawItemId)) return (rawItemId - 500_000, ItemKind.Collectible);
+        return (rawItemId, ItemKind.Normal);
+    }
+
+    /// <summary>Converts item ID with its classification to raw item ID.</summary>
+    /// <param name="itemId">Item ID.</param>
+    /// <param name="kind">Item classification.</param>
+    /// <returns>Raw Item ID.</returns>
+    internal static uint GetRawId(uint itemId, ItemKind kind)
+    {
+        return kind switch
+        {
+            ItemKind.Collectible when itemId < 500_000 => itemId + 500_000,
+            ItemKind.Hq when itemId < 1_000_000 => itemId + 1_000_000,
+            ItemKind.EventItem => itemId, // EventItem IDs are not adjusted
+            _ => itemId,
+        };
+    }
+
+    /// <summary>
+    /// Checks if the item id belongs to a normal item.
+    /// </summary>
+    /// <param name="itemId">The item id to check.</param>
+    /// <returns><c>true</c> when the item id belongs to a normal item.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool IsNormalItem(uint itemId)
+    {
+        return itemId < 500_000;
+    }
+
+    /// <summary>
+    /// Checks if the item id belongs to a collectible item.
+    /// </summary>
+    /// <param name="itemId">The item id to check.</param>
+    /// <returns><c>true</c> when the item id belongs to a collectible item.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool IsCollectible(uint itemId)
+    {
+        return itemId is >= 500_000 and < 1_000_000;
+    }
+
+    /// <summary>
+    /// Checks if the item id belongs to a high quality item.
+    /// </summary>
+    /// <param name="itemId">The item id to check.</param>
+    /// <returns><c>true</c> when the item id belongs to a high quality item.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool IsHighQuality(uint itemId)
+    {
+        return itemId is >= 1_000_000 and < 2_000_000;
+    }
+
+    /// <summary>
+    /// Checks if the item id belongs to an event item.
+    /// </summary>
+    /// <param name="itemId">The item id to check.</param>
+    /// <returns><c>true</c> when the item id belongs to an event item.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool IsEventItem(uint itemId)
+    {
+        return itemId >= 2_000_000 && itemId - 2_000_000 < (eventItemRowCount ??= Service<DataManager>.Get().GetExcelSheet<EventItem>().Count);
+    }
+
+    /// <summary>
+    /// Gets the name of an item.
+    /// </summary>
+    /// <param name="itemId">The raw item id.</param>
+    /// <param name="includeIcon">Whether to include the High Quality or Collectible icon.</param>
+    /// <param name="language">An optional client language override.</param>
+    /// <returns>The item name.</returns>
+    internal static ReadOnlySeString GetItemName(uint itemId, bool includeIcon = true, ClientLanguage? language = null)
+    {
+        var dataManager = Service<DataManager>.Get();
+
+        if (IsEventItem(itemId))
+        {
+            return dataManager
+                .GetExcelSheet<EventItem>(language)
+                .TryGetRow(itemId, out var eventItem)
+                    ? eventItem.Name
+                    : default;
+        }
+
+        var (baseId, kind) = GetBaseId(itemId);
+
+        if (!dataManager
+            .GetExcelSheet<Item>(language)
+            .TryGetRow(baseId, out var item))
+        {
+            return default;
+        }
+
+        if (!includeIcon || kind is not (ItemKind.Hq or ItemKind.Collectible))
+            return item.Name;
+
+        var builder = SeStringBuilder.SharedPool.Get();
+
+        builder.Append(item.Name);
+
+        switch (kind)
+        {
+            case ItemPayload.ItemKind.Hq:
+                builder.Append($" {(char)SeIconChar.HighQuality}");
+                break;
+            case ItemPayload.ItemKind.Collectible:
+                builder.Append($" {(char)SeIconChar.Collectible}");
+                break;
+        }
+
+        var itemName = builder.ToReadOnlySeString();
+        SeStringBuilder.SharedPool.Return(builder);
+        return itemName;
+    }
+
+    /// <summary>
+    /// Gets the color row id for an item name.
+    /// </summary>
+    /// <param name="itemId">The raw item Id.</param>
+    /// <param name="isEdgeColor">Wheather this color is used as edge color.</param>
+    /// <returns>The Color row id.</returns>
+    internal static uint GetItemRarityColorType(uint itemId, bool isEdgeColor = false)
+    {
+        var rarity = 1u;
+
+        if (!IsEventItem(itemId) && Service<DataManager>.Get().GetExcelSheet<Item>().TryGetRow(GetBaseId(itemId).ItemId, out var item))
+            rarity = item.Rarity;
+
+        return (isEdgeColor ? 548u : 547u) + (rarity * 2u);
+    }
+}

--- a/Dalamud/Utility/ObjectKindExtensions.cs
+++ b/Dalamud/Utility/ObjectKindExtensions.cs
@@ -1,0 +1,33 @@
+using Dalamud.Game.ClientState.Objects.Enums;
+
+namespace Dalamud.Utility;
+
+/// <summary>
+/// Extension methods for the <see cref="ObjectKind"/> enum.
+/// </summary>
+public static class ObjectKindExtensions
+{
+    /// <summary>
+    /// Converts the id of an ObjectKind to the id used in the ObjStr sheet redirect.
+    /// </summary>
+    /// <param name="objectKind">The ObjectKind this id is for.</param>
+    /// <param name="id">The id.</param>
+    /// <returns>An id that can be used in the ObjStr sheet redirect.</returns>
+    public static uint GetObjStrId(this ObjectKind objectKind, uint id)
+    {
+        // See "8D 41 FE 83 F8 0C 77 4D"
+        return objectKind switch
+        {
+            ObjectKind.BattleNpc => id < 1000000 ? id : id - 900000,
+            ObjectKind.EventNpc => id,
+            ObjectKind.Treasure or
+            ObjectKind.Aetheryte or
+            ObjectKind.GatheringPoint or
+            ObjectKind.Companion or
+            ObjectKind.Housing => id + (1000000 * (uint)objectKind) - 2000000,
+            ObjectKind.EventObj => id + (1000000 * (uint)objectKind) - 4000000,
+            ObjectKind.CardStand => id + 3000000,
+            _ => 0,
+        };
+    }
+}

--- a/Dalamud/Utility/SeStringExtensions.cs
+++ b/Dalamud/Utility/SeStringExtensions.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 using Lumina.Text.Parse;
 
 using Lumina.Text.ReadOnly;
@@ -92,4 +94,148 @@ public static class SeStringExtensions
     /// <param name="value">character name to validate.</param>
     /// <returns>indicator if character is name is valid.</returns>
     public static bool IsValidCharacterName(this DSeString value) => value.ToString().IsValidCharacterName();
+
+    /// <summary>
+    /// Determines whether the <see cref="ReadOnlySeString"/> contains only text payloads.
+    /// </summary>
+    /// <param name="ross">The <see cref="ReadOnlySeString"/> to check.</param>
+    /// <returns><c>true</c> if the string contains only text payloads; otherwise, <c>false</c>.</returns>
+    public static bool IsTextOnly(this ReadOnlySeString ross)
+    {
+        return ross.AsSpan().IsTextOnly();
+    }
+
+    /// <summary>
+    /// Determines whether the <see cref="ReadOnlySeStringSpan"/> contains only text payloads.
+    /// </summary>
+    /// <param name="rosss">The <see cref="ReadOnlySeStringSpan"/> to check.</param>
+    /// <returns><c>true</c> if the span contains only text payloads; otherwise, <c>false</c>.</returns>
+    public static bool IsTextOnly(this ReadOnlySeStringSpan rosss)
+    {
+        foreach (var payload in rosss)
+        {
+            if (payload.Type != ReadOnlySePayloadType.Text)
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether the <see cref="ReadOnlySeString"/> contains the specified text.
+    /// </summary>
+    /// <param name="ross">The <see cref="ReadOnlySeString"/> to search.</param>
+    /// <param name="needle">The text to find.</param>
+    /// <returns><c>true</c> if the text is found; otherwise, <c>false</c>.</returns>
+    public static bool ContainsText(this ReadOnlySeString ross, ReadOnlySpan<byte> needle)
+    {
+        return ross.AsSpan().ContainsText(needle);
+    }
+
+    /// <summary>
+    /// Determines whether the <see cref="ReadOnlySeStringSpan"/> contains the specified text.
+    /// </summary>
+    /// <param name="rosss">The <see cref="ReadOnlySeStringSpan"/> to search.</param>
+    /// <param name="needle">The text to find.</param>
+    /// <returns><c>true</c> if the text is found; otherwise, <c>false</c>.</returns>
+    public static bool ContainsText(this ReadOnlySeStringSpan rosss, ReadOnlySpan<byte> needle)
+    {
+        foreach (var payload in rosss)
+        {
+            if (payload.Type != ReadOnlySePayloadType.Text)
+                continue;
+
+            if (payload.Body.IndexOf(needle) != -1)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the <see cref="LSeStringBuilder"/> contains the specified text.
+    /// </summary>
+    /// <param name="builder">The builder to search.</param>
+    /// <param name="needle">The text to find.</param>
+    /// <returns><c>true</c> if the text is found; otherwise, <c>false</c>.</returns>
+    public static bool ContainsText(this LSeStringBuilder builder, ReadOnlySpan<byte> needle)
+    {
+        return builder.ToReadOnlySeString().ContainsText(needle);
+    }
+
+    /// <summary>
+    /// Replaces occurrences of a specified text in a <see cref="ReadOnlySeString"/> with another text.
+    /// </summary>
+    /// <param name="ross">The original string.</param>
+    /// <param name="toFind">The text to find.</param>
+    /// <param name="replacement">The replacement text.</param>
+    /// <returns>A new <see cref="ReadOnlySeString"/> with the replacements made.</returns>
+    public static ReadOnlySeString ReplaceText(this ReadOnlySeString ross, ReadOnlySpan<byte> toFind, ReadOnlySpan<byte> replacement)
+    {
+        if (ross.IsEmpty)
+            return ross;
+
+        var sb = LSeStringBuilder.SharedPool.Get();
+
+        foreach (var payload in ross)
+        {
+            if (payload.Type == ReadOnlySePayloadType.Invalid)
+                continue;
+
+            if (payload.Type != ReadOnlySePayloadType.Text)
+            {
+                sb.Append(payload);
+                continue;
+            }
+
+            var index = payload.Body.Span.IndexOf(toFind);
+            if (index == -1)
+            {
+                sb.Append(payload);
+                continue;
+            }
+
+            var lastIndex = 0;
+            while (index != -1)
+            {
+                sb.Append(payload.Body.Span[lastIndex..index]);
+
+                if (!replacement.IsEmpty)
+                {
+                    sb.Append(replacement);
+                }
+
+                lastIndex = index + toFind.Length;
+                index = payload.Body.Span[lastIndex..].IndexOf(toFind);
+
+                if (index != -1)
+                    index += lastIndex;
+            }
+
+            sb.Append(payload.Body.Span[lastIndex..]);
+        }
+
+        var output = sb.ToReadOnlySeString();
+        LSeStringBuilder.SharedPool.Return(sb);
+        return output;
+    }
+
+    /// <summary>
+    /// Replaces occurrences of a specified text in an <see cref="LSeStringBuilder"/> with another text.
+    /// </summary>
+    /// <param name="builder">The builder to modify.</param>
+    /// <param name="toFind">The text to find.</param>
+    /// <param name="replacement">The replacement text.</param>
+    public static void ReplaceText(this LSeStringBuilder builder, ReadOnlySpan<byte> toFind, ReadOnlySpan<byte> replacement)
+    {
+        if (toFind.IsEmpty)
+            return;
+
+        var str = builder.ToReadOnlySeString();
+        if (str.IsEmpty)
+            return;
+
+        builder.Clear();
+        builder.Append(ReplaceText(str, toFind, replacement));
+    }
 }

--- a/Dalamud/Utility/StringExtensions.cs
+++ b/Dalamud/Utility/StringExtensions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 using FFXIVClientStructs.FFXIV.Client.UI;
 
@@ -42,5 +43,37 @@ public static class StringExtensions
         if (string.IsNullOrEmpty(value)) return false;
         if (!UIGlobals.IsValidPlayerCharacterName(value)) return false;
         return includeLegacy || value.Length <= 21;
+    }
+
+    /// <summary>
+    /// Converts the first character of the string to uppercase while leaving the rest of the string unchanged.
+    /// </summary>
+    /// <param name="input">The input string.</param>
+    /// <returns>A new string with the first character converted to uppercase.</returns>
+    public static string FirstCharToUpper(this string input)
+    {
+        if (string.IsNullOrEmpty(input)) return string.Empty;
+        return string.Concat(input[0].ToString().ToUpper(CultureInfo.CurrentCulture), input.AsSpan(1));
+    }
+
+    /// <summary>
+    /// Converts the first character of the string to lowercase while leaving the rest of the string unchanged.
+    /// </summary>
+    /// <param name="input">The input string.</param>
+    /// <returns>A new string with the first character converted to lowercase.</returns>
+    public static string FirstCharToLower(this string input)
+    {
+        if (string.IsNullOrEmpty(input)) return string.Empty;
+        return string.Concat(input[0].ToString().ToLower(CultureInfo.CurrentCulture), input.AsSpan(1));
+    }
+
+    /// <summary>
+    /// Removes soft hyphen characters (U+00AD) from the input string.
+    /// </summary>
+    /// <param name="input">The input string to remove soft hyphen characters from.</param>
+    /// <returns>A string with all soft hyphens removed.</returns>
+    public static string StripSoftHypen(this string input)
+    {
+        return input.Replace("\u00AD", string.Empty);
     }
 }

--- a/Dalamud/Utility/StringExtensions.cs
+++ b/Dalamud/Utility/StringExtensions.cs
@@ -75,4 +75,17 @@ public static class StringExtensions
     /// <param name="input">The input string to remove soft hyphen characters from.</param>
     /// <returns>A string with all soft hyphens removed.</returns>
     public static string StripSoftHyphen(this string input) => input.Replace("\u00AD", string.Empty);
+
+    /// <summary>
+    /// Truncates the given string to the specified maximum number of characters,  
+    /// appending an ellipsis if truncation occurs.
+    /// </summary>
+    /// <param name="input">The string to truncate.</param>
+    /// <param name="maxChars">The maximum allowed length of the string.</param>
+    /// <param name="ellipses">The string to append if truncation occurs (defaults to "...").</param>
+    /// <returns>The truncated string, or the original string if no truncation is needed.</returns>
+    public static string? Truncate(this string input, int maxChars, string ellipses = "...")
+    {
+        return string.IsNullOrEmpty(input) || input.Length <= maxChars ? input : input[..maxChars] + ellipses;
+    }
 }


### PR DESCRIPTION
This PR adds the public-facing **[ISeStringEvaluator](https://github.com/Haselnussbomber/Dalamud/blob/sestringevaluator/Dalamud/Plugin/Services/ISeStringEvaluator.cs)** service.

This service allows macro payloads and their expressions to be evaluated.

- Supports local and global parameters.
- Supports a large majority of macro codes, including almost all fixed string variations. (See [SeStringEvaluator.cs](https://github.com/Haselnussbomber/Dalamud/blob/sestringevaluator/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs#L183))
- Supports an optional language override to be specified, which is used instead of Dalamuds EffectiveLanguage, for internal sheet lookups inside macros.
- The API is currently designed for ease of use rather than extensibility. For example, `SeStringEvaluator.EvaluateFromAddon(8519, [info.Ward, info.Plot])`. The `SeStringParameter`s have inplicit casts to make it as easy as possible. It does not provide an option to handle specific macros differently (you have to pre/post-process the string for that), but that is not really an issue in my opinion.

Notes:

- Originally written by Kizer. I heavily expanded on it. Some code was commented out when I made the API simpler, but I left them in as a reminder where to place them, in case someone decides to change it in the future.
- There are sadly no unit tests.
- Does not provide feature parity to the games evaluator - there are some differences/advantages for us, for example in processing macros recursively and mixing macro and fixed string evaluation, but also we're missing a couple features/macro codes.
- Can be used independently of the games loaded excel language, which is a huge plus.
- `ISeStringEvaluator` is marked experimental for now.
- This does not support Dalamuds SeString type at all, as they don't have expressions. If needed, they can just as easily be cast to ReadOnlySeString. That said, certain Dalamud SeString payloads are fundamentally wrong (looking at you, AutoTranslatePayload - which is the fixed macro), and it might be better to use the SeStringEvaluator internally for those.
- A self test `SeStringEvaluatorAgingStep` was added, which is not very exhaustive, but covers processing of macros, local and global parameters, and generating expected results.

A xldata widget has been added to create SeStrings and preview their evaluated results:

![Preview](https://github.com/user-attachments/assets/7805d0de-4073-4d8d-91e7-cded1b449d02)

It's possible to export the entries as macro string and to load strings from excel sheets:

![Preview Import](https://github.com/user-attachments/assets/e58e5a8a-e60c-4660-8b74-6dd07a62fb6c)

A second tab displays a list of global parameters, their type, value and, if known, their description.

---

In order to not clutter the SeStringEvaluator class with other things, I moved some code into their own, internal services: the NounProcessor and the SheetRedirectResolver service.

Regarding the **NounProcessor**:

- The noun system is used in a couple of sheets (see below). This service helps in processing them, for example an Item name.
- It supports handling of different language-specific grammatical features based on the Attributive sheet for the following placeholders:
  - `[t]`: Article or grammatical gender (EN: the, DE: der, die, das).
  - `[n]`: The amount of an item (number).
  - `[a]`: Declension
  - `[p]` Plural
- Used in evaluation of the `janoun`, `ennoun`, `denoun` and `frnoun` macro codes in the SeStringEvaluator.
- C# versions of the games `Component::Text::Localize::NounEn/NounDe/NounFr/NounJa` classes.
	- NounCh (Chinese) and NounKo (Korean) were omitted, since we can't use them and I cant validate them anyway.

Notes:

- There are some variables from porting over the decompiled code to C# that I didn't rename yet, because I am lazy and got tired of it. Please forgive me.
- I spent hours upon hours to reverse this and make sense of it.
- Might need to get looked over by someone who studied languages - especially for French.
- A self test `NounProcessorAgingStep` was added to do spot tests.
- A xldata widget was added in order to help with the noun payloads:

<details>
<summary>Preview</summary>

Please note that the self-test export button is only available in local debug builds.

Japanese:

![Preview Japanese](https://github.com/user-attachments/assets/cf4f6a62-6610-4869-8adb-d3a1f53a76d5)

English:

![Preview English](https://github.com/user-attachments/assets/c2b723b3-60e4-4398-8640-c3912d598037)

German:

![Preview German](https://github.com/user-attachments/assets/c2c42090-548a-4b2f-966b-74011c9487b4)

French:

![Preview French](https://github.com/user-attachments/assets/40f130dc-85c4-47d2-8062-dc8903858f92)

</details>

<details>
<summary>A list of the (to me) currently known sheets that use the noun system</summary>

- Aetheryte
- BNpcName
- BeastTribe
- DeepDungeonEquipment
- DeepDungeonItem
- DeepDungeonMagicStone
- DeepDungeonDemiclone
- ENpcResident
- EObjName
- EurekaAetherItem
- EventItem
- GCRankGridaniaFemaleText
- GCRankGridaniaMaleText
- GCRankLimsaFemaleText
- GCRankLimsaMaleText
- GCRankUldahFemaleText
- GCRankUldahMaleText
- GatheringPointName
- Glasses
- GlassesStyle
- HousingPreset
- Item
- MJIName
- Mount
- Ornament
- TripleTriadCard

</details>

---

Regarding the **SheetRedirectResolver**:

This service resolves some special (partially non-existant) sheet names, most importantly ActStr and ObjStr.

It is just a C# version of the games `Client::UI::Misc::RaptureTextModule.ResolveSheetRedirect` function.

A self test `SheetRedirectResolverAgingStep` was added to check if the results are matching the games resolver.

---

Notes:

- I coded this for my plugins and just ported it to be a Dalamud service. Technically this could be part of Lumina, but given that we fetch global parameters from the game and that it would be a *lot* of work to make the necessary API changes, I'll rather PR this to Dalamud.
- Originally, I was thinking of providing functions in a TextProvider service to get singular names from a variety of sheets, like in my [TextService](https://github.com/Haselnussbomber/HaselCommon/blob/e7d598576676b425ef4fbbf367512c820345c5a1/HaselCommon/Services/TextService.cs#L120-L235), but I felt this was a) too many functions, b) unnecessary since it's just caching and not even evaluating (except for the Fate sheet), and c) doesn't provide the capabilities of the NounProcessor (pluralization etc.).
- I added a couple Util functions and made them publicly available.

I'm sure it will need some updates in the future.

I hope this will be useful for a lot of plugins and I can't wait to no longer see those noun placeholders in names!

As a final word to plugin devs reading this: please strip [soft hyphens](https://en.wikipedia.org/wiki/Soft_hyphen) out of names.
They are basically everywhere in German sheets to indicate a word break opportunity and ImGui will render them as `-` because it can't handle it correctly. I've added a `string.StripSoftHypen()` extension function for that. If you use `ImGuiHelpers.SeStringWrapped()` you're already covered - the great Kizer made sure it renders correctly.
Lets make things work correctly in at least the 4 client languages we can support! :)