### PR TITLE
Fixing colors and NounResolver

### DIFF
--- a/Dalamud/Game/Text/Evaluator/Internal/SheetRedirectResolver.cs
+++ b/Dalamud/Game/Text/Evaluator/Internal/SheetRedirectResolver.cs
@@ -193,7 +193,7 @@ internal class SheetRedirectResolver : IServiceType
                 colIndex = 43;
 
                 if (this.dataManager.GetExcelSheet<LSheets.InstanceContent>().TryGetRow(rowId, out var row))
-                    rowId = row.SortKey;
+                    rowId = row.ContentFinderCondition.RowId;
                 break;
             }
 

--- a/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
@@ -1599,7 +1599,7 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
         if (eColorTypeVal == 0)
             context.Builder.PopColor();
         else if (this.dataManager.GetExcelSheet<UIColor>().TryGetRow(eColorTypeVal, out var row))
-            context.Builder.PushColorBgra((row.Light >> 8) | (row.Light << 24));
+            context.Builder.PushColorBgra((row.Dark >> 8) | (row.Dark << 24));
 
         return true;
     }
@@ -1613,7 +1613,7 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
         if (eColorTypeVal == 0)
             context.Builder.PopEdgeColor();
         else if (this.dataManager.GetExcelSheet<UIColor>().TryGetRow(eColorTypeVal, out var row))
-            context.Builder.PushEdgeColorBgra((row.Light >> 8) | (row.Light << 24));
+            context.Builder.PushEdgeColorBgra((row.Dark >> 8) | (row.Dark << 24));
 
         return true;
     }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/InventoryWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/InventoryWidget.cs
@@ -380,7 +380,7 @@ internal class InventoryWidget : IDataWindowWidget
 
         var rowId = this.GetItemRarityColorType(item, isEdgeColor);
         return this.dataManager.Excel.GetSheet<UIColor>().TryGetRow(rowId, out var color)
-            ? BinaryPrimitives.ReverseEndianness(color.Light) | 0xFF000000
+            ? BinaryPrimitives.ReverseEndianness(color.Dark) | 0xFF000000
             : 0xFFFFFFFF;
     }
 

--- a/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/NounProcessorAgingStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/AgingSteps/NounProcessorAgingStep.cs
@@ -191,8 +191,6 @@ internal class NounProcessorAgingStep : IAgingStep
         new(nameof(LSheets.Item), 44348, ClientLanguage.French, 2, (int)FrenchArticleType.PossessiveFirstPerson, 1, "mes mémoquartz inhabituels fantasmagoriques"),
         new(nameof(LSheets.Item), 44348, ClientLanguage.French, 2, (int)FrenchArticleType.PossessiveSecondPerson, 1, "tes mémoquartz inhabituels fantasmagoriques"),
         new(nameof(LSheets.Item), 44348, ClientLanguage.French, 2, (int)FrenchArticleType.PossessiveThirdPerson, 1, "ses mémoquartz inhabituels fantasmagoriques"),
-
-        new(nameof(LSheets.Action), 45, ClientLanguage.German, 1, (int)FrenchArticleType.Indefinite, 1, "Blumenflüsterer IV"),
     ];
 
     private enum GermanCases


### PR DESCRIPTION
Removing a special case test from the NounProcessorAgingStep that is failing.
Technically that one has to go through the SheetRedirectResolver - which would happen with the denoun payload, but that is not happening when you use the NounProcessor directly, like in the self-test.