### PR TITLE
Do not throw in Hook.IsEnabled and Disable

### DIFF
--- a/Dalamud/Hooking/Hook.cs
+++ b/Dalamud/Hooking/Hook.cs
@@ -90,6 +90,7 @@ public abstract class Hook<T> : IDalamudHook where T : Delegate
     /// <summary>
     /// Starts intercepting a call to the function.
     /// </summary>
+    /// <exception cref="ObjectDisposedException">Hook is already disposed.</exception>
     public virtual void Enable() => throw new NotImplementedException();
 
     /// <summary>

--- a/Dalamud/Hooking/Internal/FunctionPointerVariableHook.cs
+++ b/Dalamud/Hooking/Internal/FunctionPointerVariableHook.cs
@@ -115,14 +115,7 @@ internal class FunctionPointerVariableHook<T> : Hook<T>
     }
 
     /// <inheritdoc/>
-    public override bool IsEnabled
-    {
-        get
-        {
-            this.CheckDisposed();
-            return this.enabled;
-        }
-    }
+    public override bool IsEnabled => !this.IsDisposed && this.enabled;
 
     /// <inheritdoc/>
     public override string BackendName => "MinHook";
@@ -131,9 +124,7 @@ internal class FunctionPointerVariableHook<T> : Hook<T>
     public override void Dispose()
     {
         if (this.IsDisposed)
-        {
             return;
-        }
 
         this.Disable();
 
@@ -148,15 +139,13 @@ internal class FunctionPointerVariableHook<T> : Hook<T>
     /// <inheritdoc/>
     public override void Enable()
     {
-        this.CheckDisposed();
-
-        if (this.enabled)
-        {
-            return;
-        }
-
         lock (HookManager.HookEnableSyncRoot)
         {
+            this.CheckDisposed();
+
+            if (this.enabled)
+                return;
+
             Marshal.WriteIntPtr(this.ppfnThunkJumpTarget, this.pfnDetour);
             this.enabled = true;
         }
@@ -165,15 +154,14 @@ internal class FunctionPointerVariableHook<T> : Hook<T>
     /// <inheritdoc/>
     public override void Disable()
     {
-        this.CheckDisposed();
-
-        if (!this.enabled)
-        {
-            return;
-        }
-
         lock (HookManager.HookEnableSyncRoot)
         {
+            if (this.IsDisposed)
+                return;
+
+            if (!this.enabled)
+                return;
+
             Marshal.WriteIntPtr(this.ppfnThunkJumpTarget, this.pfnOriginal);
             this.enabled = false;
         }

--- a/Dalamud/Hooking/Internal/MinHookHook.cs
+++ b/Dalamud/Hooking/Internal/MinHookHook.cs
@@ -50,14 +50,7 @@ internal class MinHookHook<T> : Hook<T> where T : Delegate
     }
 
     /// <inheritdoc/>
-    public override bool IsEnabled
-    {
-        get
-        {
-            this.CheckDisposed();
-            return this.minHookImpl.Enabled;
-        }
-    }
+    public override bool IsEnabled => !this.IsDisposed && this.minHookImpl.Enabled;
 
     /// <inheritdoc/>
     public override string BackendName => "MinHook";
@@ -84,28 +77,29 @@ internal class MinHookHook<T> : Hook<T> where T : Delegate
     /// <inheritdoc/>
     public override void Enable()
     {
-        this.CheckDisposed();
-
-        if (!this.minHookImpl.Enabled)
+        lock (HookManager.HookEnableSyncRoot)
         {
-            lock (HookManager.HookEnableSyncRoot)
-            {
-                this.minHookImpl.Enable();
-            }
+            this.CheckDisposed();
+
+            if (!this.minHookImpl.Enabled)
+                return;
+
+            this.minHookImpl.Enable();
         }
     }
 
     /// <inheritdoc/>
     public override void Disable()
     {
-        this.CheckDisposed();
-
-        if (this.minHookImpl.Enabled)
+        lock (HookManager.HookEnableSyncRoot)
         {
-            lock (HookManager.HookEnableSyncRoot)
-            {
-                this.minHookImpl.Disable();
-            }
+            if (this.IsDisposed)
+                return;
+
+            if (!this.minHookImpl.Enabled)
+                return;
+
+            this.minHookImpl.Disable();
         }
     }
 }

--- a/Dalamud/Hooking/Internal/ReloadedHook.cs
+++ b/Dalamud/Hooking/Internal/ReloadedHook.cs
@@ -45,14 +45,7 @@ internal class ReloadedHook<T> : Hook<T> where T : Delegate
     }
 
     /// <inheritdoc/>
-    public override bool IsEnabled
-    {
-        get
-        {
-            this.CheckDisposed();
-            return this.hookImpl.IsHookEnabled;
-        }
-    }
+    public override bool IsEnabled => !this.IsDisposed && this.hookImpl.IsHookEnabled;
 
     /// <inheritdoc/>
     public override string BackendName => "Reloaded";
@@ -73,10 +66,10 @@ internal class ReloadedHook<T> : Hook<T> where T : Delegate
     /// <inheritdoc/>
     public override void Enable()
     {
-        this.CheckDisposed();
-
         lock (HookManager.HookEnableSyncRoot)
         {
+            this.CheckDisposed();
+
             if (!this.hookImpl.IsHookEnabled)
                 this.hookImpl.Enable();
         }
@@ -85,10 +78,11 @@ internal class ReloadedHook<T> : Hook<T> where T : Delegate
     /// <inheritdoc/>
     public override void Disable()
     {
-        this.CheckDisposed();
-
         lock (HookManager.HookEnableSyncRoot)
         {
+            if (this.IsDisposed)
+                return;
+
             if (!this.hookImpl.IsHookActivated)
                 return;
 


### PR DESCRIPTION
I noticed that accessing `IsEnabled` and calling `Disable` on a disposed Hook throws `ObjectDisposedException`.
What it should do instead, in my opinion, is to provide a safe way to access `IsEnabled` and to be able to call `Disable`, the same way `Dispose` itself handes it - by checking `IsDisposed` and return early if `true`.

I also added the info that `Enable` can throw `ObjectDisposedException` to its xmldocs, and moved checks inside the locks.