### PR TITLE
Mark main thread in Framework.Destroy detour

### DIFF
--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -474,6 +474,8 @@ internal sealed class Framework : IInternalDisposableService, IFramework
 
     private unsafe bool HandleFrameworkDestroy(CSFramework* thisPtr)
     {
+        ThreadSafety.MarkMainThread();
+
         this.frameworkDestroy.Cancel();
         this.DispatchUpdateEvents = false;
         foreach (var k in this.tickDelayedTaskCompletionSources.Keys)


### PR DESCRIPTION
When we're in the detour of Framework.Destroy we are on the main thread.
Functions guarded with `ThreadSafety.AssertMainThread();` should work in this context.