### PR TITLE
DRKGauge: Update CS

### DIFF
--- a/Dalamud/Game/ClientState/JobGauge/Enums/DeliriumStep.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Enums/DeliriumStep.cs
@@ -1,0 +1,19 @@
+namespace Dalamud.Game.ClientState.JobGauge.Enums;
+
+public enum DeliriumStep
+{
+    /// <summary>
+    /// Scarlet Delirium can be used.
+    /// </summary>
+    SCARLET_DELIRIUM = 0,
+
+    /// <summary>
+    /// Comeuppance can be used.
+    /// </summary>
+    COMEUPPANCE = 1,
+
+    /// <summary>
+    /// Torcleaver can be used.
+    /// </summary>
+    TORCLEAVER = 2,
+}

--- a/Dalamud/Game/ClientState/JobGauge/Types/DRKGauge.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Types/DRKGauge.cs
@@ -1,9 +1,12 @@
+using Dalamud.Game.ClientState.JobGauge.Enums;
+using FFXIVClientStructs.FFXIV.Client.Game.Gauge;
+
 namespace Dalamud.Game.ClientState.JobGauge.Types;
 
 /// <summary>
 /// In-memory DRK job gauge.
 /// </summary>
-public unsafe class DRKGauge : JobGaugeBase<FFXIVClientStructs.FFXIV.Client.Game.Gauge.DarkKnightGauge>
+public unsafe class DRKGauge : JobGaugeBase<DarkKnightGauge>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="DRKGauge"/> class.
@@ -34,4 +37,16 @@ public unsafe class DRKGauge : JobGaugeBase<FFXIVClientStructs.FFXIV.Client.Game
     /// </summary>
     /// <returns><c>true</c> or <c>false</c>.</returns>
     public bool HasDarkArts => this.Struct->DarkArtsState > 0;
+
+    /// <summary>
+    /// Gets the step of the Delirium Combo (Scarlet Delirium, Comeuppance,
+    /// Torcleaver) that the player is on.<br/>
+    /// Does not in any way consider whether the player is still under Delirium, or
+    /// if the player still has stacks of Delirium to use.
+    /// </summary>
+    /// <remarks>
+    /// Value will persist until combo is finished OR
+    /// if the combo is not completed then the value will stay until about halfway into Delirium's cooldown.
+    /// </remarks>
+    public DeliriumStep DeliriumComboStep => (DeliriumStep)this.Struct->DeliriumStep;
 }


### PR DESCRIPTION
This PR updates `DRKGauge` to include the latest `DeliriumStep` from ClientStruct's `DarkKnightGauge`.

- [X] Adds `DeliriumComboStep`, which gives an enum value
- [X] Adds `DeliriumStep` enum to interpret CS's `DeliriumStep` values