### PR TITLE
Refactor IAddonEventManager

### DIFF
--- a/Dalamud/Game/Addon/Events/AddonEventData.cs
+++ b/Dalamud/Game/Addon/Events/AddonEventData.cs
@@ -1,0 +1,46 @@
+﻿namespace Dalamud.Game.Addon.Events;
+
+/// <summary>
+/// Object representing data that is relevant in handling native events.
+/// </summary>
+public class AddonEventData
+{
+    /// <summary>
+    /// Gets the AtkEventType for this event.
+    /// </summary>
+    public AddonEventType AtkEventType { get; internal set; }
+
+    /// <summary>
+    /// Gets the param field for this event.
+    /// </summary>
+    public uint Param { get; internal set; }
+
+    /// <summary>
+    /// Gets the pointer to the AtkEvent object for this event.
+    /// </summary>
+    /// <remarks>Note: This is not a pointer to the AtkEventData object.<br/><br/></remarks>
+    /// <remarks>Warning: AtkEvent->Node has been modified to be the AtkUnitBase*, and AtkEvent->Target has been modified to be the AtkResNode* that triggered this event.</remarks>
+    public nint AtkEventPointer { get; internal set; }
+
+    /// <summary>
+    /// Gets the pointer to the AtkEventData object for this event.
+    /// </summary>
+    /// <remarks>This field will contain relevant data such as left vs right click, scroll up vs scroll down.</remarks>
+    public nint AtkEventDataPointer { get; internal set; }
+
+    /// <summary>
+    /// Gets the pointer to the AtkUnitBase that is handling this event.
+    /// </summary>
+    public nint AddonPointer { get; internal set; }
+
+    /// <summary>
+    /// Gets the pointer to the AtkResNode that triggered this event.
+    /// </summary>
+    public nint NodeTargetPointer { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets a pointer to the AtkEventListener responsible for handling this event.
+    /// Note: As the event listener is dalamud allocated, there's no reason to expose this field.
+    /// </summary>
+    internal nint AtkEventListener { get; set; }
+}

--- a/Dalamud/Game/Addon/Events/AddonEventEntry.cs
+++ b/Dalamud/Game/Addon/Events/AddonEventEntry.cs
@@ -1,5 +1,6 @@
-﻿using Dalamud.Memory;
-using Dalamud.Plugin.Services;
+﻿using Dalamud.Plugin.Services;
+using Dalamud.Utility;
+
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace Dalamud.Game.Addon.Events;
@@ -14,9 +15,9 @@ internal unsafe class AddonEventEntry
     /// Name of an invalid addon.
     /// </summary>
     public const string InvalidAddonName = "NullAddon";
-    
+
     private string? addonName;
-    
+
     /// <summary>
     /// Gets the pointer to the addons AtkUnitBase.
     /// </summary>
@@ -35,18 +36,25 @@ internal unsafe class AddonEventEntry
     /// <summary>
     /// Gets the handler that gets called when this event is triggered.
     /// </summary>
-    public required IAddonEventManager.AddonEventHandler Handler { get; init; }
-    
+    [Obsolete("Use AddonEventDelegate Delegate instead")]
+    public IAddonEventManager.AddonEventHandler Handler { get; init; }
+
+    /// <summary>
+    /// Gets the delegate that gets called when this event is triggered.
+    /// </summary>
+    [Api13ToDo("Make this field required")]
+    public IAddonEventManager.AddonEventDelegate Delegate { get; init; }
+
     /// <summary>
     /// Gets the unique id for this event.
     /// </summary>
     public required uint ParamKey { get; init; }
-    
+
     /// <summary>
     /// Gets the event type for this event.
     /// </summary>
     public required AddonEventType EventType { get; init; }
-    
+
     /// <summary>
     /// Gets the event handle for this event.
     /// </summary>

--- a/Dalamud/Game/Addon/Events/AddonEventManager.cs
+++ b/Dalamud/Game/Addon/Events/AddonEventManager.cs
@@ -24,21 +24,21 @@ internal unsafe class AddonEventManager : IInternalDisposableService
     /// PluginName for Dalamud Internal use.
     /// </summary>
     public static readonly Guid DalamudInternalKey = Guid.NewGuid();
-    
+
     private static readonly ModuleLog Log = new("AddonEventManager");
-    
+
     [ServiceManager.ServiceDependency]
     private readonly AddonLifecycle addonLifecycle = Service<AddonLifecycle>.Get();
 
     private readonly AddonLifecycleEventListener finalizeEventListener;
-    
+
     private readonly AddonEventManagerAddressResolver address;
     private readonly Hook<UpdateCursorDelegate> onUpdateCursor;
 
     private readonly ConcurrentDictionary<Guid, PluginEventController> pluginEventControllers;
-    
+
     private AddonCursorType? cursorOverride;
-    
+
     [ServiceManager.ServiceConstructor]
     private AddonEventManager(TargetSigScanner sigScanner)
     {
@@ -47,7 +47,7 @@ internal unsafe class AddonEventManager : IInternalDisposableService
 
         this.pluginEventControllers = new ConcurrentDictionary<Guid, PluginEventController>();
         this.pluginEventControllers.TryAdd(DalamudInternalKey, new PluginEventController());
-        
+
         this.cursorOverride = null;
 
         this.onUpdateCursor = Hook<UpdateCursorDelegate>.FromAddress(this.address.UpdateCursor, this.UpdateCursorDetour);
@@ -69,7 +69,7 @@ internal unsafe class AddonEventManager : IInternalDisposableService
         {
             pluginEventController.Dispose();
         }
-        
+
         this.addonLifecycle.UnregisterListener(this.finalizeEventListener);
     }
 
@@ -92,7 +92,30 @@ internal unsafe class AddonEventManager : IInternalDisposableService
         {
             Log.Verbose($"Unable to locate controller for {pluginId}. No event was added.");
         }
-        
+
+        return null;
+    }
+
+    /// <summary>
+    /// Registers an event handler for the specified addon, node, and type.
+    /// </summary>
+    /// <param name="pluginId">Unique ID for this plugin.</param>
+    /// <param name="atkUnitBase">The parent addon for this event.</param>
+    /// <param name="atkResNode">The node that will trigger this event.</param>
+    /// <param name="eventType">The event type for this event.</param>
+    /// <param name="eventDelegate">The delegate to call when event is triggered.</param>
+    /// <returns>IAddonEventHandle used to remove the event.</returns>
+    internal IAddonEventHandle? AddEvent(Guid pluginId, nint atkUnitBase, nint atkResNode, AddonEventType eventType, IAddonEventManager.AddonEventDelegate eventDelegate)
+    {
+        if (this.pluginEventControllers.TryGetValue(pluginId, out var controller))
+        {
+            return controller.AddEvent(atkUnitBase, atkResNode, eventType, eventDelegate);
+        }
+        else
+        {
+            Log.Verbose($"Unable to locate controller for {pluginId}. No event was added.");
+        }
+
         return null;
     }
 
