### PR TITLE
Provide native linux compatibility for Dalamud.Bindings.ImGui

### DIFF
--- a/imgui/Dalamud.Bindings.ImGui/ImGui.cs
+++ b/imgui/Dalamud.Bindings.ImGui/ImGui.cs
@@ -20,10 +20,18 @@ namespace Dalamud.Bindings.ImGui
             {
                 InitApi(new NativeLibraryContext(Process.GetCurrentProcess().MainModule!.BaseAddress));
             }
+
+            var linuxPath = Path.Combine(Path.GetDirectoryName(Assembly.GetCallingAssembly().Location)!, GetLibraryName() + ".so");
+            var windowsPath = Path.Combine(Path.GetDirectoryName(Assembly.GetCallingAssembly().Location)!, GetLibraryName() + ".dll");
+
+            // This shouldn't affect wine as it'll be reported as Win32NT
+            if (System.Environment.OSVersion.Platform == PlatformID.Unix && File.Exists(linuxPath))
+            {
+                InitApi(new NativeLibraryContext(linuxPath));
+            }
             else
             {
-                //InitApi(new NativeLibraryContext(LibraryLoader.LoadLibrary(GetLibraryName, null)));
-                InitApi(new NativeLibraryContext(Path.Combine(Path.GetDirectoryName(Assembly.GetCallingAssembly().Location)!, GetLibraryName() + ".dll")));
+                InitApi(new NativeLibraryContext(windowsPath));
             }
         }
 


### PR DESCRIPTION
I'm aware this PR probably doesn't add anything of value to most plugin developers but this allows for the bindings to run outside of the normal plugin environment(currently I rely on being able to use .so's instead of .dll's for DalaMock). This was handled automatically before but it looks like we've hardcoded in dlls.

This checks the platform(Win32NT on wine/windows) and for the existence of the .so files before loading them.

Open to suggestions if there's a smarter way to handle this

