### PR TITLE
[API13] Fire ActivePluginsChanged after a plugin loaded/unloaded

### DIFF
--- a/Dalamud/Plugin/ActivePluginsChangedEventArgs.cs
+++ b/Dalamud/Plugin/ActivePluginsChangedEventArgs.cs
@@ -5,15 +5,27 @@ namespace Dalamud.Plugin;
 /// <summary>
 /// Contains data about changes to the list of active plugins.
 /// </summary>
-public class ActivePluginsChangedEventArgs(PluginListInvalidationKind kind, IEnumerable<string> affectedInternalNames) : EventArgs
+public class ActivePluginsChangedEventArgs : EventArgs
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActivePluginsChangedEventArgs"/> class
+    /// with the specified parameters.
+    /// </summary>
+    /// <param name="kind">The kind of change that triggered the event.</param>
+    /// <param name="affectedInternalNames">The internal names of the plugins affected by the change.</param>
+    internal ActivePluginsChangedEventArgs(PluginListInvalidationKind kind, IEnumerable<string> affectedInternalNames)
+    {
+        this.Kind = kind;
+        this.AffectedInternalNames = affectedInternalNames;
+    }
+
     /// <summary>
     /// Gets the invalidation kind that caused this event to be fired.
     /// </summary>
-    public PluginListInvalidationKind Kind { get; } = kind;
+    public PluginListInvalidationKind Kind { get; }
 
     /// <summary>
     /// Gets the InternalNames of affected plugins.
     /// </summary>
-    public IEnumerable<string> AffectedInternalNames { get; } = affectedInternalNames;
+    public IEnumerable<string> AffectedInternalNames { get; }
 }

--- a/Dalamud/Plugin/ActivePluginsChangedEventArgs.cs
+++ b/Dalamud/Plugin/ActivePluginsChangedEventArgs.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Dalamud.Plugin;
+
+/// <summary>
+/// Contains data about changes to the list of active plugins.
+/// </summary>
+public class ActivePluginsChangedEventArgs(PluginListInvalidationKind kind, IEnumerable<string> affectedInternalNames) : EventArgs
+{
+    /// <summary>
+    /// Gets the invalidation kind that caused this event to be fired.
+    /// </summary>
+    public PluginListInvalidationKind Kind { get; } = kind;
+
+    /// <summary>
+    /// Gets the InternalNames of affected plugins.
+    /// </summary>
+    public IEnumerable<string> AffectedInternalNames { get; } = affectedInternalNames;
+}

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -523,15 +523,14 @@ internal sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposa
     /// <summary>
     /// Dispatch the active plugins changed event.
     /// </summary>
-    /// <param name="kind">What action caused this event to be fired.</param>
-    /// <param name="affectedThisPlugin">If this plugin was affected by the change.</param>
-    internal void NotifyActivePluginsChanged(PluginListInvalidationKind kind, bool affectedThisPlugin)
+    /// <param name="args">The event arguments containing information about the change.</param>
+    internal void NotifyActivePluginsChanged(ActivePluginsChangedEventArgs args)
     {
         foreach (var action in Delegate.EnumerateInvocationList(this.ActivePluginsChanged))
         {
             try
             {
-                action(kind, affectedThisPlugin);
+                action(args);
             }
             catch (Exception ex)
             {

--- a/Dalamud/Plugin/IDalamudPluginInterface.cs
+++ b/Dalamud/Plugin/IDalamudPluginInterface.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
@@ -32,9 +32,8 @@ public interface IDalamudPluginInterface
     /// <summary>
     /// Delegate for events that listen to changes to the list of active plugins.
     /// </summary>
-    /// <param name="kind">What action caused this event to be fired.</param>
-    /// <param name="affectedThisPlugin">If this plugin was affected by the change.</param>
-    public delegate void ActivePluginsChangedDelegate(PluginListInvalidationKind kind, bool affectedThisPlugin);
+    /// <param name="args">The event arguments containing information about the change.</param>
+    public delegate void ActivePluginsChangedDelegate(ActivePluginsChangedEventArgs args);
 
     /// <summary>
     /// Event that gets fired when loc is changed

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1307,9 +1307,7 @@ internal class PluginManager : IInternalDisposableService
                 continue;
 
             installedPlugin.DalamudInterface.NotifyActivePluginsChanged(
-                kind,
-                // ReSharper disable once PossibleMultipleEnumeration
-                affectedInternalNames.Contains(installedPlugin.Manifest.InternalName));
+                new ActivePluginsChangedEventArgs(kind, affectedInternalNames));
         }
     }
 

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1295,6 +1295,25 @@ internal class PluginManager : IInternalDisposableService
     public LocalPlugin? FindCallingPlugin() => this.FindCallingPlugin(new StackTrace());
 
     /// <summary>
