### PR TITLE
[Api13] Move ItemKind to Dalamud.Utility

### DIFF
--- a/Dalamud/Game/Text/Evaluator/Internal/SheetRedirectResolver.cs
+++ b/Dalamud/Game/Text/Evaluator/Internal/SheetRedirectResolver.cs
@@ -3,7 +3,6 @@ using Dalamud.Utility;
 
 using Lumina.Extensions;
 
-using ItemKind = Dalamud.Game.Text.SeStringHandling.Payloads.ItemPayload.ItemKind;
 using LSheets = Lumina.Excel.Sheets;
 
 namespace Dalamud.Game.Text.Evaluator.Internal;

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/ItemPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/ItemPayload.cs
@@ -72,33 +72,6 @@ public class ItemPayload : Payload
     {
     }
 
-    /// <summary>
-    /// Kinds of items that can be fetched from this payload.
-    /// </summary>
-    [Api13ToDo("Move this out of ItemPayload. It's used in other classes too.")]
-    public enum ItemKind : uint
-    {
-        /// <summary>
-        /// Normal items.
-        /// </summary>
-        Normal,
-
-        /// <summary>
-        /// Collectible Items.
-        /// </summary>
-        Collectible = 500_000,
-
-        /// <summary>
-        /// High-Quality items.
-        /// </summary>
-        Hq = 1_000_000,
-
-        /// <summary>
-        /// Event/Key items.
-        /// </summary>
-        EventItem = 2_000_000,
-    }
-
     /// <inheritdoc/>
     public override PayloadType Type => PayloadType.Item;
 

--- a/Dalamud/Game/Text/SeStringHandling/SeString.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeString.cs
@@ -181,7 +181,7 @@ public class SeString
     /// <param name="displayNameOverride">An optional name override to display, instead of the actual item name.</param>
     /// <returns>An SeString containing all the payloads necessary to display an item link in the chat log.</returns>
     public static SeString CreateItemLink(uint itemId, bool isHq, string? displayNameOverride = null) =>
-        CreateItemLink(itemId, isHq ? ItemPayload.ItemKind.Hq : ItemPayload.ItemKind.Normal, displayNameOverride);
+        CreateItemLink(itemId, isHq ? ItemKind.Hq : ItemKind.Normal, displayNameOverride);
 
     /// <summary>
     /// Creates an SeString representing an entire Payload chain that can be used to link an item in the chat log.
@@ -190,7 +190,7 @@ public class SeString
     /// <param name="kind">The kind of item to link.</param>
     /// <param name="displayNameOverride">An optional name override to display, instead of the actual item name.</param>
     /// <returns>An SeString containing all the payloads necessary to display an item link in the chat log.</returns>
-    public static SeString CreateItemLink(uint itemId, ItemPayload.ItemKind kind = ItemPayload.ItemKind.Normal, string? displayNameOverride = null)
+    public static SeString CreateItemLink(uint itemId, ItemKind kind = ItemKind.Normal, string? displayNameOverride = null)
     {
         var clientState = Service<ClientState.ClientState>.Get();
         var seStringEvaluator = Service<SeStringEvaluator>.Get();

--- a/Dalamud/Game/Text/SeStringHandling/SeStringBuilder.cs
+++ b/Dalamud/Game/Text/SeStringHandling/SeStringBuilder.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 
 using Dalamud.Game.Text.SeStringHandling.Payloads;
+using Dalamud.Utility;
 
 namespace Dalamud.Game.Text.SeStringHandling;
 
@@ -126,7 +127,7 @@ public class SeStringBuilder
     /// <param name="kind">Kind of item to encode.</param>
     /// <param name="itemNameOverride">Override for the item's name.</param>
     /// <returns>The current builder.</returns>
-    public SeStringBuilder AddItemLink(uint itemId, ItemPayload.ItemKind kind = ItemPayload.ItemKind.Normal, string? itemNameOverride = null) =>
+    public SeStringBuilder AddItemLink(uint itemId, ItemKind kind = ItemKind.Normal, string? itemNameOverride = null) =>
         this.Append(SeString.CreateItemLink(itemId, kind, itemNameOverride));
 
     /// <summary>

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ItemPayloadSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ItemPayloadSelfTestStep.cs
@@ -1,6 +1,6 @@
-﻿using Dalamud.Game.Gui;
+using Dalamud.Game.Gui;
 using Dalamud.Game.Text.SeStringHandling;
-using Dalamud.Game.Text.SeStringHandling.Payloads;
+using Dalamud.Utility;
 
 using ImGuiNET;
 
@@ -59,7 +59,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
                 this.currentSubStep++;
                 break;
             case SubStep.PrintHqItem:
-                toPrint = SeString.CreateItemLink(hqItemId, ItemPayload.ItemKind.Hq);
+                toPrint = SeString.CreateItemLink(hqItemId, ItemKind.Hq);
                 this.currentSubStep++;
                 break;
             case SubStep.HoverHqItem:
@@ -69,7 +69,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
                 this.currentSubStep++;
                 break;
             case SubStep.PrintCollectable:
-                toPrint = SeString.CreateItemLink(collectableItemId, ItemPayload.ItemKind.Collectible);
+                toPrint = SeString.CreateItemLink(collectableItemId, ItemKind.Collectible);
                 this.currentSubStep++;
                 break;
             case SubStep.HoverCollectable:
@@ -79,7 +79,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
                 this.currentSubStep++;
                 break;
             case SubStep.PrintEventItem:
-                toPrint = SeString.CreateItemLink(eventItemId, ItemPayload.ItemKind.EventItem);
+                toPrint = SeString.CreateItemLink(eventItemId, ItemKind.EventItem);
                 this.currentSubStep++;
                 break;
             case SubStep.HoverEventItem:

--- a/Dalamud/Utility/ItemUtil.cs
+++ b/Dalamud/Utility/ItemUtil.cs
@@ -7,9 +7,33 @@ using Lumina.Excel.Sheets;
 using Lumina.Text;
 using Lumina.Text.ReadOnly;
 
-using static Dalamud.Game.Text.SeStringHandling.Payloads.ItemPayload;
-
 namespace Dalamud.Utility;
+
+/// <summary>
+/// Kinds of items that can be fetched from this payload.
+/// </summary>
+public enum ItemKind : uint
+{
+    /// <summary>
+    /// Normal items.
+    /// </summary>
+    Normal,
+
+    /// <summary>
+    /// Collectible Items.
+    /// </summary>
+    Collectible = 500_000,
+
+    /// <summary>
+    /// High-Quality items.
+    /// </summary>
+    Hq = 1_000_000,
+
+    /// <summary>
+    /// Event/Key items.
+    /// </summary>
+    EventItem = 2_000_000,
+}
 
 /// <summary>
 /// Utilities related to Items.


### PR DESCRIPTION
The `ItemKind` enum, which was previously nested in `ItemPayload`, moves to the `Dalamud.Utility` namespace - specifically to the `ItemUtils.cs` file, where it is used primarily.