### PR TITLE
Allow to access all of Status span even if "NumValidStatuses" is 30

### DIFF
--- a/Dalamud/Game/ClientState/Statuses/StatusList.cs
+++ b/Dalamud/Game/ClientState/Statuses/StatusList.cs
@@ -35,12 +35,12 @@ public sealed unsafe partial class StatusList
 
     /// <summary>
     /// Gets the amount of status effect slots the actor has.
+    /// This is always the full accessible length and will retrun the higher parts of the list that might not be in use.
     /// </summary>
     public int SpanLength => Struct->Status.Length;
 
     /// <summary>
     /// Gets the amount of status effects the actor has valid. 
-    /// This might not be correct with Occult Crescent for some statuses.
     /// </summary>
     public int Length => Struct->NumValidStatuses;
 

--- a/Dalamud/Game/ClientState/Statuses/StatusList.cs
+++ b/Dalamud/Game/ClientState/Statuses/StatusList.cs
@@ -36,7 +36,13 @@ public sealed unsafe partial class StatusList
     /// <summary>
     /// Gets the amount of status effect slots the actor has.
     /// </summary>
-    public int Length => Struct->NumValidStatuses;
+    public int SpanLength => Struct->Status.Length;
+
+    /// <summary>
+    /// Gets the amount of status effects the actor has valid. 
+    /// This might not be correct with Occult Crescent for some statuses.
+    /// </summary>
+    public int Length => Struct->NumStatusAvailable
 
     private static int StatusSize { get; } = Marshal.SizeOf<FFXIVClientStructs.FFXIV.Client.Game.Status>();
 
@@ -51,7 +57,7 @@ public sealed unsafe partial class StatusList
     {
         get
         {
-            if (index < 0 || index > this.Length)
+            if (index < 0 || index > this.Struct->Status.Length)
                 return null;
 
             var addr = this.GetStatusAddress(index);
@@ -105,7 +111,7 @@ public sealed unsafe partial class StatusList
     /// <returns>The memory address of the status.</returns>
     public IntPtr GetStatusAddress(int index)
     {
-        if (index < 0 || index >= this.Length)
+        if (index < 0 || index >= this.Struct->Status.Length)
             return IntPtr.Zero;
 
         return (IntPtr)Unsafe.AsPointer(ref this.Struct->Status[index]);

--- a/Dalamud/Game/ClientState/Statuses/StatusList.cs
+++ b/Dalamud/Game/ClientState/Statuses/StatusList.cs
@@ -42,7 +42,7 @@ public sealed unsafe partial class StatusList
     /// Gets the amount of status effects the actor has valid. 
     /// This might not be correct with Occult Crescent for some statuses.
     /// </summary>
-    public int Length => Struct->NumStatusAvailable
+    public int Length => Struct->NumValidStatuses;
 
     private static int StatusSize { get; } = Marshal.SizeOf<FFXIVClientStructs.FFXIV.Client.Game.Status>();
 


### PR DESCRIPTION
The span is always allocated with 60 so introducing `SpanLength` that returns the valid count to index from the methods but retaining the `Length` to be the old accessor with a different comment.

This shouldn't change any behaviors unless people have hardcoded their lengths for index accessing to be 60 at all times.