### PR TITLE
[Api13] Update ChatLinkHandler functions

### DIFF
--- a/Dalamud/Game/ChatHandlers.cs
+++ b/Dalamud/Game/ChatHandlers.cs
@@ -119,8 +119,6 @@ internal partial class ChatHandlers : IServiceType
         if (string.IsNullOrEmpty(this.configuration.LastVersion) || !Util.AssemblyVersion.StartsWith(this.configuration.LastVersion))
         {
             var linkPayload = chatGui.AddChatLinkHandler(
-                "dalamud",
-                8459324,
                 (_, _) => dalamudInterface.OpenPluginInstallerTo(PluginInstallerOpenKind.Changelogs));
 
             var updateMessage = new SeStringBuilder()

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -50,7 +50,6 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
     [ServiceManager.ServiceDependency]
     private readonly DalamudConfiguration configuration = Service<DalamudConfiguration>.Get();
 
-    private uint dommandIdCounter = 0;
     private ImmutableDictionary<(string PluginName, Guid CommandId), Action<Guid, SeString>>? dalamudLinkHandlersCopy;
 
     [ServiceManager.ServiceConstructor]

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/DalamudLinkPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/DalamudLinkPayload.cs
@@ -16,7 +16,7 @@ public class DalamudLinkPayload : Payload
     public override PayloadType Type => PayloadType.DalamudLink;
 
     /// <summary>Gets the plugin command ID to be linked.</summary>
-    public uint CommandId { get; internal set; }
+    public Guid CommandId { get; internal set; }
 
     /// <summary>Gets an optional extra integer value 1.</summary>
     public int Extra1 { get; internal set; }
@@ -40,7 +40,7 @@ public class DalamudLinkPayload : Payload
         var ssb = Lumina.Text.SeStringBuilder.SharedPool.Get();
         var res = ssb.BeginMacro(MacroCode.Link)
                      .AppendIntExpression((int)EmbeddedInfoType.DalamudLink - 1)
-                     .AppendUIntExpression(this.CommandId)
+                     .AppendStringExpression(this.CommandId.ToString())
                      .AppendIntExpression(this.Extra1)
                      .AppendIntExpression(this.Extra2)
                      .BeginStringExpression()
@@ -72,15 +72,15 @@ public class DalamudLinkPayload : Payload
             if (!pluginExpression.TryGetString(out var pluginString))
                 return;
 
-            if (!commandIdExpression.TryGetUInt(out var commandId))
+            if (!commandIdExpression.TryGetString(out var commandId))
                 return;
 
             this.Plugin = pluginString.ExtractText();
-            this.CommandId = commandId;
+            this.CommandId = Guid.Parse(commandId.ExtractText());
         }
         else
         {
-            if (!commandIdExpression.TryGetUInt(out var commandId))
+            if (!commandIdExpression.TryGetString(out var commandId))
                 return;
 
             if (!extra1Expression.TryGetInt(out var extra1))
@@ -102,7 +102,7 @@ public class DalamudLinkPayload : Payload
                 return;
             }
 
-            this.CommandId = commandId;
+            this.CommandId = Guid.Parse(commandId.ExtractText());
             this.Extra1 = extra1;
             this.Extra2 = extra2;
             this.Plugin = extraData[0];

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -13,8 +13,6 @@ using Dalamud.Data;
 using Dalamud.Game.Gui;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.Sanitizer;
-using Dalamud.Game.Text.SeStringHandling;
-using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Interface;
 using Dalamud.Interface.Internal;
 using Dalamud.Interface.Internal.Windows.PluginInstaller;
@@ -425,39 +423,6 @@ internal sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposa
     /// <returns>directory with path of AppData/XIVLauncher/pluginConfig/PluginInternalName/loc.</returns>
     public string GetPluginLocDirectory() => this.configs.GetDirectory(Path.Combine(this.plugin.InternalName, "loc"));
 
-    #endregion
-
-    #region Chat Links
-
-    // TODO API9: Move to chatgui, don't allow passing own commandId
-
-    /// <summary>
-    /// Register a chat link handler.
-    /// </summary>
-    /// <param name="commandId">The ID of the command.</param>
-    /// <param name="commandAction">The action to be executed.</param>
-    /// <returns>Returns an SeString payload for the link.</returns>
-    public DalamudLinkPayload AddChatLinkHandler(uint commandId, Action<uint, SeString> commandAction)
-    {
-        return Service<ChatGui>.Get().AddChatLinkHandler(this.plugin.InternalName, commandId, commandAction);
-    }
-
-    /// <summary>
-    /// Remove a chat link handler.
-    /// </summary>
-    /// <param name="commandId">The ID of the command.</param>
-    public void RemoveChatLinkHandler(uint commandId)
-    {
-        Service<ChatGui>.Get().RemoveChatLinkHandler(this.plugin.InternalName, commandId);
-    }
-
-    /// <summary>
-    /// Removes all chat link handlers registered by the plugin.
-    /// </summary>
-    public void RemoveChatLinkHandler()
-    {
-        Service<ChatGui>.Get().RemoveChatLinkHandler(this.plugin.InternalName);
-    }
     #endregion
 
     #region Dependency Injection

