### PR TITLE
Update Lumina to 5.7.0 and Lumina.Excel to 7.2.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,8 +10,8 @@
 
     <!-- Dependency versions -->
     <PropertyGroup Label="Dependency Versions">
-        <LuminaVersion>5.6.1</LuminaVersion>
-        <LuminaExcelVersion>7.2.1</LuminaExcelVersion>
+        <LuminaVersion>5.7.0</LuminaVersion>
+        <LuminaExcelVersion>7.2.2</LuminaExcelVersion>
         <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
This new Lumina.Excel release adds obsoletion warnings (not errors) for fields with a `pendingName`, and adds a `Lumina.Excel.Sheets.Experimental` namespace which contains all the breaking changes for plugin developers who are fine with API breakage and are on top of things (they are marked accordingly with an Experimental attribute as well.)