### PR TITLE
SMNGauge: Fix typo, update CS

### DIFF
--- a/Dalamud/Game/ClientState/JobGauge/Enums/SummonAttunement.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Enums/SummonAttunement.cs
@@ -1,0 +1,27 @@
+﻿namespace Dalamud.Game.ClientState.JobGauge.Enums;
+
+public enum SummonAttunement
+{
+    /// <summary>
+    /// No attunement.
+    /// </summary>
+    NONE = 0,
+
+    /// <summary>
+    /// Attuned to the summon Ifrit.
+    /// Same as <see cref="JobGauge.Types.SMNGauge.IsIfritAttuned"/>.
+    /// </summary>
+    IFRIT = 1,
+
+    /// <summary>
+    /// Attuned to the summon Titan.
+    /// Same as <see cref="JobGauge.Types.SMNGauge.IsTitanAttuned"/>.
+    /// </summary>
+    TITAN = 2,
+
+    /// <summary>
+    /// Attuned to the summon Garuda.
+    /// Same as <see cref="JobGauge.Types.SMNGauge.IsGarudaAttuned"/>.
+    /// </summary>
+    GARUDA = 3,
+}

--- a/Dalamud/Game/ClientState/JobGauge/Types/SMNGauge.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Types/SMNGauge.cs
@@ -52,15 +52,15 @@ public unsafe class SMNGauge : JobGaugeBase<SummonerGauge>
     public byte Attunement => this.Struct->Attunement;
 
     /// <summary>
-    /// The count of attunement cost resource available.
+    /// Gets the count of attunement cost resource available.
     /// </summary>
     public byte AttunementCount => this.Struct->AttunementCount;
 
     /// <summary>
-    /// The type of attunement available.
+    /// Gets the type of attunement available.
     /// Use the summon attuned accessors instead.
     /// </summary>
-    public byte AttunementType => this.Struct->AttunementType;
+    public SummonAttunement AttunementType => (SummonAttunement)this.Struct->AttunementType;
 
     /// <summary>
     /// Gets the current aether flags.

--- a/Dalamud/Game/ClientState/JobGauge/Types/SMNGauge.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Types/SMNGauge.cs
@@ -102,19 +102,19 @@ public unsafe class SMNGauge : JobGaugeBase<SummonerGauge>
     /// Gets a value indicating whether if Ifrit is currently attuned.
     /// </summary>
     /// <returns><c>true</c> or <c>false</c>.</returns>
-    public bool IsIfritAttuned => this.AetherFlags.HasFlag(AetherFlags.IfritAttuned) && !this.AetherFlags.HasFlag(AetherFlags.GarudaAttuned);
+    public bool IsIfritAttuned => this.AttunementType == SummonAttunement.IFRIT;
 
     /// <summary>
     /// Gets a value indicating whether if Titan is currently attuned.
     /// </summary>
     /// <returns><c>true</c> or <c>false</c>.</returns>
-    public bool IsTitanAttuned => this.AetherFlags.HasFlag(AetherFlags.TitanAttuned) && !this.AetherFlags.HasFlag(AetherFlags.GarudaAttuned);
+    public bool IsTitanAttuned => this.AttunementType == SummonAttunement.TITAN;
 
     /// <summary>
     /// Gets a value indicating whether if Garuda is currently attuned.
     /// </summary>
     /// <returns><c>true</c> or <c>false</c>.</returns>
-    public bool IsGarudaAttuned => this.AetherFlags.HasFlag(AetherFlags.GarudaAttuned);
+    public bool IsGarudaAttuned => this.AttunementType == SummonAttunement.GARUDA;
 
     /// <summary>
     /// Gets a value indicating whether there are any Aetherflow stacks available.

--- a/Dalamud/Game/ClientState/JobGauge/Types/SMNGauge.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Types/SMNGauge.cs
@@ -22,10 +22,13 @@ public unsafe class SMNGauge : JobGaugeBase<SummonerGauge>
     /// </summary>
     public ushort SummonTimerRemaining => this.Struct->SummonTimer;
 
+    [Obsolete("Typo fixed. Use AttunementTimerRemaining instead.", true)]
+    public ushort AttunmentTimerRemaining => this.AttunementTimerRemaining;
+
     /// <summary>
     /// Gets the time remaining for the current attunement.
     /// </summary>
-    public ushort AttunmentTimerRemaining => this.Struct->AttunementTimer;
+    public ushort AttunementTimerRemaining => this.Struct->AttunementTimer;
 
     /// <summary>
     /// Gets the summon that will return after the current summon expires.
@@ -40,7 +43,7 @@ public unsafe class SMNGauge : JobGaugeBase<SummonerGauge>
     public PetGlam ReturnSummonGlam => (PetGlam)this.Struct->ReturnSummonGlam;
 
     /// <summary>
-    /// Gets the amount of aspected Attunment remaining.
+    /// Gets the amount of aspected Attunement remaining.
     /// </summary>
     /// <remarks>
     /// As of 7.01, this should be treated as a bit field.

--- a/Dalamud/Game/ClientState/JobGauge/Types/SMNGauge.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Types/SMNGauge.cs
@@ -42,7 +42,22 @@ public unsafe class SMNGauge : JobGaugeBase<SummonerGauge>
     /// <summary>
     /// Gets the amount of aspected Attunment remaining.
     /// </summary>
+    /// <remarks>
+    /// As of 7.01, this should be treated as a bit field.
+    /// Use <see cref="AttunementCount"/> and <see cref="AttunementType"/> instead.
+    /// </remarks>
     public byte Attunement => this.Struct->Attunement;
+
+    /// <summary>
+    /// The count of attunement cost resource available.
+    /// </summary>
+    public byte AttunementCount => this.Struct->AttunementCount;
+
+    /// <summary>
+    /// The type of attunement available.
+    /// Use the summon attuned accessors instead.
+    /// </summary>
+    public byte AttunementType => this.Struct->AttunementType;
 
     /// <summary>
     /// Gets the current aether flags.


### PR DESCRIPTION
This PR has some simple updates for `SMNGauge` that get it back in line with what CS has for the gauge.

- [X] Update note about how `Attunement` should be used
- [X] Add `AttunementCount` and `AttunementType`, which use `Attunement` as a bitfield
- [X] Fix `AttunmentTimerRemaining` (missing `e`) typo