### PR TITLE
SeStringEvaluator: Fix kilo macro not having thousands separators

### DIFF
--- a/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
@@ -636,7 +636,7 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
             {
                 case false when digit == 0:
                     continue;
-                case true when i % 3 == 0:
+                case true when MathF.Log10(i) % 3 == 2:
                     this.ResolveStringExpression(in context, eSep);
                     break;
             }


### PR DESCRIPTION
Not sure if I did it right, but it works! Thanks kizer for mentioning log10!

![Proof 1](https://github.com/user-attachments/assets/1a24769b-5afb-44b0-a4e5-9415f452895a)
![Proof 2](https://github.com/user-attachments/assets/62e3fd01-8756-4a25-a11a-167e48a52a60)
