### PR TITLE
SeString Creator and Evaluator fixes

### DIFF
--- a/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
@@ -1066,8 +1066,8 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
         if (!enu.MoveNext() || !this.TryResolveUInt(in context, enu.Current, out var placeNameIdInt))
             return false;
 
-        var instance = packedIds >> 0x10;
-        var mapId = packedIds & 0xFF;
+        var instance = packedIds >> 16;
+        var mapId = packedIds & 0xFFFF;
 
         if (this.dataManager.GetExcelSheet<TerritoryType>(context.Language)
                 .TryGetRow(territoryTypeId, out var territoryTypeRow))

--- a/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
@@ -1355,8 +1355,6 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
         var group = (uint)(e0Val + 1);
         var rowId = (uint)e1Val;
 
-        using var icons = new SeStringBuilderIconWrap(context.Builder, 54, 55);
-
         if (!this.dataManager.GetExcelSheet<Completion>(context.Language).TryGetFirst(
                 row => row.Group == group && !row.LookupTable.IsEmpty,
                 out var groupRow))
@@ -1380,6 +1378,8 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
 
             return true;
         }
+
+        using var icons = new SeStringBuilderIconWrap(context.Builder, 54, 55);
 
         // CategoryDataCache
         if (lookupTable.Equals("#"))

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
@@ -135,8 +135,8 @@ internal class SeStringCreatorWidget : IDataWindowWidget
         new TextEntry(TextEntryType.Macro, "<colortype(17)>"),
         new TextEntry(TextEntryType.Macro, "<edgecolortype(19)>"),
         new TextEntry(TextEntryType.String, "Dalamud"),
-        new TextEntry(TextEntryType.Macro, "<edgecolor(0)>"),
-        new TextEntry(TextEntryType.Macro, "<colortype(0)>"),
+        new TextEntry(TextEntryType.Macro, "<edgecolor(stackcolor)>"),
+        new TextEntry(TextEntryType.Macro, "<color(stackcolor)>"),
         new TextEntry(TextEntryType.Macro, " <string(lstr1)>"),
     ];
 


### PR DESCRIPTION
### SeString Creator fixes

- The example has incorrect color terminators.
  `edgecolortype` should be popped with `<edgecolor(stackcolor)>` and `colortype` should be popped with `<color(stackcolor)>`.

### SeStringEvaluator fixes

- `fixed` macro: Auto-translation brackets are shown for categories. Technically doesn't matter, because categories can't be auto translated, but I changed it anyway.
- `fixed` macro: For map links, the map id was masked with `0xFF` instead of `0xFFFF`. It should be a ushort, not a byte.