### PR TITLE
Improve null checking for badly set properties in NamePlateGui

### DIFF
--- a/Dalamud/Game/Gui/NamePlate/NamePlateQuotedParts.cs
+++ b/Dalamud/Game/Gui/NamePlate/NamePlateQuotedParts.cs
@@ -53,7 +53,7 @@ public class NamePlateQuotedParts(NamePlateStringField field, bool isFreeCompany
             return;
 
         var sb = new SeStringBuilder();
-        if (this.OuterWrap is { Item1: var outerLeft })
+        if (this.OuterWrap is { Item1: { } outerLeft })
         {
             sb.Append(outerLeft);
         }
@@ -67,7 +67,7 @@ public class NamePlateQuotedParts(NamePlateStringField field, bool isFreeCompany
             sb.Append(isFreeCompany ? " «" : "《");
         }
 
-        if (this.TextWrap is { Item1: var left, Item2: var right })
+        if (this.TextWrap is { Item1: { } left, Item2: { } right })
         {
             sb.Append(left);
             sb.Append(this.Text ?? this.GetStrippedField(handler));
@@ -87,7 +87,7 @@ public class NamePlateQuotedParts(NamePlateStringField field, bool isFreeCompany
             sb.Append(isFreeCompany ? "»" : "》");
         }
 
-        if (this.OuterWrap is { Item2: var outerRight })
+        if (this.OuterWrap is { Item2: { } outerRight })
         {
             sb.Append(outerRight);
         }

--- a/Dalamud/Game/Gui/NamePlate/NamePlateSimpleParts.cs
+++ b/Dalamud/Game/Gui/NamePlate/NamePlateSimpleParts.cs
@@ -35,7 +35,7 @@ public class NamePlateSimpleParts(NamePlateStringField field)
         if ((nint)handler.GetFieldAsPointer(field) == NamePlateGui.EmptyStringPointer)
             return;
 
-        if (this.TextWrap is { Item1: var left, Item2: var right })
+        if (this.TextWrap is { Item1: { } left, Item2: { } right })
         {
             var sb = new SeStringBuilder();
             sb.Append(left);


### PR DESCRIPTION
While a plugin setting these "wrap" tuples to `(null, null)` is clearly not correct, the error we throw happens during deferred nameplate processing and can be hard to trace to a particular plugin. With this change we also null check each tuple value and skip it if it would cause an error.