### PR TITLE
UiDebug2 Fix ComponentNode rendering

### DIFF
--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Component.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Component.cs
@@ -58,7 +58,13 @@ internal unsafe class ComponentNodeTree : ResNodeTree
     /// <inheritdoc/>
     private protected override void PrintChildNodes()
     {
-        base.PrintChildNodes();
+        var prevNode = this.CompNode->Component->UldManager.RootNode;
+        while (prevNode != null)
+        {
+            GetOrCreate(prevNode, this.AddonTree).Print(null);
+            prevNode = prevNode->PrevSiblingNode;
+        }
+
         var count = this.UldManager->NodeListCount;
         PrintNodeListAsTree(this.UldManager->NodeList, count, $"Node List [{count}]:", this.AddonTree, new(0f, 0.5f, 0.8f, 1f));
     }


### PR DESCRIPTION
The call to base.PrintChildNodes tries to access the ComponentNode's children via ComponentNode->ChildNode

However components don't render their children like that, they render them through the ComponentNode->Component.UldManage.RootNode instead.

This PR fixes that as seen below:
![image](https://github.com/user-attachments/assets/aa1d1e36-7ea8-407c-a946-f760bcf59bf2)
