### PR TITLE
[Api13] Add native wrapper structs

### DIFF
--- a/Dalamud/Game/Addon/Events/PluginEventController.cs
+++ b/Dalamud/Game/Addon/Events/PluginEventController.cs
@@ -140,7 +140,7 @@ internal unsafe class PluginEventController : IDisposable
         if (currentAddonPointer != eventEntry.Addon) return;
 
         // Make sure the addon is not unloaded
-        var atkUnitBase = (AtkUnitBase*)currentAddonPointer;
+        var atkUnitBase = currentAddonPointer.Struct;
         if (atkUnitBase->UldManager.LoadedState == AtkLoadState.Unloaded) return;
 
         // Does this addon contain the node this event is for? (by address)

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonArgs.cs
@@ -1,4 +1,4 @@
-using Dalamud.Game.Gui.NativeWrapper;
+using Dalamud.Game.NativeWrapper;
 
 namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonArgs.cs
@@ -55,6 +55,15 @@ public abstract unsafe class AddonArgs
     }
 
     /// <summary>
+    /// Clears this AddonArgs values.
+    /// </summary>
+    internal virtual void Clear()
+    {
+        this.addonName = null;
+        this.Addon = 0;
+    }
+
+    /// <summary>
     /// Helper method for ensuring the name of the addon is valid.
     /// </summary>
     /// <returns>The name of the addon for this object. <see cref="InvalidAddon"/> when invalid.</returns>

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonReceiveEventArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonReceiveEventArgs.cs
@@ -41,4 +41,14 @@ public class AddonReceiveEventArgs : AddonArgs, ICloneable
 
     /// <inheritdoc cref="Clone"/>
     object ICloneable.Clone() => this.Clone();
+
+    /// <inheritdoc cref="AddonArgs.Clear"/>
+    internal override void Clear()
+    {
+        base.Clear();
+        this.AtkEventType = default;
+        this.EventParam = default;
+        this.AtkEvent = default;
+        this.Data = default;
+    }
 }

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonRefreshArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonRefreshArgs.cs
@@ -38,4 +38,12 @@ public class AddonRefreshArgs : AddonArgs, ICloneable
 
     /// <inheritdoc cref="Clone"/>
     object ICloneable.Clone() => this.Clone();
+
+    /// <inheritdoc cref="AddonArgs.Clear"/>
+    internal override void Clear()
+    {
+        base.Clear();
+        this.AtkValueCount = default;
+        this.AtkValues = default;
+    }
 }

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonRequestedUpdateArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonRequestedUpdateArgs.cs
@@ -1,4 +1,4 @@
-﻿namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
+namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 
 /// <summary>
 /// Addon argument data for OnRequestedUpdate events.
@@ -31,4 +31,12 @@ public class AddonRequestedUpdateArgs : AddonArgs, ICloneable
 
     /// <inheritdoc cref="Clone"/>
     object ICloneable.Clone() => this.Clone();
+
+    /// <inheritdoc cref="AddonArgs.Clear"/>
+    internal override void Clear()
+    {
+        base.Clear();
+        this.NumberArrayData = default;
+        this.StringArrayData = default;
+    }
 }

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonSetupArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonSetupArgs.cs
@@ -1,4 +1,4 @@
-﻿using FFXIVClientStructs.FFXIV.Component.GUI;
+using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 
@@ -38,4 +38,12 @@ public class AddonSetupArgs : AddonArgs, ICloneable
 
     /// <inheritdoc cref="Clone"/>
     object ICloneable.Clone() => this.Clone();
+
+    /// <inheritdoc cref="AddonArgs.Clear"/>
+    internal override void Clear()
+    {
+        base.Clear();
+        this.AtkValueCount = default;
+        this.AtkValues = default;
+    }
 }

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonUpdateArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonUpdateArgs.cs
@@ -35,4 +35,11 @@ public class AddonUpdateArgs : AddonArgs, ICloneable
 
     /// <inheritdoc cref="Clone"/>
     object ICloneable.Clone() => this.Clone();
+
+    /// <inheritdoc cref="AddonArgs.Clear"/>
+    internal override void Clear()
+    {
+        base.Clear();
+        this.TimeDeltaInternal = default;
+    }
 }

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
+using Dalamud.Game.Gui.NativeWrapper;
 using Dalamud.Hooking;
 using Dalamud.Hooking.Internal;
 using Dalamud.IoC;
@@ -238,7 +239,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
         }
 
         using var returner = this.argsPool.Rent(out AddonSetupArgs arg);
-        arg.AddonInternal = (nint)addon;
+        arg.Addon = (nint)addon;
         arg.AtkValueCount = valueCount;
         arg.AtkValues = (nint)values;
         this.InvokeListenersSafely(AddonEvent.PreSetup, arg);
@@ -270,7 +271,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
         }
 
         using var returner = this.argsPool.Rent(out AddonFinalizeArgs arg);
-        arg.AddonInternal = (nint)atkUnitBase[0];
+        arg.Addon = (nint)atkUnitBase[0];
         this.InvokeListenersSafely(AddonEvent.PreFinalize, arg);
 
         try
