### PR TITLE
feat: Deprecate IGameNetwork

### DIFF
--- a/Dalamud/Game/Network/Internal/NetworkHandlers.cs
+++ b/Dalamud/Game/Network/Internal/NetworkHandlers.cs
@@ -56,7 +56,6 @@ internal unsafe class NetworkHandlers : IInternalDisposableService
 
     [ServiceManager.ServiceConstructor]
     private NetworkHandlers(
-        GameNetwork gameNetwork,
         TargetSigScanner sigScanner,
         HappyHttpClient happyHttpClient)
     {

--- a/Dalamud/Plugin/Services/IGameNetwork.cs
+++ b/Dalamud/Plugin/Services/IGameNetwork.cs
@@ -1,10 +1,13 @@
 ﻿using Dalamud.Game.Network;
+using Dalamud.Utility;
 
 namespace Dalamud.Plugin.Services;
 
 /// <summary>
 /// This class handles interacting with game network events.
 /// </summary>
+[Obsolete("To be removed with API13.")]
+[Api13ToDo("Remove")]
 public interface IGameNetwork
 {
     // TODO(v9): we shouldn't be passing pointers to the actual data here


### PR DESCRIPTION
This PR is a **proposal** to remove the `IGameNetwork` service from Dalamud. With changes in Patch 7.2 (namely, additional packet obfuscation), this service no longer really provides useful data in some cases. In general, Dalamud has encouraged developers move away from opcode management in favor of hook(s) in the appropriate locations, and this solidifies that decision.

This service may still be used by certain plugins. As such, we are seeking input from relevant community members who may still have some use for these APIs about the deprecation path here.

Identified Uses:

* [PingPlugin](https://github.com/karashiiro/PingPlugin/blob/30e45e3186af72460056ab5d7d81f6ec73a8eaab/PingPlugin/PingTrackers/PacketPingTracker.cs#L59), @karashiiro
* [StanleyParableXIV](https://github.com/rekyuu/StanleyParableXiv/blob/36ae9d6fad2ce5aa92be73edcf53e42b753431c5/StanleyParableXiv/Events/PvpEvent.cs#L318), @rekyuu
* [DeepDungeonTracker](https://github.com/marconsou/deep-dungeon-tracker/blob/16089d0a45076c0b7a3c917a4c5b43da49d07985/DeepDungeonTracker/Data/Data.cs#L245), @marconsou 

At this time, the internal service is not planned to be deprecated, as it's still used for the debug window. This feature is still deemed beneficial as it can be used to identify whether something does (or doesn't) send a network request.