### PR TITLE
Read .text section bytes from file instead of process memory

### DIFF
--- a/Dalamud/Game/SigScanner.cs
+++ b/Dalamud/Game/SigScanner.cs
@@ -496,13 +496,17 @@ public class SigScanner : IDisposable, ISigScanner
                     this.TextSectionOffset = Marshal.ReadInt32(sectionCursor, 12);
                     this.TextSectionSize = Marshal.ReadInt32(sectionCursor, 8);
 
-                    var pointerToRawData = Marshal.ReadInt32(sectionCursor, 20);
+                    if (this.IsCopy)
+                    {
+                        var pointerToRawData = Marshal.ReadInt32(sectionCursor, 20);
 
-                    Marshal.Copy(
-                                 fileBytes.AsSpan(pointerToRawData, this.TextSectionSize).ToArray(),
-                                 0,
-                                 this.moduleCopyPtr + (nint)this.TextSectionOffset,
-                                 this.TextSectionSize);
+                        Marshal.Copy(
+                                     fileBytes.AsSpan(pointerToRawData, this.TextSectionSize).ToArray(),
+                                     0,
+                                     this.moduleCopyPtr + (nint)this.TextSectionOffset,
+                                     this.TextSectionSize);
+                    }
+
                     break;
                 case 0x617461642E: // .data
                     this.DataSectionOffset = Marshal.ReadInt32(sectionCursor, 12);

--- a/Dalamud/Game/SigScanner.cs
+++ b/Dalamud/Game/SigScanner.cs
@@ -7,11 +7,8 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
-
 using Iced.Intel;
-
 using Newtonsoft.Json;
-
 using Serilog;
 
 namespace Dalamud.Game;
@@ -506,17 +503,14 @@ public class SigScanner : IDisposable, ISigScanner
                                  0,
                                  this.moduleCopyPtr + (nint)this.TextSectionOffset,
                                  this.TextSectionSize);
-
                     break;
                 case 0x617461642E: // .data
                     this.DataSectionOffset = Marshal.ReadInt32(sectionCursor, 12);
                     this.DataSectionSize = Marshal.ReadInt32(sectionCursor, 8);
-
                     break;
                 case 0x61746164722E: // .rdata
                     this.RDataSectionOffset = Marshal.ReadInt32(sectionCursor, 12);
                     this.RDataSectionSize = Marshal.ReadInt32(sectionCursor, 8);
-
                     break;
             }
 

--- a/Dalamud/Game/SigScanner.cs
+++ b/Dalamud/Game/SigScanner.cs
@@ -20,6 +20,8 @@ namespace Dalamud.Game;
 /// </summary>
 public class SigScanner : IDisposable, ISigScanner
 {
+    private static byte[]? fileBytes;
+
     private readonly FileInfo? cacheFile;
 
     private nint moduleCopyPtr;
@@ -51,7 +53,11 @@ public class SigScanner : IDisposable, ISigScanner
         this.IsCopy = doCopy;
 
         if (this.IsCopy)
+        {
             this.SetupCopiedSegments();
+
+            fileBytes ??= File.ReadAllBytes(module.FileName);
+        }
 
         // Limit the search space to .text section.
         this.SetupSearchSpace(module);
@@ -462,8 +468,6 @@ public class SigScanner : IDisposable, ISigScanner
 
     private void SetupSearchSpace(ProcessModule module)
     {
-        var fileBytes = File.ReadAllBytes(module.FileName);
-
         var baseAddress = module.BaseAddress;
 
         // We don't want to read all of IMAGE_DOS_HEADER or IMAGE_NT_HEADER stuff so we cheat here.


### PR DESCRIPTION
This PR addresses issue where .text section can be modified by other tools before Dalamud loads, which may cause some plugins to fail to find signatures