@@ -286,7 +287,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
     private void OnAddonDraw(AtkUnitBase* addon)
     {
         using var returner = this.argsPool.Rent(out AddonDrawArgs arg);
-        arg.AddonInternal = (nint)addon;
+        arg.Addon = (nint)addon;
         this.InvokeListenersSafely(AddonEvent.PreDraw, arg);
 
         try
@@ -304,7 +305,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
     private void OnAddonUpdate(AtkUnitBase* addon, float delta)
     {
         using var returner = this.argsPool.Rent(out AddonUpdateArgs arg);
-        arg.AddonInternal = (nint)addon;
+        arg.Addon = (nint)addon;
         arg.TimeDeltaInternal = delta;
         this.InvokeListenersSafely(AddonEvent.PreUpdate, arg);
 
@@ -325,7 +326,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
         var result = false;
 
         using var returner = this.argsPool.Rent(out AddonRefreshArgs arg);
-        arg.AddonInternal = (nint)addon;
+        arg.Addon = (nint)addon;
         arg.AtkValueCount = valueCount;
         arg.AtkValues = (nint)values;
         this.InvokeListenersSafely(AddonEvent.PreRefresh, arg);
@@ -348,7 +349,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
     private void OnRequestedUpdate(AtkUnitBase* addon, NumberArrayData** numberArrayData, StringArrayData** stringArrayData)
     {
         using var returner = this.argsPool.Rent(out AddonRequestedUpdateArgs arg);
-        arg.AddonInternal = (nint)addon;
+        arg.Addon = (nint)addon;
         arg.NumberArrayData = (nint)numberArrayData;
         arg.StringArrayData = (nint)stringArrayData;
         this.InvokeListenersSafely(AddonEvent.PreRequestedUpdate, arg);

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
-using Dalamud.Game.Gui.NativeWrapper;
 using Dalamud.Hooking;
 using Dalamud.Hooking.Internal;
 using Dalamud.IoC;

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -239,6 +239,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
         }
 
         using var returner = this.argsPool.Rent(out AddonSetupArgs arg);
+        arg.Clear();
         arg.Addon = (nint)addon;
         arg.AtkValueCount = valueCount;
         arg.AtkValues = (nint)values;
@@ -271,6 +272,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
         }
 
         using var returner = this.argsPool.Rent(out AddonFinalizeArgs arg);
+        arg.Clear();
         arg.Addon = (nint)atkUnitBase[0];
         this.InvokeListenersSafely(AddonEvent.PreFinalize, arg);
 
@@ -287,6 +289,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
     private void OnAddonDraw(AtkUnitBase* addon)
     {
         using var returner = this.argsPool.Rent(out AddonDrawArgs arg);
+        arg.Clear();
         arg.Addon = (nint)addon;
         this.InvokeListenersSafely(AddonEvent.PreDraw, arg);
 
@@ -305,6 +308,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
     private void OnAddonUpdate(AtkUnitBase* addon, float delta)
     {
         using var returner = this.argsPool.Rent(out AddonUpdateArgs arg);
+        arg.Clear();
         arg.Addon = (nint)addon;
         arg.TimeDeltaInternal = delta;
         this.InvokeListenersSafely(AddonEvent.PreUpdate, arg);
@@ -326,6 +330,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
         var result = false;
 
         using var returner = this.argsPool.Rent(out AddonRefreshArgs arg);
+        arg.Clear();
         arg.Addon = (nint)addon;
         arg.AtkValueCount = valueCount;
         arg.AtkValues = (nint)values;
@@ -349,6 +354,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
     private void OnRequestedUpdate(AtkUnitBase* addon, NumberArrayData** numberArrayData, StringArrayData** stringArrayData)
     {
         using var returner = this.argsPool.Rent(out AddonRequestedUpdateArgs arg);
+        arg.Clear();
         arg.Addon = (nint)addon;
         arg.NumberArrayData = (nint)numberArrayData;
         arg.StringArrayData = (nint)stringArrayData;

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycleReceiveEventListener.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycleReceiveEventListener.cs
@@ -86,6 +86,7 @@ internal unsafe class AddonLifecycleReceiveEventListener : IDisposable
         }
 
         using var returner = this.argsPool.Rent(out AddonReceiveEventArgs arg);
+        arg.Clear();
         arg.Addon = (nint)addon;
         arg.AtkEventType = (byte)eventType;
         arg.EventParam = eventParam;

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycleReceiveEventListener.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycleReceiveEventListener.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using Dalamud.Hooking;
@@ -86,7 +86,7 @@ internal unsafe class AddonLifecycleReceiveEventListener : IDisposable
         }
 
         using var returner = this.argsPool.Rent(out AddonReceiveEventArgs arg);
-        arg.AddonInternal = (nint)addon;
+        arg.Addon = (nint)addon;
         arg.AtkEventType = (byte)eventType;
         arg.EventParam = eventParam;
         arg.AtkEvent = (IntPtr)atkEvent;

--- a/Dalamud/Game/Gui/Dtr/DtrBar.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBar.cs
@@ -330,7 +330,7 @@ internal sealed unsafe class DtrBar : IInternalDisposableService, IDtrBar
         this.entriesReadOnlyCopy = null;
     }
 
-    private AtkUnitBase* GetDtr() => (AtkUnitBase*)this.gameGui.GetAddonByName("_DTR").ToPointer();
+    private AtkUnitBase* GetDtr() => this.gameGui.GetAddonByName("_DTR").Struct;
 
     private void Update(IFramework unused)
     {

--- a/Dalamud/Game/Gui/Dtr/DtrBar.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBar.cs
@@ -427,7 +427,7 @@ internal sealed unsafe class DtrBar : IInternalDisposableService, IDtrBar
 
     private void FixCollision(AddonEvent eventType, AddonArgs addonInfo)
     {
-        var addon = (AtkUnitBase*)addonInfo.Addon;
+        var addon = addonInfo.Addon.Struct;
         if (addon->RootNode is null || addon->UldManager.NodeList is null) return;
 
         float minX = addon->RootNode->Width;

--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -168,7 +168,7 @@ internal sealed unsafe class GameGui : IInternalDisposableService, IGameGui
     }
 
     /// <inheritdoc/>
-    public IntPtr GetUIModule()
+    public UIModulePtr GetUIModule()
     {
         return (nint)UIModule.Instance();
     }
@@ -180,11 +180,7 @@ internal sealed unsafe class GameGui : IInternalDisposableService, IGameGui
         if (unitManager == null)
             return 0;
 
-        var addon = unitManager->GetAddonByName(name, index);
-        if (addon == null)
-            return 0;
-
-        return (nint)addon;
+        return (nint)unitManager->GetAddonByName(name, index);
     }
 
     /// <inheritdoc/>
@@ -439,7 +435,7 @@ internal class GameGuiPluginScoped : IInternalDisposableService, IGameGui
         => this.gameGuiService.ScreenToWorld(screenPos, out worldPos, rayDistance);
 
     /// <inheritdoc/>
-    public IntPtr GetUIModule()
+    public UIModulePtr GetUIModule()
         => this.gameGuiService.GetUIModule();
 
     /// <inheritdoc/>

--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 
+using Dalamud.Game.Gui.NativeWrapper;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Hooking;
 using Dalamud.Interface.Utility;
@@ -181,21 +182,21 @@ internal sealed unsafe class GameGui : IInternalDisposableService, IGameGui
     }
 
     /// <inheritdoc/>
-    public IntPtr GetAddonByName(string name, int index = 1)
+    public AtkUnitBasePtr GetAddonByName(string name, int index = 1)
     {
         var atkStage = AtkStage.Instance();
         if (atkStage == null)
-            return IntPtr.Zero;
+            return 0;
 
         var unitMgr = atkStage->RaptureAtkUnitManager;
         if (unitMgr == null)
-            return IntPtr.Zero;
+            return 0;
 
         var addon = unitMgr->GetAddonByName(name, index);
         if (addon == null)
-            return IntPtr.Zero;
+            return 0;
 
-        return (IntPtr)addon;
+        return (nint)addon;
     }
 
     /// <inheritdoc/>
@@ -458,7 +459,7 @@ internal class GameGuiPluginScoped : IInternalDisposableService, IGameGui
         => this.gameGuiService.GetUIModule();
 
     /// <inheritdoc/>
-    public IntPtr GetAddonByName(string name, int index = 1)
+    public AtkUnitBasePtr GetAddonByName(string name, int index = 1)
         => this.gameGuiService.GetAddonByName(name, index);
 
     /// <inheritdoc/>

--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-using Dalamud.Game.Gui.NativeWrapper;
+using Dalamud.Game.NativeWrapper;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Hooking;
 using Dalamud.Interface.Utility;

