### PR TITLE
SeStringEvaluator: fallback to games ClientLanguage

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Dalamud.Configuration.Internal;
 using Dalamud.Data;
 using Dalamud.Game;
+using Dalamud.Game.ClientState;
 using Dalamud.Game.Text.Evaluator;
 using Dalamud.Game.Text.Noun.Enums;
 using Dalamud.Game.Text.SeStringHandling;
@@ -168,7 +169,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
     /// <inheritdoc/>
     public void Load()
     {
-        this.language = Service<DalamudConfiguration>.Get().EffectiveLanguage.ToClientLanguage();
+        this.language = Service<ClientState>.Get().ClientLanguage;
         this.UpdateInputString(false);
         this.Ready = true;
     }


### PR DESCRIPTION
Using a Dalamud UI language other than the available ClientLanguages breaks the SeStringEvaluator because `string.ToClientLanguage()` will throw `Specified argument was out of the range of valid values.`.
This PR adds a local function in SeStringEvaluator which falls back to the games ClientLanguage if it couldn't be properly converted.