### PR TITLE
Config Options for 7.2

### DIFF
--- a/Dalamud/Game/Config/SystemConfigOption.cs
+++ b/Dalamud/Game/Config/SystemConfigOption.cs
@@ -598,6 +598,20 @@ public enum SystemConfigOption
     EnablePsFunction,
 
     /// <summary>
+    /// System option with the internal name ActiveInstanceGuid.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("ActiveInstanceGuid", ConfigType.String)]
+    ActiveInstanceGuid,
+
+    /// <summary>
+    /// System option with the internal name ActiveProductGuid.
+    /// This option is a String.
+    /// </summary>
+    [GameConfigOption("ActiveProductGuid", ConfigType.String)]
+    ActiveProductGuid,
+
+    /// <summary>
     /// System option with the internal name WaterWet.
     /// This option is a UInt.
     /// </summary>
@@ -997,6 +1011,27 @@ public enum SystemConfigOption
     AutoChangeCameraMode,
 
     /// <summary>
+    /// System option with the internal name MsqProgress.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("MsqProgress", ConfigType.UInt)]
+    MsqProgress,
+
+    /// <summary>
+    /// System option with the internal name PromptConfigUpdate.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PromptConfigUpdate", ConfigType.UInt)]
+    PromptConfigUpdate,
+
+    /// <summary>
+    /// System option with the internal name TitleScreenType.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("TitleScreenType", ConfigType.UInt)]
+    TitleScreenType,
+
+    /// <summary>
     /// System option with the internal name AccessibilitySoundVisualEnable.
     /// This option is a UInt.
     /// </summary>
@@ -1058,6 +1093,13 @@ public enum SystemConfigOption
     /// </summary>
     [GameConfigOption("IdlingCameraAFK", ConfigType.UInt)]
     IdlingCameraAFK,
+
+    /// <summary>
+    /// System option with the internal name FirstConfigBackup.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("FirstConfigBackup", ConfigType.UInt)]
+    FirstConfigBackup,
 
     /// <summary>
     /// System option with the internal name MouseSpeed.
@@ -1436,46 +1478,4 @@ public enum SystemConfigOption
     /// </summary>
     [GameConfigOption("PadButton_R3", ConfigType.String)]
     PadButton_R3,
-
-    /// <summary>
-    /// System option with the internal name ActiveInstanceGuid.
-    /// This option is a String.
-    /// </summary>
-    [GameConfigOption("ActiveInstanceGuid", ConfigType.String)]
-    ActiveInstanceGuid,
-
-    /// <summary>
-    /// System option with the internal name ActiveProductGuid.
-    /// This option is a String.
-    /// </summary>
-    [GameConfigOption("ActiveProductGuid", ConfigType.String)]
-    ActiveProductGuid,
-
-    /// <summary>
-    /// System option with the internal name MsqProgress.
-    /// This option is a UInt.
-    /// </summary>
-    [GameConfigOption("MsqProgress", ConfigType.UInt)]
-    MsqProgress,
-
-    /// <summary>
-    /// System option with the internal name PromptConfigUpdate.
-    /// This option is a UInt.
-    /// </summary>
-    [GameConfigOption("PromptConfigUpdate", ConfigType.UInt)]
-    PromptConfigUpdate,
-
-    /// <summary>
-    /// System option with the internal name TitleScreenType.
-    /// This option is a UInt.
-    /// </summary>
-    [GameConfigOption("TitleScreenType", ConfigType.UInt)]
-    TitleScreenType,
-
-    /// <summary>
-    /// System option with the internal name FirstConfigBackup.
-    /// This option is a UInt.
-    /// </summary>
-    [GameConfigOption("FirstConfigBackup", ConfigType.UInt)]
-    FirstConfigBackup,
 }

--- a/Dalamud/Game/Config/UiConfigOption.cs
+++ b/Dalamud/Game/Config/UiConfigOption.cs
@@ -38,6 +38,13 @@ public enum UiConfigOption
     BattleEffectPvPEnemyPc,
 
     /// <summary>
+    /// UiConfig option with the internal name PadMode.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("PadMode", ConfigType.UInt)]
+    PadMode,
+
+    /// <summary>
     /// UiConfig option with the internal name WeaponAutoPutAway.
     /// This option is a UInt.
     /// </summary>
