### PR TITLE
Self-Test Window improvements

### DIFF
--- a/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
@@ -57,8 +57,8 @@ internal class SelfTestWindow : Window
         new SheetRedirectResolverSelfTestStep(),
         new NounProcessorSelfTestStep(),
         new SeStringEvaluatorSelfTestStep(),
-        new LogoutEventSelfTestStep(),
-        new CompletionSelfTestStep()
+        new CompletionSelfTestStep(),
+        new LogoutEventSelfTestStep()
     ];
 
     private readonly Dictionary<int, (SelfTestStepResult Result, TimeSpan? Duration)> testIndexToResult = new();

--- a/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
@@ -152,6 +152,9 @@ internal class SelfTestWindow : Window
             return;
         }
 
+        using var resultChild = ImRaii.Child("SelfTestResultChild", ImGui.GetContentRegionAvail());
+        if (!resultChild) return;
+
         var step = this.steps[this.currentStep];
         ImGui.TextUnformatted($"Current: {step.Name}");
 
@@ -184,7 +187,7 @@ internal class SelfTestWindow : Window
         var tableSize = ImGui.GetContentRegionAvail();
 
         if (this.selfTestRunning)
-            tableSize -= new Vector2(0, 150);
+            tableSize -= new Vector2(0, 200);
 
         tableSize.Y = Math.Min(tableSize.Y, ImGui.GetWindowViewport().Size.Y * 0.5f);
 

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/CompletionSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/CompletionSelfTestStep.cs
@@ -32,7 +32,7 @@ internal class CompletionSelfTestStep : ISelfTestStep
 
             case 1:
                 ImGui.Text("[Chat Log]");
-                ImGui.Text("Use the category menus to navigate to [Dalamud], then complete a command from the list. Did it work?");
+                ImGui.TextWrapped("Use the category menus to navigate to [Dalamud], then complete a command from the list. Did it work?");
                 if (ImGui.Button("Yes"))
                     this.step++;
                 ImGui.SameLine();

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ContextMenuSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ContextMenuSelfTestStep.cs
@@ -145,7 +145,7 @@ internal class ContextMenuSelfTestStep : ISelfTestStep
                             var targetItem = (a.Target as MenuTargetInventory)!.TargetItem;
                             if (targetItem is { } item)
                             {
-                                name = (this.itemSheet.GetRowOrDefault(item.ItemId)?.Name.ExtractText() ?? $"Unknown ({item.ItemId})") + (item.IsHq ? $" {SeIconChar.HighQuality.ToIconString()}" : string.Empty);
+                                name = (this.itemSheet.GetRowOrDefault(item.BaseItemId)?.Name.ExtractText() ?? $"Unknown ({item.BaseItemId})") + (item.IsHq ? $" {SeIconChar.HighQuality.ToIconString()}" : string.Empty);
                                 count = item.Quantity;
                             }
                             else

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/MarketBoardSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/MarketBoardSelfTestStep.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Linq;
 
 using Dalamud.Game.MarketBoard;
@@ -109,7 +109,7 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
                 }
                 else
                 {
-                    ImGui.Text("Does this information match the purchase you made? This is testing the request to the server.");
+                    ImGui.TextWrapped("Does this information match the purchase you made? This is testing the request to the server.");
                     ImGui.Separator();
                     ImGui.Text($"Quantity: {this.marketBoardPurchaseRequest.ItemQuantity.ToString()}");
                     ImGui.Text($"Item ID: {this.marketBoardPurchaseRequest.CatalogId}");
@@ -135,7 +135,7 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
                 }
                 else
                 {
-                    ImGui.Text("Does this information match the purchase you made? This is testing the response from the server.");
+                    ImGui.TextWrapped("Does this information match the purchase you made? This is testing the response from the server.");
                     ImGui.Separator();
                     ImGui.Text($"Quantity: {this.marketBoardPurchase.ItemQuantity.ToString()}");
                     ImGui.Text($"Item ID: {this.marketBoardPurchase.CatalogId}");
@@ -156,7 +156,7 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
             case SubStep.Taxes:
                 if (this.marketTaxRate == null)
                 {
-                    ImGui.Text("Goto a Retainer Vocate and talk to then. Click the 'View market tax rates' menu item.");
+                    ImGui.TextWrapped("Goto a Retainer Vocate and talk to then. Click the 'View market tax rates' menu item.");
                 }
                 else
                 {


### PR DESCRIPTION
- Move Logout self-test to the bottom of the list, since the Completion test requires inputs
- Increase self-test result and make it scrollable
- Allow text wrapping for some strings in self-tests
- Fix context menu self-test not working properly on HQ items - use BaseItemId for row lookup