--- a/Dalamud/Game/Gui/NamePlate/NamePlateGui.cs
+++ b/Dalamud/Game/Gui/NamePlate/NamePlateGui.cs
@@ -72,7 +72,7 @@ internal sealed class NamePlateGui : IInternalDisposableService, INamePlateGui
     /// <inheritdoc/>
     public unsafe void RequestRedraw()
     {
-        var addon = (AddonNamePlate*)this.gameGui.GetAddonByName("NamePlate");
+        var addon = (AddonNamePlate*)(nint)this.gameGui.GetAddonByName("NamePlate");
         if (addon != null)
         {
             addon->DoFullUpdate = 1;

--- a/Dalamud/Game/Gui/NativeWrapper/AtkUnitBasePtr.cs
+++ b/Dalamud/Game/Gui/NativeWrapper/AtkUnitBasePtr.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using FFXIVClientStructs.Interop;
+
+namespace Dalamud.Game.Gui.NativeWrapper;
+
+/// <summary>
+/// A wrapper for AtkUnitBase.
+/// </summary>
+/// <param name="address">The address to the AtkUnitBase.</param>
+[StructLayout(LayoutKind.Explicit, Size = 0x08)]
+public readonly unsafe struct AtkUnitBasePtr(nint address) : IEquatable<AtkUnitBasePtr>
+{
+    /// <summary>
+    /// The address to the AtkUnitBase.
+    /// </summary>
+    [FieldOffset(0x00)]
+    public readonly nint Address = address;
+
+    /// <summary>
+    /// Gets a value indicating whether the underlying pointer is a nullptr.
+    /// </summary>
+    public readonly bool IsNull => this.Address == 0;
+
+    /// <summary>
+    /// Gets a value indicating whether the OnSetup function of the AtkUnitBase has been called.
+    /// </summary>
+    public readonly bool IsReady => !this.IsNull && this.Struct->IsReady;
+
+    /// <summary>
+    /// Gets a value indicating whether the AtkUnitBase is visible.
+    /// </summary>
+    public readonly bool IsVisible => !this.IsNull && this.Struct->IsVisible;
+
+    /// <summary>
+    /// Gets the name of the AtkUnitBase.
+    /// </summary>
+    public readonly string Name => this.IsNull ? string.Empty : this.Struct->NameString;
+
+    /// <summary>
+    /// Gets the id of the AtkUnitBase.
+    /// </summary>
+    public readonly ushort Id => this.IsNull ? (ushort)0 : this.Struct->Id;
+
+    /// <summary>
+    /// Gets the parent id of the AtkUnitBase.
+    /// </summary>
+    public readonly ushort ParentId => this.IsNull ? (ushort)0 : this.Struct->ParentId;
+
+    /// <summary>
+    /// Gets the host id of the AtkUnitBase.
+    /// </summary>
+    public readonly ushort HostId => this.IsNull ? (ushort)0 : this.Struct->HostId;
+
+    /// <summary>
+    /// Gets the scale of the AtkUnitBase.
+    /// </summary>
+    public readonly float Scale => this.IsNull ? 0f : this.Struct->Scale;
+
+    /// <summary>
+    /// Gets the x-position of the AtkUnitBase.
+    /// </summary>
+    public readonly short X => this.IsNull ? (short)0 : this.Struct->X;
+
+    /// <summary>
+    /// Gets the y-position of the AtkUnitBase.
+    /// </summary>
+    public readonly short Y => this.IsNull ? (short)0 : this.Struct->Y;
+
+    /// <summary>
+    /// Gets the width of the AtkUnitBase.
+    /// </summary>
+    public readonly float Width => this.IsNull ? 0f : this.Struct->GetScaledWidth(false);
+
+    /// <summary>
+    /// Gets the height of the AtkUnitBase.
+    /// </summary>
+    public readonly float Height => this.IsNull ? 0f : this.Struct->GetScaledHeight(false);
+
+    /// <summary>
+    /// Gets the scaled width of the AtkUnitBase.
+    /// </summary>
+    public readonly float ScaledWidth => this.IsNull ? 0f : this.Struct->GetScaledWidth(true);
+
+    /// <summary>
+    /// Gets the scaled height of the AtkUnitBase.
+    /// </summary>
+    public readonly float ScaledHeight => this.IsNull ? 0f : this.Struct->GetScaledHeight(true);
+
+    /// <summary>
+    /// Gets the position of the AtkUnitBase.
+    /// </summary>
+    public readonly Vector2 Position => new(this.X, this.Y);
+
+    /// <summary>
+    /// Gets the size of the AtkUnitBase.
+    /// </summary>
+    public readonly Vector2 Size => new(this.Width, this.Height);
+
+    /// <summary>
+    /// Gets the scaled size of the AtkUnitBase.
+    /// </summary>
+    public readonly Vector2 ScaledSize => new(this.ScaledWidth, this.ScaledHeight);
+
+    /// <summary>
+    /// Gets the AtkUnitBase*.
+    /// </summary>
+    /// <remarks> Internal use only. </remarks>
+    internal readonly AtkUnitBase* Struct => (AtkUnitBase*)this.Address;
+
+    public static implicit operator nint(AtkUnitBasePtr wrapper) => wrapper.Address;
+
+    public static implicit operator AtkUnitBasePtr(nint address) => new(address);
+
+    public static bool operator ==(AtkUnitBasePtr left, AtkUnitBasePtr right) => left.Address == right.Address;
+
+    public static bool operator !=(AtkUnitBasePtr left, AtkUnitBasePtr right) => left.Address != right.Address;
+
+    /// <summary>
+    /// Focuses the AtkUnitBase.
+    /// </summary>
+    public readonly void Focus()
+    {
+        if (!this.IsNull)
+            this.Struct->Focus();
+    }
+
+    /// <summary>Determines whether the specified AtkUnitBasePtr is equal to the current AtkUnitBasePtr.</summary>
+    /// <param name="other">The AtkUnitBasePtr to compare with the current AtkUnitBasePtr.</param>
+    /// <returns><c>true</c> if the specified AtkUnitBasePtr is equal to the current AtkUnitBasePtr; otherwise, <c>false</c>.</returns>
+    public readonly bool Equals(AtkUnitBasePtr other) => this.Address == other.Address;
+
+    /// <inheritdoc cref="object.Equals(object?)"/>
+    public override readonly bool Equals(object obj) => obj is AtkUnitBasePtr wrapper && this.Equals(wrapper);
+
+    /// <inheritdoc cref="object.GetHashCode()"/>
+    public override readonly int GetHashCode() => ((nuint)this.Address).GetHashCode();
+}

--- a/Dalamud/Game/Gui/NativeWrapper/AtkUnitBasePtr.cs
+++ b/Dalamud/Game/Gui/NativeWrapper/AtkUnitBasePtr.cs
@@ -1,9 +1,7 @@
-using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
 using FFXIVClientStructs.FFXIV.Component.GUI;
-using FFXIVClientStructs.Interop;
 
 namespace Dalamud.Game.Gui.NativeWrapper;
 

--- a/Dalamud/Game/NativeWrapper/AgentInterfacePtr.cs
+++ b/Dalamud/Game/NativeWrapper/AgentInterfacePtr.cs
@@ -1,0 +1,94 @@
+using System.Runtime.InteropServices;
+
+using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+
+namespace Dalamud.Game.NativeWrapper;
+
+/// <summary>
+/// A wrapper for AgentInterface.
+/// </summary>
+/// <param name="address">The address to the AgentInterface.</param>
+[StructLayout(LayoutKind.Explicit, Size = 0x08)]
+public readonly unsafe struct AgentInterfacePtr(nint address) : IEquatable<AgentInterfacePtr>
+{
+    /// <summary>
+    /// The address to the AgentInterface.
+    /// </summary>
+    [FieldOffset(0x00)]
+    public readonly nint Address = address;
+
+    /// <summary>
+    /// Gets a value indicating whether the underlying pointer is a nullptr.
+    /// </summary>
+    public readonly bool IsNull => this.Address == 0;
+
+    /// <summary>
+    /// Gets a value indicating whether the agents addon is visible.
+    /// </summary>
+    public readonly AtkUnitBasePtr Addon
+    {
+        get
+        {
+            if (this.IsNull)
+                return 0;
+
+            var raptureAtkUnitManager = RaptureAtkUnitManager.Instance();
+            if (raptureAtkUnitManager == null)
+                return 0;
+
+            return (nint)raptureAtkUnitManager->GetAddonById(this.AddonId);
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the agent is active.
+    /// </summary>
+    public readonly ushort AddonId => (ushort)(this.IsNull ? 0 : this.Struct->GetAddonId());
+
+    /// <summary>
+    /// Gets a value indicating whether the agent is active.
+    /// </summary>
+    public readonly bool IsAgentActive => !this.IsNull && this.Struct->IsAgentActive();
+
+    /// <summary>
+    /// Gets a value indicating whether the agents addon is ready.
+    /// </summary>
+    public readonly bool IsAddonReady => !this.IsNull && this.Struct->IsAddonReady();
+
+    /// <summary>
+    /// Gets a value indicating whether the agents addon is visible.
+    /// </summary>
+    public readonly bool IsAddonShown => !this.IsNull && this.Struct->IsAddonShown();
+
+    /// <summary>
+    /// Gets the AgentInterface*.
+    /// </summary>
+    /// <remarks> Internal use only. </remarks>
+    internal readonly AgentInterface* Struct => (AgentInterface*)this.Address;
+
+    public static implicit operator nint(AgentInterfacePtr wrapper) => wrapper.Address;
+
+    public static implicit operator AgentInterfacePtr(nint address) => new(address);
+
+    public static bool operator ==(AgentInterfacePtr left, AgentInterfacePtr right) => left.Address == right.Address;
+
+    public static bool operator !=(AgentInterfacePtr left, AgentInterfacePtr right) => left.Address != right.Address;
+
+    /// <summary>
+    /// Focuses the AtkUnitBase.
+    /// </summary>
+    /// <returns> <c>true</c> when the addon was focused, <c>false</c> otherwise. </returns>
+    public readonly bool FocusAddon() => this.IsNull && this.Struct->FocusAddon();
+
+    /// <summary>Determines whether the specified AgentInterfacePtr is equal to the current AgentInterfacePtr.</summary>
+    /// <param name="other">The AgentInterfacePtr to compare with the current AgentInterfacePtr.</param>
+    /// <returns><c>true</c> if the specified AgentInterfacePtr is equal to the current AgentInterfacePtr; otherwise, <c>false</c>.</returns>
+    public readonly bool Equals(AgentInterfacePtr other) => this.Address == other.Address;
+
+    /// <inheritdoc cref="object.Equals(object?)"/>
+    public override readonly bool Equals(object obj) => obj is AgentInterfacePtr wrapper && this.Equals(wrapper);
+
+    /// <inheritdoc cref="object.GetHashCode()"/>
+    public override readonly int GetHashCode() => ((nuint)this.Address).GetHashCode();
+}

--- a/Dalamud/Game/NativeWrapper/AgentInterfacePtr.cs
+++ b/Dalamud/Game/NativeWrapper/AgentInterfacePtr.cs
@@ -71,6 +71,8 @@ public readonly unsafe struct AgentInterfacePtr(nint address) : IEquatable<Agent
 
     public static implicit operator AgentInterfacePtr(nint address) => new(address);
 
+    public static implicit operator AgentInterfacePtr(void* ptr) => new((nint)ptr);
+
     public static bool operator ==(AgentInterfacePtr left, AgentInterfacePtr right) => left.Address == right.Address;
 
     public static bool operator !=(AgentInterfacePtr left, AgentInterfacePtr right) => left.Address != right.Address;

--- a/Dalamud/Game/NativeWrapper/AgentInterfacePtr.cs
+++ b/Dalamud/Game/NativeWrapper/AgentInterfacePtr.cs
@@ -6,7 +6,7 @@ using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 namespace Dalamud.Game.NativeWrapper;
 
 /// <summary>
-/// A wrapper for AgentInterface.
+/// A readonly wrapper for AgentInterface.
 /// </summary>
 /// <param name="address">The address to the AgentInterface.</param>
 [StructLayout(LayoutKind.Explicit, Size = 0x08)]

--- a/Dalamud/Game/NativeWrapper/AtkUnitBasePtr.cs
+++ b/Dalamud/Game/NativeWrapper/AtkUnitBasePtr.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
-namespace Dalamud.Game.Gui.NativeWrapper;
+namespace Dalamud.Game.NativeWrapper;
 
 /// <summary>
 /// A wrapper for AtkUnitBase.

--- a/Dalamud/Game/NativeWrapper/AtkUnitBasePtr.cs
+++ b/Dalamud/Game/NativeWrapper/AtkUnitBasePtr.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
 using FFXIVClientStructs.FFXIV.Component.GUI;
+using FFXIVClientStructs.Interop;
 
 namespace Dalamud.Game.NativeWrapper;
 
@@ -24,7 +26,7 @@ public readonly unsafe struct AtkUnitBasePtr(nint address) : IEquatable<AtkUnitB
     public readonly bool IsNull => this.Address == 0;
 
     /// <summary>
-    /// Gets a value indicating whether the OnSetup function of the AtkUnitBase has been called.
+    /// Gets a value indicating whether the OnSetup function has been called.
     /// </summary>
     public readonly bool IsReady => !this.IsNull && this.Struct->IsReady;
 
@@ -34,74 +36,102 @@ public readonly unsafe struct AtkUnitBasePtr(nint address) : IEquatable<AtkUnitB
     public readonly bool IsVisible => !this.IsNull && this.Struct->IsVisible;
 
     /// <summary>
-    /// Gets the name of the AtkUnitBase.
+    /// Gets the name.
     /// </summary>
     public readonly string Name => this.IsNull ? string.Empty : this.Struct->NameString;
 
     /// <summary>
-    /// Gets the id of the AtkUnitBase.
+    /// Gets the id.
     /// </summary>
     public readonly ushort Id => this.IsNull ? (ushort)0 : this.Struct->Id;
 
     /// <summary>
-    /// Gets the parent id of the AtkUnitBase.
+    /// Gets the parent id.
     /// </summary>
     public readonly ushort ParentId => this.IsNull ? (ushort)0 : this.Struct->ParentId;
 
     /// <summary>
-    /// Gets the host id of the AtkUnitBase.
+    /// Gets the host id.
     /// </summary>
     public readonly ushort HostId => this.IsNull ? (ushort)0 : this.Struct->HostId;
 
     /// <summary>
-    /// Gets the scale of the AtkUnitBase.
+    /// Gets the scale.
     /// </summary>
     public readonly float Scale => this.IsNull ? 0f : this.Struct->Scale;
 
     /// <summary>
-    /// Gets the x-position of the AtkUnitBase.
+    /// Gets the x-position.
     /// </summary>
     public readonly short X => this.IsNull ? (short)0 : this.Struct->X;
 
     /// <summary>
-    /// Gets the y-position of the AtkUnitBase.
+    /// Gets the y-position.
     /// </summary>
     public readonly short Y => this.IsNull ? (short)0 : this.Struct->Y;
 
     /// <summary>
-    /// Gets the width of the AtkUnitBase.
+    /// Gets the width.
     /// </summary>
     public readonly float Width => this.IsNull ? 0f : this.Struct->GetScaledWidth(false);
 
     /// <summary>
-    /// Gets the height of the AtkUnitBase.
+    /// Gets the height.
     /// </summary>
     public readonly float Height => this.IsNull ? 0f : this.Struct->GetScaledHeight(false);
 
     /// <summary>
-    /// Gets the scaled width of the AtkUnitBase.
+    /// Gets the scaled width.
     /// </summary>
     public readonly float ScaledWidth => this.IsNull ? 0f : this.Struct->GetScaledWidth(true);
 
     /// <summary>
-    /// Gets the scaled height of the AtkUnitBase.
+    /// Gets the scaled height.
     /// </summary>
     public readonly float ScaledHeight => this.IsNull ? 0f : this.Struct->GetScaledHeight(true);
 
     /// <summary>
-    /// Gets the position of the AtkUnitBase.
+    /// Gets the position.
     /// </summary>
     public readonly Vector2 Position => new(this.X, this.Y);
 
     /// <summary>
-    /// Gets the size of the AtkUnitBase.
+    /// Gets the size.
     /// </summary>
     public readonly Vector2 Size => new(this.Width, this.Height);
 
     /// <summary>
-    /// Gets the scaled size of the AtkUnitBase.
+    /// Gets the scaled size.
     /// </summary>
     public readonly Vector2 ScaledSize => new(this.ScaledWidth, this.ScaledHeight);
+
+    /// <summary>
+    /// Gets the number of <see cref="AtkValue"/> entries.
+    /// </summary>
+    public readonly int AtkValuesCount => this.Struct->AtkValuesCount;
+
+    /// <summary>
+    /// Gets an enumerable collection of <see cref="AtkValuePtr"/> of the addons current AtkValues.
+    /// </summary>
+    /// <returns>
+    /// An <see cref="IEnumerable{T}"/> of <see cref="AtkValuePtr"/> corresponding to the addons AtkValues.
+    /// </returns>
+    public IEnumerable<AtkValuePtr> AtkValues
+    {
+        get
+        {
+            for (var i = 0; i < this.AtkValuesCount; i++)
+            {
+                AtkValuePtr ptr;
+                unsafe
+                {
+                    ptr = new AtkValuePtr((nint)this.Struct->AtkValuesSpan.GetPointer(i));
+                }
+
+                yield return ptr;
+            }
+        }
+    }
 
     /// <summary>
     /// Gets the AtkUnitBase*.

--- a/Dalamud/Game/NativeWrapper/AtkUnitBasePtr.cs
+++ b/Dalamud/Game/NativeWrapper/AtkUnitBasePtr.cs
@@ -6,7 +6,7 @@ using FFXIVClientStructs.FFXIV.Component.GUI;
 namespace Dalamud.Game.NativeWrapper;
 
 /// <summary>
-/// A wrapper for AtkUnitBase.
+/// A readonly wrapper for AtkUnitBase.
 /// </summary>
 /// <param name="address">The address to the AtkUnitBase.</param>
 [StructLayout(LayoutKind.Explicit, Size = 0x08)]

--- a/Dalamud/Game/NativeWrapper/AtkUnitBasePtr.cs
+++ b/Dalamud/Game/NativeWrapper/AtkUnitBasePtr.cs
@@ -113,6 +113,8 @@ public readonly unsafe struct AtkUnitBasePtr(nint address) : IEquatable<AtkUnitB
 
     public static implicit operator AtkUnitBasePtr(nint address) => new(address);
 
+    public static implicit operator AtkUnitBasePtr(void* ptr) => new((nint)ptr);
+
     public static bool operator ==(AtkUnitBasePtr left, AtkUnitBasePtr right) => left.Address == right.Address;
 
     public static bool operator !=(AtkUnitBasePtr left, AtkUnitBasePtr right) => left.Address != right.Address;

--- a/Dalamud/Game/NativeWrapper/AtkValuePtr.cs
+++ b/Dalamud/Game/NativeWrapper/AtkValuePtr.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+using Dalamud.Utility;
+
+using FFXIVClientStructs.FFXIV.Component.GUI;
+
+namespace Dalamud.Game.NativeWrapper;
+
+/// <summary>
+/// A readonly wrapper for AtkValue.
+/// </summary>
+/// <param name="address">The address to the AtkValue.</param>
+[StructLayout(LayoutKind.Explicit, Size = 0x08)]
+public readonly unsafe struct AtkValuePtr(nint address) : IEquatable<AtkValuePtr>
+{
+    /// <summary>
+    /// The address to the AtkValue.
+    /// </summary>
+    [FieldOffset(0x00)]
+    public readonly nint Address = address;
+
+    /// <summary>
+    /// Gets a value indicating whether the underlying pointer is a nullptr.
+    /// </summary>
+    public readonly bool IsNull => this.Address == 0;
+
+    /// <summary>
+    /// Gets the value type.
+    /// </summary>
+    public readonly AtkValueType ValueType => (AtkValueType)this.Struct->Type;
+
+    /// <summary>
+    /// Gets the AtkValue*.
+    /// </summary>
+    /// <remarks> Internal use only. </remarks>
+    internal readonly AtkValue* Struct => (AtkValue*)this.Address;
+
+    public static implicit operator nint(AtkValuePtr wrapper) => wrapper.Address;
+
+    public static implicit operator AtkValuePtr(nint address) => new(address);
+
+    public static implicit operator AtkValuePtr(void* ptr) => new((nint)ptr);
+
+    public static bool operator ==(AtkValuePtr left, AtkValuePtr right) => left.Address == right.Address;
+
+    public static bool operator !=(AtkValuePtr left, AtkValuePtr right) => left.Address != right.Address;
+
+    /// <summary>
+    /// Gets the value of the underlying <see cref="AtkValue"/> as a boxed object, based on its <see cref="AtkValueType"/>.
+    /// </summary>
+    /// <returns>
+    /// The boxed value represented by this <see cref="AtkValuePtr"/>, or <c>null</c> if the value is null or undefined.
+    /// </returns>
+    /// <exception cref="NotImplementedException">
+    /// Thrown if the value type is not currently handled by this implementation.
+    /// </exception>
+    public unsafe object? GetValue()
+    {
+        if (this.Struct == null)
+            return null;
+
+        return this.ValueType switch
+        {
+            AtkValueType.Undefined or AtkValueType.Null => null,
+            AtkValueType.Bool => this.Struct->Bool,
+            AtkValueType.Int => this.Struct->Int,
+            AtkValueType.Int64 => this.Struct->Int64,
+            AtkValueType.UInt => this.Struct->UInt,
+            AtkValueType.UInt64 => this.Struct->UInt64,
+            AtkValueType.Float => this.Struct->Float,
+            AtkValueType.String or AtkValueType.String8 or AtkValueType.ManagedString => this.Struct->String == null ? default : this.Struct->String.AsReadOnlySeString(),
+            AtkValueType.WideString => this.Struct->WideString == null ? string.Empty : new string(this.Struct->WideString),
+            AtkValueType.Pointer => (nint)this.Struct->Pointer,
+            _ => throw new NotImplementedException($"AtkValueType {this.ValueType} is currently not supported"),
+        };
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the value as a strongly-typed object if the underlying type matches.
+    /// </summary>
+    /// <typeparam name="T">The expected value type to extract.</typeparam>
+    /// <param name="result">
+    /// When this method returns <c>true</c>, contains the extracted value of type <typeparamref name="T"/>.
+    /// Otherwise, contains the default value of type <typeparamref name="T"/>.
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if the value was successfully extracted and matched <typeparamref name="T"/>; otherwise, <c>false</c>.
+    /// </returns>
+    public unsafe bool TryGet<T>([NotNullWhen(true)] out T? result) where T : struct
+    {
+        object? value = this.GetValue();
+        if (value is T typed)
+        {
+            result = typed;
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+
+    /// <summary>Determines whether the specified AtkValuePtr is equal to the current AtkValuePtr.</summary>
+    /// <param name="other">The AtkValuePtr to compare with the current AtkValuePtr.</param>
+    /// <returns><c>true</c> if the specified AtkValuePtr is equal to the current AtkValuePtr; otherwise, <c>false</c>.</returns>
+    public readonly bool Equals(AtkValuePtr other) => this.Address == other.Address || this.Struct->EqualTo(other.Struct);
+
+    /// <inheritdoc cref="object.Equals(object?)"/>
+    public override readonly bool Equals(object obj) => obj is AtkValuePtr wrapper && this.Equals(wrapper);
+
+    /// <inheritdoc cref="object.GetHashCode()"/>
+    public override readonly int GetHashCode() => ((nuint)this.Address).GetHashCode();
+}

--- a/Dalamud/Game/NativeWrapper/AtkValueType.cs
+++ b/Dalamud/Game/NativeWrapper/AtkValueType.cs
@@ -1,0 +1,87 @@
+namespace Dalamud.Game.NativeWrapper;
+
+/// <summary>
+/// Represents the data type of the AtkValue.
+/// </summary>
+public enum AtkValueType
+{
+    /// <summary>
+    /// The value is undefined or invalid.
+    /// </summary>
+    Undefined = 0,
+
+    /// <summary>
+    /// The value is null.
+    /// </summary>
+    Null = 0x1,
+
+    /// <summary>
+    /// The value is a boolean.
+    /// </summary>
+    Bool = 0x2,
+
+    /// <summary>
+    /// The value is a 32-bit signed integer.
+    /// </summary>
+    Int = 0x3,
+
+    /// <summary>
+    /// The value is a 64-bit signed integer.
+    /// </summary>
+    Int64 = 0x4,
+
+    /// <summary>
+    /// The value is a 32-bit unsigned integer.
+    /// </summary>
+    UInt = 0x5,
+
+    /// <summary>
+    /// The value is a 64-bit unsigned integer.
+    /// </summary>
+    UInt64 = 0x6,
+
+    /// <summary>
+    /// The value is a 32-bit floating-point number.
+    /// </summary>
+    Float = 0x7,
+
+    /// <summary>
+    /// The value points to a null-terminated 8-bit character string (ASCII or UTF-8).
+    /// </summary>
+    String = 0x8,
+
+    /// <summary>
+    /// The value points to a null-terminated 16-bit character string (UTF-16 / wide string).
+    /// </summary>
+    WideString = 0x9,
+
+    /// <summary>
+    /// The value points to a constant null-terminated 8-bit character string (const char*).
+    /// </summary>
+    String8 = 0xA,
+
+    /// <summary>
+    /// The value is a vector.
+    /// </summary>
+    Vector = 0xB,
+
+    /// <summary>
+    /// The value is a pointer.
+    /// </summary>
+    Pointer = 0xC,
+
+    /// <summary>
+    /// The value is pointing to an array of AtkValue entries.
+    /// </summary>
+    AtkValues = 0xD,
+
+    /// <summary>
+    /// The value is a managed string. See <see cref="String"/>.
+    /// </summary>
+    ManagedString = 0x28,
+
+    /// <summary>
+    /// The value is a managed vector. See <see cref="Vector"/>.
+    /// </summary>
+    ManagedVector = 0x2B,
+}

--- a/Dalamud/Game/NativeWrapper/UIModulePtr.cs
+++ b/Dalamud/Game/NativeWrapper/UIModulePtr.cs
@@ -1,0 +1,49 @@
+using System.Runtime.InteropServices;
+
+using FFXIVClientStructs.FFXIV.Client.UI;
+
+namespace Dalamud.Game.NativeWrapper;
+
+/// <summary>
+/// A wrapper for UIModule.
+/// </summary>
+/// <param name="address">The address to the UIModule.</param>
+[StructLayout(LayoutKind.Explicit, Size = 0x08)]
+public readonly unsafe struct UIModulePtr(nint address) : IEquatable<UIModulePtr>
+{
+    /// <summary>
+    /// The address to the UIModule.
+    /// </summary>
+    [FieldOffset(0x00)]
+    public readonly nint Address = address;
+
+    /// <summary>
+    /// Gets a value indicating whether the underlying pointer is a nullptr.
+    /// </summary>
+    public readonly bool IsNull => this.Address == 0;
+
+    /// <summary>
+    /// Gets the UIModule*.
+    /// </summary>
+    /// <remarks> Internal use only. </remarks>
+    internal readonly UIModule* Struct => (UIModule*)this.Address;
+
+    public static implicit operator nint(UIModulePtr wrapper) => wrapper.Address;
+
+    public static implicit operator UIModulePtr(nint address) => new(address);
+
+    public static bool operator ==(UIModulePtr left, UIModulePtr right) => left.Address == right.Address;
+
+    public static bool operator !=(UIModulePtr left, UIModulePtr right) => left.Address != right.Address;
+
+    /// <summary>Determines whether the specified UIModulePtr is equal to the current UIModulePtr.</summary>
+    /// <param name="other">The UIModulePtr to compare with the current UIModulePtr.</param>
+    /// <returns><c>true</c> if the specified UIModulePtr is equal to the current UIModulePtr; otherwise, <c>false</c>.</returns>
+    public readonly bool Equals(UIModulePtr other) => this.Address == other.Address;
+
+    /// <inheritdoc cref="object.Equals(object?)"/>
+    public override readonly bool Equals(object obj) => obj is UIModulePtr wrapper && this.Equals(wrapper);
+
+    /// <inheritdoc cref="object.GetHashCode()"/>
+    public override readonly int GetHashCode() => ((nuint)this.Address).GetHashCode();
+}

--- a/Dalamud/Game/NativeWrapper/UIModulePtr.cs
+++ b/Dalamud/Game/NativeWrapper/UIModulePtr.cs
@@ -32,6 +32,8 @@ public readonly unsafe struct UIModulePtr(nint address) : IEquatable<UIModulePtr
 
     public static implicit operator UIModulePtr(nint address) => new(address);
 
+    public static implicit operator UIModulePtr(void* ptr) => new((nint)ptr);
+
     public static bool operator ==(UIModulePtr left, UIModulePtr right) => left.Address == right.Address;
 
     public static bool operator !=(UIModulePtr left, UIModulePtr right) => left.Address != right.Address;

--- a/Dalamud/Game/NativeWrapper/UIModulePtr.cs
+++ b/Dalamud/Game/NativeWrapper/UIModulePtr.cs
@@ -5,7 +5,7 @@ using FFXIVClientStructs.FFXIV.Client.UI;
 namespace Dalamud.Game.NativeWrapper;
 
 /// <summary>
-/// A wrapper for UIModule.
+/// A readonly wrapper for UIModule.
 /// </summary>
 /// <param name="address">The address to the UIModule.</param>
 [StructLayout(LayoutKind.Explicit, Size = 0x08)]

--- a/Dalamud/Interface/Internal/UiDebug.cs
+++ b/Dalamud/Interface/Internal/UiDebug.cs
@@ -12,8 +12,6 @@ using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using ImGuiNET;
 
-using Lumina.Text.ReadOnly;
-
 // Customised version of https://github.com/aers/FFXIVUIDebug
 
 namespace Dalamud.Interface.Internal;
@@ -87,7 +85,7 @@ internal unsafe class UiDebug
     {
         var isVisible = atkUnitBase->IsVisible;
         var addonName = atkUnitBase->NameString;
-        var agent = Service<GameGui>.Get().FindAgentInterface((nint)atkUnitBase);
+        var agent = Service<GameGui>.Get().FindAgentInterface(atkUnitBase);
 
         ImGui.Text($"{addonName}");
         ImGui.SameLine();

--- a/Dalamud/Interface/Internal/UiDebug.cs
+++ b/Dalamud/Interface/Internal/UiDebug.cs
@@ -87,7 +87,7 @@ internal unsafe class UiDebug
     {
         var isVisible = atkUnitBase->IsVisible;
         var addonName = atkUnitBase->NameString;
-        var agent = Service<GameGui>.Get().FindAgentInterface(atkUnitBase);
+        var agent = Service<GameGui>.Get().FindAgentInterface((nint)atkUnitBase);
 
         ImGui.Text($"{addonName}");
         ImGui.SameLine();
@@ -102,8 +102,8 @@ internal unsafe class UiDebug
         }
 
         ImGui.Separator();
-        ImGuiHelpers.ClickToCopyText($"Address: {(ulong)atkUnitBase:X}", $"{(ulong)atkUnitBase:X}");
-        ImGuiHelpers.ClickToCopyText($"Agent: {(ulong)agent:X}", $"{(ulong)agent:X}");
+        ImGuiHelpers.ClickToCopyText($"Address: {(nint)atkUnitBase:X}", $"{(nint)atkUnitBase:X}");
+        ImGuiHelpers.ClickToCopyText($"Agent: {(nint)agent:X}", $"{(nint)agent:X}");
         ImGui.Separator();
 
         ImGui.Text($"Position: [ {atkUnitBase->X} , {atkUnitBase->Y} ]");

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.cs
@@ -152,7 +152,7 @@ public unsafe partial class AddonTree : IDisposable
         var uldManager = addon->UldManager;
 
         PrintFieldValuePair("Address", $"{(nint)addon:X}");
-        PrintFieldValuePair("Agent", $"{GameGui.FindAgentInterface(addon):X}");
+        PrintFieldValuePair("Agent", $"{(nint)GameGui.FindAgentInterface(addon):X}");
 
         PrintFieldValuePairs(
             ("X", $"{addon->X}"),

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.cs
@@ -81,7 +81,7 @@ public unsafe partial class AddonTree : IDisposable
         {
             var ptr = GameGui.GetAddonByName(name);
 
-            if ((AtkUnitBase*)ptr != null)
+            if (!ptr.IsNull)
             {
                 if (AddonTrees.TryGetValue(name, out var tree))
                 {
@@ -234,7 +234,7 @@ public unsafe partial class AddonTree : IDisposable
     /// <returns>true if the addon is found.</returns>
     private bool ValidateAddon(out AtkUnitBase* addon)
     {
-        addon = (AtkUnitBase*)GameGui.GetAddonByName(this.AddonName);
+        addon = GameGui.GetAddonByName(this.AddonName).Struct;
         if (addon == null || (nint)addon != this.InitialPtr)
         {
             this.Dispose();

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.cs
@@ -152,7 +152,7 @@ public unsafe partial class AddonTree : IDisposable
         var uldManager = addon->UldManager;
 
         PrintFieldValuePair("Address", $"{(nint)addon:X}");
-        PrintFieldValuePair("Agent", $"{GameGui.FindAgentInterface(addon):X}");
+        PrintFieldValuePair("Agent", $"{GameGui.FindAgentInterface((nint)addon):X}");
 
         PrintFieldValuePairs(
             ("X", $"{addon->X}"),

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.cs
@@ -152,7 +152,7 @@ public unsafe partial class AddonTree : IDisposable
         var uldManager = addon->UldManager;
 
         PrintFieldValuePair("Address", $"{(nint)addon:X}");
-        PrintFieldValuePair("Agent", $"{GameGui.FindAgentInterface((nint)addon):X}");
+        PrintFieldValuePair("Agent", $"{GameGui.FindAgentInterface(addon):X}");
 
         PrintFieldValuePairs(
             ("X", $"{addon->X}"),

--- a/Dalamud/Interface/Internal/UiDebug2/UiDebug2.Sidebar.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/UiDebug2.Sidebar.cs
@@ -49,7 +49,7 @@ internal unsafe partial class UiDebug2
     /// Gets the base address for all unit lists.
     /// </summary>
     /// <returns>The address, if found.</returns>
-    internal static AtkUnitList* GetUnitListBaseAddr() => &((UIModule*)GameGui.GetUIModule())->GetRaptureAtkModule()->RaptureAtkUnitManager.AtkUnitManager.DepthLayerOneList;
+    internal static AtkUnitList* GetUnitListBaseAddr() => &RaptureAtkUnitManager.Instance()->DepthLayerOneList;
 
     private void DrawSidebar()
     {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonWidget.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.Gui;
+using Dalamud.Game.Gui;
 using Dalamud.Memory;
 using Dalamud.Utility;
 using ImGuiNET;
@@ -48,7 +48,7 @@ internal unsafe class AddonWidget : IDataWindowWidget
             return;
         }
 
-        var addon = (FFXIVClientStructs.FFXIV.Component.GUI.AtkUnitBase*)address;
+        var addon = address.Struct;
         var name = addon->NameString;
         ImGui.TextUnformatted($"{name} - {Util.DescribeAddress(address)}\n    v:{addon->IsVisible} x:{addon->X} y:{addon->Y} s:{addon->Scale}, w:{addon->RootNode->Width}, h:{addon->RootNode->Height}");
 

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonWidget.cs
@@ -1,6 +1,7 @@
 using Dalamud.Game.Gui;
-using Dalamud.Memory;
+using Dalamud.Game.NativeWrapper;
 using Dalamud.Utility;
+
 using ImGuiNET;
 
 namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
@@ -12,7 +13,7 @@ internal unsafe class AddonWidget : IDataWindowWidget
 {
     private string inputAddonName = string.Empty;
     private int inputAddonIndex;
-    private nint findAgentInterfacePtr;
+    private AgentInterfacePtr agentInterfacePtr;
 
     /// <inheritdoc/>
     public string DisplayName { get; init; } = "Addon"; 
@@ -40,30 +41,27 @@ internal unsafe class AddonWidget : IDataWindowWidget
         if (this.inputAddonName.IsNullOrEmpty())
             return;
 
-        var address = gameGui.GetAddonByName(this.inputAddonName, this.inputAddonIndex);
-
-        if (address == nint.Zero)
+        var addon = gameGui.GetAddonByName(this.inputAddonName, this.inputAddonIndex);
+        if (addon.IsNull)
         {
             ImGui.Text("Null");
             return;
         }
 
-        var addon = address.Struct;
-        var name = addon->NameString;
-        ImGui.TextUnformatted($"{name} - {Util.DescribeAddress(address)}\n    v:{addon->IsVisible} x:{addon->X} y:{addon->Y} s:{addon->Scale}, w:{addon->RootNode->Width}, h:{addon->RootNode->Height}");
+        ImGui.TextUnformatted($"{addon.Name} - {Util.DescribeAddress(addon)}\n    v:{addon.IsVisible} x:{addon.X} y:{addon.Y} s:{addon.Scale}, w:{addon.Width}, h:{addon.Height}");
 
         if (ImGui.Button("Find Agent"))
         {
-            this.findAgentInterfacePtr = gameGui.FindAgentInterface(address);
+            this.agentInterfacePtr = gameGui.FindAgentInterface(addon);
         }
 
-        if (this.findAgentInterfacePtr != nint.Zero)
+        if (!this.agentInterfacePtr.IsNull)
         {
-            ImGui.TextUnformatted($"Agent: {Util.DescribeAddress(this.findAgentInterfacePtr)}");
+            ImGui.TextUnformatted($"Agent: {Util.DescribeAddress(this.agentInterfacePtr)}");
             ImGui.SameLine();
 
             if (ImGui.Button("C"))
-                ImGui.SetClipboardText(this.findAgentInterfacePtr.ToInt64().ToString("X"));
+                ImGui.SetClipboardText(this.agentInterfacePtr.Address.ToString("X"));
         }
     }
 }

--- a/Dalamud/Interface/Internal/Windows/TitleScreenMenuWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/TitleScreenMenuWindow.cs
@@ -477,7 +477,7 @@ internal class TitleScreenMenuWindow : Window, IDisposable
     {
         if (args is not AddonDrawArgs drawArgs) return;
 
-        var addon = (AtkUnitBase*)drawArgs.Addon;
+        var addon = drawArgs.Addon.Struct;
         var textNode = addon->GetTextNodeById(3);
 
         // look and feel init. should be harmless to set.

--- a/Dalamud/Plugin/Services/IGameGui.cs
+++ b/Dalamud/Plugin/Services/IGameGui.cs
@@ -86,27 +86,27 @@ public unsafe interface IGameGui
     /// </summary>
     /// <param name="name">Name of addon to find.</param>
     /// <param name="index">Index of addon to find (1-indexed).</param>
-    /// <returns>nint.Zero if unable to find UI, otherwise nint pointing to the start of the addon.</returns>
+    /// <returns>A pointer to the addon.</returns>
     public AtkUnitBasePtr GetAddonByName(string name, int index = 1);
+
+    /// <summary>
+    /// Find the agent associated with an addon, if possible.
+    /// </summary>
+    /// <param name="id">The agent id.</param>
+    /// <returns>A pointer to the agent interface.</returns>
+    public AgentInterfacePtr GetAgentById(int id);
 
     /// <summary>
     /// Find the agent associated with an addon, if possible.
     /// </summary>
     /// <param name="addonName">The addon name.</param>
     /// <returns>A pointer to the agent interface.</returns>
-    public nint FindAgentInterface(string addonName);
+    public AgentInterfacePtr FindAgentInterface(string addonName);
 
     /// <summary>
     /// Find the agent associated with an addon, if possible.
     /// </summary>
     /// <param name="addon">The addon address.</param>
     /// <returns>A pointer to the agent interface.</returns>
-    public nint FindAgentInterface(void* addon);
-
-    /// <summary>
-    /// Find the agent associated with an addon, if possible.
-    /// </summary>
-    /// <param name="addonPtr">The addon address.</param>
-    /// <returns>A pointer to the agent interface.</returns>
-    public IntPtr FindAgentInterface(IntPtr addonPtr);
+    public AgentInterfacePtr FindAgentInterface(AtkUnitBasePtr addon);
 }

--- a/Dalamud/Plugin/Services/IGameGui.cs
+++ b/Dalamud/Plugin/Services/IGameGui.cs
@@ -1,6 +1,7 @@
-﻿using System.Numerics;
+using System.Numerics;
 
 using Dalamud.Game.Gui;
+using Dalamud.Game.Gui.NativeWrapper;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 
 namespace Dalamud.Plugin.Services;
@@ -86,7 +87,7 @@ public unsafe interface IGameGui
     /// <param name="name">Name of addon to find.</param>
     /// <param name="index">Index of addon to find (1-indexed).</param>
     /// <returns>nint.Zero if unable to find UI, otherwise nint pointing to the start of the addon.</returns>
-    public nint GetAddonByName(string name, int index = 1);
+    public AtkUnitBasePtr GetAddonByName(string name, int index = 1);
 
     /// <summary>
     /// Find the agent associated with an addon, if possible.

--- a/Dalamud/Plugin/Services/IGameGui.cs
+++ b/Dalamud/Plugin/Services/IGameGui.cs
@@ -1,7 +1,7 @@
 using System.Numerics;
 
 using Dalamud.Game.Gui;
-using Dalamud.Game.Gui.NativeWrapper;
+using Dalamud.Game.NativeWrapper;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 
 namespace Dalamud.Plugin.Services;

--- a/Dalamud/Plugin/Services/IGameGui.cs
+++ b/Dalamud/Plugin/Services/IGameGui.cs
@@ -76,37 +76,37 @@ public unsafe interface IGameGui
     public bool ScreenToWorld(Vector2 screenPos, out Vector3 worldPos, float rayDistance = 100000.0f);
 
     /// <summary>
-    /// Gets a pointer to the game's UI module.
+    /// Gets a pointer to the game's UIModule instance.
     /// </summary>
-    /// <returns>IntPtr pointing to UI module.</returns>
-    public nint GetUIModule();
+    /// <returns>A pointer wrapper to UIModule.</returns>
+    public UIModulePtr GetUIModule();
 
     /// <summary>
     /// Gets the pointer to the Addon with the given name and index.
     /// </summary>
     /// <param name="name">Name of addon to find.</param>
     /// <param name="index">Index of addon to find (1-indexed).</param>
-    /// <returns>A pointer to the addon.</returns>
+    /// <returns>A pointer wrapper to the addon.</returns>
     public AtkUnitBasePtr GetAddonByName(string name, int index = 1);
 
     /// <summary>
     /// Find the agent associated with an addon, if possible.
     /// </summary>
     /// <param name="id">The agent id.</param>
-    /// <returns>A pointer to the agent interface.</returns>
+    /// <returns>A pointer wrapper to the agent interface.</returns>
     public AgentInterfacePtr GetAgentById(int id);
 
     /// <summary>
     /// Find the agent associated with an addon, if possible.
     /// </summary>
     /// <param name="addonName">The addon name.</param>
-    /// <returns>A pointer to the agent interface.</returns>
+    /// <returns>A pointer wrapper to the agent interface.</returns>
     public AgentInterfacePtr FindAgentInterface(string addonName);
 
     /// <summary>
     /// Find the agent associated with an addon, if possible.
     /// </summary>
     /// <param name="addon">The addon address.</param>
-    /// <returns>A pointer to the agent interface.</returns>
+    /// <returns>A pointer wrapper to the agent interface.</returns>
     public AgentInterfacePtr FindAgentInterface(AtkUnitBasePtr addon);
 }


### PR DESCRIPTION
Adds ClientStructs-independent wrappers around `AtkUnitBase`, `AtkValue`, `AgentInterface` and `UIModule`, providing basic properties (well, except for UIModulePtr which is just a placeholder for now).
The `IGameGui` functions were updated appropriately.
The wrappers implicitly cast from and to `nint`, but the address is also exposed as readonly field, so adapting to it should be pretty trivial.