### PR TITLE
[Possible Breaking Changes] Update Lumina.Excel to 7.2.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <!-- Dependency versions -->
     <PropertyGroup Label="Dependency Versions">
         <LuminaVersion>5.7.0</LuminaVersion>
-        <LuminaExcelVersion>7.2.2</LuminaExcelVersion>
+        <LuminaExcelVersion>7.2.3</LuminaExcelVersion>
         <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
Because EXDSchema has moved to a monthly breaking release cadence, Lumina.Excel is following suit to do the same. 7.2.3 contains [changes from EXDSchema v2025.05 with some additional experimental changes](https://github.com/NotAdam/Lumina.Excel/compare/7.2.2...7.2.3) (part of the Lumina.Sheets.Experimental namespace). I may consider changing Lumina.Excel versioning to match with EXDSchema, but that's still TBD.