+    /// Notifies all plugins that the active plugins list changed.
+    /// </summary>
+    /// <param name="kind">The invalidation kind.</param>
+    /// <param name="affectedInternalNames">The affected plugins.</param>
+    public void NotifyPluginsForStateChange(PluginListInvalidationKind kind, IEnumerable<string> affectedInternalNames)
+    {
+        foreach (var installedPlugin in this.installedPluginsList)
+        {
+            if (!installedPlugin.IsLoaded || installedPlugin.DalamudInterface == null)
+                continue;
+
+            installedPlugin.DalamudInterface.NotifyActivePluginsChanged(
+                kind,
+                // ReSharper disable once PossibleMultipleEnumeration
+                affectedInternalNames.Contains(installedPlugin.Manifest.InternalName));
+        }
+    }
+
+    /// <summary>
     /// Resolves the services that a plugin may have a dependency on.<br />
     /// This is required, as the lifetime of a plugin cannot be longer than PluginManager,
     /// and we want to ensure that dependency services to be kept alive at least until all the plugins, and thus
@@ -1821,20 +1840,6 @@ internal class PluginManager : IInternalDisposableService
         this.DetectAvailablePluginUpdates();
 
         this.OnInstalledPluginsChanged?.InvokeSafely();
-    }
-
-    private void NotifyPluginsForStateChange(PluginListInvalidationKind kind, IEnumerable<string> affectedInternalNames)
-    {
-        foreach (var installedPlugin in this.installedPluginsList)
-        {
-            if (!installedPlugin.IsLoaded || installedPlugin.DalamudInterface == null)
-                continue;
-
-            installedPlugin.DalamudInterface.NotifyActivePluginsChanged(
-                kind,
-                // ReSharper disable once PossibleMultipleEnumeration
-                affectedInternalNames.Contains(installedPlugin.Manifest.InternalName));
-        }
     }
 
     private void LoadAndStartLoadSyncPlugins()

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -395,6 +395,9 @@ internal class LocalPlugin : IAsyncDisposable
                                     this.dalamudInterface);
                 this.State = PluginState.Loaded;
                 Log.Information("Finished loading {PluginName}", this.InternalName);
+
+                var manager = Service<PluginManager>.Get();
+                manager.NotifyPluginsForStateChange(PluginListInvalidationKind.Load, [this.manifest.InternalName]);
             }
             catch (Exception ex)
             {
@@ -470,6 +473,9 @@ internal class LocalPlugin : IAsyncDisposable
 
             this.State = PluginState.Unloaded;
             Log.Information("Finished unloading {PluginName}", this.InternalName);
+
+            var manager = Service<PluginManager>.Get();
+            manager.NotifyPluginsForStateChange(PluginListInvalidationKind.Unload, [this.manifest.InternalName]);
         }
         catch (Exception ex)
         {

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -397,7 +397,7 @@ internal class LocalPlugin : IAsyncDisposable
                 Log.Information("Finished loading {PluginName}", this.InternalName);
 
                 var manager = Service<PluginManager>.Get();
-                manager.NotifyPluginsForStateChange(PluginListInvalidationKind.Load, [this.manifest.InternalName]);
+                manager.NotifyPluginsForStateChange(PluginListInvalidationKind.Loaded, [this.manifest.InternalName]);
             }
             catch (Exception ex)
             {
@@ -475,7 +475,7 @@ internal class LocalPlugin : IAsyncDisposable
             Log.Information("Finished unloading {PluginName}", this.InternalName);
 
             var manager = Service<PluginManager>.Get();
-            manager.NotifyPluginsForStateChange(PluginListInvalidationKind.Unload, [this.manifest.InternalName]);
+            manager.NotifyPluginsForStateChange(PluginListInvalidationKind.Unloaded, [this.manifest.InternalName]);
         }
         catch (Exception ex)
         {

--- a/Dalamud/Plugin/PluginListInvalidationKind.cs
+++ b/Dalamud/Plugin/PluginListInvalidationKind.cs
@@ -8,12 +8,12 @@ public enum PluginListInvalidationKind
     /// <summary>
     /// A plugin was loaded.
     /// </summary>
-    Load,
+    Loaded,
 
     /// <summary>
     /// A plugin was unloaded.
     /// </summary>
-    Unload,
+    Unloaded,
 
     /// <summary>
     /// An installer-initiated update reloaded plugins.

--- a/Dalamud/Plugin/PluginListInvalidationKind.cs
+++ b/Dalamud/Plugin/PluginListInvalidationKind.cs
@@ -1,10 +1,20 @@
-﻿namespace Dalamud.Plugin;
+namespace Dalamud.Plugin;
 
 /// <summary>
 /// Causes for a change to the plugin list.
 /// </summary>
 public enum PluginListInvalidationKind
 {
+    /// <summary>
+    /// A plugin was loaded.
+    /// </summary>
+    Load,
+
+    /// <summary>
+    /// A plugin was unloaded.
+    /// </summary>
+    Unload,
+
     /// <summary>
     /// An installer-initiated update reloaded plugins.
     /// </summary>


### PR DESCRIPTION
I kept it very simple: all plugins are notified whenever a plugin loaded or unloaded.
For this I added two new `PluginListInvalidationKind` values: `Loaded` and `Unloaded`.
No changes to the behavior of `Update` or `AutoUpdate`, so these events will be triggered too.

Closes #2300 (actually it doesn't because "The pull request must be on the default branch." 🙄 )