@@ -112,7 +135,7 @@ internal unsafe class AddonEventManager : IInternalDisposableService
             Log.Verbose($"Unable to locate controller for {pluginId}. No event was removed.");
         }
     }
-    
+
     /// <summary>
     /// Force the game cursor to be the specified cursor.
     /// </summary>
@@ -167,21 +190,21 @@ internal unsafe class AddonEventManager : IInternalDisposableService
             pluginList.Value.RemoveForAddon(addonInfo.AddonName);
         }
     }
-    
+
     private nint UpdateCursorDetour(RaptureAtkModule* module)
     {
         try
         {
             var atkStage = AtkStage.Instance();
-            
+
             if (this.cursorOverride is not null && atkStage is not null)
             {
                 var cursor = (AddonCursorType)atkStage->AtkCursor.Type;
-                if (cursor != this.cursorOverride) 
+                if (cursor != this.cursorOverride)
                 {
                     AtkStage.Instance()->AtkCursor.SetCursorType((AtkCursor.CursorType)this.cursorOverride, 1);
                 }
-                
+
                 return nint.Zero;
             }
         }
@@ -218,7 +241,7 @@ internal class AddonEventManagerPluginScoped : IInternalDisposableService, IAddo
     public AddonEventManagerPluginScoped(LocalPlugin plugin)
     {
         this.plugin = plugin;
-        
+
         this.eventManagerService.AddPluginEventController(plugin.EffectiveWorkingPluginId);
     }
 
@@ -236,28 +259,32 @@ internal class AddonEventManagerPluginScoped : IInternalDisposableService, IAddo
             this.eventManagerService.RemovePluginEventController(this.plugin.EffectiveWorkingPluginId);
         }).Wait();
     }
-    
+
     /// <inheritdoc/>
-    public IAddonEventHandle? AddEvent(IntPtr atkUnitBase, IntPtr atkResNode, AddonEventType eventType, IAddonEventManager.AddonEventHandler eventHandler) 
+    public IAddonEventHandle? AddEvent(IntPtr atkUnitBase, IntPtr atkResNode, AddonEventType eventType, IAddonEventManager.AddonEventHandler eventHandler)
         => this.eventManagerService.AddEvent(this.plugin.EffectiveWorkingPluginId, atkUnitBase, atkResNode, eventType, eventHandler);