--- a/Dalamud/Plugin/IDalamudPluginInterface.cs
+++ b/Dalamud/Plugin/IDalamudPluginInterface.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
@@ -280,25 +280,6 @@ public interface IDalamudPluginInterface
     /// </summary>
     /// <returns>directory with path of AppData/XIVLauncher/pluginConfig/PluginInternalName/loc.</returns>
     string GetPluginLocDirectory();
-
-    /// <summary>
-    /// Register a chat link handler.
-    /// </summary>
-    /// <param name="commandId">The ID of the command.</param>
-    /// <param name="commandAction">The action to be executed.</param>
-    /// <returns>Returns an SeString payload for the link.</returns>
-    DalamudLinkPayload AddChatLinkHandler(uint commandId, Action<uint, SeString> commandAction);
-
-    /// <summary>
-    /// Remove a chat link handler.
-    /// </summary>
-    /// <param name="commandId">The ID of the command.</param>
-    void RemoveChatLinkHandler(uint commandId);
-
-    /// <summary>
-    /// Removes all chat link handlers registered by the plugin.
-    /// </summary>
-    void RemoveChatLinkHandler();
 
     /// <summary>
     /// Create a new object of the provided type using its default constructor, then inject objects and properties.

--- a/Dalamud/Plugin/Internal/AutoUpdate/AutoUpdateManager.cs
+++ b/Dalamud/Plugin/Internal/AutoUpdate/AutoUpdateManager.cs
@@ -102,8 +102,6 @@ internal class AutoUpdateManager : IServiceType
         this.openInstallerWindowLinkTask =
             Service<ChatGui>.GetAsync().ContinueWith(
                 chatGuiTask => chatGuiTask.Result.AddChatLinkHandler(
-                    "Dalamud",
-                    1001,
                     (_, _) =>
                      {
                          Service<DalamudInterface>.GetNullable()?.OpenPluginInstallerTo(PluginInstallerOpenKind.InstalledPlugins);

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -125,8 +125,6 @@ internal class PluginManager : IInternalDisposableService
         this.openInstallerWindowPluginChangelogsLink =
             Service<ChatGui>.GetAsync().ContinueWith(
                 chatGuiTask => chatGuiTask.Result.AddChatLinkHandler(
-                    "Dalamud",
-                    1003,
                     (_, _) =>
                     {
                         Service<DalamudInterface>.GetNullable()?.OpenPluginInstallerTo(

--- a/Dalamud/Plugin/Services/IChatGui.cs
+++ b/Dalamud/Plugin/Services/IChatGui.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Dalamud.Game.Gui;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Game.Text.SeStringHandling.Payloads;
 
 namespace Dalamud.Plugin.Services;
 
@@ -82,7 +83,25 @@ public interface IChatGui
     /// <summary>
     /// Gets the dictionary of Dalamud Link Handlers.
     /// </summary>
-    public IReadOnlyDictionary<(string PluginName, uint CommandId), Action<uint, SeString>> RegisteredLinkHandlers { get; }
+    public IReadOnlyDictionary<(string PluginName, Guid CommandId), Action<Guid, SeString>> RegisteredLinkHandlers { get; }
+
+    /// <summary>
+    /// Register a chat link handler.
+    /// </summary>
+    /// <param name="commandAction">The action to be executed.</param>
+    /// <returns>Returns an SeString payload for the link.</returns>
+    public DalamudLinkPayload AddChatLinkHandler(Action<Guid, SeString> commandAction);
+
+    /// <summary>
+    /// Remove a chat link handler.
+    /// </summary>
+    /// <param name="commandId">The ID of the command.</param>
+    public void RemoveChatLinkHandler(Guid commandId);
+
+    /// <summary>
+    /// Removes all chat link handlers registered by the plugin.
+    /// </summary>
+    public void RemoveChatLinkHandler();
 
     /// <summary>
     /// Queue a chat message. Dalamud will send queued messages on the next framework event.


### PR DESCRIPTION
- Move functions from `IDalamudPluginInterface` to `IChatGui`
- Switch type of `CommandId` from `uint` to `Guid`, so they are unique
- Generate `CommandId` automatically when registering a command, so plugins don't have to specify them