### PR TITLE
feat: handle UNC paths in FileDialog

### DIFF
--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.Files.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.Files.cs
@@ -36,6 +36,20 @@ public partial class FileDialog
 
     private static string ComposeNewPath(List<string> decomp)
     {
+        // Handle UNC paths (network paths)
+        if (decomp.Count >= 2 && string.IsNullOrEmpty(decomp[0]) && string.IsNullOrEmpty(decomp[1]))
+        {
+            var pathParts = new List<string>(decomp);
+            pathParts.RemoveRange(0, 2);
+            // Can not access server level or UNC root
+            if (pathParts.Count <= 1)
+            {
+                return string.Empty;
+            }
+
+            return $"\\\\{string.Join('\\', pathParts)}";
+        }
+        
         if (decomp.Count == 1)
         {
             var drivePath = decomp[0];


### PR DESCRIPTION
Hello, this is a PR (also my first PR on a community project) to try to solve the issue https://github.com/goatcorp/Dalamud/issues/1823 

This PR allow on a window OS to navigate to parent folders on a network drive when using the FileDialog.

I did not use the Path.DirectorySeparatorChar to build the new UNC path because I think the separator can not be something else than a backslash for the directory separator char?

There is also some interesting discussion about this solution on the #dalamud-dev channel on discord.

Feel free to edit the PR.

Edit : I also tested this solution on Windows and with the FileDialog via Penumbra plugin