+
+    /// <inheritdoc/>
+    public IAddonEventHandle? AddEvent(nint atkUnitBase, nint atkResNode, AddonEventType eventType, IAddonEventManager.AddonEventDelegate eventDelegate)
+        => this.eventManagerService.AddEvent(this.plugin.EffectiveWorkingPluginId, atkUnitBase, atkResNode, eventType, eventDelegate);
 
     /// <inheritdoc/>
     public void RemoveEvent(IAddonEventHandle eventHandle)
         => this.eventManagerService.RemoveEvent(this.plugin.EffectiveWorkingPluginId, eventHandle);
-    
+
     /// <inheritdoc/>
     public void SetCursor(AddonCursorType cursor)
     {
         this.isForcingCursor = true;
-        
+
         this.eventManagerService.SetCursor(cursor);
     }
-    
+
     /// <inheritdoc/>
     public void ResetCursor()
     {
         this.isForcingCursor = false;
-        
+
         this.eventManagerService.ResetCursor();
     }
 }

--- a/Dalamud/Plugin/Services/IAddonEventManager.cs
+++ b/Dalamud/Plugin/Services/IAddonEventManager.cs
@@ -13,7 +13,15 @@ public interface IAddonEventManager
     /// <param name="atkEventType">Event type for this event handler.</param>
     /// <param name="atkUnitBase">The parent addon for this event handler.</param>
     /// <param name="atkResNode">The specific node that will trigger this event handler.</param>
+    [Obsolete("Use AddonEventDelegate instead")]
     public delegate void AddonEventHandler(AddonEventType atkEventType, nint atkUnitBase, nint atkResNode);
+
+    /// <summary>
+    /// Delegate to be called when an event is received.
+    /// </summary>
+    /// <param name="atkEventType">The AtkEventType that triggered this event.</param>
+    /// <param name="data">The event data object for use in handling this event.</param>
+    public delegate void AddonEventDelegate(AddonEventType atkEventType, AddonEventData data);
 
     /// <summary>
     /// Registers an event handler for the specified addon, node, and type.
@@ -23,7 +31,18 @@ public interface IAddonEventManager
     /// <param name="eventType">The event type for this event.</param>
     /// <param name="eventHandler">The handler to call when event is triggered.</param>
     /// <returns>IAddonEventHandle used to remove the event. Null if no event was added.</returns>
+    [Obsolete("Use AddEvent with AddonEventDelegate instead of AddonEventHandler")]
     IAddonEventHandle? AddEvent(nint atkUnitBase, nint atkResNode, AddonEventType eventType, AddonEventHandler eventHandler);
+
+    /// <summary>
+    /// Registers an event handler for the specified addon, node, and type.
+    /// </summary>
+    /// <param name="atkUnitBase">The parent addon for this event.</param>
+    /// <param name="atkResNode">The node that will trigger this event.</param>
+    /// <param name="eventType">The event type for this event.</param>
+    /// <param name="eventDelegate">The handler to call when event is triggered.</param>
+    /// <returns>IAddonEventHandle used to remove the event. Null if no event was added.</returns>
+    IAddonEventHandle? AddEvent(nint atkUnitBase, nint atkResNode, AddonEventType eventType, AddonEventDelegate eventDelegate);
 
     /// <summary>
     /// Unregisters an event handler with the specified event id and event type.


### PR DESCRIPTION
Reworks AddonEventManager to include other relevant data from the native callback

Also done in such a way that if more data is discovered/required later it can be easily added, for example can switch on AddonEventType to return specific objects such as "MouseEventData" for example.

Tested to be working via KamiToolKit, previously I was not able to get data such as click coordinates when getting native callbacks via dalamud.

https://github.com/user-attachments/assets/4e21e5ec-8c74-4df7-b353-6a94405f8f05

```cs
CollisionNode.AddEvent(AddonEventType.MouseClick, data => {
    IsCollapsed = !IsCollapsed;
    Timeline?.StartAnimation(IsCollapsed ? 2 : 9);
    ChildContainer.IsVisible = !IsCollapsed;
    Height = IsCollapsed ? BackgroundNode.Height : ChildContainer.Height + BackgroundNode.Height;
    ParentTreeListNode?.RefreshLayout();

    unsafe {
        var eventData = (AtkEventData*) data.AtkEventDataPointer;
        var mouseData = eventData->MouseData;
        
        Log.Debug($"X: {mouseData.PosX}, Y: {mouseData.PosY}");
    }
});
```