### PR TITLE
More InvokeSafely calls

### DIFF
--- a/Dalamud/Game/DutyState/DutyState.cs
+++ b/Dalamud/Game/DutyState/DutyState.cs
@@ -1,10 +1,11 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Hooking;
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
 using Dalamud.Plugin.Services;
+using Dalamud.Utility;
 
 namespace Dalamud.Game.DutyState;
 
@@ -81,33 +82,33 @@ internal unsafe class DutyState : IInternalDisposableService, IDutyState
                 // Duty Commenced
                 case 0x4000_0001:
                     this.IsDutyStarted = true;
-                    this.DutyStarted?.Invoke(this, this.clientState.TerritoryType);
+                    this.DutyStarted?.InvokeSafely(this, this.clientState.TerritoryType);
                     break;
 
                 // Party Wipe
                 case 0x4000_0005:
                     this.IsDutyStarted = false;
-                    this.DutyWiped?.Invoke(this, this.clientState.TerritoryType);
+                    this.DutyWiped?.InvokeSafely(this, this.clientState.TerritoryType);
                     break;
 
                 // Duty Recommence
                 case 0x4000_0006:
                     this.IsDutyStarted = true;
-                    this.DutyRecommenced?.Invoke(this, this.clientState.TerritoryType);
+                    this.DutyRecommenced?.InvokeSafely(this, this.clientState.TerritoryType);
                     break;
 
                 // Duty Completed Flytext Shown
                 case 0x4000_0002 when !this.CompletedThisTerritory:
                     this.IsDutyStarted = false;
                     this.CompletedThisTerritory = true;
-                    this.DutyCompleted?.Invoke(this, this.clientState.TerritoryType);
+                    this.DutyCompleted?.InvokeSafely(this, this.clientState.TerritoryType);
                     break;
 
                 // Duty Completed
                 case 0x4000_0003 when !this.CompletedThisTerritory:
                     this.IsDutyStarted = false;
                     this.CompletedThisTerritory = true;
-                    this.DutyCompleted?.Invoke(this, this.clientState.TerritoryType);
+                    this.DutyCompleted?.InvokeSafely(this, this.clientState.TerritoryType);
                     break;
             }
         }

--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -307,15 +307,7 @@ internal sealed unsafe class GameGui : IInternalDisposableService, IGameGui
         if (values != null && valueCount == 1 && values->Int == -1)
         {
             this.HoveredItem = 0;
-
-            try
-            {
-                this.HoveredItemChanged?.Invoke(this, 0);
-            }
-            catch (Exception e)
-            {
-                Log.Error(e, "Could not dispatch HoveredItemChanged event.");
-            }
+            this.HoveredItemChanged?.InvokeSafely(this, 0ul);
 
             Log.Verbose("HoveredItem changed: 0");
         }
@@ -347,15 +339,7 @@ internal sealed unsafe class GameGui : IInternalDisposableService, IGameGui
                 this.HoveredAction.ActionKind = HoverActionKind.None;
                 this.HoveredAction.BaseActionID = 0;
                 this.HoveredAction.ActionID = 0;
-
-                try
-                {
-                    this.HoveredActionChanged?.Invoke(this, this.HoveredAction);
-                }
-                catch (Exception e)
-                {
-                    Log.Error(e, "Could not dispatch HoveredActionChanged event.");
-                }
+                this.HoveredActionChanged?.InvokeSafely(this, this.HoveredAction);
 
                 Log.Verbose("HoverActionId: 0");
             }


### PR DESCRIPTION
Glyceri said the Duty Complete event didn't fire for her, so I checked and could confirm that the event is indeed invoked.

![Screenie](https://github.com/user-attachments/assets/030da22a-507f-4175-afd9-2a83a1624720)

But I noticed that these are not being called with the InvokeSafely extension, which means if a plugin throws, it will stop propagating the event.
Not sure if there are more somewhere.

Hope I did that correctly (not in the plugin-scoped service as the MarketBoard service is doing)!?