### PR TITLE
UIDebug2 Timeline Labelset support

### DIFF
--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/TimelineTree.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/TimelineTree.cs
@@ -55,7 +55,7 @@ public readonly unsafe partial struct TimelineTree
         var animationCount = this.Resource->AnimationCount;
         var labelSetCount = this.Resource->LabelSetCount;
 
-        if (animationCount > 0 || labelSetCount > 0)
+        if (animationCount > 0)
         {
             using var tree = ImRaii.TreeNode($"Timeline##{(nint)this.node:X}timeline", SpanFullWidth);
 
@@ -84,11 +84,16 @@ public readonly unsafe partial struct TimelineTree
                         this.PrintAnimation(animation, a, isActive, (nint)(this.NodeTimeline->Resource->Animations + a));
                     }
                 }
+            }
+        }
 
-                if (this.Resource->LabelSets is not null)
-                {
-                    this.DrawLabelSets();
-                }
+        if (labelSetCount > 0 && this.Resource->LabelSets is not null)
+        {
+            using var tree = ImRaii.TreeNode($"Timeline Label Sets##{(nint)this.node:X}LabelSets", SpanFullWidth);
+
+            if (tree.Success)
+            {
+                this.DrawLabelSets();
             }
         }
     }
@@ -393,8 +398,6 @@ public readonly unsafe partial struct TimelineTree
 
     private void DrawLabelSets()
     {
-        ImGui.TextColored(new(0.6f, 0.6f, 0.6f, 1), "LabelSet List");
-
         PrintFieldValuePair("LabelSet", $"{(nint)this.NodeTimeline->Resource->LabelSets:X}");
 
         ImGui.SameLine();
@@ -403,9 +406,9 @@ public readonly unsafe partial struct TimelineTree
 
         PrintFieldValuePairs(
             ("StartFrameIdx", $"{this.NodeTimeline->Resource->LabelSets->StartFrameIdx}"),
-            ("EndFrameIdx Time", $"{this.NodeTimeline->Resource->LabelSets->EndFrameIdx}"));
+            ("EndFrameIdx", $"{this.NodeTimeline->Resource->LabelSets->EndFrameIdx}"));
 
-        using var labelSetTable = ImRaii.TreeNode("Label Set Table");
+        using var labelSetTable = ImRaii.TreeNode("Entries");
         if (labelSetTable.Success)
         {
             var keyFrameGroup = this.Resource->LabelSets->LabelKeyGroup;
@@ -419,7 +422,7 @@ public readonly unsafe partial struct TimelineTree
                 ImGui.TableSetupColumn("Interpolation", WidthFixed);
                 ImGui.TableSetupColumn("Label ID", WidthFixed);
                 ImGui.TableSetupColumn("Jump Behavior", WidthFixed);
-                ImGui.TableSetupColumn("Target ID", WidthFixed);
+                ImGui.TableSetupColumn("Target Label ID", WidthFixed);
 
                 ImGui.TableHeadersRow();
 

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/TimelineTree.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/TimelineTree.cs
@@ -52,9 +52,10 @@ public readonly unsafe partial struct TimelineTree
             return;
         }
 
-        var count = this.Resource->AnimationCount;
+        var animationCount = this.Resource->AnimationCount;
+        var labelSetCount = this.Resource->LabelSetCount;
 
