### PR TITLE
Add events for certain style changes from within Dalamud.

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs
@@ -102,19 +102,30 @@ internal class SettingsWindow : Window
         var interfaceManager = Service<InterfaceManager>.Get();
         var fontAtlasFactory = Service<FontAtlasFactory>.Get();
 
+        var scaleChanged = !Equals(ImGui.GetIO().FontGlobalScale, configuration.GlobalUiScale);
         var rebuildFont = !Equals(fontAtlasFactory.DefaultFontSpec, configuration.DefaultFontSpec);
-        rebuildFont |= !Equals(ImGui.GetIO().FontGlobalScale, configuration.GlobalUiScale);
+        rebuildFont |= scaleChanged;
 
         ImGui.GetIO().FontGlobalScale = configuration.GlobalUiScale;
+        if (scaleChanged)
+        {
+            UiBuilder.InvokeGlobalScaleChanged();
+        }
+
         fontAtlasFactory.DefaultFontSpecOverride = null;
 
         if (rebuildFont)
+        {
             interfaceManager.RebuildFonts();
+            UiBuilder.InvokeFontChanged();
+        }
 
         foreach (var settingsTab in this.tabs)
         {
             if (settingsTab.IsOpen)
+            {
                 settingsTab.OnClose();
+            }
 
             settingsTab.IsOpen = false;
         }

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
@@ -198,6 +198,7 @@ public class SettingsTabLook : SettingsTab
             {
                 ImGui.GetIO().FontGlobalScale = this.globalUiScale = scale;
                 interfaceManager.RebuildFonts();
+                UiBuilder.InvokeGlobalScaleChanged();
             }
         }
 
@@ -220,6 +221,7 @@ public class SettingsTabLook : SettingsTab
             this.globalUiScale = globalUiScaleInPct / 100f;
             ImGui.GetIO().FontGlobalScale = this.globalUiScale;
             interfaceManager.RebuildFonts();
+            UiBuilder.InvokeGlobalScaleChanged();
         }
 
         ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsGlobalUiScaleHint", "Scale text in all XIVLauncher UI elements - this is useful for 4K displays."));
@@ -260,6 +262,7 @@ public class SettingsTabLook : SettingsTab
 
                         faf.DefaultFontSpecOverride = this.defaultFontSpec = r.Result;
                         interfaceManager.RebuildFonts();
+                        UiBuilder.InvokeFontChanged();
                     }));
         }
 
@@ -274,6 +277,7 @@ public class SettingsTabLook : SettingsTab
                     this.defaultFontSpec =
                         new SingleFontSpec { FontId = new GameFontAndFamilyId(GameFontFamily.Axis) };
                 interfaceManager.RebuildFonts();
+                UiBuilder.InvokeFontChanged();
             }
         }
 

--- a/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
@@ -89,6 +89,7 @@ public class StyleEditorWindow : Window
         {
             var newStyle = config.SavedStyles[this.currentSel];
             newStyle.Apply();
+            UiBuilder.InvokeStyleChanged();
             appliedThisFrame = true;
         }
 
@@ -103,6 +104,7 @@ public class StyleEditorWindow : Window
             this.currentSel = config.SavedStyles.Count - 1;
 
             newStyle.Apply();
+            UiBuilder.InvokeStyleChanged();
             appliedThisFrame = true;
 
             config.QueueSave();
@@ -118,6 +120,7 @@ public class StyleEditorWindow : Window
             this.currentSel--;
             var newStyle = config.SavedStyles[this.currentSel];
             newStyle.Apply();
+            UiBuilder.InvokeStyleChanged();
             appliedThisFrame = true;
 
             config.SavedStyles.RemoveAt(this.currentSel + 1);
@@ -182,6 +185,7 @@ public class StyleEditorWindow : Window
 
                 config.SavedStyles.Add(newStyle);
                 newStyle.Apply();
+                UiBuilder.InvokeStyleChanged();
                 appliedThisFrame = true;
 
                 this.currentSel = config.SavedStyles.Count - 1;
