### PR TITLE
[imgui-bindings] Small fixes

### DIFF
--- a/Dalamud/Interface/ImGuiBackend/Dx11Win32Backend.cs
+++ b/Dalamud/Interface/ImGuiBackend/Dx11Win32Backend.cs
@@ -241,6 +241,7 @@ internal sealed unsafe class Dx11Win32Backend : IWin32Backend
         this.imguiRenderer?.Dispose();
         this.imguiInput?.Dispose();
 
+        ImPlot.DestroyContext();
         ImGui.DestroyContext();
 
         this.swapChain.Dispose();

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -640,9 +640,9 @@ internal class DalamudInterface : IInternalDisposableService
                 ImGui.SetNextItemWidth(40);
                 if (ImGui.Button("###devMenuOpener", new Vector2(20, 20)))
                     this.isImGuiDrawDevMenu = true;
-
-                ImGui.End();
             }
+
+            ImGui.End();
 
             if (EnvironmentConfiguration.DalamudForceMinHook)
             {

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -709,14 +709,17 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
             this.stopwatch.Restart();
         }
 
-        if (this.hasErrorWindow && ImGui.Begin($"{this.namespaceName} Error", ref this.hasErrorWindow, ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize))
+        if (this.hasErrorWindow)
         {
-            ImGui.Text($"The plugin {this.namespaceName} ran into an error.\nContact the plugin developer for support.\n\nPlease try restarting your game.");
-            ImGui.Spacing();
-
-            if (ImGui.Button("OK"))
+            if (ImGui.Begin($"{this.namespaceName} Error", ref this.hasErrorWindow, ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize))
             {
-                this.hasErrorWindow = false;
+                ImGui.Text($"The plugin {this.namespaceName} ran into an error.\nContact the plugin developer for support.\n\nPlease try restarting your game.");
+                ImGui.Spacing();
+
+                if (ImGui.Button("OK"))
+                {
+                    this.hasErrorWindow = false;
+                }
             }
 
             ImGui.End();


### PR DESCRIPTION
Just some minor things I found:

- `ImPlot.DestroyContext` wasn't called
- 2 `ImGui.Begin` calls had `ImGui.End` inside the if block, which should've been outside