-        if (count > 0)
+        if (animationCount > 0 || labelSetCount > 0)
         {
             using var tree = ImRaii.TreeNode($"Timeline##{(nint)this.node:X}timeline", SpanFullWidth);
 
@@ -66,19 +67,27 @@ public readonly unsafe partial struct TimelineTree
 
                 ShowStruct(this.NodeTimeline);
 
-                PrintFieldValuePairs(
-                    ("Id", $"{this.NodeTimeline->Resource->Id}"),
-                    ("Parent Time", $"{this.NodeTimeline->ParentFrameTime:F2} ({this.NodeTimeline->ParentFrameTime * 30:F0})"),
-                    ("Frame Time", $"{this.NodeTimeline->FrameTime:F2} ({this.NodeTimeline->FrameTime * 30:F0})"));
-
-                PrintFieldValuePairs(("Active Label Id", $"{this.NodeTimeline->ActiveLabelId}"), ("Duration", $"{this.NodeTimeline->LabelFrameIdxDuration}"), ("End Frame", $"{this.NodeTimeline->LabelEndFrameIdx}"));
-                ImGui.TextColored(new(0.6f, 0.6f, 0.6f, 1), "Animation List");
-
-                for (var a = 0; a < count; a++)
+                if (this.Resource->Animations is not null)
                 {
-                    var animation = this.Resource->Animations[a];
-                    var isActive = this.ActiveAnimation != null && &animation == this.ActiveAnimation;
-                    this.PrintAnimation(animation, a, isActive, (nint)(this.NodeTimeline->Resource->Animations + a));
+                    PrintFieldValuePairs(
+                        ("Id", $"{this.NodeTimeline->Resource->Id}"),
+                        ("Parent Time", $"{this.NodeTimeline->ParentFrameTime:F2} ({this.NodeTimeline->ParentFrameTime * 30:F0})"),
+                        ("Frame Time", $"{this.NodeTimeline->FrameTime:F2} ({this.NodeTimeline->FrameTime * 30:F0})"));
+
+                    PrintFieldValuePairs(("Active Label Id", $"{this.NodeTimeline->ActiveLabelId}"), ("Duration", $"{this.NodeTimeline->LabelFrameIdxDuration}"), ("End Frame", $"{this.NodeTimeline->LabelEndFrameIdx}"));
+                    ImGui.TextColored(new(0.6f, 0.6f, 0.6f, 1), "Animation List");
+
+                    for (var a = 0; a < animationCount; a++)
+                    {
+                        var animation = this.Resource->Animations[a];
+                        var isActive = this.ActiveAnimation != null && &animation == this.ActiveAnimation;
+                        this.PrintAnimation(animation, a, isActive, (nint)(this.NodeTimeline->Resource->Animations + a));
+                    }
+                }
+
+                if (this.Resource->LabelSets is not null)
+                {
+                    this.DrawLabelSets();
                 }
             }
         }
@@ -380,5 +389,66 @@ public readonly unsafe partial struct TimelineTree
         GetLabelColumn(keyGroups[7], columns);
 
         return columns;
+    }
+
+    private void DrawLabelSets()
+    {
+        ImGui.TextColored(new(0.6f, 0.6f, 0.6f, 1), "LabelSet List");
+
+        PrintFieldValuePair("LabelSet", $"{(nint)this.NodeTimeline->Resource->LabelSets:X}");
+
+        ImGui.SameLine();
+
+        ShowStruct(this.NodeTimeline->Resource->LabelSets);
+
+        PrintFieldValuePairs(
+            ("StartFrameIdx", $"{this.NodeTimeline->Resource->LabelSets->StartFrameIdx}"),
+            ("EndFrameIdx Time", $"{this.NodeTimeline->Resource->LabelSets->EndFrameIdx}"));
+
+        using var labelSetTable = ImRaii.TreeNode("Label Set Table");
+        if (labelSetTable.Success)
+        {
+            var keyFrameGroup = this.Resource->LabelSets->LabelKeyGroup;
+
+            using var table = ImRaii.Table($"##{(nint)this.node}labelSetKeyFrameTable", 7, Borders | SizingFixedFit | RowBg | NoHostExtendX);
+            if (table.Success)
+            {
+                ImGui.TableSetupColumn("Frame ID", WidthFixed);
+                ImGui.TableSetupColumn("Speed Start", WidthFixed);
+                ImGui.TableSetupColumn("Speed End", WidthFixed);
+                ImGui.TableSetupColumn("Interpolation", WidthFixed);
+                ImGui.TableSetupColumn("Label ID", WidthFixed);
+                ImGui.TableSetupColumn("Jump Behavior", WidthFixed);
+                ImGui.TableSetupColumn("Target ID", WidthFixed);
+
+                ImGui.TableHeadersRow();
+
+                for (var l = 0; l < keyFrameGroup.KeyFrameCount; l++)
+                {
+                    var keyFrame = keyFrameGroup.KeyFrames[l];
+
+                    ImGui.TableNextColumn();
+                    ImGui.TextUnformatted($"{keyFrame.FrameIdx}");
+
+                    ImGui.TableNextColumn();
+                    ImGui.TextUnformatted($"{keyFrame.SpeedCoefficient1:F2}");
+
+                    ImGui.TableNextColumn();
+                    ImGui.TextUnformatted($"{keyFrame.SpeedCoefficient2:F2}");
+
+                    ImGui.TableNextColumn();
+                    ImGui.TextUnformatted($"{keyFrame.Interpolation}");
+
+                    ImGui.TableNextColumn();
+                    ImGui.TextUnformatted($"{keyFrame.Value.Label.LabelId}");
+
+                    ImGui.TableNextColumn();
+                    ImGui.TextUnformatted($"{keyFrame.Value.Label.JumpBehavior}");
+
+                    ImGui.TableNextColumn();
+                    ImGui.TextUnformatted($"{keyFrame.Value.Label.JumpLabelId}");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds support for displaying data with regards to a timelines Labelset

This element defines the parents controller for child timelines

![image](https://github.com/user-attachments/assets/28940257-a42e-414b-9f42-9f20330fde64)
