### PR TITLE
SeStringEvaluator: Fix reading world name for PcName macro

### DIFF
--- a/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
@@ -24,6 +24,7 @@ using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Client.UI.Info;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using FFXIVClientStructs.FFXIV.Component.Text;
+using FFXIVClientStructs.Interop;
 
 using Lumina.Data.Structs.Excel;
 using Lumina.Excel;
@@ -445,7 +446,7 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
 
                 if (this.gameConfig.UiConfig.TryGetUInt("LogCrossWorldName", out var logCrossWorldName) &&
                     logCrossWorldName == 1)
-                    context.Builder.Append((ReadOnlySeStringSpan)world.Name);
+                    context.Builder.Append(new ReadOnlySeStringSpan(world.Name.GetPointer(0)));
             }
 
             return true;


### PR DESCRIPTION
Passing the world name as pointer makes sure it [reads until null terminator](https://github.com/NotAdam/Lumina/blob/master/src/Lumina/Text/ReadOnly/ReadOnlySeStringSpan.cs#L27).