@@ -113,14 +120,6 @@ public enum UiConfigOption
     /// </summary>
     [GameConfigOption("LockonDefaultZoom", ConfigType.Float)]
     LockonDefaultZoom,
-
-    /// <summary>
-    /// UiConfig option with the internal name LockonDefaultZoom_179.
-    /// This option is a Float.
-    /// </summary>
-    [Obsolete("This option won't work. Use LockonDefaultZoom.", true)]
-    [GameConfigOption("LockonDefaultZoom_179", ConfigType.Float)]
-    LockonDefaultZoom_179,
 
     /// <summary>
     /// UiConfig option with the internal name CameraProductionOfAction.
@@ -310,6 +309,27 @@ public enum UiConfigOption
     /// </summary>
     [GameConfigOption("RightClickExclusionMinion", ConfigType.UInt)]
     RightClickExclusionMinion,
+
+    /// <summary>
+    /// UiConfig option with the internal name EnableMoveTiltCharacter.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("EnableMoveTiltCharacter", ConfigType.UInt)]
+    EnableMoveTiltCharacter,
+
+    /// <summary>
+    /// UiConfig option with the internal name EnableMoveTiltMountGround.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("EnableMoveTiltMountGround", ConfigType.UInt)]
+    EnableMoveTiltMountGround,
+
+    /// <summary>
+    /// UiConfig option with the internal name EnableMoveTiltMountFly.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("EnableMoveTiltMountFly", ConfigType.UInt)]
+    EnableMoveTiltMountFly,
 
     /// <summary>
     /// UiConfig option with the internal name TurnSpeed.
@@ -1129,6 +1149,27 @@ public enum UiConfigOption
     /// </summary>
     [GameConfigOption("HotbarXHBEditEnable", ConfigType.UInt)]
     HotbarXHBEditEnable,
+
+    /// <summary>
+    /// UiConfig option with the internal name HotbarContentsAction2ReverseOperation.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarContentsAction2ReverseOperation", ConfigType.UInt)]
+    HotbarContentsAction2ReverseOperation,
+
+    /// <summary>
+    /// UiConfig option with the internal name HotbarContentsAction2ReturnInitialSlot.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarContentsAction2ReturnInitialSlot", ConfigType.UInt)]
+    HotbarContentsAction2ReturnInitialSlot,
+
+    /// <summary>
+    /// UiConfig option with the internal name HotbarContentsAction2ReverseRotate.
+    /// This option is a UInt.
+    /// </summary>
+    [GameConfigOption("HotbarContentsAction2ReverseRotate", ConfigType.UInt)]
+    HotbarContentsAction2ReverseRotate,
 
     /// <summary>
     /// UiConfig option with the internal name PlateType.
@@ -3572,32 +3613,4 @@ public enum UiConfigOption
     /// </summary>
     [GameConfigOption("PvPFrontlinesGCFree", ConfigType.UInt)]
     PvPFrontlinesGCFree,
-
-    /// <summary>
-    /// UiConfig option with the internal name PadMode.
-    /// This option is a UInt.
-    /// </summary>
-    [GameConfigOption("PadMode", ConfigType.UInt)]
-    PadMode,
-
-    /// <summary>
-    /// UiConfig option with the internal name EnableMoveTiltCharacter.
-    /// This option is a UInt.
-    /// </summary>
-    [GameConfigOption("EnableMoveTiltCharacter", ConfigType.UInt)]
-    EnableMoveTiltCharacter,
-
-    /// <summary>
-    /// UiConfig option with the internal name EnableMoveTiltMountGround.
-    /// This option is a UInt.
-    /// </summary>
-    [GameConfigOption("EnableMoveTiltMountGround", ConfigType.UInt)]
-    EnableMoveTiltMountGround,
-
-    /// <summary>
-    /// UiConfig option with the internal name EnableMoveTiltMountFly.
-    /// This option is a UInt.
-    /// </summary>
-    [GameConfigOption("EnableMoveTiltMountFly", ConfigType.UInt)]
-    EnableMoveTiltMountFly,
 }


### PR DESCRIPTION
Removed erroring obsolete `LockonDefaultZoom_179` in SystemConfigOption. 

New in UiConfigOption:

- `HotbarContentsAction2ReverseOperation`
- `HotbarContentsAction2ReturnInitialSlot`
- `HotbarContentsAction2ReverseRotate`

Ordered as my script gave it to me this time.