@@ -212,49 +216,53 @@ public class StyleEditorWindow : Window
         else if (ImGui.BeginTabBar("StyleEditorTabs"))
         {
             var style = ImGui.GetStyle();
-
+            var changes = false;
             if (ImGui.BeginTabItem(Loc.Localize("StyleEditorVariables", "Variables")))
             {
                 if (ImGui.BeginChild($"ScrollingVars", ImGuiHelpers.ScaledVector2(0, -32), true, ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.NoBackground))
                 {
                     ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 5);
 
-                    ImGui.SliderFloat2("WindowPadding", ref style.WindowPadding, 0.0f, 20.0f, "%.0f");
-                    ImGui.SliderFloat2("FramePadding", ref style.FramePadding, 0.0f, 20.0f, "%.0f");
-                    ImGui.SliderFloat2("CellPadding", ref style.CellPadding, 0.0f, 20.0f, "%.0f");
-                    ImGui.SliderFloat2("ItemSpacing", ref style.ItemSpacing, 0.0f, 20.0f, "%.0f");
-                    ImGui.SliderFloat2("ItemInnerSpacing", ref style.ItemInnerSpacing, 0.0f, 20.0f, "%.0f");
-                    ImGui.SliderFloat2("TouchExtraPadding", ref style.TouchExtraPadding, 0.0f, 10.0f, "%.0f");
-                    ImGui.SliderFloat("IndentSpacing", ref style.IndentSpacing, 0.0f, 30.0f, "%.0f");
-                    ImGui.SliderFloat("ScrollbarSize", ref style.ScrollbarSize, 1.0f, 20.0f, "%.0f");
-                    ImGui.SliderFloat("GrabMinSize", ref style.GrabMinSize, 1.0f, 20.0f, "%.0f");
+                    changes |= ImGui.SliderFloat2("WindowPadding", ref style.WindowPadding, 0.0f, 20.0f, "%.0f");
+                    changes |= ImGui.SliderFloat2("FramePadding", ref style.FramePadding, 0.0f, 20.0f, "%.0f");
+                    changes |= ImGui.SliderFloat2("CellPadding", ref style.CellPadding, 0.0f, 20.0f, "%.0f");
+                    changes |= ImGui.SliderFloat2("ItemSpacing", ref style.ItemSpacing, 0.0f, 20.0f, "%.0f");
+                    changes |= ImGui.SliderFloat2("ItemInnerSpacing", ref style.ItemInnerSpacing, 0.0f, 20.0f, "%.0f");
+                    changes |= ImGui.SliderFloat2("TouchExtraPadding", ref style.TouchExtraPadding, 0.0f, 10.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("IndentSpacing", ref style.IndentSpacing, 0.0f, 30.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("ScrollbarSize", ref style.ScrollbarSize, 1.0f, 20.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("GrabMinSize", ref style.GrabMinSize, 1.0f, 20.0f, "%.0f");
                     ImGui.Text("Borders");
-                    ImGui.SliderFloat("WindowBorderSize", ref style.WindowBorderSize, 0.0f, 1.0f, "%.0f");
-                    ImGui.SliderFloat("ChildBorderSize", ref style.ChildBorderSize, 0.0f, 1.0f, "%.0f");
-                    ImGui.SliderFloat("PopupBorderSize", ref style.PopupBorderSize, 0.0f, 1.0f, "%.0f");
-                    ImGui.SliderFloat("FrameBorderSize", ref style.FrameBorderSize, 0.0f, 1.0f, "%.0f");
-                    ImGui.SliderFloat("TabBorderSize", ref style.TabBorderSize, 0.0f, 1.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("WindowBorderSize", ref style.WindowBorderSize, 0.0f, 1.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("ChildBorderSize", ref style.ChildBorderSize, 0.0f, 1.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("PopupBorderSize", ref style.PopupBorderSize, 0.0f, 1.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("FrameBorderSize", ref style.FrameBorderSize, 0.0f, 1.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("TabBorderSize", ref style.TabBorderSize, 0.0f, 1.0f, "%.0f");
                     ImGui.Text("Rounding");
-                    ImGui.SliderFloat("WindowRounding", ref style.WindowRounding, 0.0f, 12.0f, "%.0f");
-                    ImGui.SliderFloat("ChildRounding", ref style.ChildRounding, 0.0f, 12.0f, "%.0f");
-                    ImGui.SliderFloat("FrameRounding", ref style.FrameRounding, 0.0f, 12.0f, "%.0f");
-                    ImGui.SliderFloat("PopupRounding", ref style.PopupRounding, 0.0f, 12.0f, "%.0f");
-                    ImGui.SliderFloat("ScrollbarRounding", ref style.ScrollbarRounding, 0.0f, 12.0f, "%.0f");
-                    ImGui.SliderFloat("GrabRounding", ref style.GrabRounding, 0.0f, 12.0f, "%.0f");
-                    ImGui.SliderFloat("LogSliderDeadzone", ref style.LogSliderDeadzone, 0.0f, 12.0f, "%.0f");
-                    ImGui.SliderFloat("TabRounding", ref style.TabRounding, 0.0f, 12.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("WindowRounding", ref style.WindowRounding, 0.0f, 12.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("ChildRounding", ref style.ChildRounding, 0.0f, 12.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("FrameRounding", ref style.FrameRounding, 0.0f, 12.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("PopupRounding", ref style.PopupRounding, 0.0f, 12.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("ScrollbarRounding", ref style.ScrollbarRounding, 0.0f, 12.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("GrabRounding", ref style.GrabRounding, 0.0f, 12.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("LogSliderDeadzone", ref style.LogSliderDeadzone, 0.0f, 12.0f, "%.0f");
+                    changes |= ImGui.SliderFloat("TabRounding", ref style.TabRounding, 0.0f, 12.0f, "%.0f");
                     ImGui.Text("Alignment");
-                    ImGui.SliderFloat2("WindowTitleAlign", ref style.WindowTitleAlign, 0.0f, 1.0f, "%.2f");
+                    changes |= ImGui.SliderFloat2("WindowTitleAlign", ref style.WindowTitleAlign, 0.0f, 1.0f, "%.2f");
                     var windowMenuButtonPosition = (int)style.WindowMenuButtonPosition + 1;
                     if (ImGui.Combo("WindowMenuButtonPosition", ref windowMenuButtonPosition, "None\0Left\0Right\0"))
+                    {
                         style.WindowMenuButtonPosition = (ImGuiDir)(windowMenuButtonPosition - 1);
-                    ImGui.SliderFloat2("ButtonTextAlign", ref style.ButtonTextAlign, 0.0f, 1.0f, "%.2f");
+                        changes = true;
+                    }
+
+                    changes |= ImGui.SliderFloat2("ButtonTextAlign", ref style.ButtonTextAlign, 0.0f, 1.0f, "%.2f");
                     ImGui.SameLine();
                     ImGuiComponents.HelpMarker("Alignment applies when a button is larger than its text content.");
-                    ImGui.SliderFloat2("SelectableTextAlign", ref style.SelectableTextAlign, 0.0f, 1.0f, "%.2f");
+                    changes |= ImGui.SliderFloat2("SelectableTextAlign", ref style.SelectableTextAlign, 0.0f, 1.0f, "%.2f");
                     ImGui.SameLine();
                     ImGuiComponents.HelpMarker("Alignment applies when a selectable is larger than its text content.");
-                    ImGui.SliderFloat2("DisplaySafeAreaPadding", ref style.DisplaySafeAreaPadding, 0.0f, 30.0f, "%.0f");
+                    changes |= ImGui.SliderFloat2("DisplaySafeAreaPadding", ref style.DisplaySafeAreaPadding, 0.0f, 30.0f, "%.0f");
                     ImGui.SameLine();
                     ImGuiComponents.HelpMarker(
                         "Adjust if you cannot see the edges of your screen (e.g. on a TV where scaling has not been configured).");
@@ -293,7 +301,7 @@ public class StyleEditorWindow : Window
 
                         ImGui.PushID(imGuiCol.ToString());
 
-                        ImGui.ColorEdit4("##color", ref style.Colors[(int)imGuiCol], ImGuiColorEditFlags.AlphaBar | this.alphaFlags);
+                        changes |= ImGui.ColorEdit4("##color", ref style.Colors[(int)imGuiCol], ImGuiColorEditFlags.AlphaBar | this.alphaFlags);
 
                         ImGui.SameLine(0.0f, style.ItemInnerSpacing.X);
                         ImGui.TextUnformatted(imGuiCol.ToString());
@@ -320,6 +328,7 @@ public class StyleEditorWindow : Window
                         {
                             property.SetValue(workStyle.BuiltInColors, color);
                             workStyle.BuiltInColors?.Apply();
+                            changes = true;
                         }
 
                         ImGui.SameLine(0.0f, style.ItemInnerSpacing.X);
@@ -332,6 +341,11 @@ public class StyleEditorWindow : Window
                 }
 
                 ImGui.EndTabItem();
+            }
+
+            if (changes)
+            {
+                UiBuilder.InvokeStyleChanged();
             }
 
             ImGui.EndTabBar();

--- a/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
@@ -27,6 +27,7 @@ public class StyleEditorWindow : Window
     private int currentSel = 0;
     private string initialStyle = string.Empty;
     private bool didSave = false;
+    private bool anyChanges = false;
 
     private string renameText = string.Empty;
     private bool renameModalDrawing = false;
@@ -66,6 +67,10 @@ public class StyleEditorWindow : Window
             var config = Service<DalamudConfiguration>.Get();
             var newStyle = config.SavedStyles.FirstOrDefault(x => x.Name == this.initialStyle);
             newStyle?.Apply();
+            if (this.anyChanges)
+            {
+                UiBuilder.InvokeStyleChanged();
+            }
         }
 
         base.OnClose();
@@ -89,7 +94,7 @@ public class StyleEditorWindow : Window
         {
             var newStyle = config.SavedStyles[this.currentSel];
             newStyle.Apply();
-            UiBuilder.InvokeStyleChanged();
+            this.Change();
             appliedThisFrame = true;
         }
 
@@ -104,7 +109,7 @@ public class StyleEditorWindow : Window
             this.currentSel = config.SavedStyles.Count - 1;
 
             newStyle.Apply();
-            UiBuilder.InvokeStyleChanged();
+            this.Change();
             appliedThisFrame = true;
 
             config.QueueSave();
@@ -120,7 +125,7 @@ public class StyleEditorWindow : Window
             this.currentSel--;
             var newStyle = config.SavedStyles[this.currentSel];
             newStyle.Apply();
-            UiBuilder.InvokeStyleChanged();
+            this.Change();
             appliedThisFrame = true;
 
             config.SavedStyles.RemoveAt(this.currentSel + 1);
@@ -185,7 +190,7 @@ public class StyleEditorWindow : Window
 
                 config.SavedStyles.Add(newStyle);
                 newStyle.Apply();
-                UiBuilder.InvokeStyleChanged();
+                this.Change();
                 appliedThisFrame = true;
 
                 this.currentSel = config.SavedStyles.Count - 1;
@@ -345,7 +350,7 @@ public class StyleEditorWindow : Window
 
             if (changes)
             {
-                UiBuilder.InvokeStyleChanged();
+                this.Change();
             }
 
             ImGui.EndTabBar();
@@ -409,5 +414,11 @@ public class StyleEditorWindow : Window
         newStyle.Apply();
 
         config.QueueSave();
+    }
+
+    private void Change()
+    {
+        this.anyChanges = true;
+        UiBuilder.InvokeStyleChanged();
     }
 }

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -293,6 +293,21 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
         }
     }
 
+    /// <summary>
+    /// Invoked when the default global scale used by ImGui has been changed through Dalamud.
+    /// </summary>
+    public static event Action? DefaultGlobalScaleChanged;
+
+    /// <summary>
+    /// Invoked when the default font used by ImGui has been changed through Dalamud.
+    /// </summary>
+    public static event Action? DefaultFontChanged;
+
+    /// <summary>
+    /// Invoked when either the currently chosen style in Dalamud or a style or color variable within the currently chosen style has been changed through Dalamud.
+    /// </summary>
+    public static event Action? DefaultStyleChanged;
+
     /// <inheritdoc/>
     public event Action? Draw;
 
@@ -493,6 +508,18 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
     /// intrusive animations, or disable them entirely.
     /// </summary>
     public bool ShouldUseReducedMotion => Service<DalamudConfiguration>.Get().ReduceMotions ?? false;
+
+    /// <summary> Safely invoke <seealso cref="DefaultGlobalScaleChanged"/>. </summary>
+    internal static void InvokeGlobalScaleChanged()
+        => DefaultGlobalScaleChanged.InvokeSafely();
+
+    /// <summary> Safely invoke <seealso cref="DefaultFontChanged"/>. </summary>
+    internal static void InvokeFontChanged()
+        => DefaultFontChanged.InvokeSafely();
+
+    /// <summary> Safely invoke <seealso cref="DefaultStyleChanged"/>. </summary>
+    internal static void InvokeStyleChanged()
+        => DefaultStyleChanged.InvokeSafely();
 
     /// <summary>
     /// Gets or sets a value indicating whether statistics about UI draw time should be collected.


### PR DESCRIPTION
Add 3 static events to UIBuilder that get fired when style-related things are changed from within Dalamud.
- DefaultGlobalScaleChanged
- DefaultFontChanged
- DefaultStyleChanged
This should allow plugins to better cache their layout data safely without having to poll these values every frame and check them against  their prior values.

I don't know if the static implementation and/or the invocations are in the correct spots but they are not within the save functions by design, because all those changes are applied to the current style before they are saved (for previewing).
I'm also unsure if I got the place where they would be reset after closing a window without saving?