### PR TITLE
Update text-related ImGui calls

### DIFF
--- a/Dalamud/Interface/Components/ImGuiComponents.HelpMarker.cs
+++ b/Dalamud/Interface/Components/ImGuiComponents.HelpMarker.cs
@@ -43,7 +43,7 @@ public static partial class ImGuiComponents
             {
                 using (ImRaii.TextWrapPos(ImGui.GetFontSize() * 35.0f))
                 {
-                    ImGui.TextUnformatted(helpText);
+                    ImGui.Text(helpText);
                 }
             }
         }

--- a/Dalamud/Interface/Components/ImGuiComponents.Test.cs
+++ b/Dalamud/Interface/Components/ImGuiComponents.Test.cs
@@ -12,6 +12,6 @@ public static partial class ImGuiComponents
     /// </summary>
     public static void Test()
     {
-        ImGui.TextUnformatted("You are viewing the test component. The test was a success."u8);
+        ImGui.Text("You are viewing the test component. The test was a success."u8);
     }
 }

--- a/Dalamud/Interface/Components/ImGuiComponents.Test.cs
+++ b/Dalamud/Interface/Components/ImGuiComponents.Test.cs
@@ -12,6 +12,6 @@ public static partial class ImGuiComponents
     /// </summary>
     public static void Test()
     {
-        ImGui.Text("You are viewing the test component. The test was a success.");
+        ImGui.TextUnformatted("You are viewing the test component. The test was a success."u8);
     }
 }

--- a/Dalamud/Interface/Components/ImGuiComponents.TextWithLabel.cs
+++ b/Dalamud/Interface/Components/ImGuiComponents.TextWithLabel.cs
@@ -16,15 +16,15 @@ public static partial class ImGuiComponents
     /// <param name="hint">The hint to show on hover.</param>
     public static void TextWithLabel(string label, string value, string hint = "")
     {
-        ImGui.Text(label + ": ");
+        ImGui.TextUnformatted(label + ": ");
         ImGui.SameLine();
         if (string.IsNullOrEmpty(hint))
         {
-            ImGui.Text(value);
+            ImGui.TextUnformatted(value);
         }
         else
         {
-            ImGui.Text(value + "*");
+            ImGui.TextUnformatted(value + "*");
             if (ImGui.IsItemHovered())
             {
                 using (ImRaii.Tooltip())

--- a/Dalamud/Interface/Components/ImGuiComponents.TextWithLabel.cs
+++ b/Dalamud/Interface/Components/ImGuiComponents.TextWithLabel.cs
@@ -16,20 +16,20 @@ public static partial class ImGuiComponents
     /// <param name="hint">The hint to show on hover.</param>
     public static void TextWithLabel(string label, string value, string hint = "")
     {
-        ImGui.TextUnformatted(label + ": ");
+        ImGui.Text(label + ": ");
         ImGui.SameLine();
         if (string.IsNullOrEmpty(hint))
         {
-            ImGui.TextUnformatted(value);
+            ImGui.Text(value);
         }
         else
         {
-            ImGui.TextUnformatted(value + "*");
+            ImGui.Text(value + "*");
             if (ImGui.IsItemHovered())
             {
                 using (ImRaii.Tooltip())
                 {
-                    ImGui.TextUnformatted(hint);
+                    ImGui.Text(hint);
                 }
             }
         }

--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.UI.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.UI.cs
@@ -168,7 +168,7 @@ public partial class FileDialog
             if (this.pathInputActivated)
             {
                 ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
-                ImGui.InputText("##pathedit", ref this.pathInputBuffer, 255);
+                ImGui.InputText("##pathedit"u8, ref this.pathInputBuffer, 255);
             }
             else
             {
@@ -216,7 +216,7 @@ public partial class FileDialog
 
         if (ImGui.IsItemHovered())
         {
-            ImGui.SetTooltip("Reset to current directory");
+            ImGui.SetTooltip("Reset to current directory"u8);
         }
 
         ImGui.SameLine();
@@ -226,10 +226,10 @@ public partial class FileDialog
         if (!this.createDirectoryMode)
         {
             ImGui.SameLine();
-            ImGui.TextUnformatted("Search :");
+            ImGui.TextUnformatted("Search :"u8);
             ImGui.SameLine();
             ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
-            if (ImGui.InputText("##InputImGuiFileDialogSearchField", ref this.searchBuffer, 255))
+            if (ImGui.InputText("##InputImGuiFileDialogSearchField"u8, ref this.searchBuffer, 255))
             {
                 this.ApplyFilteringOnFileList();
             }
@@ -251,21 +251,21 @@ public partial class FileDialog
 
         if (ImGui.IsItemHovered())
         {
-            ImGui.SetTooltip("Create Directory");
+            ImGui.SetTooltip("Create Directory"u8);
         }
 
         if (this.createDirectoryMode)
         {
             ImGui.SameLine();
-            ImGui.TextUnformatted("New Directory Name");
+            ImGui.TextUnformatted("New Directory Name"u8);
 
             ImGui.SameLine();
             ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X - Scaled(100));
-            ImGui.InputText("##DirectoryFileName", ref this.createDirectoryBuffer, 255);
+            ImGui.InputText("##DirectoryFileName"u8, ref this.createDirectoryBuffer, 255);
 
             ImGui.SameLine();
 
-            if (ImGui.Button("Ok"))
+            if (ImGui.Button("Ok"u8))
             {
                 if (this.CreateDir(this.createDirectoryBuffer))
                 {
@@ -277,7 +277,7 @@ public partial class FileDialog
 
             ImGui.SameLine();
 
-            if (ImGui.Button("Cancel"))
+            if (ImGui.Button("Cancel"u8))
             {
                 this.createDirectoryMode = false;
             }
@@ -290,9 +290,9 @@ public partial class FileDialog
 
         if (!this.flags.HasFlag(ImGuiFileDialogFlags.HideSideBar))
         {
-            if (ImGui.BeginChild("##FileDialog_ColumnChild", size))
+            if (ImGui.BeginChild("##FileDialog_ColumnChild"u8, size))
             {
-                ImGui.Columns(2, "##FileDialog_Columns");
+                ImGui.Columns(2, "##FileDialog_Columns"u8);
 
                 this.DrawSideBar(size with { X = Scaled(150) });
 
@@ -314,7 +314,7 @@ public partial class FileDialog
 
     private void DrawSideBar(Vector2 size)
     {
-        if (ImGui.BeginChild("##FileDialog_SideBar", size))
+        if (ImGui.BeginChild("##FileDialog_SideBar"u8, size))
         {
             ImGui.SetCursorPosY(ImGui.GetCursorPosY() + Scaled(5));
 
@@ -344,14 +344,14 @@ public partial class FileDialog
 
     private unsafe void DrawFileListView(Vector2 size)
     {
-        if (!ImGui.BeginChild("##FileDialog_FileList", size))
+        if (!ImGui.BeginChild("##FileDialog_FileList"u8, size))
         {
             ImGui.EndChild();
             return;
         }
 
         const ImGuiTableFlags tableFlags = ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg | ImGuiTableFlags.Hideable | ImGuiTableFlags.ScrollY | ImGuiTableFlags.NoHostExtendX;
-        if (ImGui.BeginTable("##FileTable", 4, tableFlags, size))
+        if (ImGui.BeginTable("##FileTable"u8, 4, tableFlags, size))
         {
             ImGui.TableSetupScrollFreeze(0, 1);
 
@@ -359,10 +359,10 @@ public partial class FileDialog
             var hideSize = this.flags.HasFlag(ImGuiFileDialogFlags.HideColumnSize);
             var hideDate = this.flags.HasFlag(ImGuiFileDialogFlags.HideColumnDate);
 
-            ImGui.TableSetupColumn(" File Name", ImGuiTableColumnFlags.WidthStretch, -1, 0);
-            ImGui.TableSetupColumn("Type", ImGuiTableColumnFlags.WidthFixed | (hideType ? ImGuiTableColumnFlags.DefaultHide : ImGuiTableColumnFlags.None), -1, 1);
-            ImGui.TableSetupColumn("Size", ImGuiTableColumnFlags.WidthFixed | (hideSize ? ImGuiTableColumnFlags.DefaultHide : ImGuiTableColumnFlags.None), -1, 2);
-            ImGui.TableSetupColumn("Date", ImGuiTableColumnFlags.WidthFixed | (hideDate ? ImGuiTableColumnFlags.DefaultHide : ImGuiTableColumnFlags.None), -1, 3);
+            ImGui.TableSetupColumn(" File Name"u8, ImGuiTableColumnFlags.WidthStretch, -1, 0);
+            ImGui.TableSetupColumn("Type"u8, ImGuiTableColumnFlags.WidthFixed | (hideType ? ImGuiTableColumnFlags.DefaultHide : ImGuiTableColumnFlags.None), -1, 1);
+            ImGui.TableSetupColumn("Size"u8, ImGuiTableColumnFlags.WidthFixed | (hideSize ? ImGuiTableColumnFlags.DefaultHide : ImGuiTableColumnFlags.None), -1, 2);
+            ImGui.TableSetupColumn("Date"u8, ImGuiTableColumnFlags.WidthFixed | (hideDate ? ImGuiTableColumnFlags.DefaultHide : ImGuiTableColumnFlags.None), -1, 3);
 
             ImGui.TableNextRow(ImGuiTableRowFlags.Headers);
             for (var column = 0; column < 4; column++)
@@ -425,7 +425,7 @@ public partial class FileDialog
                                 }
                                 else
                                 {
-                                    ImGui.TextUnformatted(" ");
+                                    ImGui.TextUnformatted(" "u8);
                                 }
                             }
 
@@ -682,11 +682,11 @@ public partial class FileDialog
 
         if (this.IsDirectoryMode())
         {
-            ImGui.TextUnformatted("Directory Path :");
+            ImGui.TextUnformatted("Directory Path :"u8);
         }
         else
         {
-            ImGui.TextUnformatted("File Name :");
+            ImGui.TextUnformatted("File Name :"u8);
         }
 
         ImGui.SameLine();
@@ -701,7 +701,7 @@ public partial class FileDialog
 
         ImGui.SetNextItemWidth(width);
         if (selectOnly) ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f);
-        ImGui.InputText("##FileName", ref this.fileNameBuffer, 255, selectOnly ? ImGuiInputTextFlags.ReadOnly : ImGuiInputTextFlags.None);
+        ImGui.InputText("##FileName"u8, ref this.fileNameBuffer, 255, selectOnly ? ImGuiInputTextFlags.ReadOnly : ImGuiInputTextFlags.None);
         if (selectOnly) ImGui.PopStyleVar();
 
         if (this.filters.Count > 0)
@@ -710,7 +710,7 @@ public partial class FileDialog
             var needToApplyNewFilter = false;
 
             ImGui.SetNextItemWidth(Scaled(150f));
-            if (ImGui.BeginCombo("##Filters", this.selectedFilter.Filter, ImGuiComboFlags.None))
+            if (ImGui.BeginCombo("##Filters"u8, this.selectedFilter.Filter, ImGuiComboFlags.None))
             {
                 var idx = 0;
                 foreach (var filter in this.filters)
@@ -742,7 +742,7 @@ public partial class FileDialog
         var disableOk = string.IsNullOrEmpty(this.fileNameBuffer) || (selectOnly && !this.IsItemSelected());
         if (disableOk) ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f);
 
-        if (ImGui.Button("Ok") && !disableOk)
+        if (ImGui.Button("Ok"u8) && !disableOk)
         {
             this.isOk = true;
             res = true;
@@ -752,7 +752,7 @@ public partial class FileDialog
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Cancel"))
+        if (ImGui.Button("Cancel"u8))
         {
             this.isOk = false;
             res = true;
@@ -805,8 +805,8 @@ public partial class FileDialog
             ImGui.OpenPopup(name);
             if (ImGui.BeginPopupModal(name, ref open, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove))
             {
-                ImGui.TextUnformatted("Would you like to Overwrite it ?");
-                if (ImGui.Button("Confirm"))
+                ImGui.TextUnformatted("Would you like to Overwrite it ?"u8);
+                if (ImGui.Button("Confirm"u8))
                 {
                     this.okResultToConfirm = false;
                     this.isOk = true;
@@ -815,7 +815,7 @@ public partial class FileDialog
                 }
 
                 ImGui.SameLine();
-                if (ImGui.Button("Cancel"))
+                if (ImGui.Button("Cancel"u8))
                 {
                     this.okResultToConfirm = false;
                     this.isOk = false;

--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.UI.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.UI.cs
@@ -226,7 +226,7 @@ public partial class FileDialog
         if (!this.createDirectoryMode)
         {
             ImGui.SameLine();
-            ImGui.TextUnformatted("Search :"u8);
+            ImGui.Text("Search :"u8);
             ImGui.SameLine();
             ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
             if (ImGui.InputText("##InputImGuiFileDialogSearchField"u8, ref this.searchBuffer, 255))
@@ -257,7 +257,7 @@ public partial class FileDialog
         if (this.createDirectoryMode)
         {
             ImGui.SameLine();
-            ImGui.TextUnformatted("New Directory Name"u8);
+            ImGui.Text("New Directory Name"u8);
 
             ImGui.SameLine();
             ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X - Scaled(100));
@@ -332,7 +332,7 @@ public partial class FileDialog
                 ImGui.PushFont(InterfaceManager.IconFont);
                 ImGui.SameLine();
                 ImGui.SetCursorPosX(0);
-                ImGui.TextUnformatted(qa.Icon.ToIconString());
+                ImGui.Text(qa.Icon.ToIconString());
 
                 ImGui.PopFont();
                 ImGui.PopID();
@@ -414,18 +414,18 @@ public partial class FileDialog
 
                             if (ImGui.TableNextColumn())
                             {
-                                ImGui.TextUnformatted(file.Ext);
+                                ImGui.Text(file.Ext);
                             }
 
                             if (ImGui.TableNextColumn())
                             {
                                 if (file.Type == FileStructType.File)
                                 {
-                                    ImGui.TextUnformatted(file.FormattedFileSize + " ");
+                                    ImGui.Text(file.FormattedFileSize + " ");
                                 }
                                 else
                                 {
-                                    ImGui.TextUnformatted(" "u8);
+                                    ImGui.Text(" "u8);
                                 }
                             }
 
@@ -433,7 +433,7 @@ public partial class FileDialog
                             {
                                 var sz = ImGui.CalcTextSize(file.FileModifiedDate);
                                 ImGui.SetNextItemWidth(sz.X + Scaled(5));
-                                ImGui.TextUnformatted(file.FileModifiedDate + " ");
+                                ImGui.Text(file.FileModifiedDate + " ");
                             }
 
                             ImGui.PopStyleColor();
@@ -478,7 +478,7 @@ public partial class FileDialog
 
         ImGui.PushFont(InterfaceManager.IconFont);
 
-        ImGui.TextUnformatted(icon.ToIconString());
+        ImGui.Text(icon.ToIconString());
         ImGui.PopFont();
 
         ImGui.SameLine(Scaled(25f));
@@ -682,11 +682,11 @@ public partial class FileDialog
 
         if (this.IsDirectoryMode())
         {
-            ImGui.TextUnformatted("Directory Path :"u8);
+            ImGui.Text("Directory Path :"u8);
         }
         else
         {
-            ImGui.TextUnformatted("File Name :"u8);
+            ImGui.Text("File Name :"u8);
         }
 
         ImGui.SameLine();
@@ -805,7 +805,7 @@ public partial class FileDialog
             ImGui.OpenPopup(name);
             if (ImGui.BeginPopupModal(name, ref open, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove))
             {
-                ImGui.TextUnformatted("Would you like to Overwrite it ?"u8);
+                ImGui.Text("Would you like to Overwrite it ?"u8);
                 if (ImGui.Button("Confirm"u8))
                 {
                     this.okResultToConfirm = false;

--- a/Dalamud/Interface/ImGuiFontChooserDialog/SingleFontChooserDialog.cs
+++ b/Dalamud/Interface/ImGuiFontChooserDialog/SingleFontChooserDialog.cs
@@ -391,16 +391,16 @@ public sealed class SingleFontChooserDialog : IDisposable
         var baseOffset = ImGui.GetCursorPos() - windowPad;
 
         var actionSize = Vector2.Zero;
-        actionSize = Vector2.Max(actionSize, ImGui.CalcTextSize("OK"));
-        actionSize = Vector2.Max(actionSize, ImGui.CalcTextSize("Cancel"));
-        actionSize = Vector2.Max(actionSize, ImGui.CalcTextSize("Refresh"));
-        actionSize = Vector2.Max(actionSize, ImGui.CalcTextSize("Reset"));
+        actionSize = Vector2.Max(actionSize, ImGui.CalcTextSize("OK"u8));
+        actionSize = Vector2.Max(actionSize, ImGui.CalcTextSize("Cancel"u8));
+        actionSize = Vector2.Max(actionSize, ImGui.CalcTextSize("Refresh"u8));
+        actionSize = Vector2.Max(actionSize, ImGui.CalcTextSize("Reset"u8));
         actionSize += framePad * 2;
 
         var bodySize = ImGui.GetContentRegionAvail();
         ImGui.SetCursorPos(baseOffset + windowPad);
         if (ImGui.BeginChild(
-                "##choicesBlock",
+                "##choicesBlock"u8,
                 bodySize with { X = bodySize.X - windowPad.X - actionSize.X },
                 false,
                 ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse))
@@ -412,7 +412,7 @@ public sealed class SingleFontChooserDialog : IDisposable
 
         ImGui.SetCursorPos(baseOffset + windowPad + new Vector2(bodySize.X - actionSize.X, 0));
 
-        if (ImGui.BeginChild("##actionsBlock", bodySize with { X = actionSize.X }))
+        if (ImGui.BeginChild("##actionsBlock"u8, bodySize with { X = actionSize.X }))
         {
             this.DrawActionButtons(actionSize);
         }
@@ -460,25 +460,25 @@ public sealed class SingleFontChooserDialog : IDisposable
         var tableSize = ImGui.GetContentRegionAvail() -
                         new Vector2(0, ImGui.GetStyle().WindowPadding.Y + previewHeight + advancedOptionsHeight);
         if (ImGui.BeginChild(
-                "##tableContainer",
+                "##tableContainer"u8,
                 tableSize,
                 false,
                 ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse)
-            && ImGui.BeginTable("##table", 3, ImGuiTableFlags.None))
+            && ImGui.BeginTable("##table"u8, 3, ImGuiTableFlags.None))
         {
             ImGui.PushStyleColor(ImGuiCol.TableHeaderBg, Vector4.Zero);
             ImGui.PushStyleColor(ImGuiCol.HeaderHovered, Vector4.Zero);
             ImGui.PushStyleColor(ImGuiCol.HeaderActive, Vector4.Zero);
             ImGui.TableSetupColumn(
-                "Font:##familyColumn",
+                "Font:##familyColumn"u8,
                 ImGuiTableColumnFlags.WidthStretch,
                 0.4f);
             ImGui.TableSetupColumn(
-                "Style:##fontColumn",
+                "Style:##fontColumn"u8,
                 ImGuiTableColumnFlags.WidthStretch,
                 0.4f);
             ImGui.TableSetupColumn(
-                "Size:##sizeColumn",
+                "Size:##sizeColumn"u8,
                 ImGuiTableColumnFlags.WidthStretch,
                 0.2f);
             ImGui.TableHeadersRow();
@@ -510,7 +510,7 @@ public sealed class SingleFontChooserDialog : IDisposable
 
         ImGui.EndChild();
 
-        ImGui.Checkbox("Show advanced options", ref this.useAdvancedOptions);
+        ImGui.Checkbox("Show advanced options"u8, ref this.useAdvancedOptions);
         if (this.useAdvancedOptions)
         {
             if (this.DrawAdvancedOptions())
@@ -539,7 +539,7 @@ public sealed class SingleFontChooserDialog : IDisposable
         if (this.fontHandle is null)
         {
             ImGui.SetCursorPos(ImGui.GetCursorPos() + ImGui.GetStyle().FramePadding);
-            ImGui.TextUnformatted("Select a font.");
+            ImGui.TextUnformatted("Select a font."u8);
         }
         else if (this.fontHandle.LoadException is { } loadException)
         {
@@ -551,7 +551,7 @@ public sealed class SingleFontChooserDialog : IDisposable
         else if (!this.fontHandle.Available)
         {
             ImGui.SetCursorPos(ImGui.GetCursorPos() + ImGui.GetStyle().FramePadding);
-            ImGui.TextUnformatted("Loading font...");
+            ImGui.TextUnformatted("Loading font..."u8);
         }
         else
         {
@@ -571,7 +571,7 @@ public sealed class SingleFontChooserDialog : IDisposable
         if (this.fontFamilies?.IsCompleted is not true)
         {
             ImGui.SetScrollY(0);
-            ImGui.TextUnformatted("Loading...");
+            ImGui.TextUnformatted("Loading..."u8);
             return false;
         }
 
@@ -593,7 +593,7 @@ public sealed class SingleFontChooserDialog : IDisposable
 
         var changed = false;
         if (ImGui.InputText(
-                "##familySearch",
+                "##familySearch"u8,
                 ref this.familySearch,
                 255,
                 ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.CallbackHistory,
@@ -676,7 +676,7 @@ public sealed class SingleFontChooserDialog : IDisposable
             }
         }
 
-        if (ImGui.BeginChild("##familyList", ImGui.GetContentRegionAvail()))
+        if (ImGui.BeginChild("##familyList"u8, ImGui.GetContentRegionAvail()))
         {
             var clipper = ImGui.ImGuiListClipper();
             var lineHeight = ImGui.GetTextLineHeightWithSpacing();
@@ -695,7 +695,7 @@ public sealed class SingleFontChooserDialog : IDisposable
                 {
                     if (i < 0)
                     {
-                        ImGui.TextUnformatted(" ");
+                        ImGui.TextUnformatted(" "u8);
                         continue;
                     }
 
@@ -735,7 +735,7 @@ public sealed class SingleFontChooserDialog : IDisposable
     {
         if (this.fontFamilies?.IsCompleted is not true)
         {
-            ImGui.TextUnformatted("Loading...");
+            ImGui.TextUnformatted("Loading..."u8);
             return changed;
         }
 
@@ -761,7 +761,7 @@ public sealed class SingleFontChooserDialog : IDisposable
         }
 
         if (ImGui.InputText(
-                "##fontSearch",
+                "##fontSearch"u8,
                 ref this.fontSearch,
                 255,
                 ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.CallbackHistory,
@@ -843,7 +843,7 @@ public sealed class SingleFontChooserDialog : IDisposable
             }
         }
 
-        if (ImGui.BeginChild("##fontList"))
+        if (ImGui.BeginChild("##fontList"u8))
         {
             var clipper = ImGui.ImGuiListClipper();
             var lineHeight = ImGui.GetTextLineHeightWithSpacing();
@@ -862,7 +862,7 @@ public sealed class SingleFontChooserDialog : IDisposable
                 {
                     if (i < 0)
                     {
-                        ImGui.TextUnformatted(" ");
+                        ImGui.TextUnformatted(" "u8);
                         continue;
                     }
 
@@ -909,7 +909,7 @@ public sealed class SingleFontChooserDialog : IDisposable
         }
 
         if (ImGui.InputText(
-                "##fontSizeSearch",
+                "##fontSizeSearch"u8,
                 ref this.fontSizeSearch,
                 255,
                 ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.CallbackHistory |
@@ -947,7 +947,7 @@ public sealed class SingleFontChooserDialog : IDisposable
             }
         }
 
-        if (ImGui.BeginChild("##fontSizeList"))
+        if (ImGui.BeginChild("##fontSizeList"u8))
         {
             var clipper = ImGui.ImGuiListClipper();
             var lineHeight = ImGui.GetTextLineHeightWithSpacing();
@@ -966,7 +966,7 @@ public sealed class SingleFontChooserDialog : IDisposable
                 {
                     if (i < 0)
                     {
-                        ImGui.TextUnformatted(" ");
+                        ImGui.TextUnformatted(" "u8);
                         continue;
                     }
 
@@ -1010,36 +1010,36 @@ public sealed class SingleFontChooserDialog : IDisposable
     {
         var changed = false;
 
-        if (!ImGui.BeginTable("##advancedOptions", 4))
+        if (!ImGui.BeginTable("##advancedOptions"u8, 4))
             return false;
 
-        var labelWidth = ImGui.CalcTextSize("Letter Spacing:").X;
-        labelWidth = Math.Max(labelWidth, ImGui.CalcTextSize("Offset:").X);
-        labelWidth = Math.Max(labelWidth, ImGui.CalcTextSize("Line Height:").X);
+        var labelWidth = ImGui.CalcTextSize("Letter Spacing:"u8).X;
+        labelWidth = Math.Max(labelWidth, ImGui.CalcTextSize("Offset:"u8).X);
+        labelWidth = Math.Max(labelWidth, ImGui.CalcTextSize("Line Height:"u8).X);
         labelWidth += ImGui.GetStyle().FramePadding.X;
 
-        var inputWidth = ImGui.CalcTextSize("000.000").X + (ImGui.GetStyle().FramePadding.X * 2);
+        var inputWidth = ImGui.CalcTextSize("000.000"u8).X + (ImGui.GetStyle().FramePadding.X * 2);
         ImGui.TableSetupColumn(
-            "##inputLabelColumn",
+            "##inputLabelColumn"u8,
             ImGuiTableColumnFlags.WidthFixed,
             labelWidth);
         ImGui.TableSetupColumn(
-            "##input1Column",
+            "##input1Column"u8,
             ImGuiTableColumnFlags.WidthFixed,
             inputWidth);
         ImGui.TableSetupColumn(
-            "##input2Column",
+            "##input2Column"u8,
             ImGuiTableColumnFlags.WidthFixed,
             inputWidth);
         ImGui.TableSetupColumn(
-            "##fillerColumn",
+            "##fillerColumn"u8,
             ImGuiTableColumnFlags.WidthStretch,
             1f);
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
         ImGui.AlignTextToFramePadding();
-        ImGui.TextUnformatted("Offset:");
+        ImGui.TextUnformatted("Offset:"u8);
 
         ImGui.TableNextColumn();
         if (FloatInputText(
@@ -1070,7 +1070,7 @@ public sealed class SingleFontChooserDialog : IDisposable
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
         ImGui.AlignTextToFramePadding();
-        ImGui.TextUnformatted("Letter Spacing:");
+        ImGui.TextUnformatted("Letter Spacing:"u8);
 
         ImGui.TableNextColumn();
         if (FloatInputText(
@@ -1085,7 +1085,7 @@ public sealed class SingleFontChooserDialog : IDisposable
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
         ImGui.AlignTextToFramePadding();
-        ImGui.TextUnformatted("Line Height:");
+        ImGui.TextUnformatted("Line Height:"u8);
 
         ImGui.TableNextColumn();
         if (FloatInputText(
@@ -1159,15 +1159,15 @@ public sealed class SingleFontChooserDialog : IDisposable
             || this.FontFamilyExcludeFilter?.Invoke(this.selectedFont.FontId.Family) is true)
         {
             ImGui.BeginDisabled();
-            ImGui.Button("OK", buttonSize);
+            ImGui.Button("OK"u8, buttonSize);
             ImGui.EndDisabled();
         }
-        else if (ImGui.Button("OK", buttonSize))
+        else if (ImGui.Button("OK"u8, buttonSize))
         {
             this.tcs.SetResult(this.selectedFont);
         }
 
-        if (ImGui.Button("Cancel", buttonSize))
+        if (ImGui.Button("Cancel"u8, buttonSize))
         {
             this.Cancel();
         }
@@ -1178,10 +1178,10 @@ public sealed class SingleFontChooserDialog : IDisposable
         {
             isFirst = doRefresh = this.fontFamilies is null;
             ImGui.BeginDisabled();
-            ImGui.Button("Refresh", buttonSize);
+            ImGui.Button("Refresh"u8, buttonSize);
             ImGui.EndDisabled();
         }
-        else if (ImGui.Button("Refresh", buttonSize))
+        else if (ImGui.Button("Refresh"u8, buttonSize))
         {
             doRefresh = true;
         }
@@ -1218,7 +1218,7 @@ public sealed class SingleFontChooserDialog : IDisposable
 
         if (this.useAdvancedOptions)
         {
-            if (ImGui.Button("Reset", buttonSize))
+            if (ImGui.Button("Reset"u8, buttonSize))
             {
                 this.selectedFont = this.selectedFont with
                 {

--- a/Dalamud/Interface/ImGuiFontChooserDialog/SingleFontChooserDialog.cs
+++ b/Dalamud/Interface/ImGuiFontChooserDialog/SingleFontChooserDialog.cs
@@ -539,19 +539,19 @@ public sealed class SingleFontChooserDialog : IDisposable
         if (this.fontHandle is null)
         {
             ImGui.SetCursorPos(ImGui.GetCursorPos() + ImGui.GetStyle().FramePadding);
-            ImGui.TextUnformatted("Select a font."u8);
+            ImGui.Text("Select a font."u8);
         }
         else if (this.fontHandle.LoadException is { } loadException)
         {
             ImGui.SetCursorPos(ImGui.GetCursorPos() + ImGui.GetStyle().FramePadding);
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-            ImGui.TextUnformatted(loadException.Message);
+            ImGui.Text(loadException.Message);
             ImGui.PopStyleColor();
         }
         else if (!this.fontHandle.Available)
         {
             ImGui.SetCursorPos(ImGui.GetCursorPos() + ImGui.GetStyle().FramePadding);
-            ImGui.TextUnformatted("Loading font..."u8);
+            ImGui.Text("Loading font..."u8);
         }
         else
         {
@@ -571,14 +571,14 @@ public sealed class SingleFontChooserDialog : IDisposable
         if (this.fontFamilies?.IsCompleted is not true)
         {
             ImGui.SetScrollY(0);
-            ImGui.TextUnformatted("Loading..."u8);
+            ImGui.Text("Loading..."u8);
             return false;
         }
 
         if (!this.fontFamilies.IsCompletedSuccessfully)
         {
             ImGui.SetScrollY(0);
-            ImGui.TextUnformatted("Error: " + this.fontFamilies.Exception);
+            ImGui.Text("Error: " + this.fontFamilies.Exception);
             return false;
         }
 
@@ -695,7 +695,7 @@ public sealed class SingleFontChooserDialog : IDisposable
                 {
                     if (i < 0)
                     {
-                        ImGui.TextUnformatted(" "u8);
+                        ImGui.Text(" "u8);
                         continue;
                     }
 
@@ -735,13 +735,13 @@ public sealed class SingleFontChooserDialog : IDisposable
     {
         if (this.fontFamilies?.IsCompleted is not true)
         {
-            ImGui.TextUnformatted("Loading..."u8);
+            ImGui.Text("Loading..."u8);
             return changed;
         }
 
         if (!this.fontFamilies.IsCompletedSuccessfully)
         {
-            ImGui.TextUnformatted("Error: " + this.fontFamilies.Exception);
+            ImGui.Text("Error: " + this.fontFamilies.Exception);
             return changed;
         }
 
@@ -862,7 +862,7 @@ public sealed class SingleFontChooserDialog : IDisposable
                 {
                     if (i < 0)
                     {
-                        ImGui.TextUnformatted(" "u8);
+                        ImGui.Text(" "u8);
                         continue;
                     }
 
@@ -966,7 +966,7 @@ public sealed class SingleFontChooserDialog : IDisposable
                 {
                     if (i < 0)
                     {
-                        ImGui.TextUnformatted(" "u8);
+                        ImGui.Text(" "u8);
                         continue;
                     }
 
@@ -1039,7 +1039,7 @@ public sealed class SingleFontChooserDialog : IDisposable
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
         ImGui.AlignTextToFramePadding();
-        ImGui.TextUnformatted("Offset:"u8);
+        ImGui.Text("Offset:"u8);
 
         ImGui.TableNextColumn();
         if (FloatInputText(
@@ -1070,7 +1070,7 @@ public sealed class SingleFontChooserDialog : IDisposable
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
         ImGui.AlignTextToFramePadding();
-        ImGui.TextUnformatted("Letter Spacing:"u8);
+        ImGui.Text("Letter Spacing:"u8);
 
         ImGui.TableNextColumn();
         if (FloatInputText(
@@ -1085,7 +1085,7 @@ public sealed class SingleFontChooserDialog : IDisposable
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
         ImGui.AlignTextToFramePadding();
-        ImGui.TextUnformatted("Line Height:"u8);
+        ImGui.Text("Line Height:"u8);
 
         ImGui.TableNextColumn();
         if (FloatInputText(

--- a/Dalamud/Interface/ImGuiNotification/Internal/ActiveNotification.ImGui.cs
+++ b/Dalamud/Interface/ImGuiNotification/Internal/ActiveNotification.ImGui.cs
@@ -383,7 +383,7 @@ internal sealed partial class ActiveNotification
             ImGui.PushStyleVar(ImGuiStyleVar.Alpha, ImGui.GetStyle().Alpha * relativeOpacity);
             ImGui.SetCursorPos(new(NotificationConstants.ScaledWindowPadding));
             ImGui.PushStyleColor(ImGuiCol.Text, NotificationConstants.WhenTextColor);
-            ImGui.TextUnformatted(
+            ImGui.Text(
                 ImGui.IsWindowHovered(ImGuiHoveredFlags.AllowWhenBlockedByActiveItem)
                     ? this.CreatedAt.LocAbsolute()
                     : ReducedMotions
@@ -404,7 +404,7 @@ internal sealed partial class ActiveNotification
             var agoSize = ImGui.CalcTextSize(agoText);
             ImGui.SetCursorPos(new(width - ((height + agoSize.X) / 2f), NotificationConstants.ScaledWindowPadding));
             ImGui.PushStyleColor(ImGuiCol.Text, NotificationConstants.WhenTextColor);
-            ImGui.TextUnformatted(agoText);
+            ImGui.Text(agoText);
             ImGui.PopStyleColor();
 
             this.DrawIcon(
@@ -415,7 +415,7 @@ internal sealed partial class ActiveNotification
                 windowPos + new Vector2(width - height, height),
                 true);
             ImGui.SetCursorPos(new(height, NotificationConstants.ScaledWindowPadding));
-            ImGui.TextUnformatted(this.EffectiveMinimizedText);
+            ImGui.Text(this.EffectiveMinimizedText);
             ImGui.PopClipRect();
 
             ImGui.PopStyleVar();
@@ -502,13 +502,13 @@ internal sealed partial class ActiveNotification
         if ((this.Title ?? this.Type.ToTitle()) is { } title)
         {
             ImGui.PushStyleColor(ImGuiCol.Text, NotificationConstants.TitleTextColor);
-            ImGui.TextUnformatted(title);
+            ImGui.Text(title);
             ImGui.PopStyleColor();
         }
 
         ImGui.PushStyleColor(ImGuiCol.Text, NotificationConstants.BlameTextColor);
         ImGui.SetCursorPos(minCoord with { Y = ImGui.GetCursorPosY() });
-        ImGui.TextUnformatted(this.InitiatorString);
+        ImGui.Text(this.InitiatorString);
         ImGui.PopStyleColor();
 
         ImGui.PopTextWrapPos();
@@ -520,7 +520,7 @@ internal sealed partial class ActiveNotification
         ImGui.SetCursorPos(minCoord);
         ImGui.PushTextWrapPos(minCoord.X + width);
         ImGui.PushStyleColor(ImGuiCol.Text, NotificationConstants.BodyTextColor);
-        ImGui.TextUnformatted(this.Content);
+        ImGui.Text(this.Content);
         ImGui.PopStyleColor();
         ImGui.PopTextWrapPos();
     }

--- a/Dalamud/Interface/ImGuiNotification/Internal/NotificationPositionChooser.cs
+++ b/Dalamud/Interface/ImGuiNotification/Internal/NotificationPositionChooser.cs
@@ -54,7 +54,7 @@ internal class NotificationPositionChooser
         ImGui.SetNextWindowBgAlpha(0.6f);
 
         ImGui.Begin(
-            "###NotificationPositionChooser",
+            "###NotificationPositionChooser"u8,
             ImGuiWindowFlags.NoDocking | ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoMove |
             ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoFocusOnAppearing | ImGuiWindowFlags.NoNav);
 

--- a/Dalamud/Interface/ImGuiSeStringRenderer/Internal/SeStringRenderer.cs
+++ b/Dalamud/Interface/ImGuiSeStringRenderer/Internal/SeStringRenderer.cs
@@ -203,7 +203,7 @@ internal unsafe class SeStringRenderer : IInternalDisposableService
 
                     var cursorPosBackup = ImGui.GetCursorScreenPos();
                     ImGui.SetCursorScreenPos(state.ScreenOffset + f.Offset);
-                    clicked = ImGui.InvisibleButton("##link", sz, buttonFlags);
+                    clicked = ImGui.InvisibleButton("##link"u8, sz, buttonFlags);
                     if (ImGui.IsItemHovered())
                         hoveredLinkOffset = f.Link;
                     if (ImGui.IsItemActive())
@@ -218,7 +218,7 @@ internal unsafe class SeStringRenderer : IInternalDisposableService
             if (!invisibleButtonDrawn)
             {
                 ImGui.SetCursorScreenPos(state.ScreenOffset);
-                clicked = ImGui.InvisibleButton("##text", itemSize, buttonFlags);
+                clicked = ImGui.InvisibleButton("##text"u8, itemSize, buttonFlags);
             }
 
             ImGui.PopID();

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -656,7 +656,7 @@ internal class DalamudInterface : IInternalDisposableService
                         ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoMouseInputs |
                         ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoSavedSettings))
                 {
-                    ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, "Is force MinHook!"u8);
+                    ImGui.TextColoredWrapped(ImGuiColors.DalamudRed, "Is force MinHook!"u8);
                 }
 
                 ImGui.End();

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -606,7 +606,7 @@ internal class DalamudInterface : IInternalDisposableService
         ImGui.SetNextWindowBgAlpha(Math.Min(this.creditsDarkeningAnimation.EasedPoint.X, CreditsDarkeningMaxAlpha));
 
         ImGui.Begin(
-            "###CreditsDarkenWindow",
+            "###CreditsDarkenWindow"u8,
             ImGuiWindowFlags.NoInputs | ImGuiWindowFlags.NoDocking | ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoMove |
             ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoFocusOnAppearing | ImGuiWindowFlags.NoBringToFrontOnFocus |
             ImGuiWindowFlags.NoNav);
@@ -635,10 +635,10 @@ internal class DalamudInterface : IInternalDisposableService
             ImGui.SetNextWindowPos(windowPos, ImGuiCond.Always);
             ImGui.SetNextWindowBgAlpha(1);
 
-            if (ImGui.Begin("DevMenu Opener", ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoBackground | ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoSavedSettings))
+            if (ImGui.Begin("DevMenu Opener"u8, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoBackground | ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoSavedSettings))
             {
                 ImGui.SetNextItemWidth(40);
-                if (ImGui.Button("###devMenuOpener", new Vector2(20, 20)))
+                if (ImGui.Button("###devMenuOpener"u8, new Vector2(20, 20)))
                     this.isImGuiDrawDevMenu = true;
             }
 
@@ -650,13 +650,13 @@ internal class DalamudInterface : IInternalDisposableService
                 ImGui.SetNextWindowBgAlpha(1);
 
                 if (ImGui.Begin(
-                        "Disclaimer",
+                        "Disclaimer"u8,
                         ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoBackground |
                         ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove |
                         ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoMouseInputs |
                         ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoSavedSettings))
                 {
-                    ImGui.TextColored(ImGuiColors.DalamudRed, "Is force MinHook!");
+                    ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, "Is force MinHook!"u8);
                 }
 
                 ImGui.End();
@@ -672,11 +672,11 @@ internal class DalamudInterface : IInternalDisposableService
             {
                 var pluginManager = Service<PluginManager>.Get();
 
-                if (ImGui.BeginMenu("Dalamud"))
+                if (ImGui.BeginMenu("Dalamud"u8))
                 {
-                    ImGui.MenuItem("Draw dev menu", string.Empty, ref this.isImGuiDrawDevMenu);
-                    var devBarAtStartup = this.configuration.DevBarOpenAtStartup;
-                    if (ImGui.MenuItem("Draw dev menu at startup", string.Empty, ref devBarAtStartup))
+                    ImGui.MenuItem("Draw dev menu"u8, (byte*)null, ref this.isImGuiDrawDevMenu);
+
+                    if (ImGui.MenuItem("Draw dev menu at startup"u8, (byte*)null, this.configuration.DevBarOpenAtStartup))
                     {
                         this.configuration.DevBarOpenAtStartup ^= true;
                         this.configuration.QueueSave();
@@ -684,16 +684,16 @@ internal class DalamudInterface : IInternalDisposableService
 
                     ImGui.Separator();
 
-                    if (ImGui.MenuItem("Open Log window"))
+                    if (ImGui.MenuItem("Open Log window"u8))
                     {
                         this.OpenLogWindow();
                     }
 
-                    if (ImGui.BeginMenu("Set log level..."))
+                    if (ImGui.BeginMenu("Set log level..."u8))
                     {
                         foreach (var logLevel in Enum.GetValues(typeof(LogEventLevel)).Cast<LogEventLevel>())
                         {
-                            if (ImGui.MenuItem(logLevel + "##logLevelSwitch", string.Empty, EntryPoint.LogLevelSwitch.MinimumLevel == logLevel))
+                            if (ImGui.MenuItem(logLevel + "##logLevelSwitch", (byte*)null, EntryPoint.LogLevelSwitch.MinimumLevel == logLevel))
                             {
                                 EntryPoint.LogLevelSwitch.MinimumLevel = logLevel;
                                 this.configuration.LogLevel = logLevel;
@@ -704,10 +704,9 @@ internal class DalamudInterface : IInternalDisposableService
                         ImGui.EndMenu();
                     }
 
-                    var logSynchronously = this.configuration.LogSynchronously;
-                    if (ImGui.MenuItem("Log Synchronously", (byte*)null, ref logSynchronously))
+                    if (ImGui.MenuItem("Log Synchronously"u8, (byte*)null, this.configuration.LogSynchronously))
                     {
-                        this.configuration.LogSynchronously = logSynchronously;
+                        this.configuration.LogSynchronously ^= true;
                         this.configuration.QueueSave();
 
                         EntryPoint.InitLogging(
@@ -719,78 +718,78 @@ internal class DalamudInterface : IInternalDisposableService
 
                     ImGui.Separator();
 
-                    if (ImGui.MenuItem("Open Data window"))
+                    if (ImGui.MenuItem("Open Data window"u8))
                     {
                         this.OpenDataWindow();
                     }
 
-                    if (ImGui.MenuItem("Open Settings window"))
+                    if (ImGui.MenuItem("Open Settings window"u8))
                     {
                         this.OpenSettings();
                     }
 
-                    if (ImGui.MenuItem("Open Changelog window"))
+                    if (ImGui.MenuItem("Open Changelog window"u8))
                     {
                         this.OpenChangelogWindow();
                     }
 
-                    if (ImGui.MenuItem("Open Components Demo"))
+                    if (ImGui.MenuItem("Open Components Demo"u8))
                     {
                         this.OpenComponentDemoWindow();
                     }
 
-                    if (ImGui.MenuItem("Open Colors Demo"))
+                    if (ImGui.MenuItem("Open Colors Demo"u8))
                     {
                         this.OpenColorsDemoWindow();
                     }
 
-                    if (ImGui.MenuItem("Open Self-Test"))
+                    if (ImGui.MenuItem("Open Self-Test"u8))
                     {
                         this.OpenSelfTest();
                     }
 
-                    if (ImGui.MenuItem("Open Style Editor"))
+                    if (ImGui.MenuItem("Open Style Editor"u8))
                     {
                         this.OpenStyleEditor();
                     }
 
-                    if (ImGui.MenuItem("Open Profiler"))
+                    if (ImGui.MenuItem("Open Profiler"u8))
                     {
                         this.OpenProfiler();
                     }
 
-                    if (ImGui.MenuItem("Open Hitch Settings"))
+                    if (ImGui.MenuItem("Open Hitch Settings"u8))
                     {
                         this.OpenHitchSettings();
                     }
 
                     ImGui.Separator();
 
-                    if (ImGui.MenuItem("Unload Dalamud"))
+                    if (ImGui.MenuItem("Unload Dalamud"u8))
                     {
                         Service<Dalamud>.Get().Unload();
                     }
 
-                    if (ImGui.MenuItem("Restart game"))
+                    if (ImGui.MenuItem("Restart game"u8))
                     {
                         Dalamud.RestartGame();
                     }
 
-                    if (ImGui.MenuItem("Kill game"))
+                    if (ImGui.MenuItem("Kill game"u8))
                     {
                         Process.GetCurrentProcess().Kill();
                     }
 
                     ImGui.Separator();
 
-                    if (ImGui.BeginMenu("Crash game"))
+                    if (ImGui.BeginMenu("Crash game"u8))
                     {
-                        if (ImGui.MenuItem("Access Violation"))
+                        if (ImGui.MenuItem("Access Violation"u8))
                         {
                             Marshal.ReadByte(IntPtr.Zero);
                         }
 
-                        if (ImGui.MenuItem("Set UiModule to NULL"))
+                        if (ImGui.MenuItem("Set UiModule to NULL"u8))
                         {
                             unsafe
                             {
@@ -799,7 +798,7 @@ internal class DalamudInterface : IInternalDisposableService
                             }
                         }
 
-                        if (ImGui.MenuItem("Set UiModule to invalid ptr"))
+                        if (ImGui.MenuItem("Set UiModule to invalid ptr"u8))
                         {
                             unsafe
                             {
@@ -808,7 +807,7 @@ internal class DalamudInterface : IInternalDisposableService
                             }
                         }
 
-                        if (ImGui.MenuItem("Deref nullptr in Hook"))
+                        if (ImGui.MenuItem("Deref nullptr in Hook"u8))
                         {
                             unsafe
                             {
@@ -823,7 +822,7 @@ internal class DalamudInterface : IInternalDisposableService
                             }
                         }
 
-                        if (ImGui.MenuItem("Cause CLR fastfail"))
+                        if (ImGui.MenuItem("Cause CLR fastfail"u8))
                         {
                             unsafe void CauseFastFail()
                             {
@@ -835,7 +834,7 @@ internal class DalamudInterface : IInternalDisposableService
                             Service<Game.Framework>.Get().RunOnTick(CauseFastFail);
                         }
 
-                        if (ImGui.MenuItem("Cause ImGui assert"))
+                        if (ImGui.MenuItem("Cause ImGui assert"u8))
                         {
                             ImGui.PopStyleVar();
                             ImGui.PopStyleVar();
@@ -844,49 +843,47 @@ internal class DalamudInterface : IInternalDisposableService
                         ImGui.EndMenu();
                     }
 
-                    if (ImGui.MenuItem("Report crashes at shutdown", (byte*)null, this.configuration.ReportShutdownCrashes))
+                    if (ImGui.MenuItem("Report crashes at shutdown"u8, (byte*)null, this.configuration.ReportShutdownCrashes))
                     {
-                        this.configuration.ReportShutdownCrashes = !this.configuration.ReportShutdownCrashes;
+                        this.configuration.ReportShutdownCrashes ^= true;
                         this.configuration.QueueSave();
                     }
 
                     ImGui.Separator();
 
-                    if (ImGui.MenuItem("Open Dalamud branch switcher"))
+                    if (ImGui.MenuItem("Open Dalamud branch switcher"u8))
                     {
                         this.OpenBranchSwitcher();
                     }
 
-                    ImGui.MenuItem(this.dalamud.StartInfo.GameVersion?.ToString() ?? "Unknown version", false, false);
-                    ImGui.MenuItem($"D: {Util.GetScmVersion()} CS: {Util.GetGitHashClientStructs()}[{FFXIVClientStructs.ThisAssembly.Git.Commits}]", false, false);
-                    ImGui.MenuItem($"CLR: {Environment.Version}", false, false);
+                    ImGui.MenuItem(this.dalamud.StartInfo.GameVersion?.ToString() ?? "Unknown version", false);
+                    ImGui.MenuItem($"D: {Util.GetScmVersion()} CS: {Util.GetGitHashClientStructs()}[{FFXIVClientStructs.ThisAssembly.Git.Commits}]", false);
+                    ImGui.MenuItem($"CLR: {Environment.Version}", false);
 
                     ImGui.EndMenu();
                 }
 
-                if (ImGui.BeginMenu("GUI"))
+                if (ImGui.BeginMenu("GUI"u8))
                 {
-                    ImGui.MenuItem("Use Monospace font for following windows", string.Empty, ref this.isImGuiTestWindowsInMonospace);
-                    ImGui.MenuItem("Draw ImGui demo", string.Empty, ref this.isImGuiDrawDemoWindow);
-                    ImGui.MenuItem("Draw ImPlot demo", string.Empty, ref this.isImPlotDrawDemoWindow);
-                    ImGui.MenuItem("Draw metrics", string.Empty, ref this.isImGuiDrawMetricsWindow);
+                    ImGui.MenuItem("Use Monospace font for following windows"u8, (byte*)null, ref this.isImGuiTestWindowsInMonospace);
+                    ImGui.MenuItem("Draw ImGui demo"u8, (byte*)null, ref this.isImGuiDrawDemoWindow);
+                    ImGui.MenuItem("Draw ImPlot demo"u8, (byte*)null, ref this.isImPlotDrawDemoWindow);
+                    ImGui.MenuItem("Draw metrics"u8, (byte*)null, ref this.isImGuiDrawMetricsWindow);
 
                     ImGui.Separator();
 
-                    var showAsserts = this.interfaceManager.ShowAsserts;
-                    if (ImGui.MenuItem("Enable assert popups", string.Empty, ref showAsserts))
+                    if (ImGui.MenuItem("Enable assert popups"u8, (byte*)null, this.interfaceManager.ShowAsserts))
                     {
-                        this.interfaceManager.ShowAsserts = showAsserts;
+                        this.interfaceManager.ShowAsserts ^= true;
                     }
 
-                    var enableVerboseAsserts = this.interfaceManager.EnableVerboseAssertLogging;
-                    if (ImGui.MenuItem("Enable verbose assert logging", string.Empty, ref enableVerboseAsserts))
+                    if (ImGui.MenuItem("Enable verbose assert logging"u8, (byte*)null, this.interfaceManager.EnableVerboseAssertLogging))
                     {
-                        this.interfaceManager.EnableVerboseAssertLogging = enableVerboseAsserts;
+                        this.interfaceManager.EnableVerboseAssertLogging ^= true;
                     }
 
                     var assertsEnabled = this.configuration.ImGuiAssertsEnabledAtStartup ?? false;
-                    if (ImGui.MenuItem("Enable asserts at startup", (byte*)null, assertsEnabled))
+                    if (ImGui.MenuItem("Enable asserts at startup"u8, (byte*)null, assertsEnabled))
                     {
                         this.configuration.ImGuiAssertsEnabledAtStartup = !assertsEnabled;
                         this.configuration.QueueSave();
@@ -894,17 +891,17 @@ internal class DalamudInterface : IInternalDisposableService
 
                     ImGui.Separator();
 
-                    if (ImGui.MenuItem("Clear focus"))
+                    if (ImGui.MenuItem("Clear focus"u8))
                     {
                         ImGui.SetWindowFocus((byte*)null);
                     }
 
-                    if (ImGui.MenuItem("Clear stacks"))
+                    if (ImGui.MenuItem("Clear stacks"u8))
                     {
                         this.interfaceManager.ClearStacks();
                     }
 
-                    if (ImGui.MenuItem("Dump style"))
+                    if (ImGui.MenuItem("Dump style"u8))
                     {
                         var info = string.Empty;
                         var style = StyleModelV1.Get();
@@ -937,14 +934,14 @@ internal class DalamudInterface : IInternalDisposableService
                         Log.Information(info);
                     }
 
-                    if (ImGui.MenuItem("Show dev bar info", (byte*)null, this.configuration.ShowDevBarInfo))
+                    if (ImGui.MenuItem("Show dev bar info"u8, (byte*)null, this.configuration.ShowDevBarInfo))
                     {
-                        this.configuration.ShowDevBarInfo = !this.configuration.ShowDevBarInfo;
+                        this.configuration.ShowDevBarInfo ^= true;
                     }
 
                     ImGui.Separator();
 
-                    if (ImGui.MenuItem("Show loading window"))
+                    if (ImGui.MenuItem("Show loading window"u8))
                     {
                         var dialog = new LoadingDialog();
                         dialog.Show();
@@ -953,19 +950,19 @@ internal class DalamudInterface : IInternalDisposableService
                     ImGui.EndMenu();
                 }
 
-                if (ImGui.BeginMenu("Game"))
+                if (ImGui.BeginMenu("Game"u8))
                 {
-                    if (ImGui.MenuItem("Use in-game default ExceptionHandler"))
+                    if (ImGui.MenuItem("Use in-game default ExceptionHandler"u8))
                     {
                         this.dalamud.UseDefaultExceptionHandler();
                     }
 
-                    if (ImGui.MenuItem("Use in-game debug ExceptionHandler"))
+                    if (ImGui.MenuItem("Use in-game debug ExceptionHandler"u8))
                     {
                         this.dalamud.UseDebugExceptionHandler();
                     }
 
-                    if (ImGui.MenuItem("Disable in-game ExceptionHandler"))
+                    if (ImGui.MenuItem("Disable in-game ExceptionHandler"u8))
                     {
                         this.dalamud.UseNoExceptionHandler();
                     }
@@ -973,26 +970,26 @@ internal class DalamudInterface : IInternalDisposableService
                     ImGui.EndMenu();
                 }
 
-                if (ImGui.BeginMenu("Plugins"))
+                if (ImGui.BeginMenu("Plugins"u8))
                 {
-                    if (ImGui.MenuItem("Open Plugin installer"))
+                    if (ImGui.MenuItem("Open Plugin installer"u8))
                     {
                         this.OpenPluginInstaller();
                     }
 
-                    if (ImGui.MenuItem("Clear cached images/icons"))
+                    if (ImGui.MenuItem("Clear cached images/icons"u8))
                     {
                         this.pluginWindow?.ClearIconCache();
                     }
 
                     ImGui.Separator();
 
-                    if (ImGui.MenuItem("Open Plugin Stats"))
+                    if (ImGui.MenuItem("Open Plugin Stats"u8))
                     {
                         this.OpenPluginStats();
                     }
 
-                    if (ImGui.MenuItem("Print plugin info"))
+                    if (ImGui.MenuItem("Print plugin info"u8))
                     {
                         foreach (var plugin in pluginManager.InstalledPlugins)
                         {
@@ -1001,51 +998,51 @@ internal class DalamudInterface : IInternalDisposableService
                         }
                     }
 
-                    if (ImGui.MenuItem("Scan dev plugins"))
+                    if (ImGui.MenuItem("Scan dev plugins"u8))
                     {
                         _ = pluginManager.ScanDevPluginsAsync();
                     }
 
                     ImGui.Separator();
 
-                    if (ImGui.MenuItem("Load all API levels", (byte*)null, pluginManager.LoadAllApiLevels))
+                    if (ImGui.MenuItem("Load all API levels"u8, (byte*)null, pluginManager.LoadAllApiLevels))
                     {
-                        pluginManager.LoadAllApiLevels = !pluginManager.LoadAllApiLevels;
+                        pluginManager.LoadAllApiLevels ^= true;
                     }
 
-                    if (ImGui.MenuItem("Load blacklisted plugins", (byte*)null, pluginManager.LoadBannedPlugins))
+                    if (ImGui.MenuItem("Load blacklisted plugins"u8, (byte*)null, pluginManager.LoadBannedPlugins))
                     {
-                        pluginManager.LoadBannedPlugins = !pluginManager.LoadBannedPlugins;
+                        pluginManager.LoadBannedPlugins ^= true;
                     }
 
-                    if (pluginManager.SafeMode && ImGui.MenuItem("Disable Safe Mode"))
+                    if (pluginManager.SafeMode && ImGui.MenuItem("Disable Safe Mode"u8))
                     {
                         pluginManager.SafeMode = false;
                     }
 
                     ImGui.Separator();
-                    ImGui.MenuItem("API Level:" + PluginManager.DalamudApiLevel, false, false);
-                    ImGui.MenuItem("Loaded plugins:" + pluginManager.InstalledPlugins.Count(), false, false);
+                    ImGui.MenuItem("API Level:" + PluginManager.DalamudApiLevel, false);
+                    ImGui.MenuItem("Loaded plugins:" + pluginManager.InstalledPlugins.Count(), false);
                     ImGui.EndMenu();
                 }
 
-                if (ImGui.BeginMenu("Localization"))
+                if (ImGui.BeginMenu("Localization"u8))
                 {
                     var localization = Service<Localization>.Get();
 
-                    if (ImGui.MenuItem("Export localizable"))
+                    if (ImGui.MenuItem("Export localizable"u8))
                     {
                         localization.ExportLocalizable(true);
                     }
 
-                    if (ImGui.BeginMenu("Load language..."))
+                    if (ImGui.BeginMenu("Load language..."u8))
                     {
-                        if (ImGui.MenuItem("From Fallbacks"))
+                        if (ImGui.MenuItem("From Fallbacks"u8))
                         {
                             localization.SetupWithFallbacks();
                         }
 
-                        if (ImGui.MenuItem("From UICulture"))
+                        if (ImGui.MenuItem("From UICulture"u8))
                         {
                             localization.SetupWithUiCulture();
                         }
@@ -1065,7 +1062,7 @@ internal class DalamudInterface : IInternalDisposableService
                 }
 
                 if (Service<GameGui>.Get().GameUiHidden)
-                    ImGui.BeginMenu("UI is hidden...", false);
+                    ImGui.BeginMenu("UI is hidden..."u8, false);
 
                 if (this.configuration.ShowDevBarInfo)
                 {

--- a/Dalamud/Interface/Internal/DesignSystem/DalamudComponents.PluginPicker.cs
+++ b/Dalamud/Interface/Internal/DesignSystem/DalamudComponents.PluginPicker.cs
@@ -39,11 +39,11 @@ internal static partial class DalamudComponents
             var width = ImGuiHelpers.GlobalScale * 300;
 
             ImGui.SetNextItemWidth(width);
-            ImGui.InputTextWithHint("###pluginPickerSearch", Locs.SearchHint, ref pickerSearch, 255);
+            ImGui.InputTextWithHint("###pluginPickerSearch"u8, Locs.SearchHint, ref pickerSearch, 255);
 
             var currentSearchString = pickerSearch;
 
-            using var listBox = ImRaii.ListBox("###pluginPicker", new Vector2(width, width - 80));
+            using var listBox = ImRaii.ListBox("###pluginPicker"u8, new Vector2(width, width - 80));
             if (listBox.Success)
             {
                 // TODO: Plugin searching should be abstracted... installer and this should use the same search

--- a/Dalamud/Interface/Internal/UiDebug.cs
+++ b/Dalamud/Interface/Internal/UiDebug.cs
@@ -64,17 +64,17 @@ internal unsafe class UiDebug
     public void Draw()
     {
         ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(3, 2));
-        ImGui.BeginChild("st_uiDebug_unitBaseSelect", new Vector2(250, -1), true);
+        ImGui.BeginChild("st_uiDebug_unitBaseSelect"u8, new Vector2(250, -1), true);
 
         ImGui.SetNextItemWidth(-1);
-        ImGui.InputTextWithHint("###atkUnitBaseSearch", "Search", ref this.searchInput, 0x20);
+        ImGui.InputTextWithHint("###atkUnitBaseSearch"u8, "Search"u8, ref this.searchInput, 0x20);
 
         this.DrawUnitBaseList();
         ImGui.EndChild();
         if (this.selectedUnitBase != null)
         {
             ImGui.SameLine();
-            ImGui.BeginChild("st_uiDebug_selectedUnitBase", new Vector2(-1, -1), true);
+            ImGui.BeginChild("st_uiDebug_selectedUnitBase"u8, new Vector2(-1, -1), true);
             this.DrawUnitBase(this.selectedUnitBase);
             ImGui.EndChild();
         }
@@ -88,14 +88,14 @@ internal unsafe class UiDebug
         var addonName = atkUnitBase->NameString;
         var agent = Service<GameGui>.Get().FindAgentInterface(atkUnitBase);
 
-        ImGui.Text(addonName);
+        ImGui.TextUnformatted(addonName);
         ImGui.SameLine();
         ImGui.PushStyleColor(ImGuiCol.Text, isVisible ? 0xFF00FF00 : 0xFF0000FF);
-        ImGui.Text(isVisible ? "Visible" : "Not Visible");
+        ImGui.TextUnformatted(isVisible ? "Visible" : "Not Visible");
         ImGui.PopStyleColor();
 
         ImGui.SameLine(ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X - 25);
-        if (ImGui.SmallButton("V"))
+        if (ImGui.SmallButton("V"u8))
         {
             atkUnitBase->IsVisible = !atkUnitBase->IsVisible;
         }
@@ -105,9 +105,9 @@ internal unsafe class UiDebug
         ImGuiHelpers.ClickToCopyText($"Agent: {(nint)agent:X}", $"{(nint)agent:X}");
         ImGui.Separator();
 
-        ImGui.Text($"Position: [ {atkUnitBase->X} , {atkUnitBase->Y} ]");
-        ImGui.Text($"Scale: {atkUnitBase->Scale * 100}%%");
-        ImGui.Text($"Widget Count {atkUnitBase->UldManager.ObjectCount}");
+        ImGui.TextUnformatted($"Position: [ {atkUnitBase->X} , {atkUnitBase->Y} ]");
+        ImGui.TextUnformatted($"Scale: {atkUnitBase->Scale * 100}%%");
+        ImGui.TextUnformatted($"Widget Count {atkUnitBase->UldManager.ObjectCount}");
 
         ImGui.Separator();
 
@@ -184,7 +184,7 @@ internal unsafe class UiDebug
                 popped = true;
             }
 
-            ImGui.Text("Node: ");
+            ImGui.TextUnformatted("Node: "u8);
             ImGui.SameLine();
             ImGuiHelpers.ClickToCopyText($"{(ulong)node:X}");
             ImGui.SameLine();
@@ -208,7 +208,7 @@ internal unsafe class UiDebug
             {
                 case NodeType.Text:
                     var textNode = (AtkTextNode*)node;
-                    ImGui.Text("text: ");
+                    ImGui.TextUnformatted("text: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textNode->NodeText);
 
@@ -226,7 +226,7 @@ internal unsafe class UiDebug
                     if (ImGui.Button($"Decode##{(ulong)textNode:X}"))
                         textNode->NodeText.SetString(textNode->NodeText.StringPtr.AsReadOnlySeStringSpan().ToString());
 
-                    ImGui.Text($"AlignmentType: {(AlignmentType)textNode->AlignmentFontType}  FontSize: {textNode->FontSize}");
+                    ImGui.TextUnformatted($"AlignmentType: {(AlignmentType)textNode->AlignmentFontType}  FontSize: {textNode->FontSize}");
                     int b = textNode->AlignmentFontType;
                     if (ImGui.InputInt($"###setAlignment{(ulong)textNode:X}", ref b, 1))
                     {
@@ -236,20 +236,20 @@ internal unsafe class UiDebug
                         textNode->AtkResNode.DrawFlags |= 0x1;
                     }
 
-                    ImGui.Text($"Color: #{textNode->TextColor.R:X2}{textNode->TextColor.G:X2}{textNode->TextColor.B:X2}{textNode->TextColor.A:X2}");
+                    ImGui.TextUnformatted($"Color: #{textNode->TextColor.R:X2}{textNode->TextColor.G:X2}{textNode->TextColor.B:X2}{textNode->TextColor.A:X2}");
                     ImGui.SameLine();
-                    ImGui.Text($"EdgeColor: #{textNode->EdgeColor.R:X2}{textNode->EdgeColor.G:X2}{textNode->EdgeColor.B:X2}{textNode->EdgeColor.A:X2}");
+                    ImGui.TextUnformatted($"EdgeColor: #{textNode->EdgeColor.R:X2}{textNode->EdgeColor.G:X2}{textNode->EdgeColor.B:X2}{textNode->EdgeColor.A:X2}");
                     ImGui.SameLine();
-                    ImGui.Text($"BGColor: #{textNode->BackgroundColor.R:X2}{textNode->BackgroundColor.G:X2}{textNode->BackgroundColor.B:X2}{textNode->BackgroundColor.A:X2}");
+                    ImGui.TextUnformatted($"BGColor: #{textNode->BackgroundColor.R:X2}{textNode->BackgroundColor.G:X2}{textNode->BackgroundColor.B:X2}{textNode->BackgroundColor.A:X2}");
 
-                    ImGui.Text($"TextFlags: {textNode->TextFlags}");
+                    ImGui.TextUnformatted($"TextFlags: {textNode->TextFlags}");
                     ImGui.SameLine();
-                    ImGui.Text($"TextFlags2: {textNode->TextFlags2}");
+                    ImGui.TextUnformatted($"TextFlags2: {textNode->TextFlags2}");
 
                     break;
                 case NodeType.Counter:
                     var counterNode = (AtkCounterNode*)node;
-                    ImGui.Text("text: ");
+                    ImGui.TextUnformatted("text: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(counterNode->NodeText);
                     break;
@@ -283,17 +283,17 @@ internal unsafe class UiDebug
             {
                 if (partId > partsList->PartCount)
                 {
-                    ImGui.Text("part id > part count?");
+                    ImGui.TextUnformatted("part id > part count?"u8);
                 }
                 else
                 {
                     var textureInfo = partsList->Parts[partId].UldAsset;
                     var texType = textureInfo->AtkTexture.TextureType;
-                    ImGui.Text(
+                    ImGui.TextUnformatted(
                         $"texture type: {texType} part_id={partId} part_id_count={partsList->PartCount}");
                     if (texType == TextureType.Resource)
                     {
-                        ImGui.Text(
+                        ImGui.TextUnformatted(
                             $"texture path: {textureInfo->AtkTexture.Resource->TexFileResourceHandle->ResourceHandle.FileName}");
                         var kernelTexture = textureInfo->AtkTexture.Resource->KernelTextureObject;
 
@@ -348,7 +348,7 @@ internal unsafe class UiDebug
             }
             else
             {
-                ImGui.Text("no texture loaded");
+                ImGui.TextUnformatted("no texture loaded"u8);
             }
         }
     }
@@ -384,12 +384,12 @@ internal unsafe class UiDebug
                 popped = true;
             }
 
-            ImGui.Text("Node: ");
+            ImGui.TextUnformatted("Node: "u8);
             ImGui.SameLine();
             ImGuiHelpers.ClickToCopyText($"{(ulong)node:X}");
             ImGui.SameLine();
             Util.ShowStruct(*compNode, (ulong)compNode);
-            ImGui.Text("Component: ");
+            ImGui.TextUnformatted("Component: "u8);
             ImGui.SameLine();
             ImGuiHelpers.ClickToCopyText($"{(ulong)compNode->Component:X}");
             ImGui.SameLine();
@@ -414,31 +414,31 @@ internal unsafe class UiDebug
             {
                 case ComponentType.TextInput:
                     var textInputComponent = (AtkComponentTextInput*)compNode->Component;
-                    ImGui.Text("InputBase Text1: ");
+                    ImGui.TextUnformatted("InputBase Text1: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textInputComponent->AtkComponentInputBase.UnkText1);
 
-                    ImGui.Text("InputBase Text2: ");
+                    ImGui.TextUnformatted("InputBase Text2: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textInputComponent->AtkComponentInputBase.UnkText2);
 
-                    ImGui.Text("Text1: ");
+                    ImGui.TextUnformatted("Text1: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textInputComponent->UnkText01);
 
-                    ImGui.Text("Text2: ");
+                    ImGui.TextUnformatted("Text2: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textInputComponent->UnkText02);
 
-                    ImGui.Text("AvailableLines: ");
+                    ImGui.TextUnformatted("AvailableLines: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textInputComponent->AvailableLines);
 
-                    ImGui.Text("HighlightedAutoTranslateOptionColorPrefix: ");
+                    ImGui.TextUnformatted("HighlightedAutoTranslateOptionColorPrefix: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textInputComponent->HighlightedAutoTranslateOptionColorPrefix);
 
-                    ImGui.Text("HighlightedAutoTranslateOptionColorSuffix: ");
+                    ImGui.TextUnformatted("HighlightedAutoTranslateOptionColorSuffix: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textInputComponent->HighlightedAutoTranslateOptionColorSuffix);
                     break;
@@ -474,7 +474,7 @@ internal unsafe class UiDebug
 
     private void PrintResNode(AtkResNode* node)
     {
-        ImGui.Text($"NodeID: {node->NodeId}");
+        ImGui.TextUnformatted($"NodeID: {node->NodeId}");
         ImGui.SameLine();
         if (ImGui.SmallButton($"T:Visible##{(ulong)node:X}"))
         {
@@ -487,13 +487,13 @@ internal unsafe class UiDebug
             ImGui.SetClipboardText($"{(ulong)node:X}");
         }
 
-        ImGui.Text(
+        ImGui.TextUnformatted(
             $"X: {node->X} Y: {node->Y} " +
             $"ScaleX: {node->ScaleX} ScaleY: {node->ScaleY} " +
             $"Rotation: {node->Rotation} " +
             $"Width: {node->Width} Height: {node->Height} " +
             $"OriginX: {node->OriginX} OriginY: {node->OriginY}");
-        ImGui.Text(
+        ImGui.TextUnformatted(
             $"RGBA: 0x{node->Color.R:X2}{node->Color.G:X2}{node->Color.B:X2}{node->Color.A:X2} " +
             $"AddRGB: {node->AddRed} {node->AddGreen} {node->AddBlue} " +
             $"MultiplyRGB: {node->MultiplyRed} {node->MultiplyGreen} {node->MultiplyBlue}");
@@ -604,7 +604,7 @@ internal unsafe class UiDebug
 
         if (noResults)
         {
-            ImGui.TextDisabled("No Results");
+            ImGui.TextDisabled("No Results"u8);
         }
 
         if (!foundSelected)

--- a/Dalamud/Interface/Internal/UiDebug.cs
+++ b/Dalamud/Interface/Internal/UiDebug.cs
@@ -88,10 +88,10 @@ internal unsafe class UiDebug
         var addonName = atkUnitBase->NameString;
         var agent = Service<GameGui>.Get().FindAgentInterface(atkUnitBase);
 
-        ImGui.TextUnformatted(addonName);
+        ImGui.Text(addonName);
         ImGui.SameLine();
         ImGui.PushStyleColor(ImGuiCol.Text, isVisible ? 0xFF00FF00 : 0xFF0000FF);
-        ImGui.TextUnformatted(isVisible ? "Visible" : "Not Visible");
+        ImGui.Text(isVisible ? "Visible" : "Not Visible");
         ImGui.PopStyleColor();
 
         ImGui.SameLine(ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X - 25);
@@ -105,9 +105,9 @@ internal unsafe class UiDebug
         ImGuiHelpers.ClickToCopyText($"Agent: {(nint)agent:X}", $"{(nint)agent:X}");
         ImGui.Separator();
 
-        ImGui.TextUnformatted($"Position: [ {atkUnitBase->X} , {atkUnitBase->Y} ]");
-        ImGui.TextUnformatted($"Scale: {atkUnitBase->Scale * 100}%%");
-        ImGui.TextUnformatted($"Widget Count {atkUnitBase->UldManager.ObjectCount}");
+        ImGui.Text($"Position: [ {atkUnitBase->X} , {atkUnitBase->Y} ]");
+        ImGui.Text($"Scale: {atkUnitBase->Scale * 100}%%");
+        ImGui.Text($"Widget Count {atkUnitBase->UldManager.ObjectCount}");
 
         ImGui.Separator();
 
@@ -184,7 +184,7 @@ internal unsafe class UiDebug
                 popped = true;
             }
 
-            ImGui.TextUnformatted("Node: "u8);
+            ImGui.Text("Node: "u8);
             ImGui.SameLine();
             ImGuiHelpers.ClickToCopyText($"{(ulong)node:X}");
             ImGui.SameLine();
@@ -208,7 +208,7 @@ internal unsafe class UiDebug
             {
                 case NodeType.Text:
                     var textNode = (AtkTextNode*)node;
-                    ImGui.TextUnformatted("text: "u8);
+                    ImGui.Text("text: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textNode->NodeText);
 
@@ -226,7 +226,7 @@ internal unsafe class UiDebug
                     if (ImGui.Button($"Decode##{(ulong)textNode:X}"))
                         textNode->NodeText.SetString(textNode->NodeText.StringPtr.AsReadOnlySeStringSpan().ToString());
 
-                    ImGui.TextUnformatted($"AlignmentType: {(AlignmentType)textNode->AlignmentFontType}  FontSize: {textNode->FontSize}");
+                    ImGui.Text($"AlignmentType: {(AlignmentType)textNode->AlignmentFontType}  FontSize: {textNode->FontSize}");
                     int b = textNode->AlignmentFontType;
                     if (ImGui.InputInt($"###setAlignment{(ulong)textNode:X}", ref b, 1))
                     {
@@ -236,20 +236,20 @@ internal unsafe class UiDebug
                         textNode->AtkResNode.DrawFlags |= 0x1;
                     }
 
-                    ImGui.TextUnformatted($"Color: #{textNode->TextColor.R:X2}{textNode->TextColor.G:X2}{textNode->TextColor.B:X2}{textNode->TextColor.A:X2}");
+                    ImGui.Text($"Color: #{textNode->TextColor.R:X2}{textNode->TextColor.G:X2}{textNode->TextColor.B:X2}{textNode->TextColor.A:X2}");
                     ImGui.SameLine();
-                    ImGui.TextUnformatted($"EdgeColor: #{textNode->EdgeColor.R:X2}{textNode->EdgeColor.G:X2}{textNode->EdgeColor.B:X2}{textNode->EdgeColor.A:X2}");
+                    ImGui.Text($"EdgeColor: #{textNode->EdgeColor.R:X2}{textNode->EdgeColor.G:X2}{textNode->EdgeColor.B:X2}{textNode->EdgeColor.A:X2}");
                     ImGui.SameLine();
-                    ImGui.TextUnformatted($"BGColor: #{textNode->BackgroundColor.R:X2}{textNode->BackgroundColor.G:X2}{textNode->BackgroundColor.B:X2}{textNode->BackgroundColor.A:X2}");
+                    ImGui.Text($"BGColor: #{textNode->BackgroundColor.R:X2}{textNode->BackgroundColor.G:X2}{textNode->BackgroundColor.B:X2}{textNode->BackgroundColor.A:X2}");
 
-                    ImGui.TextUnformatted($"TextFlags: {textNode->TextFlags}");
+                    ImGui.Text($"TextFlags: {textNode->TextFlags}");
                     ImGui.SameLine();
-                    ImGui.TextUnformatted($"TextFlags2: {textNode->TextFlags2}");
+                    ImGui.Text($"TextFlags2: {textNode->TextFlags2}");
 
                     break;
                 case NodeType.Counter:
                     var counterNode = (AtkCounterNode*)node;
-                    ImGui.TextUnformatted("text: "u8);
+                    ImGui.Text("text: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(counterNode->NodeText);
                     break;
@@ -283,17 +283,17 @@ internal unsafe class UiDebug
             {
                 if (partId > partsList->PartCount)
                 {
-                    ImGui.TextUnformatted("part id > part count?"u8);
+                    ImGui.Text("part id > part count?"u8);
                 }
                 else
                 {
                     var textureInfo = partsList->Parts[partId].UldAsset;
                     var texType = textureInfo->AtkTexture.TextureType;
-                    ImGui.TextUnformatted(
+                    ImGui.Text(
                         $"texture type: {texType} part_id={partId} part_id_count={partsList->PartCount}");
                     if (texType == TextureType.Resource)
                     {
-                        ImGui.TextUnformatted(
+                        ImGui.Text(
                             $"texture path: {textureInfo->AtkTexture.Resource->TexFileResourceHandle->ResourceHandle.FileName}");
                         var kernelTexture = textureInfo->AtkTexture.Resource->KernelTextureObject;
 
@@ -348,7 +348,7 @@ internal unsafe class UiDebug
             }
             else
             {
-                ImGui.TextUnformatted("no texture loaded"u8);
+                ImGui.Text("no texture loaded"u8);
             }
         }
     }
@@ -384,12 +384,12 @@ internal unsafe class UiDebug
                 popped = true;
             }
 
-            ImGui.TextUnformatted("Node: "u8);
+            ImGui.Text("Node: "u8);
             ImGui.SameLine();
             ImGuiHelpers.ClickToCopyText($"{(ulong)node:X}");
             ImGui.SameLine();
             Util.ShowStruct(*compNode, (ulong)compNode);
-            ImGui.TextUnformatted("Component: "u8);
+            ImGui.Text("Component: "u8);
             ImGui.SameLine();
             ImGuiHelpers.ClickToCopyText($"{(ulong)compNode->Component:X}");
             ImGui.SameLine();
@@ -414,31 +414,31 @@ internal unsafe class UiDebug
             {
                 case ComponentType.TextInput:
                     var textInputComponent = (AtkComponentTextInput*)compNode->Component;
-                    ImGui.TextUnformatted("InputBase Text1: "u8);
+                    ImGui.Text("InputBase Text1: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textInputComponent->AtkComponentInputBase.UnkText1);
 
-                    ImGui.TextUnformatted("InputBase Text2: "u8);
+                    ImGui.Text("InputBase Text2: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textInputComponent->AtkComponentInputBase.UnkText2);
 
-                    ImGui.TextUnformatted("Text1: "u8);
+                    ImGui.Text("Text1: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textInputComponent->UnkText01);
 
-                    ImGui.TextUnformatted("Text2: "u8);
+                    ImGui.Text("Text2: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textInputComponent->UnkText02);
 
-                    ImGui.TextUnformatted("AvailableLines: "u8);
+                    ImGui.Text("AvailableLines: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textInputComponent->AvailableLines);
 
-                    ImGui.TextUnformatted("HighlightedAutoTranslateOptionColorPrefix: "u8);
+                    ImGui.Text("HighlightedAutoTranslateOptionColorPrefix: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textInputComponent->HighlightedAutoTranslateOptionColorPrefix);
 
-                    ImGui.TextUnformatted("HighlightedAutoTranslateOptionColorSuffix: "u8);
+                    ImGui.Text("HighlightedAutoTranslateOptionColorSuffix: "u8);
                     ImGui.SameLine();
                     Service<SeStringRenderer>.Get().Draw(textInputComponent->HighlightedAutoTranslateOptionColorSuffix);
                     break;
@@ -474,7 +474,7 @@ internal unsafe class UiDebug
 
     private void PrintResNode(AtkResNode* node)
     {
-        ImGui.TextUnformatted($"NodeID: {node->NodeId}");
+        ImGui.Text($"NodeID: {node->NodeId}");
         ImGui.SameLine();
         if (ImGui.SmallButton($"T:Visible##{(ulong)node:X}"))
         {
@@ -487,13 +487,13 @@ internal unsafe class UiDebug
             ImGui.SetClipboardText($"{(ulong)node:X}");
         }
 
-        ImGui.TextUnformatted(
+        ImGui.Text(
             $"X: {node->X} Y: {node->Y} " +
             $"ScaleX: {node->ScaleX} ScaleY: {node->ScaleY} " +
             $"Rotation: {node->Rotation} " +
             $"Width: {node->Width} Height: {node->Height} " +
             $"OriginX: {node->OriginX} OriginY: {node->OriginY}");
-        ImGui.TextUnformatted(
+        ImGui.Text(
             $"RGBA: 0x{node->Color.R:X2}{node->Color.G:X2}{node->Color.B:X2}{node->Color.A:X2} " +
             $"AddRGB: {node->AddRed} {node->AddGreen} {node->AddBlue} " +
             $"MultiplyRGB: {node->MultiplyRed} {node->MultiplyGreen} {node->MultiplyBlue}");

--- a/Dalamud/Interface/Internal/UiDebug.cs
+++ b/Dalamud/Interface/Internal/UiDebug.cs
@@ -106,7 +106,7 @@ internal unsafe class UiDebug
         ImGui.Separator();
 
         ImGui.Text($"Position: [ {atkUnitBase->X} , {atkUnitBase->Y} ]");
-        ImGui.Text($"Scale: {atkUnitBase->Scale * 100}%%");
+        ImGui.Text($"Scale: {atkUnitBase->Scale * 100}%");
         ImGui.Text($"Widget Count {atkUnitBase->UldManager.ObjectCount}");
 
         ImGui.Separator();

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.AtkValues.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.AtkValues.cs
@@ -47,7 +47,7 @@ public unsafe partial class AddonTree
                             }
                             else
                             {
-                                ImGui.TextUnformatted($"#{i}");
+                                ImGui.Text($"#{i}");
                             }
 
                             ImGui.TableNextColumn();
@@ -57,7 +57,7 @@ public unsafe partial class AddonTree
                             }
                             else
                             {
-                                ImGui.TextUnformatted($"{atkValue->Type}");
+                                ImGui.Text($"{atkValue->Type}");
                             }
 
                             ImGui.TableNextColumn();
@@ -69,7 +69,7 @@ public unsafe partial class AddonTree
                                 case ValueType.Int:
                                 case ValueType.UInt:
                                 {
-                                    ImGui.TextUnformatted($"{atkValue->Int}");
+                                    ImGui.Text($"{atkValue->Int}");
                                     break;
                                 }
 
@@ -91,12 +91,12 @@ public unsafe partial class AddonTree
 
                                 case ValueType.Bool:
                                 {
-                                    ImGui.TextUnformatted($"{atkValue->Byte != 0}");
+                                    ImGui.Text($"{atkValue->Byte != 0}");
                                     break;
                                 }
 
                                 case ValueType.Pointer:
-                                    ImGui.TextUnformatted($"{(nint)atkValue->Pointer}");
+                                    ImGui.Text($"{(nint)atkValue->Pointer}");
                                     break;
 
                                 default:

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.AtkValues.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.AtkValues.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Internal.UiDebug2.Utility;
+using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Memory;
 using Dalamud.Utility;
@@ -26,13 +27,13 @@ public unsafe partial class AddonTree
             using var tree = ImRaii.TreeNode($"Atk Values [{addon->AtkValuesCount}]###atkValues_{addon->NameString}");
             if (tree.Success)
             {
-                using var tbl = ImRaii.Table("atkUnitBase_atkValueTable", 3, ImGuiTableFlags.Borders | ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg);
+                using var tbl = ImRaii.Table("atkUnitBase_atkValueTable"u8, 3, ImGuiTableFlags.Borders | ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg);
 
                 if (tbl.Success)
                 {
-                    ImGui.TableSetupColumn("Index");
-                    ImGui.TableSetupColumn("Type");
-                    ImGui.TableSetupColumn("Value");
+                    ImGui.TableSetupColumn("Index"u8);
+                    ImGui.TableSetupColumn("Type"u8);
+                    ImGui.TableSetupColumn("Value"u8);
                     ImGui.TableHeadersRow();
 
                     try
@@ -46,17 +47,17 @@ public unsafe partial class AddonTree
                             }
                             else
                             {
-                                ImGui.Text($"#{i}");
+                                ImGui.TextUnformatted($"#{i}");
                             }
 
                             ImGui.TableNextColumn();
                             if (atkValue->Type == 0)
                             {
-                                ImGui.TextDisabled("Not Set");
+                                ImGui.TextDisabled("Not Set"u8);
                             }
                             else
                             {
-                                ImGui.Text($"{atkValue->Type}");
+                                ImGui.TextUnformatted($"{atkValue->Type}");
                             }
 
                             ImGui.TableNextColumn();
@@ -78,7 +79,7 @@ public unsafe partial class AddonTree
                                 {
                                     if (atkValue->String.Value == null)
                                     {
-                                        ImGui.TextDisabled("null");
+                                        ImGui.TextDisabled("null"u8);
                                     }
                                     else
                                     {
@@ -100,7 +101,7 @@ public unsafe partial class AddonTree
 
                                 default:
                                 {
-                                    ImGui.TextDisabled("Unhandled Type");
+                                    ImGui.TextDisabled("Unhandled Type"u8);
                                     ImGui.SameLine();
                                     Util.ShowStruct(atkValue);
                                     break;

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.cs
@@ -123,7 +123,7 @@ public unsafe partial class AddonTree : IDisposable
         ImGui.SameLine();
 
         ImGui.SameLine();
-        ImGuiHelpers.SafeTextColored(isVisible ? new Vector4(0.1f, 1f, 0.1f, 1f) : new(0.6f, 0.6f, 0.6f, 1), isVisible ? "Visible"u8 : "Not Visible"u8);
+        ImGui.TextColored(isVisible ? new Vector4(0.1f, 1f, 0.1f, 1f) : new(0.6f, 0.6f, 0.6f, 1), isVisible ? "Visible"u8 : "Not Visible"u8);
 
         ImGui.SameLine(ImGui.GetWindowWidth() - 100);
 

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.cs
@@ -119,7 +119,7 @@ public unsafe partial class AddonTree : IDisposable
 
         var isVisible = addon->IsVisible;
 
-        ImGui.TextUnformatted($"{this.AddonName}");
+        ImGui.Text($"{this.AddonName}");
         ImGui.SameLine();
 
         ImGui.SameLine();

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/AddonTree.cs
@@ -4,6 +4,8 @@ using System.Numerics;
 
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Components;
+using Dalamud.Interface.Utility;
+
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 using static Dalamud.Interface.FontAwesomeIcon;
@@ -121,7 +123,7 @@ public unsafe partial class AddonTree : IDisposable
         ImGui.SameLine();
 
         ImGui.SameLine();
-        ImGui.TextColored(isVisible ? new Vector4(0.1f, 1f, 0.1f, 1f) : new(0.6f, 0.6f, 0.6f, 1), isVisible ? "Visible" : "Not Visible");
+        ImGuiHelpers.SafeTextColored(isVisible ? new Vector4(0.1f, 1f, 0.1f, 1f) : new(0.6f, 0.6f, 0.6f, 1), isVisible ? "Visible"u8 : "Not Visible"u8);
 
         ImGui.SameLine(ImGui.GetWindowWidth() - 100);
 
@@ -132,7 +134,7 @@ public unsafe partial class AddonTree : IDisposable
 
         if (ImGui.IsItemHovered())
         {
-            ImGui.SetTooltip("Toggle Visibility");
+            ImGui.SetTooltip("Toggle Visibility"u8);
         }
 
         ImGui.SameLine();
@@ -143,7 +145,7 @@ public unsafe partial class AddonTree : IDisposable
 
         if (ImGui.IsItemHovered())
         {
-            ImGui.SetTooltip("Toggle Popout Window");
+            ImGui.SetTooltip("Toggle Popout Window"u8);
         }
 
         PaddedSeparator(1);

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/Events.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/Events.cs
@@ -35,13 +35,13 @@ public static class Events
 
             if (tbl.Success)
             {
-                ImGui.TableSetupColumn("#", WidthFixed);
-                ImGui.TableSetupColumn("Type", WidthFixed);
-                ImGui.TableSetupColumn("Param", WidthFixed);
-                ImGui.TableSetupColumn("Flags", WidthFixed);
-                ImGui.TableSetupColumn("StateFlags1", WidthFixed);
-                ImGui.TableSetupColumn("Target", WidthFixed);
-                ImGui.TableSetupColumn("Listener", WidthFixed);
+                ImGui.TableSetupColumn("#"u8, WidthFixed);
+                ImGui.TableSetupColumn("Type"u8, WidthFixed);
+                ImGui.TableSetupColumn("Param"u8, WidthFixed);
+                ImGui.TableSetupColumn("Flags"u8, WidthFixed);
+                ImGui.TableSetupColumn("StateFlags1"u8, WidthFixed);
+                ImGui.TableSetupColumn("Target"u8, WidthFixed);
+                ImGui.TableSetupColumn("Listener"u8, WidthFixed);
 
                 ImGui.TableHeadersRow();
 

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/Events.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/Events.cs
@@ -49,15 +49,15 @@ public static class Events
                 while (evt != null)
                 {
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted($"{i++}");
+                    ImGui.Text($"{i++}");
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted($"{evt->State.EventType}");
+                    ImGui.Text($"{evt->State.EventType}");
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted($"{evt->Param}");
+                    ImGui.Text($"{evt->Param}");
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted($"{evt->State.StateFlags}");
+                    ImGui.Text($"{evt->State.StateFlags}");
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted($"{evt->State.ReturnFlags}");
+                    ImGui.Text($"{evt->State.ReturnFlags}");
                     ImGui.TableNextColumn();
                     ImGuiHelpers.ClickToCopyText($"{(nint)evt->Target:X}", default, new Vector4(0.6f, 0.6f, 0.6f, 1));
                     ImGui.TableNextColumn();

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Component.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Component.cs
@@ -107,7 +107,7 @@ internal unsafe class ComponentNodeTree : ResNodeTree
             case List:
             case TreeList:
                 var l = (AtkComponentList*)this.Component;
-                if (ImGui.SmallButton("Inc.Selected"))
+                if (ImGui.SmallButton("Inc.Selected"u8))
                 {
                     l->SelectedItemIndex++;
                 }

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Component.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Component.cs
@@ -89,19 +89,19 @@ internal unsafe class ComponentNodeTree : ResNodeTree
         {
             case TextInput:
                 var textInputComponent = (AtkComponentTextInput*)this.Component;
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $"InputBase Text1: {Marshal.PtrToStringAnsi(new(textInputComponent->AtkComponentInputBase.UnkText1.StringPtr))}");
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $"InputBase Text2: {Marshal.PtrToStringAnsi(new(textInputComponent->AtkComponentInputBase.UnkText2.StringPtr))}");
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $"Text1: {Marshal.PtrToStringAnsi(new(textInputComponent->UnkText01.StringPtr))}");
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $"Text2: {Marshal.PtrToStringAnsi(new(textInputComponent->UnkText02.StringPtr))}");
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $"AvailableLines: {Marshal.PtrToStringAnsi(new(textInputComponent->AvailableLines.StringPtr))}");
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $"HighlightedAutoTranslateOptionColorPrefix: {Marshal.PtrToStringAnsi(new(textInputComponent->HighlightedAutoTranslateOptionColorPrefix.StringPtr))}");
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $"HighlightedAutoTranslateOptionColorSuffix: {Marshal.PtrToStringAnsi(new(textInputComponent->HighlightedAutoTranslateOptionColorSuffix.StringPtr))}");
                 break;
             case List:

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Editor.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Editor.cs
@@ -50,12 +50,12 @@ internal unsafe partial class ResNodeTree
 
         var hov = false;
 
-        ImGui.TableSetupColumn("Labels", WidthFixed);
-        ImGui.TableSetupColumn("Editors", WidthFixed);
+        ImGui.TableSetupColumn("Labels"u8, WidthFixed);
+        ImGui.TableSetupColumn("Editors"u8, WidthFixed);
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Position:");
+        ImGui.TextUnformatted("Position:"u8);
 
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
@@ -70,7 +70,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Size:");
+        ImGui.TextUnformatted("Size:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.DragFloat2($"##{(nint)this.Node:X}size", ref size, 1, 0, default, "%.0f"))
@@ -84,7 +84,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Scale:");
+        ImGui.TextUnformatted("Scale:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.DragFloat2($"##{(nint)this.Node:X}scale", ref scale, 0.05f))
@@ -98,7 +98,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Origin:");
+        ImGui.TextUnformatted("Origin:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.DragFloat2($"##{(nint)this.Node:X}origin", ref origin, 1, default, default, "%.0f"))
@@ -112,7 +112,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Rotation:");
+        ImGui.TextUnformatted("Rotation:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         while (angle > 180)
@@ -128,7 +128,7 @@ internal unsafe partial class ResNodeTree
 
         if (ImGui.IsItemHovered())
         {
-            ImGui.SetTooltip("Rotation (deg)");
+            ImGui.SetTooltip("Rotation (deg)"u8);
             hov = true;
         }
 
@@ -143,7 +143,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("RGBA:");
+        ImGui.TextUnformatted("RGBA:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.ColorEdit4($"##{(nint)this.Node:X}RGBA", ref rgba, DisplayHex))
@@ -153,7 +153,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Multiply:");
+        ImGui.TextUnformatted("Multiply:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.ColorEdit3($"##{(nint)this.Node:X}multiplyRGB", ref mult, DisplayHex))
@@ -165,7 +165,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Add:");
+        ImGui.TextUnformatted("Add:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(124);
 
@@ -203,7 +203,7 @@ internal unsafe partial class CounterNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Counter:");
+        ImGui.TextUnformatted("Counter:"u8);
         ImGui.TableNextColumn();
 
         ImGui.SetNextItemWidth(150);
@@ -229,7 +229,7 @@ internal unsafe partial class ImageNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Part Id:");
+        ImGui.TextUnformatted("Part Id:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.InputInt($"##partId{(nint)this.Node:X}", ref partId, 1, 1))
@@ -262,7 +262,7 @@ internal unsafe partial class NineGridNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Ninegrid Offsets:");
+        ImGui.TextUnformatted("Ninegrid Offsets:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.DragFloat2($"##{(nint)this.Node:X}ngOffsetLR", ref lr, 1f, 0f))
@@ -308,7 +308,7 @@ internal unsafe partial class TextNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Text:");
+        ImGui.TextUnformatted("Text:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(Math.Max(ImGui.GetWindowContentRegionMax().X - ImGui.GetCursorPosX() - 50f, 150));
         if (ImGui.InputText($"##{(nint)this.Node:X}textEdit", ref text, 512, EnterReturnsTrue))
@@ -318,7 +318,7 @@ internal unsafe partial class TextNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Font:");
+        ImGui.TextUnformatted("Font:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.Combo($"##{(nint)this.Node:X}fontType", ref fontIndex, FontNames))
@@ -328,7 +328,7 @@ internal unsafe partial class TextNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Font Size:");
+        ImGui.TextUnformatted("Font Size:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.InputInt($"##{(nint)this.Node:X}fontSize", ref fontSize, 1, 10))
@@ -338,7 +338,7 @@ internal unsafe partial class TextNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Alignment:");
+        ImGui.TextUnformatted("Alignment:"u8);
         ImGui.TableNextColumn();
         if (InputAlignment($"##{(nint)this.Node:X}alignment", ref alignment))
         {
@@ -347,7 +347,7 @@ internal unsafe partial class TextNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Text Color:");
+        ImGui.TextUnformatted("Text Color:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.ColorEdit4($"##{(nint)this.Node:X}TextRGB", ref textColor, DisplayHex))
@@ -357,7 +357,7 @@ internal unsafe partial class TextNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.Text("Edge Color:");
+        ImGui.TextUnformatted("Edge Color:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.ColorEdit4($"##{(nint)this.Node:X}EdgeRGB", ref edgeColor, DisplayHex))

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Editor.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Editor.cs
@@ -55,7 +55,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Position:"u8);
+        ImGui.Text("Position:"u8);
 
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
@@ -70,7 +70,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Size:"u8);
+        ImGui.Text("Size:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.DragFloat2($"##{(nint)this.Node:X}size", ref size, 1, 0, default, "%.0f"))
@@ -84,7 +84,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Scale:"u8);
+        ImGui.Text("Scale:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.DragFloat2($"##{(nint)this.Node:X}scale", ref scale, 0.05f))
@@ -98,7 +98,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Origin:"u8);
+        ImGui.Text("Origin:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.DragFloat2($"##{(nint)this.Node:X}origin", ref origin, 1, default, default, "%.0f"))
@@ -112,7 +112,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Rotation:"u8);
+        ImGui.Text("Rotation:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         while (angle > 180)
@@ -143,7 +143,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("RGBA:"u8);
+        ImGui.Text("RGBA:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.ColorEdit4($"##{(nint)this.Node:X}RGBA", ref rgba, DisplayHex))
@@ -153,7 +153,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Multiply:"u8);
+        ImGui.Text("Multiply:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.ColorEdit3($"##{(nint)this.Node:X}multiplyRGB", ref mult, DisplayHex))
@@ -165,7 +165,7 @@ internal unsafe partial class ResNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Add:"u8);
+        ImGui.Text("Add:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(124);
 
@@ -203,7 +203,7 @@ internal unsafe partial class CounterNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Counter:"u8);
+        ImGui.Text("Counter:"u8);
         ImGui.TableNextColumn();
 
         ImGui.SetNextItemWidth(150);
@@ -229,7 +229,7 @@ internal unsafe partial class ImageNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Part Id:"u8);
+        ImGui.Text("Part Id:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.InputInt($"##partId{(nint)this.Node:X}", ref partId, 1, 1))
@@ -262,7 +262,7 @@ internal unsafe partial class NineGridNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Ninegrid Offsets:"u8);
+        ImGui.Text("Ninegrid Offsets:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.DragFloat2($"##{(nint)this.Node:X}ngOffsetLR", ref lr, 1f, 0f))
@@ -308,7 +308,7 @@ internal unsafe partial class TextNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Text:"u8);
+        ImGui.Text("Text:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(Math.Max(ImGui.GetWindowContentRegionMax().X - ImGui.GetCursorPosX() - 50f, 150));
         if (ImGui.InputText($"##{(nint)this.Node:X}textEdit", ref text, 512, EnterReturnsTrue))
@@ -318,7 +318,7 @@ internal unsafe partial class TextNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Font:"u8);
+        ImGui.Text("Font:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.Combo($"##{(nint)this.Node:X}fontType", ref fontIndex, FontNames))
@@ -328,7 +328,7 @@ internal unsafe partial class TextNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Font Size:"u8);
+        ImGui.Text("Font Size:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.InputInt($"##{(nint)this.Node:X}fontSize", ref fontSize, 1, 10))
@@ -338,7 +338,7 @@ internal unsafe partial class TextNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Alignment:"u8);
+        ImGui.Text("Alignment:"u8);
         ImGui.TableNextColumn();
         if (InputAlignment($"##{(nint)this.Node:X}alignment", ref alignment))
         {
@@ -347,7 +347,7 @@ internal unsafe partial class TextNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Text Color:"u8);
+        ImGui.Text("Text Color:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.ColorEdit4($"##{(nint)this.Node:X}TextRGB", ref textColor, DisplayHex))
@@ -357,7 +357,7 @@ internal unsafe partial class TextNodeTree
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Edge Color:"u8);
+        ImGui.Text("Edge Color:"u8);
         ImGui.TableNextColumn();
         ImGui.SetNextItemWidth(150);
         if (ImGui.ColorEdit4($"##{(nint)this.Node:X}EdgeRGB", ref edgeColor, DisplayHex))

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Image.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Image.cs
@@ -239,7 +239,7 @@ internal unsafe partial class ImageNodeTree : ResNodeTree
 
                 PrintPartCoords(u, v, width, height);
 
-                ImGui.TextUnformatted("UV:\t"u8);
+                ImGui.Text("UV:\t"u8);
                 ImGui.SameLine();
                 ImGui.SetCursorPosX(cursX);
 

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Image.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Image.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using System.Runtime.InteropServices;
 
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using FFXIVClientStructs.FFXIV.Client.Graphics.Kernel;
 using FFXIVClientStructs.FFXIV.Component.GUI;
@@ -76,13 +77,13 @@ internal unsafe partial class ImageNodeTree : ResNodeTree
                 PrintFieldValuePairs(("Texture Path", this.TexData.Path));
             }
 
-            if (ImGui.RadioButton("Full Image##textureDisplayStyle0", TexDisplayStyle == 0))
+            if (ImGui.RadioButton("Full Image##textureDisplayStyle0"u8, TexDisplayStyle == 0))
             {
                 TexDisplayStyle = 0;
             }
 
             ImGui.SameLine();
-            if (ImGui.RadioButton("Parts List##textureDisplayStyle1", TexDisplayStyle == 1))
+            if (ImGui.RadioButton("Parts List##textureDisplayStyle1"u8, TexDisplayStyle == 1))
             {
                 TexDisplayStyle = 1;
             }
@@ -130,7 +131,7 @@ internal unsafe partial class ImageNodeTree : ResNodeTree
         ImGui.GetWindowDrawList().AddRect(partBegin, partEnd, RgbaVector4ToUint(col));
 
         ImGui.SetCursorPos(cursorLocalPos + uv + new Vector2(0, -20));
-        ImGui.TextColored(col, $"[#{partId}]\t{part.U}, {part.V}\t{part.Width}x{part.Height}");
+        ImGuiHelpers.SafeTextColored(col, $"[#{partId}]\t{part.U}, {part.V}\t{part.Width}x{part.Height}");
         ImGui.SetCursorPos(savePos);
     }
 
@@ -152,7 +153,7 @@ internal unsafe partial class ImageNodeTree : ResNodeTree
 
         if (ImGui.IsItemHovered())
         {
-            ImGui.SetTooltip("Click to copy as Vector2\nShift-click to copy as Vector4");
+            ImGui.SetTooltip("Click to copy as Vector2\nShift-click to copy as Vector4"u8);
         }
 
         var suffix = asFloat ? "f" : string.Empty;
@@ -191,9 +192,9 @@ internal unsafe partial class ImageNodeTree : ResNodeTree
         using var tbl = ImRaii.Table($"partsTable##{(nint)this.TexData.Texture->D3D11ShaderResourceView:X}", 3, Borders | RowBg | Reorderable);
         if (tbl.Success)
         {
-            ImGui.TableSetupColumn("Part ID", WidthFixed);
-            ImGui.TableSetupColumn("Part Texture", WidthFixed);
-            ImGui.TableSetupColumn("Coordinates", WidthFixed);
+            ImGui.TableSetupColumn("Part ID"u8, WidthFixed);
+            ImGui.TableSetupColumn("Part Texture"u8, WidthFixed);
+            ImGui.TableSetupColumn("Coordinates"u8, WidthFixed);
 
             ImGui.TableHeadersRow();
 
@@ -206,7 +207,7 @@ internal unsafe partial class ImageNodeTree : ResNodeTree
                 ImGui.TableNextColumn();
 
                 var col = i == this.TexData.PartId ? new Vector4(0, 0.85F, 1, 1) : new(1);
-                ImGui.TextColored(col, $"#{i.ToString().PadLeft(this.TexData.PartCount.ToString().Length, '0')}");
+                ImGuiHelpers.SafeTextColored(col, $"#{i.ToString().PadLeft(this.TexData.PartCount.ToString().Length, '0')}");
 
                 ImGui.TableNextColumn();
 
@@ -226,19 +227,19 @@ internal unsafe partial class ImageNodeTree : ResNodeTree
 
                 ImGui.TableNextColumn();
 
-                ImGui.TextColored(!hiRes ? new Vector4(1) : new(0.6f, 0.6f, 0.6f, 1), "Standard:\t");
+                ImGuiHelpers.SafeTextColored(!hiRes ? new Vector4(1) : new(0.6f, 0.6f, 0.6f, 1), "Standard:\t");
                 ImGui.SameLine();
                 var cursX = ImGui.GetCursorPosX();
 
                 PrintPartCoords(u / 2f, v / 2f, width / 2f, height / 2f);
 
-                ImGui.TextColored(hiRes ? new Vector4(1) : new(0.6f, 0.6f, 0.6f, 1), "Hi-Res:\t");
+                ImGuiHelpers.SafeTextColored(hiRes ? new Vector4(1) : new(0.6f, 0.6f, 0.6f, 1), "Hi-Res:\t");
                 ImGui.SameLine();
                 ImGui.SetCursorPosX(cursX);
 
                 PrintPartCoords(u, v, width, height);
 
-                ImGui.Text("UV:\t");
+                ImGui.TextUnformatted("UV:\t"u8);
                 ImGui.SameLine();
                 ImGui.SetCursorPosX(cursX);
 

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Image.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Image.cs
@@ -131,7 +131,7 @@ internal unsafe partial class ImageNodeTree : ResNodeTree
         ImGui.GetWindowDrawList().AddRect(partBegin, partEnd, RgbaVector4ToUint(col));
 
         ImGui.SetCursorPos(cursorLocalPos + uv + new Vector2(0, -20));
-        ImGuiHelpers.SafeTextColored(col, $"[#{partId}]\t{part.U}, {part.V}\t{part.Width}x{part.Height}");
+        ImGui.TextColored(col, $"[#{partId}]\t{part.U}, {part.V}\t{part.Width}x{part.Height}");
         ImGui.SetCursorPos(savePos);
     }
 
@@ -207,7 +207,7 @@ internal unsafe partial class ImageNodeTree : ResNodeTree
                 ImGui.TableNextColumn();
 
                 var col = i == this.TexData.PartId ? new Vector4(0, 0.85F, 1, 1) : new(1);
-                ImGuiHelpers.SafeTextColored(col, $"#{i.ToString().PadLeft(this.TexData.PartCount.ToString().Length, '0')}");
+                ImGui.TextColored(col, $"#{i.ToString().PadLeft(this.TexData.PartCount.ToString().Length, '0')}");
 
                 ImGui.TableNextColumn();
 
@@ -227,13 +227,13 @@ internal unsafe partial class ImageNodeTree : ResNodeTree
 
                 ImGui.TableNextColumn();
 
-                ImGuiHelpers.SafeTextColored(!hiRes ? new Vector4(1) : new(0.6f, 0.6f, 0.6f, 1), "Standard:\t");
+                ImGui.TextColored(!hiRes ? new Vector4(1) : new(0.6f, 0.6f, 0.6f, 1), "Standard:\t");
                 ImGui.SameLine();
                 var cursX = ImGui.GetCursorPosX();
 
                 PrintPartCoords(u / 2f, v / 2f, width / 2f, height / 2f);
 
-                ImGuiHelpers.SafeTextColored(hiRes ? new Vector4(1) : new(0.6f, 0.6f, 0.6f, 1), "Hi-Res:\t");
+                ImGui.TextColored(hiRes ? new Vector4(1) : new(0.6f, 0.6f, 0.6f, 1), "Hi-Res:\t");
                 ImGui.SameLine();
                 ImGui.SetCursorPosX(cursX);
 

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.NineGrid.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.NineGrid.cs
@@ -1,5 +1,7 @@
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Internal.UiDebug2.Utility;
+using Dalamud.Interface.Utility;
+
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 using static Dalamud.Interface.ColorHelpers;
@@ -65,7 +67,7 @@ internal unsafe partial class NineGridNodeTree : ImageNodeTree
             ImGui.GetWindowDrawList().AddRect(ngBegin2, ngEnd2, ngCol);
 
             ImGui.SetCursorPos(cursorLocalPos + uv + new Vector2(0, -20));
-            ImGui.TextColored(col, $"[#{partId}]\t{part.U}, {part.V}\t{part.Width}x{part.Height}");
+            ImGuiHelpers.SafeTextColored(col, $"[#{partId}]\t{part.U}, {part.V}\t{part.Width}x{part.Height}");
         }
 
         ImGui.SetCursorPos(savePos);
@@ -79,7 +81,7 @@ internal unsafe partial class NineGridNodeTree : ImageNodeTree
     {
         if (!isEditorOpen)
         {
-            ImGui.Text("NineGrid Offsets:\t");
+            ImGui.TextUnformatted("NineGrid Offsets:\t"u8);
             ImGui.SameLine();
             this.Offsets.Print();
         }

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.NineGrid.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.NineGrid.cs
@@ -67,7 +67,7 @@ internal unsafe partial class NineGridNodeTree : ImageNodeTree
             ImGui.GetWindowDrawList().AddRect(ngBegin2, ngEnd2, ngCol);
 
             ImGui.SetCursorPos(cursorLocalPos + uv + new Vector2(0, -20));
-            ImGuiHelpers.SafeTextColored(col, $"[#{partId}]\t{part.U}, {part.V}\t{part.Width}x{part.Height}");
+            ImGui.TextColored(col, $"[#{partId}]\t{part.U}, {part.V}\t{part.Width}x{part.Height}");
         }
 
         ImGui.SetCursorPos(savePos);

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.NineGrid.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.NineGrid.cs
@@ -81,7 +81,7 @@ internal unsafe partial class NineGridNodeTree : ImageNodeTree
     {
         if (!isEditorOpen)
         {
-            ImGui.TextUnformatted("NineGrid Offsets:\t"u8);
+            ImGui.Text("NineGrid Offsets:\t"u8);
             ImGui.SameLine();
             this.Offsets.Print();
         }

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Res.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Res.cs
@@ -168,7 +168,7 @@ internal unsafe partial class ResNodeTree : IDisposable
     /// </summary>
     internal void WriteTreeHeading()
     {
-        ImGui.TextUnformatted(this.GetHeaderText());
+        ImGui.Text(this.GetHeaderText());
         this.PrintFieldLabels();
     }
 

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Res.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Res.cs
@@ -183,13 +183,13 @@ internal unsafe partial class ResNodeTree : IDisposable
         if (fieldOffset != null)
         {
             ImGui.SameLine(0, -1);
-            ImGuiHelpers.SafeTextColored(color * 0.85f, $"[0x{fieldOffset:X}]");
+            ImGui.TextColored(color * 0.85f, $"[0x{fieldOffset:X}]");
         }
 
         if (this.AddonTree.FieldNames.TryGetValue(ptr, out var result))
         {
             ImGui.SameLine(0, -1);
-            ImGuiHelpers.SafeTextColored(color, string.Join(".", result));
+            ImGui.TextColored(color, string.Join(".", result));
         }
     }
 

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Res.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Res.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Components;
 using Dalamud.Interface.Internal.UiDebug2.Utility;
+using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
@@ -182,13 +183,13 @@ internal unsafe partial class ResNodeTree : IDisposable
         if (fieldOffset != null)
         {
             ImGui.SameLine(0, -1);
-            ImGui.TextColored(color * 0.85f, $"[0x{fieldOffset:X}]");
+            ImGuiHelpers.SafeTextColored(color * 0.85f, $"[0x{fieldOffset:X}]");
         }
 
         if (this.AddonTree.FieldNames.TryGetValue(ptr, out var result))
         {
             ImGui.SameLine(0, -1);
-            ImGui.TextColored(color, string.Join(".", result));
+            ImGuiHelpers.SafeTextColored(color, string.Join(".", result));
         }
     }
 
@@ -383,7 +384,7 @@ internal unsafe partial class ResNodeTree : IDisposable
 
         if (ImGui.IsItemHovered())
         {
-            ImGui.SetTooltip("Toggle Visibility");
+            ImGui.SetTooltip("Toggle Visibility"u8);
         }
 
         ImGui.SameLine();
@@ -399,7 +400,7 @@ internal unsafe partial class ResNodeTree : IDisposable
 
         if (ImGui.IsItemHovered())
         {
-            ImGui.SetTooltip("Toggle Popout Window");
+            ImGui.SetTooltip("Toggle Popout Window"u8);
         }
     }
 

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Text.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Text.cs
@@ -47,7 +47,7 @@ internal unsafe partial class TextNodeTree : ResNodeTree
             return;
         }
 
-        ImGui.TextColored(new Vector4(1), "Text:");
+        ImGuiHelpers.SafeTextColored(new Vector4(1), "Text:"u8);
         ImGui.SameLine();
 
         try

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Text.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Text.cs
@@ -47,7 +47,7 @@ internal unsafe partial class TextNodeTree : ResNodeTree
             return;
         }
 
-        ImGuiHelpers.SafeTextColored(new Vector4(1), "Text:"u8);
+        ImGui.TextColored(new Vector4(1), "Text:"u8);
         ImGui.SameLine();
 
         try

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Text.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/NodeTree.Text.cs
@@ -64,7 +64,7 @@ internal unsafe partial class TextNodeTree : ResNodeTree
         }
         catch
         {
-            ImGui.TextUnformatted(Marshal.PtrToStringAnsi(new(this.NodeText.StringPtr)) ?? string.Empty);
+            ImGui.Text(Marshal.PtrToStringAnsi(new(this.NodeText.StringPtr)) ?? string.Empty);
         }
 
         PrintFieldValuePairs(
@@ -96,7 +96,7 @@ internal unsafe partial class TextNodeTree : ResNodeTree
             for (var i = 0; i < seString.Payloads.Count; i++)
             {
                 var payload = seString.Payloads[i];
-                ImGui.TextUnformatted($"[{i}]");
+                ImGui.Text($"[{i}]");
                 ImGui.SameLine();
                 switch (payload.Type)
                 {
@@ -108,7 +108,7 @@ internal unsafe partial class TextNodeTree : ResNodeTree
 
                     default:
                     {
-                        ImGui.TextUnformatted(payload.ToString());
+                        ImGui.Text(payload.ToString());
                         break;
                     }
                 }

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/TimelineTree.KeyGroupColumn.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/TimelineTree.KeyGroupColumn.cs
@@ -83,7 +83,7 @@ public readonly partial struct TimelineTree
             }
             else
             {
-                ImGui.TextDisabled("...");
+                ImGui.TextDisabled("..."u8);
             }
         }
     }

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/TimelineTree.KeyGroupColumn.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/TimelineTree.KeyGroupColumn.cs
@@ -66,7 +66,7 @@ public readonly partial struct TimelineTree
         /// The default print function, if none is specified.
         /// </summary>
         /// <param name="value">The value to print.</param>
-        public static void PlainTextCell(T value) => ImGui.TextUnformatted($"{value}");
+        public static void PlainTextCell(T value) => ImGui.Text($"{value}");
 
         /// <summary>
         /// Adds a value to this column.

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/TimelineTree.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/TimelineTree.cs
@@ -151,7 +151,7 @@ public readonly unsafe partial struct TimelineTree
             return;
         }
 
-        var rotColumn = new KeyGroupColumn<float>("Rotation", static r => ImGui.TextUnformatted($"{r * (180d / Math.PI):F1}°"));
+        var rotColumn = new KeyGroupColumn<float>("Rotation", static r => ImGui.Text($"{r * (180d / Math.PI):F1}°"));
 
         for (var f = 0; f < keyGroup.KeyFrameCount; f++)
         {
@@ -430,25 +430,25 @@ public readonly unsafe partial struct TimelineTree
                     var keyFrame = keyFrameGroup.KeyFrames[l];
 
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted($"{keyFrame.FrameIdx}");
+                    ImGui.Text($"{keyFrame.FrameIdx}");
 
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted($"{keyFrame.SpeedCoefficient1:F2}");
+                    ImGui.Text($"{keyFrame.SpeedCoefficient1:F2}");
 
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted($"{keyFrame.SpeedCoefficient2:F2}");
+                    ImGui.Text($"{keyFrame.SpeedCoefficient2:F2}");
 
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted($"{keyFrame.Interpolation}");
+                    ImGui.Text($"{keyFrame.Interpolation}");
 
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted($"{keyFrame.Value.Label.LabelId}");
+                    ImGui.Text($"{keyFrame.Value.Label.LabelId}");
 
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted($"{keyFrame.Value.Label.JumpBehavior}");
+                    ImGui.Text($"{keyFrame.Value.Label.JumpBehavior}");
 
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted($"{keyFrame.Value.Label.JumpLabelId}");
+                    ImGui.Text($"{keyFrame.Value.Label.JumpLabelId}");
                 }
             }
         }

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/TimelineTree.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/TimelineTree.cs
@@ -74,7 +74,7 @@ public readonly unsafe partial struct TimelineTree
                         ("Frame Time", $"{this.NodeTimeline->FrameTime:F2} ({this.NodeTimeline->FrameTime * 30:F0})"));
 
                     PrintFieldValuePairs(("Active Label Id", $"{this.NodeTimeline->ActiveLabelId}"), ("Duration", $"{this.NodeTimeline->LabelFrameIdxDuration}"), ("End Frame", $"{this.NodeTimeline->LabelEndFrameIdx}"));
-                    ImGuiHelpers.SafeTextColored(new Vector4(0.6f, 0.6f, 0.6f, 1), "Animation List"u8);
+                    ImGui.TextColored(new Vector4(0.6f, 0.6f, 0.6f, 1), "Animation List"u8);
 
                     for (var a = 0; a < animationCount; a++)
                     {

--- a/Dalamud/Interface/Internal/UiDebug2/Browsing/TimelineTree.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Browsing/TimelineTree.cs
@@ -74,7 +74,7 @@ public readonly unsafe partial struct TimelineTree
                         ("Frame Time", $"{this.NodeTimeline->FrameTime:F2} ({this.NodeTimeline->FrameTime * 30:F0})"));
 
                     PrintFieldValuePairs(("Active Label Id", $"{this.NodeTimeline->ActiveLabelId}"), ("Duration", $"{this.NodeTimeline->LabelFrameIdxDuration}"), ("End Frame", $"{this.NodeTimeline->LabelEndFrameIdx}"));
-                    ImGui.TextColored(new Vector4(0.6f, 0.6f, 0.6f, 1), "Animation List");
+                    ImGuiHelpers.SafeTextColored(new Vector4(0.6f, 0.6f, 0.6f, 1), "Animation List"u8);
 
                     for (var a = 0; a < animationCount; a++)
                     {
@@ -407,7 +407,7 @@ public readonly unsafe partial struct TimelineTree
             ("StartFrameIdx", $"{this.NodeTimeline->Resource->LabelSets->StartFrameIdx}"),
             ("EndFrameIdx", $"{this.NodeTimeline->Resource->LabelSets->EndFrameIdx}"));
 
-        using var labelSetTable = ImRaii.TreeNode("Entries");
+        using var labelSetTable = ImRaii.TreeNode("Entries"u8);
         if (labelSetTable.Success)
         {
             var keyFrameGroup = this.Resource->LabelSets->LabelKeyGroup;
@@ -415,13 +415,13 @@ public readonly unsafe partial struct TimelineTree
             using var table = ImRaii.Table($"##{(nint)this.node}labelSetKeyFrameTable", 7, Borders | SizingFixedFit | RowBg | NoHostExtendX);
             if (table.Success)
             {
-                ImGui.TableSetupColumn("Frame ID", WidthFixed);
-                ImGui.TableSetupColumn("Speed Start", WidthFixed);
-                ImGui.TableSetupColumn("Speed End", WidthFixed);
-                ImGui.TableSetupColumn("Interpolation", WidthFixed);
-                ImGui.TableSetupColumn("Label ID", WidthFixed);
-                ImGui.TableSetupColumn("Jump Behavior", WidthFixed);
-                ImGui.TableSetupColumn("Target Label ID", WidthFixed);
+                ImGui.TableSetupColumn("Frame ID"u8, WidthFixed);
+                ImGui.TableSetupColumn("Speed Start"u8, WidthFixed);
+                ImGui.TableSetupColumn("Speed End"u8, WidthFixed);
+                ImGui.TableSetupColumn("Interpolation"u8, WidthFixed);
+                ImGui.TableSetupColumn("Label ID"u8, WidthFixed);
+                ImGui.TableSetupColumn("Jump Behavior"u8, WidthFixed);
+                ImGui.TableSetupColumn("Target Label ID"u8, WidthFixed);
 
                 ImGui.TableHeadersRow();
 

--- a/Dalamud/Interface/Internal/UiDebug2/ElementSelector.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/ElementSelector.cs
@@ -79,7 +79,7 @@ internal unsafe class ElementSelector : IDisposable
     /// </summary>
     internal void DrawInterface()
     {
-        using var ch = ImRaii.Child("###sidebar_elementSelector", new(250, -1), true);
+        using var ch = ImRaii.Child("###sidebar_elementSelector"u8, new(250, -1), true);
 
         if (ch.Success)
         {
@@ -105,15 +105,15 @@ internal unsafe class ElementSelector : IDisposable
 
             if (ImGui.IsItemHovered())
             {
-                ImGui.SetTooltip("Element Selector");
+                ImGui.SetTooltip("Element Selector"u8);
             }
 
             ImGui.SameLine();
 
             ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X - 32);
             ImGui.InputTextWithHint(
-                "###addressSearchInput",
-                "Address Search",
+                "###addressSearchInput"u8,
+                "Address Search"u8,
                 ref this.addressSearchInput,
                 18,
                 ImGuiInputTextFlags.AutoSelectAll);
@@ -144,10 +144,10 @@ internal unsafe class ElementSelector : IDisposable
             return;
         }
 
-        ImGui.Text("ELEMENT SELECTOR");
-        ImGui.TextDisabled("Use the mouse to hover and identify UI elements, then click to jump to them in the inspector");
-        ImGui.TextDisabled("Use the scrollwheel to choose between overlapping elements");
-        ImGui.TextDisabled("Press ESCAPE to cancel");
+        ImGui.TextUnformatted("ELEMENT SELECTOR"u8);
+        ImGui.TextDisabled("Use the mouse to hover and identify UI elements, then click to jump to them in the inspector"u8);
+        ImGui.TextDisabled("Use the scrollwheel to choose between overlapping elements"u8);
+        ImGui.TextDisabled("Press ESCAPE to cancel"u8);
         ImGui.Spacing();
 
         var mousePos = ImGui.GetMousePos() - MainViewport.Pos;
@@ -155,7 +155,7 @@ internal unsafe class ElementSelector : IDisposable
 
         using (ImRaii.PushColor(WindowBg, new Vector4(0.5f)))
         {
-            using var ch = ImRaii.Child("noClick", new(800, 2000), false, NoInputs | NoBackground | NoScrollWithMouse);
+            using var ch = ImRaii.Child("noClick"u8, new(800, 2000), false, NoInputs | NoBackground | NoScrollWithMouse);
             if (ch.Success)
             {
                 using var gr = ImRaii.Group();
@@ -163,7 +163,7 @@ internal unsafe class ElementSelector : IDisposable
                 {
                     Gui.PrintFieldValuePair("Mouse Position", $"{mousePos.X}, {mousePos.Y}");
                     ImGui.Spacing();
-                    ImGui.Text("RESULTS:\n");
+                    ImGui.TextUnformatted("RESULTS:\n"u8);
 
                     var i = 0;
                     foreach (var a in addonResults)

--- a/Dalamud/Interface/Internal/UiDebug2/ElementSelector.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/ElementSelector.cs
@@ -144,7 +144,7 @@ internal unsafe class ElementSelector : IDisposable
             return;
         }
 
-        ImGui.TextUnformatted("ELEMENT SELECTOR"u8);
+        ImGui.Text("ELEMENT SELECTOR"u8);
         ImGui.TextDisabled("Use the mouse to hover and identify UI elements, then click to jump to them in the inspector"u8);
         ImGui.TextDisabled("Use the scrollwheel to choose between overlapping elements"u8);
         ImGui.TextDisabled("Press ESCAPE to cancel"u8);
@@ -163,13 +163,13 @@ internal unsafe class ElementSelector : IDisposable
                 {
                     Gui.PrintFieldValuePair("Mouse Position", $"{mousePos.X}, {mousePos.Y}");
                     ImGui.Spacing();
-                    ImGui.TextUnformatted("RESULTS:\n"u8);
+                    ImGui.Text("RESULTS:\n"u8);
 
                     var i = 0;
                     foreach (var a in addonResults)
                     {
                         var name = a.Addon->NameString;
-                        ImGui.TextUnformatted($"[Addon] {name}");
+                        ImGui.Text($"[Addon] {name}");
                         ImGui.Indent(15);
                         foreach (var n in a.Nodes)
                         {

--- a/Dalamud/Interface/Internal/UiDebug2/UiDebug2.Sidebar.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/UiDebug2.Sidebar.cs
@@ -64,7 +64,7 @@ internal unsafe partial class UiDebug2
 
     private void DrawNameSearch()
     {
-        using var ch = ImRaii.Child("###sidebar_nameSearch", new(250, 40), true);
+        using var ch = ImRaii.Child("###sidebar_nameSearch"u8, new(250, 40), true);
 
         if (ch.Success)
         {
@@ -78,13 +78,13 @@ internal unsafe partial class UiDebug2
 
             if (ImGui.IsItemHovered())
             {
-                ImGui.SetTooltip("Filter by visibility");
+                ImGui.SetTooltip("Filter by visibility"u8);
             }
 
             ImGui.SameLine();
 
             ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
-            if (ImGui.InputTextWithHint("###atkUnitBaseSearch", "Filter by name", ref atkUnitBaseSearch, 0x20))
+            if (ImGui.InputTextWithHint("###atkUnitBaseSearch"u8, "Filter by name"u8, ref atkUnitBaseSearch, 0x20))
             {
                 this.addonNameSearch = atkUnitBaseSearch;
             }
@@ -93,7 +93,7 @@ internal unsafe partial class UiDebug2
 
     private void DrawAddonSelectionList()
     {
-        using var ch = ImRaii.Child("###sideBar_addonList", new(250, -44), true, ImGuiWindowFlags.AlwaysVerticalScrollbar);
+        using var ch = ImRaii.Child("###sideBar_addonList"u8, new(250, -44), true, ImGuiWindowFlags.AlwaysVerticalScrollbar);
         if (ch.Success)
         {
             var unitListBaseAddr = GetUnitListBaseAddr();

--- a/Dalamud/Interface/Internal/UiDebug2/UiDebug2.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/UiDebug2.cs
@@ -81,7 +81,7 @@ internal partial class UiDebug2 : IDisposable
     {
         ImGui.SameLine();
 
-        using var ch = ImRaii.Child("###uiDebugMainPanel", new(-1, -1), true, HorizontalScrollbar);
+        using var ch = ImRaii.Child("###uiDebugMainPanel"u8, new(-1, -1), true, HorizontalScrollbar);
 
         if (ch.Success)
         {

--- a/Dalamud/Interface/Internal/UiDebug2/Utility/Gui.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Utility/Gui.cs
@@ -32,7 +32,7 @@ internal static class Gui
         }
         else
         {
-            ImGuiHelpers.SafeTextColored(grey60, value);
+            ImGui.TextColored(grey60, value);
         }
     }
 

--- a/Dalamud/Interface/Internal/UiDebug2/Utility/Gui.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Utility/Gui.cs
@@ -23,7 +23,7 @@ internal static class Gui
     /// <param name="copy">Whether to enable click-to-copy.</param>
     internal static void PrintFieldValuePair(string fieldName, string value, bool copy = true)
     {
-        ImGui.TextUnformatted($"{fieldName}:");
+        ImGui.Text($"{fieldName}:");
         ImGui.SameLine();
         var grey60 = new Vector4(0.6f, 0.6f, 0.6f, 1);
         if (copy)
@@ -108,7 +108,7 @@ internal static class Gui
 
         if (tt.Success)
         {
-            ImGui.TextUnformatted(tooltips[index]);
+            ImGui.Text(tooltips[index]);
         }
 
         return true;

--- a/Dalamud/Interface/Internal/UiDebug2/Utility/Gui.cs
+++ b/Dalamud/Interface/Internal/UiDebug2/Utility/Gui.cs
@@ -32,7 +32,7 @@ internal static class Gui
         }
         else
         {
-            ImGui.TextColored(grey60, value);
+            ImGuiHelpers.SafeTextColored(grey60, value);
         }
     }
 

--- a/Dalamud/Interface/Internal/Windows/BranchSwitcherWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/BranchSwitcherWindow.cs
@@ -61,7 +61,7 @@ public class BranchSwitcherWindow : Window
     {
         if (this.branches == null)
         {
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, "Loading branches..."u8);
+            ImGui.TextColored(ImGuiColors.DalamudGrey, "Loading branches..."u8);
             return;
         }
 
@@ -74,7 +74,7 @@ public class BranchSwitcherWindow : Window
 
         if (pickedBranch.Value.SupportedGameVer != si.GameVersion)
         {
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, "Can't pick this branch. GameVer != SupportedGameVer."u8);
+            ImGui.TextColored(ImGuiColors.DalamudRed, "Can't pick this branch. GameVer != SupportedGameVer."u8);
         }
         else
         {

--- a/Dalamud/Interface/Internal/Windows/BranchSwitcherWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/BranchSwitcherWindow.cs
@@ -61,7 +61,7 @@ public class BranchSwitcherWindow : Window
     {
         if (this.branches == null)
         {
-            ImGui.TextColored(ImGuiColors.DalamudGrey, "Loading branches...");
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, "Loading branches..."u8);
             return;
         }
 
@@ -74,12 +74,12 @@ public class BranchSwitcherWindow : Window
 
         if (pickedBranch.Value.SupportedGameVer != si.GameVersion)
         {
-            ImGui.TextColored(ImGuiColors.DalamudRed, "Can't pick this branch. GameVer != SupportedGameVer.");
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, "Can't pick this branch. GameVer != SupportedGameVer."u8);
         }
         else
         {
-            ImGui.Text($"Version: {pickedBranch.Value.AssemblyVersion} ({pickedBranch.Value.GitSha ?? "unk"})");
-            ImGui.Text($"Runtime: {pickedBranch.Value.RuntimeVersion}");
+            ImGui.TextUnformatted($"Version: {pickedBranch.Value.AssemblyVersion} ({pickedBranch.Value.GitSha ?? "unk"})");
+            ImGui.TextUnformatted($"Runtime: {pickedBranch.Value.RuntimeVersion}");
 
             ImGuiHelpers.ScaledDummy(5);
 
@@ -91,7 +91,7 @@ public class BranchSwitcherWindow : Window
                 config.QueueSave();
             }
 
-            if (ImGui.Button("Pick"))
+            if (ImGui.Button("Pick"u8))
             {
                 Pick();
                 this.IsOpen = false;
@@ -99,7 +99,7 @@ public class BranchSwitcherWindow : Window
 
             ImGui.SameLine();
 
-            if (ImGui.Button("Pick & Restart"))
+            if (ImGui.Button("Pick & Restart"u8))
             {
                 Pick();
 

--- a/Dalamud/Interface/Internal/Windows/BranchSwitcherWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/BranchSwitcherWindow.cs
@@ -78,8 +78,8 @@ public class BranchSwitcherWindow : Window
         }
         else
         {
-            ImGui.TextUnformatted($"Version: {pickedBranch.Value.AssemblyVersion} ({pickedBranch.Value.GitSha ?? "unk"})");
-            ImGui.TextUnformatted($"Runtime: {pickedBranch.Value.RuntimeVersion}");
+            ImGui.Text($"Version: {pickedBranch.Value.AssemblyVersion} ({pickedBranch.Value.GitSha ?? "unk"})");
+            ImGui.Text($"Runtime: {pickedBranch.Value.RuntimeVersion}");
 
             ImGuiHelpers.ScaledDummy(5);
 

--- a/Dalamud/Interface/Internal/Windows/ChangelogWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ChangelogWindow.cs
@@ -357,24 +357,24 @@ internal sealed class ChangelogWindow : Window, IDisposable
                 {
                     case State.WindowFadeIn:
                     case State.ExplainerIntro:
-                        ImGuiHelpers.SafeTextWrapped($"Welcome to Dalamud v{Util.GetScmVersion()}!");
+                        ImGui.TextWrapped($"Welcome to Dalamud v{Util.GetScmVersion()}!");
                         ImGuiHelpers.ScaledDummy(5);
-                        ImGuiHelpers.SafeTextWrapped(ChangeLog);
+                        ImGui.TextWrapped(ChangeLog);
                         ImGuiHelpers.ScaledDummy(5);
-                        ImGuiHelpers.SafeTextWrapped("This changelog is a quick overview of the most important changes in this version."u8);
-                        ImGuiHelpers.SafeTextWrapped("Please click next to see a quick guide to updating your plugins."u8);
+                        ImGui.TextWrapped("This changelog is a quick overview of the most important changes in this version."u8);
+                        ImGui.TextWrapped("Please click next to see a quick guide to updating your plugins."u8);
 
                         DrawNextButton(State.ExplainerApiBump);
                         break;
 
                     case State.ExplainerApiBump:
-                        ImGuiHelpers.SafeTextWrapped("Take care! Due to changes in this patch, all of your plugins need to be updated and were disabled automatically."u8);
-                        ImGuiHelpers.SafeTextWrapped("This is normal and required for major game updates."u8);
+                        ImGui.TextWrapped("Take care! Due to changes in this patch, all of your plugins need to be updated and were disabled automatically."u8);
+                        ImGui.TextWrapped("This is normal and required for major game updates."u8);
                         ImGuiHelpers.ScaledDummy(5);
-                        ImGuiHelpers.SafeTextWrapped("To update your plugins, open the plugin installer and click 'update plugins'. Updated plugins should update and then re-enable themselves."u8);
+                        ImGui.TextWrapped("To update your plugins, open the plugin installer and click 'update plugins'. Updated plugins should update and then re-enable themselves."u8);
                         ImGuiHelpers.ScaledDummy(5);
-                        ImGuiHelpers.SafeTextWrapped("Please keep in mind that not all of your plugins may already be updated for the new version."u8);
-                        ImGuiHelpers.SafeTextWrapped("If some plugins are displayed with a red cross in the 'Installed Plugins' tab, they may not yet be available."u8);
+                        ImGui.TextWrapped("Please keep in mind that not all of your plugins may already be updated for the new version."u8);
+                        ImGui.TextWrapped("If some plugins are displayed with a red cross in the 'Installed Plugins' tab, they may not yet be available."u8);
 
                         ImGuiHelpers.ScaledDummy(15);
 
@@ -398,15 +398,15 @@ internal sealed class ChangelogWindow : Window, IDisposable
                         break;
 
                     case State.AskAutoUpdate:
-                        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudWhite, Loc.Localize("DalamudSettingsAutoUpdateHint",
+                        ImGui.TextColoredWrapped(ImGuiColors.DalamudWhite, Loc.Localize("DalamudSettingsAutoUpdateHint",
                                                 "Dalamud can update your plugins automatically, making sure that you always " +
                                                 "have the newest features and bug fixes. You can choose when and how auto-updates are run here."));
                         ImGuiHelpers.ScaledDummy(2);
 
-                        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsAutoUpdateDisclaimer1",
+                        ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsAutoUpdateDisclaimer1",
                                                                 "You can always update your plugins manually by clicking the update button in the plugin list. " +
                                                                 "You can also opt into updates for specific plugins by right-clicking them and selecting \"Always auto-update\"."));
-                        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsAutoUpdateDisclaimer2",
+                        ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsAutoUpdateDisclaimer2",
                                                                 "Dalamud will only notify you about updates while you are idle."));
 
                         ImGuiHelpers.ScaledDummy(15);
@@ -446,8 +446,8 @@ internal sealed class ChangelogWindow : Window, IDisposable
                         break;
 
                     case State.Links:
-                        ImGuiHelpers.SafeTextWrapped("If you note any issues or need help, please check the FAQ, and reach out on our Discord if you need help."u8);
-                        ImGuiHelpers.SafeTextWrapped("Enjoy your time with the game and Dalamud!"u8);
+                        ImGui.TextWrapped("If you note any issues or need help, please check the FAQ, and reach out on our Discord if you need help."u8);
+                        ImGui.TextWrapped("Enjoy your time with the game and Dalamud!"u8);
 
                         ImGuiHelpers.ScaledDummy(45);
 

--- a/Dalamud/Interface/Internal/Windows/ChangelogWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ChangelogWindow.cs
@@ -253,7 +253,7 @@ internal sealed class ChangelogWindow : Window, IDisposable
         ImGui.SameLine();
 
         var logoContainerSize = new Vector2(windowSize.X * 0.2f - dummySize, windowSize.Y);
-        using (var child = ImRaii.Child("###logoContainer", logoContainerSize, false))
+        using (var child = ImRaii.Child("###logoContainer"u8, logoContainerSize, false))
         {
             if (!child)
                 return;
@@ -271,7 +271,7 @@ internal sealed class ChangelogWindow : Window, IDisposable
         ImGui.Dummy(new Vector2(dummySize));
         ImGui.SameLine();
 
-        using (var child = ImRaii.Child("###textContainer", new Vector2((windowSize.X * 0.8f) - dummySize * 4, windowSize.Y), false))
+        using (var child = ImRaii.Child("###textContainer"u8, new Vector2((windowSize.X * 0.8f) - dummySize * 4, windowSize.Y), false))
         {
             if (!child)
                 return;
@@ -357,24 +357,24 @@ internal sealed class ChangelogWindow : Window, IDisposable
                 {
                     case State.WindowFadeIn:
                     case State.ExplainerIntro:
-                        ImGui.TextWrapped($"Welcome to Dalamud v{Util.GetScmVersion()}!");
+                        ImGuiHelpers.SafeTextWrapped($"Welcome to Dalamud v{Util.GetScmVersion()}!");
                         ImGuiHelpers.ScaledDummy(5);
-                        ImGui.TextWrapped(ChangeLog);
+                        ImGuiHelpers.SafeTextWrapped(ChangeLog);
                         ImGuiHelpers.ScaledDummy(5);
-                        ImGui.TextWrapped("This changelog is a quick overview of the most important changes in this version.");
-                        ImGui.TextWrapped("Please click next to see a quick guide to updating your plugins.");
+                        ImGuiHelpers.SafeTextWrapped("This changelog is a quick overview of the most important changes in this version."u8);
+                        ImGuiHelpers.SafeTextWrapped("Please click next to see a quick guide to updating your plugins."u8);
 
                         DrawNextButton(State.ExplainerApiBump);
                         break;
 
                     case State.ExplainerApiBump:
-                        ImGui.TextWrapped("Take care! Due to changes in this patch, all of your plugins need to be updated and were disabled automatically.");
-                        ImGui.TextWrapped("This is normal and required for major game updates.");
+                        ImGuiHelpers.SafeTextWrapped("Take care! Due to changes in this patch, all of your plugins need to be updated and were disabled automatically."u8);
+                        ImGuiHelpers.SafeTextWrapped("This is normal and required for major game updates."u8);
                         ImGuiHelpers.ScaledDummy(5);
-                        ImGui.TextWrapped("To update your plugins, open the plugin installer and click 'update plugins'. Updated plugins should update and then re-enable themselves.");
+                        ImGuiHelpers.SafeTextWrapped("To update your plugins, open the plugin installer and click 'update plugins'. Updated plugins should update and then re-enable themselves."u8);
                         ImGuiHelpers.ScaledDummy(5);
-                        ImGui.TextWrapped("Please keep in mind that not all of your plugins may already be updated for the new version.");
-                        ImGui.TextWrapped("If some plugins are displayed with a red cross in the 'Installed Plugins' tab, they may not yet be available.");
+                        ImGuiHelpers.SafeTextWrapped("Please keep in mind that not all of your plugins may already be updated for the new version."u8);
+                        ImGuiHelpers.SafeTextWrapped("If some plugins are displayed with a red cross in the 'Installed Plugins' tab, they may not yet be available."u8);
 
                         ImGuiHelpers.ScaledDummy(15);
 
@@ -446,8 +446,8 @@ internal sealed class ChangelogWindow : Window, IDisposable
                         break;
 
                     case State.Links:
-                        ImGui.TextWrapped("If you note any issues or need help, please check the FAQ, and reach out on our Discord if you need help.");
-                        ImGui.TextWrapped("Enjoy your time with the game and Dalamud!");
+                        ImGuiHelpers.SafeTextWrapped("If you note any issues or need help, please check the FAQ, and reach out on our Discord if you need help."u8);
+                        ImGuiHelpers.SafeTextWrapped("Enjoy your time with the game and Dalamud!"u8);
 
                         ImGuiHelpers.ScaledDummy(45);
 
@@ -529,7 +529,7 @@ internal sealed class ChangelogWindow : Window, IDisposable
 
             if (ImGui.IsItemHovered())
             {
-                ImGui.SetTooltip("I don't care about this");
+                ImGui.SetTooltip("I don't care about this"u8);
             }
         }
     }

--- a/Dalamud/Interface/Internal/Windows/ColorDemoWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ColorDemoWindow.cs
@@ -53,7 +53,7 @@ internal sealed class ColorDemoWindow : Window
     /// <inheritdoc/>
     public override void Draw()
     {
-        ImGui.TextUnformatted("This is a collection of UI colors you can use in your plugin."u8);
+        ImGui.Text("This is a collection of UI colors you can use in your plugin."u8);
 
         ImGui.Separator();
 

--- a/Dalamud/Interface/Internal/Windows/ColorDemoWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ColorDemoWindow.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
+using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
 
 namespace Dalamud.Interface.Internal.Windows;
@@ -52,14 +53,14 @@ internal sealed class ColorDemoWindow : Window
     /// <inheritdoc/>
     public override void Draw()
     {
-        ImGui.Text("This is a collection of UI colors you can use in your plugin.");
+        ImGui.TextUnformatted("This is a collection of UI colors you can use in your plugin."u8);
 
         ImGui.Separator();
 
         foreach (var property in typeof(ImGuiColors).GetProperties(BindingFlags.Public | BindingFlags.Static))
         {
             var color = (Vector4)property.GetValue(null);
-            ImGui.TextColored(color, property.Name);
+            ImGuiHelpers.SafeTextColored(color, property.Name);
         }
     }
 }

--- a/Dalamud/Interface/Internal/Windows/ColorDemoWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ColorDemoWindow.cs
@@ -60,7 +60,7 @@ internal sealed class ColorDemoWindow : Window
         foreach (var property in typeof(ImGuiColors).GetProperties(BindingFlags.Public | BindingFlags.Static))
         {
             var color = (Vector4)property.GetValue(null);
-            ImGuiHelpers.SafeTextColored(color, property.Name);
+            ImGui.TextColored(color, property.Name);
         }
     }
 }

--- a/Dalamud/Interface/Internal/Windows/ComponentDemoWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ComponentDemoWindow.cs
@@ -73,7 +73,7 @@ internal sealed class ComponentDemoWindow : Window
     /// <inheritdoc/>
     public override void Draw()
     {
-        ImGui.Text("This is a collection of UI components you can use in your plugin.");
+        ImGui.TextUnformatted("This is a collection of UI components you can use in your plugin."u8);
 
         for (var i = 0; i < this.componentDemos.Count; i++)
         {
@@ -85,7 +85,7 @@ internal sealed class ComponentDemoWindow : Window
             }
         }
 
-        if (ImGui.CollapsingHeader("Easing animations"))
+        if (ImGui.CollapsingHeader("Easing animations"u8))
         {
             this.EasingsDemo();
         }
@@ -93,22 +93,22 @@ internal sealed class ComponentDemoWindow : Window
 
     private static void HelpMarkerDemo()
     {
-        ImGui.Text("Hover over the icon to learn more.");
+        ImGui.TextUnformatted("Hover over the icon to learn more."u8);
         ImGuiComponents.HelpMarker("help me!");
     }
 
     private static void IconButtonDemo()
     {
-        ImGui.Text("Click on the icon to use as a button.");
+        ImGui.TextUnformatted("Click on the icon to use as a button."u8);
         ImGui.SameLine();
         if (ImGuiComponents.IconButton(1, FontAwesomeIcon.Carrot))
         {
-            ImGui.OpenPopup("IconButtonDemoPopup");
+            ImGui.OpenPopup("IconButtonDemoPopup"u8);
         }
 
-        if (ImGui.BeginPopup("IconButtonDemoPopup"))
+        if (ImGui.BeginPopup("IconButtonDemoPopup"u8))
         {
-            ImGui.Text("You clicked!");
+            ImGui.TextUnformatted("You clicked!"u8);
             ImGui.EndPopup();
         }
     }
@@ -120,7 +120,7 @@ internal sealed class ComponentDemoWindow : Window
 
     private void EasingsDemo()
     {
-        ImGui.SliderInt("Speed in MS", ref this.animationTimeMs, 200, 5000);
+        ImGui.SliderInt("Speed in MS"u8, ref this.animationTimeMs, 200, 5000);
 
         foreach (var easing in this.easings)
         {
@@ -147,14 +147,14 @@ internal sealed class ComponentDemoWindow : Window
             ImGui.Bullet();
 
             ImGui.SetCursorPos(cursor + new Vector2(0, 10));
-            ImGui.Text($"{easing.GetType().Name} ({easing.ValueClamped})");
+            ImGui.TextUnformatted($"{easing.GetType().Name} ({easing.ValueClamped})");
             ImGuiHelpers.ScaledDummy(5);
         }
     }
 
     private void ColorPickerWithPaletteDemo()
     {
-        ImGui.Text("Click on the color button to use the picker.");
+        ImGui.TextUnformatted("Click on the color button to use the picker."u8);
         ImGui.SameLine();
         this.defaultColor = ImGuiComponents.ColorPickerWithPalette(1, "ColorPickerWithPalette Demo", this.defaultColor);
     }

--- a/Dalamud/Interface/Internal/Windows/ComponentDemoWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ComponentDemoWindow.cs
@@ -73,7 +73,7 @@ internal sealed class ComponentDemoWindow : Window
     /// <inheritdoc/>
     public override void Draw()
     {
-        ImGui.TextUnformatted("This is a collection of UI components you can use in your plugin."u8);
+        ImGui.Text("This is a collection of UI components you can use in your plugin."u8);
 
         for (var i = 0; i < this.componentDemos.Count; i++)
         {
@@ -93,13 +93,13 @@ internal sealed class ComponentDemoWindow : Window
 
     private static void HelpMarkerDemo()
     {
-        ImGui.TextUnformatted("Hover over the icon to learn more."u8);
+        ImGui.Text("Hover over the icon to learn more."u8);
         ImGuiComponents.HelpMarker("help me!");
     }
 
     private static void IconButtonDemo()
     {
-        ImGui.TextUnformatted("Click on the icon to use as a button."u8);
+        ImGui.Text("Click on the icon to use as a button."u8);
         ImGui.SameLine();
         if (ImGuiComponents.IconButton(1, FontAwesomeIcon.Carrot))
         {
@@ -108,7 +108,7 @@ internal sealed class ComponentDemoWindow : Window
 
         if (ImGui.BeginPopup("IconButtonDemoPopup"u8))
         {
-            ImGui.TextUnformatted("You clicked!"u8);
+            ImGui.Text("You clicked!"u8);
             ImGui.EndPopup();
         }
     }
@@ -147,14 +147,14 @@ internal sealed class ComponentDemoWindow : Window
             ImGui.Bullet();
 
             ImGui.SetCursorPos(cursor + new Vector2(0, 10));
-            ImGui.TextUnformatted($"{easing.GetType().Name} ({easing.ValueClamped})");
+            ImGui.Text($"{easing.GetType().Name} ({easing.ValueClamped})");
             ImGuiHelpers.ScaledDummy(5);
         }
     }
 
     private void ColorPickerWithPaletteDemo()
     {
-        ImGui.TextUnformatted("Click on the color button to use the picker."u8);
+        ImGui.Text("Click on the color button to use the picker."u8);
         ImGui.SameLine();
         this.defaultColor = ImGuiComponents.ColorPickerWithPalette(1, "ColorPickerWithPalette Demo", this.defaultColor);
     }

--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -158,7 +158,7 @@ internal class ConsoleWindow : Window, IDisposable
 
         if (this.exceptionLogFilter is not null)
         {
-            ImGui.TextColored(
+            ImGuiHelpers.SafeTextColored(
                 ImGuiColors.DalamudRed,
                 $"Regex Filter Error: {this.exceptionLogFilter.GetType().Name}");
             ImGui.TextUnformatted(this.exceptionLogFilter.Message);
@@ -166,17 +166,17 @@ internal class ConsoleWindow : Window, IDisposable
 
         if (this.exceptionLogHighlight is not null)
         {
-            ImGui.TextColored(
+            ImGuiHelpers.SafeTextColored(
                 ImGuiColors.DalamudRed,
                 $"Regex Highlight Error: {this.exceptionLogHighlight.GetType().Name}");
             ImGui.TextUnformatted(this.exceptionLogHighlight.Message);
         }
 
-        var sendButtonSize = ImGui.CalcTextSize("Send") +
+        var sendButtonSize = ImGui.CalcTextSize("Send"u8) +
                              ((new Vector2(16, 0) + (ImGui.GetStyle().FramePadding * 2)) * ImGuiHelpers.GlobalScale);
         var scrollingHeight = ImGui.GetContentRegionAvail().Y - sendButtonSize.Y;
         ImGui.BeginChild(
-            "scrolling",
+            "scrolling"u8,
             new Vector2(0, scrollingHeight),
             false,
             ImGuiWindowFlags.AlwaysHorizontalScrollbar | ImGuiWindowFlags.AlwaysVerticalScrollbar);
@@ -189,9 +189,9 @@ internal class ConsoleWindow : Window, IDisposable
         var childDrawList = ImGui.GetWindowDrawList();
         var childSize = ImGui.GetWindowSize();
 
-        var timestampWidth = ImGui.CalcTextSize("00:00:00.000").X;
-        var levelWidth = ImGui.CalcTextSize("AAA").X;
-        var separatorWidth = ImGui.CalcTextSize(" | ").X;
+        var timestampWidth = ImGui.CalcTextSize("00:00:00.000"u8).X;
+        var levelWidth = ImGui.CalcTextSize("AAA"u8).X;
+        var separatorWidth = ImGui.CalcTextSize(" | "u8).X;
         var cursorLogLevel = timestampWidth + separatorWidth;
         var cursorLogLine = cursorLogLevel + levelWidth + separatorWidth;
 
@@ -225,7 +225,7 @@ internal class ConsoleWindow : Window, IDisposable
                 }
 
                 ImGui.Selectable(
-                    "###console_null",
+                    "###console_null"u8,
                     true,
                     ImGuiSelectableFlags.AllowItemOverlap | ImGuiSelectableFlags.SpanAllColumns);
 
@@ -321,7 +321,7 @@ internal class ConsoleWindow : Window, IDisposable
         unsafe
         {
             if (ImGui.InputText(
-                    "##command_box",
+                    "##command_box"u8,
                     ref this.commandText,
                     255,
                     ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.CallbackCompletion |
@@ -341,7 +341,7 @@ internal class ConsoleWindow : Window, IDisposable
 
         if (hadColor) ImGui.PopStyleColor();
 
-        if (ImGui.Button("Send", sendButtonSize))
+        if (ImGui.Button("Send"u8, sendButtonSize))
         {
             this.ProcessCommand();
         }
@@ -473,7 +473,7 @@ internal class ConsoleWindow : Window, IDisposable
     private void DrawOptionsToolbar()
     {
         ImGui.PushItemWidth(150.0f * ImGuiHelpers.GlobalScale);
-        if (ImGui.BeginCombo("##log_level", $"{EntryPoint.LogLevelSwitch.MinimumLevel}+"))
+        if (ImGui.BeginCombo("##log_level"u8, $"{EntryPoint.LogLevelSwitch.MinimumLevel}+"))
         {
             foreach (var value in Enum.GetValues<LogEventLevel>())
             {
@@ -491,7 +491,7 @@ internal class ConsoleWindow : Window, IDisposable
 
         ImGui.SameLine();
 
-        var settingsPopup = ImGui.BeginPopup("##console_settings");
+        var settingsPopup = ImGui.BeginPopup("##console_settings"u8);
         if (settingsPopup)
         {
             this.DrawSettingsPopup();
@@ -506,7 +506,7 @@ internal class ConsoleWindow : Window, IDisposable
         this.settingsPopupWasOpen = settingsPopup;
 
         if (this.DrawToggleButtonWithTooltip("show_settings", "Show settings", FontAwesomeIcon.List, ref settingsPopup))
-            ImGui.OpenPopup("##console_settings");
+            ImGui.OpenPopup("##console_settings"u8);
 
         ImGui.SameLine();
 
@@ -537,7 +537,7 @@ internal class ConsoleWindow : Window, IDisposable
             this.QueueClear();
         }
 
-        if (ImGui.IsItemHovered()) ImGui.SetTooltip("Clear Log");
+        if (ImGui.IsItemHovered()) ImGui.SetTooltip("Clear Log"u8);
 
         ImGui.SameLine();
 
@@ -573,7 +573,7 @@ internal class ConsoleWindow : Window, IDisposable
                 this.killGameArmed = true;
         }
 
-        if (ImGui.IsItemHovered()) ImGui.SetTooltip("Kill game");
+        if (ImGui.IsItemHovered()) ImGui.SetTooltip("Kill game"u8);
 
         ImGui.SameLine();
 
@@ -595,8 +595,8 @@ internal class ConsoleWindow : Window, IDisposable
 
         ImGui.PushItemWidth(inputWidth);
         if (ImGui.InputTextWithHint(
-                "##textHighlight",
-                "regex highlight",
+                "##textHighlight"u8,
+                "regex highlight"u8,
                 ref this.textHighlight,
                 2048,
                 ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.AutoSelectAll)
@@ -623,8 +623,8 @@ internal class ConsoleWindow : Window, IDisposable
 
         ImGui.PushItemWidth(inputWidth);
         if (ImGui.InputTextWithHint(
-                "##textFilter",
-                "regex global filter",
+                "##textFilter"u8,
+                "regex global filter"u8,
                 ref this.textFilter,
                 2048,
                 ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.AutoSelectAll)
@@ -655,21 +655,21 @@ internal class ConsoleWindow : Window, IDisposable
 
     private void DrawSettingsPopup()
     {
-        if (ImGui.Checkbox("Open at startup", ref this.autoOpen))
+        if (ImGui.Checkbox("Open at startup"u8, ref this.autoOpen))
         {
             this.configuration.LogOpenAtStartup = this.autoOpen;
             this.configuration.QueueSave();
         }
 
-        if (ImGui.Checkbox("Auto-scroll", ref this.autoScroll))
+        if (ImGui.Checkbox("Auto-scroll"u8, ref this.autoScroll))
         {
             this.configuration.LogAutoScroll = this.autoScroll;
             this.configuration.QueueSave();
         }
 
-        ImGui.TextUnformatted("Logs buffer");
-        ImGui.SliderInt("lines", ref this.logLinesLimit, LogLinesMinimum, LogLinesMaximum);
-        if (ImGui.Button("Apply"))
+        ImGui.TextUnformatted("Logs buffer"u8);
+        ImGui.SliderInt("lines"u8, ref this.logLinesLimit, LogLinesMinimum, LogLinesMaximum);
+        if (ImGui.Button("Apply"u8))
         {
             this.logLinesLimit = Math.Max(LogLinesMinimum, this.logLinesLimit);
 
@@ -686,15 +686,15 @@ internal class ConsoleWindow : Window, IDisposable
 
         PluginFilterEntry? removalEntry = null;
         using var table = ImRaii.Table(
-            "plugin_filter_entries",
+            "plugin_filter_entries"u8,
             4,
             ImGuiTableFlags.Resizable | ImGuiTableFlags.BordersInnerV);
         if (!table) return;
 
-        ImGui.TableSetupColumn("##remove_button", ImGuiTableColumnFlags.WidthFixed, 25.0f * ImGuiHelpers.GlobalScale);
-        ImGui.TableSetupColumn("##source_name", ImGuiTableColumnFlags.WidthFixed, 150.0f * ImGuiHelpers.GlobalScale);
-        ImGui.TableSetupColumn("##log_level", ImGuiTableColumnFlags.WidthFixed, 150.0f * ImGuiHelpers.GlobalScale);
-        ImGui.TableSetupColumn("##filter_text", ImGuiTableColumnFlags.WidthStretch);
+        ImGui.TableSetupColumn("##remove_button"u8, ImGuiTableColumnFlags.WidthFixed, 25.0f * ImGuiHelpers.GlobalScale);
+        ImGui.TableSetupColumn("##source_name"u8, ImGuiTableColumnFlags.WidthFixed, 150.0f * ImGuiHelpers.GlobalScale);
+        ImGui.TableSetupColumn("##log_level"u8, ImGuiTableColumnFlags.WidthFixed, 150.0f * ImGuiHelpers.GlobalScale);
+        ImGui.TableSetupColumn("##filter_text"u8, ImGuiTableColumnFlags.WidthStretch);
 
         ImGui.TableNextColumn();
         if (ImGuiComponents.IconButton("add_entry", FontAwesomeIcon.Plus))
@@ -715,7 +715,7 @@ internal class ConsoleWindow : Window, IDisposable
 
         ImGui.TableNextColumn();
         ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X);
-        if (ImGui.BeginCombo("##Sources", this.selectedSource, ImGuiComboFlags.HeightLarge))
+        if (ImGui.BeginCombo("##Sources"u8, this.selectedSource, ImGuiComboFlags.HeightLarge))
         {
             var sourceNames = Service<PluginManager>.Get().InstalledPlugins
                                                     .Select(p => p.Manifest.InternalName)
@@ -729,12 +729,12 @@ internal class ConsoleWindow : Window, IDisposable
                                                     .ToList();
 
             ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X);
-            ImGui.InputTextWithHint("##PluginSearchFilter", "Filter Plugin List", ref this.pluginFilter, 2048);
+            ImGui.InputTextWithHint("##PluginSearchFilter"u8, "Filter Plugin List"u8, ref this.pluginFilter, 2048);
             ImGui.Separator();
 
-            if (!sourceNames.Any())
+            if (sourceNames.Count == 0)
             {
-                ImGui.TextColored(ImGuiColors.DalamudRed, "No Results");
+                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, "No Results"u8);
             }
 
             foreach (var selectable in sourceNames)
@@ -762,11 +762,11 @@ internal class ConsoleWindow : Window, IDisposable
             }
 
             ImGui.TableNextColumn();
-            ImGui.Text(entry.Source);
+            ImGui.TextUnformatted(entry.Source);
 
             ImGui.TableNextColumn();
             ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
-            if (ImGui.BeginCombo("##levels", $"{entry.Level}+"))
+            if (ImGui.BeginCombo("##levels"u8, $"{entry.Level}+"))
             {
                 foreach (var value in Enum.GetValues<LogEventLevel>())
                 {
@@ -784,7 +784,7 @@ internal class ConsoleWindow : Window, IDisposable
             ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
             var entryFilter = entry.Filter;
             if (ImGui.InputTextWithHint(
-                    "##filter",
+                    "##filter"u8,
                     $"{entry.Source} regex filter",
                     ref entryFilter,
                     2048,

--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -161,7 +161,7 @@ internal class ConsoleWindow : Window, IDisposable
             ImGuiHelpers.SafeTextColored(
                 ImGuiColors.DalamudRed,
                 $"Regex Filter Error: {this.exceptionLogFilter.GetType().Name}");
-            ImGui.TextUnformatted(this.exceptionLogFilter.Message);
+            ImGui.Text(this.exceptionLogFilter.Message);
         }
 
         if (this.exceptionLogHighlight is not null)
@@ -169,7 +169,7 @@ internal class ConsoleWindow : Window, IDisposable
             ImGuiHelpers.SafeTextColored(
                 ImGuiColors.DalamudRed,
                 $"Regex Highlight Error: {this.exceptionLogHighlight.GetType().Name}");
-            ImGui.TextUnformatted(this.exceptionLogHighlight.Message);
+            ImGui.Text(this.exceptionLogHighlight.Message);
         }
 
         var sendButtonSize = ImGui.CalcTextSize("Send"u8) +
@@ -238,11 +238,11 @@ internal class ConsoleWindow : Window, IDisposable
 
                 if (!line.IsMultiline)
                 {
-                    ImGui.TextUnformatted(line.TimestampString);
+                    ImGui.Text(line.TimestampString);
                     ImGui.SameLine();
 
                     ImGui.SetCursorPosX(cursorLogLevel);
-                    ImGui.TextUnformatted(GetTextForLogEventLevel(line.Level));
+                    ImGui.Text(GetTextForLogEventLevel(line.Level));
                     ImGui.SameLine();
                 }
 
@@ -258,7 +258,7 @@ internal class ConsoleWindow : Window, IDisposable
                 }
                 else
                 {
-                    ImGui.TextUnformatted(line.Line);
+                    ImGui.Text(line.Line);
                 }
 
                 var currentLinePosY = ImGui.GetCursorPosY();
@@ -667,7 +667,7 @@ internal class ConsoleWindow : Window, IDisposable
             this.configuration.QueueSave();
         }
 
-        ImGui.TextUnformatted("Logs buffer"u8);
+        ImGui.Text("Logs buffer"u8);
         ImGui.SliderInt("lines"u8, ref this.logLinesLimit, LogLinesMinimum, LogLinesMaximum);
         if (ImGui.Button("Apply"u8))
         {
@@ -762,7 +762,7 @@ internal class ConsoleWindow : Window, IDisposable
             }
 
             ImGui.TableNextColumn();
-            ImGui.TextUnformatted(entry.Source);
+            ImGui.Text(entry.Source);
 
             ImGui.TableNextColumn();
             ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);

--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -158,7 +158,7 @@ internal class ConsoleWindow : Window, IDisposable
 
         if (this.exceptionLogFilter is not null)
         {
-            ImGuiHelpers.SafeTextColored(
+            ImGui.TextColored(
                 ImGuiColors.DalamudRed,
                 $"Regex Filter Error: {this.exceptionLogFilter.GetType().Name}");
             ImGui.Text(this.exceptionLogFilter.Message);
@@ -166,7 +166,7 @@ internal class ConsoleWindow : Window, IDisposable
 
         if (this.exceptionLogHighlight is not null)
         {
-            ImGuiHelpers.SafeTextColored(
+            ImGui.TextColored(
                 ImGuiColors.DalamudRed,
                 $"Regex Highlight Error: {this.exceptionLogHighlight.GetType().Name}");
             ImGui.Text(this.exceptionLogHighlight.Message);
@@ -734,7 +734,7 @@ internal class ConsoleWindow : Window, IDisposable
 
             if (sourceNames.Count == 0)
             {
-                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, "No Results"u8);
+                ImGui.TextColored(ImGuiColors.DalamudRed, "No Results"u8);
             }
 
             foreach (var selectable in sourceNames)

--- a/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
@@ -130,10 +130,10 @@ internal class DataWindow : Window, IDisposable
             return;
         }
 
-        if (ImGui.BeginTable("XlData_Table", 2, ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.Resizable))
+        if (ImGui.BeginTable("XlData_Table"u8, 2, ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.Resizable))
         {
-            ImGui.TableSetupColumn("##SelectionColumn", ImGuiTableColumnFlags.WidthFixed, 200.0f * ImGuiHelpers.GlobalScale);
-            ImGui.TableSetupColumn("##ContentsColumn", ImGuiTableColumnFlags.WidthStretch);
+            ImGui.TableSetupColumn("##SelectionColumn"u8, ImGuiTableColumnFlags.WidthFixed, 200.0f * ImGuiHelpers.GlobalScale);
+            ImGui.TableSetupColumn("##ContentsColumn"u8, ImGuiTableColumnFlags.WidthStretch);
 
             ImGui.TableNextColumn();
             this.DrawSelection();
@@ -147,9 +147,9 @@ internal class DataWindow : Window, IDisposable
 
     private void DrawSelection()
     {
-        if (ImGui.BeginChild("XlData_SelectionPane", ImGui.GetContentRegionAvail()))
+        if (ImGui.BeginChild("XlData_SelectionPane"u8, ImGui.GetContentRegionAvail()))
         {
-            if (ImGui.BeginListBox("WidgetSelectionListbox", ImGui.GetContentRegionAvail()))
+            if (ImGui.BeginListBox("WidgetSelectionListbox"u8, ImGui.GetContentRegionAvail()))
             {
                 foreach (var widget in this.orderedModules)
                 {
@@ -168,7 +168,7 @@ internal class DataWindow : Window, IDisposable
 
     private void DrawContents()
     {
-        if (ImGui.BeginChild("XlData_ContentsPane", ImGui.GetContentRegionAvail()))
+        if (ImGui.BeginChild("XlData_ContentsPane"u8, ImGui.GetContentRegionAvail()))
         {
             if (ImGuiComponents.IconButton("collapse-expand", this.selectionCollapsed ? FontAwesomeIcon.ArrowRight : FontAwesomeIcon.ArrowLeft))
             {
@@ -190,7 +190,7 @@ internal class DataWindow : Window, IDisposable
 
             if (ImGui.IsItemHovered())
             {
-                ImGui.SetTooltip("Force Reload");
+                ImGui.SetTooltip("Force Reload"u8);
             }
 
             ImGui.SameLine();
@@ -199,7 +199,7 @@ internal class DataWindow : Window, IDisposable
 
             ImGuiHelpers.ScaledDummy(10.0f);
 
-            if (ImGui.BeginChild("XlData_WidgetContents", ImGui.GetContentRegionAvail()))
+            if (ImGui.BeginChild("XlData_WidgetContents"u8, ImGui.GetContentRegionAvail()))
             {
                 if (copy)
                     ImGui.LogToClipboard();
@@ -212,7 +212,7 @@ internal class DataWindow : Window, IDisposable
                     }
                     else
                     {
-                        ImGui.TextUnformatted("Data not ready.");
+                        ImGui.TextUnformatted("Data not ready."u8);
                     }
 
                     this.isExcept = false;

--- a/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs
@@ -212,7 +212,7 @@ internal class DataWindow : Window, IDisposable
                     }
                     else
                     {
-                        ImGui.TextUnformatted("Data not ready."u8);
+                        ImGui.Text("Data not ready."u8);
                     }
 
                     this.isExcept = false;
@@ -226,7 +226,7 @@ internal class DataWindow : Window, IDisposable
 
                     this.isExcept = true;
 
-                    ImGui.TextUnformatted(ex.ToString());
+                    ImGui.Text(ex.ToString());
                 }
             }
 

--- a/Dalamud/Interface/Internal/Windows/Data/DataWindowWidgetExtensions.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindowWidgetExtensions.cs
@@ -41,7 +41,7 @@ internal static class DataWindowWidgetExtensions
             ImGui.SetNextWindowSizeConstraints(Vector2.One, new(wrx, float.MaxValue));
             ImGui.BeginTooltip();
             ImGui.PushTextWrapPos(wrx);
-            ImGuiHelpers.SafeTextWrapped(s.Replace("%", "%%"));
+            ImGui.TextWrapped(s.Replace("%", "%%"));
             ImGui.PopTextWrapPos();
             ImGui.EndTooltip();
         }

--- a/Dalamud/Interface/Internal/Windows/Data/DataWindowWidgetExtensions.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindowWidgetExtensions.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.ImGuiNotification;
 using Dalamud.Interface.ImGuiNotification.Internal;
+using Dalamud.Interface.Utility;
 
 namespace Dalamud.Interface.Internal.Windows.Data;
 
@@ -40,7 +41,7 @@ internal static class DataWindowWidgetExtensions
             ImGui.SetNextWindowSizeConstraints(Vector2.One, new(wrx, float.MaxValue));
             ImGui.BeginTooltip();
             ImGui.PushTextWrapPos(wrx);
-            ImGui.TextWrapped(s.Replace("%", "%%"));
+            ImGuiHelpers.SafeTextWrapped(s.Replace("%", "%%"));
             ImGui.PopTextWrapPos();
             ImGui.EndTooltip();
         }

--- a/Dalamud/Interface/Internal/Windows/Data/DataWindowWidgetExtensions.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindowWidgetExtensions.cs
@@ -41,7 +41,7 @@ internal static class DataWindowWidgetExtensions
             ImGui.SetNextWindowSizeConstraints(Vector2.One, new(wrx, float.MaxValue));
             ImGui.BeginTooltip();
             ImGui.PushTextWrapPos(wrx);
-            ImGui.TextWrapped(s.Replace("%", "%%"));
+            ImGui.TextWrapped(s);
             ImGui.PopTextWrapPos();
             ImGui.EndTooltip();
         }

--- a/Dalamud/Interface/Internal/Windows/Data/DataWindowWidgetExtensions.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/DataWindowWidgetExtensions.cs
@@ -26,11 +26,11 @@ internal static class DataWindowWidgetExtensions
             var xoff = ImGui.GetColumnWidth() - width;
             offset.X += xoff;
             ImGui.SetCursorPosX(ImGui.GetCursorPosX() + xoff);
-            ImGui.TextUnformatted(s);
+            ImGui.Text(s);
         }
         else
         {
-            ImGui.TextUnformatted(s);
+            ImGui.Text(s);
         }
 
         if (ImGui.IsItemHovered())

--- a/Dalamud/Interface/Internal/Windows/Data/GameInventoryTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/GameInventoryTestWidget.cs
@@ -40,7 +40,7 @@ internal class GameInventoryTestWidget : IDataWindowWidget
     {
         if (Service<DalamudConfiguration>.Get().LogLevel > LogEventLevel.Information)
         {
-            ImGuiHelpers.SafeTextColoredWrapped(
+            ImGui.TextColoredWrapped(
                 ImGuiColors.DalamudRed,
                 "Enable LogLevel=Information display to see the logs."u8);
         }

--- a/Dalamud/Interface/Internal/Windows/Data/GameInventoryTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/GameInventoryTestWidget.cs
@@ -42,7 +42,7 @@ internal class GameInventoryTestWidget : IDataWindowWidget
         {
             ImGuiHelpers.SafeTextColoredWrapped(
                 ImGuiColors.DalamudRed,
-                "Enable LogLevel=Information display to see the logs.");
+                "Enable LogLevel=Information display to see the logs."u8);
         }
 
         using var table = ImRaii.Table(this.DisplayName, 3, ImGuiTableFlags.SizingFixedFit);
@@ -50,12 +50,12 @@ internal class GameInventoryTestWidget : IDataWindowWidget
             return;
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Standard Logging");
+        ImGui.TextUnformatted("Standard Logging"u8);
 
         ImGui.TableNextColumn();
         using (ImRaii.Disabled(this.standardEnabled))
         {
-            if (ImGui.Button("Enable##standard-enable") && !this.standardEnabled)
+            if (ImGui.Button("Enable##standard-enable"u8) && !this.standardEnabled)
             {
                 this.scoped ??= new();
                 this.scoped.InventoryChanged += ScopedOnInventoryChanged;
@@ -66,7 +66,7 @@ internal class GameInventoryTestWidget : IDataWindowWidget
         ImGui.TableNextColumn();
         using (ImRaii.Disabled(!this.standardEnabled))
         {
-            if (ImGui.Button("Disable##standard-disable") && this.scoped is not null && this.standardEnabled)
+            if (ImGui.Button("Disable##standard-disable"u8) && this.scoped is not null && this.standardEnabled)
             {
                 this.scoped.InventoryChanged -= ScopedOnInventoryChanged;
                 this.standardEnabled = false;
@@ -81,12 +81,12 @@ internal class GameInventoryTestWidget : IDataWindowWidget
         ImGui.TableNextRow();
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Raw Logging");
+        ImGui.TextUnformatted("Raw Logging"u8);
 
         ImGui.TableNextColumn();
         using (ImRaii.Disabled(this.rawEnabled))
         {
-            if (ImGui.Button("Enable##raw-enable") && !this.rawEnabled)
+            if (ImGui.Button("Enable##raw-enable"u8) && !this.rawEnabled)
             {
                 this.scoped ??= new();
                 this.scoped.InventoryChangedRaw += ScopedOnInventoryChangedRaw;
@@ -97,7 +97,7 @@ internal class GameInventoryTestWidget : IDataWindowWidget
         ImGui.TableNextColumn();
         using (ImRaii.Disabled(!this.rawEnabled))
         {
-            if (ImGui.Button("Disable##raw-disable") && this.scoped is not null && this.rawEnabled)
+            if (ImGui.Button("Disable##raw-disable"u8) && this.scoped is not null && this.rawEnabled)
             {
                 this.scoped.InventoryChangedRaw -= ScopedOnInventoryChangedRaw;
                 this.rawEnabled = false;
@@ -112,12 +112,12 @@ internal class GameInventoryTestWidget : IDataWindowWidget
         ImGui.TableNextRow();
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("All");
+        ImGui.TextUnformatted("All"u8);
 
         ImGui.TableNextColumn();
         using (ImRaii.Disabled(this.standardEnabled && this.rawEnabled))
         {
-            if (ImGui.Button("Enable##all-enable"))
+            if (ImGui.Button("Enable##all-enable"u8))
             {
                 this.scoped ??= new();
                 if (!this.standardEnabled)
@@ -131,7 +131,7 @@ internal class GameInventoryTestWidget : IDataWindowWidget
         ImGui.TableNextColumn();
         using (ImRaii.Disabled(this.scoped is null))
         {
-            if (ImGui.Button("Disable##all-disable"))
+            if (ImGui.Button("Disable##all-disable"u8))
             {
                 ((IInternalDisposableService)this.scoped)?.DisposeService();
                 this.scoped = null;

--- a/Dalamud/Interface/Internal/Windows/Data/GameInventoryTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/GameInventoryTestWidget.cs
@@ -50,7 +50,7 @@ internal class GameInventoryTestWidget : IDataWindowWidget
             return;
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Standard Logging"u8);
+        ImGui.Text("Standard Logging"u8);
 
         ImGui.TableNextColumn();
         using (ImRaii.Disabled(this.standardEnabled))
@@ -81,7 +81,7 @@ internal class GameInventoryTestWidget : IDataWindowWidget
         ImGui.TableNextRow();
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("Raw Logging"u8);
+        ImGui.Text("Raw Logging"u8);
 
         ImGui.TableNextColumn();
         using (ImRaii.Disabled(this.rawEnabled))
@@ -112,7 +112,7 @@ internal class GameInventoryTestWidget : IDataWindowWidget
         ImGui.TableNextRow();
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted("All"u8);
+        ImGui.Text("All"u8);
 
         ImGui.TableNextColumn();
         using (ImRaii.Disabled(this.standardEnabled && this.rawEnabled))

--- a/Dalamud/Interface/Internal/Windows/Data/WidgetUtil.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/WidgetUtil.cs
@@ -15,7 +15,7 @@ internal class WidgetUtil
     /// <param name="tooltipText">The text in the tooltip.</param>
     internal static void DrawCopyableText(string text, string tooltipText = "Copy")
     {
-        ImGuiHelpers.SafeTextWrapped(text);
+        ImGui.TextWrapped(text);
 
         if (ImGui.IsItemHovered())
         {

--- a/Dalamud/Interface/Internal/Windows/Data/WidgetUtil.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/WidgetUtil.cs
@@ -21,7 +21,7 @@ internal class WidgetUtil
         {
             ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
             ImGui.BeginTooltip();
-            ImGui.TextUnformatted(tooltipText);
+            ImGui.Text(tooltipText);
             ImGui.EndTooltip();
         }
 

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonLifecycleWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonLifecycleWidget.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 using Dalamud.Bindings.ImGui;
@@ -43,18 +43,18 @@ public class AddonLifecycleWidget : IDataWindowWidget
     {
         if (!this.Ready)
         {
-            ImGui.Text("AddonLifecycle Reference is null, reload module.");
+            ImGui.TextUnformatted("AddonLifecycle Reference is null, reload module."u8);
             return;
         }
 
-        if (ImGui.CollapsingHeader("Listeners"))
+        if (ImGui.CollapsingHeader("Listeners"u8))
         {
             ImGui.Indent();
             this.DrawEventListeners();
             ImGui.Unindent();
         }
 
-        if (ImGui.CollapsingHeader("ReceiveEvent Hooks"))
+        if (ImGui.CollapsingHeader("ReceiveEvent Hooks"u8))
         {
             ImGui.Indent();
             this.DrawReceiveEventHooks();
@@ -75,21 +75,21 @@ public class AddonLifecycleWidget : IDataWindowWidget
 
                 if (listeners.Count == 0)
                 {
-                    ImGui.Text("No Listeners Registered for Event");
+                    ImGui.TextUnformatted("No Listeners Registered for Event"u8);
                 }
 
-                if (ImGui.BeginTable("AddonLifecycleListenersTable", 2))
+                if (ImGui.BeginTable("AddonLifecycleListenersTable"u8, 2))
                 {
-                    ImGui.TableSetupColumn("##AddonName", ImGuiTableColumnFlags.WidthFixed, 100.0f * ImGuiHelpers.GlobalScale);
-                    ImGui.TableSetupColumn("##MethodInvoke", ImGuiTableColumnFlags.WidthStretch);
+                    ImGui.TableSetupColumn("##AddonName"u8, ImGuiTableColumnFlags.WidthFixed, 100.0f * ImGuiHelpers.GlobalScale);
+                    ImGui.TableSetupColumn("##MethodInvoke"u8, ImGuiTableColumnFlags.WidthStretch);
 
                     foreach (var listener in listeners)
                     {
                         ImGui.TableNextColumn();
-                        ImGui.Text(listener.AddonName is "" ? "GLOBAL" : listener.AddonName);
+                        ImGui.TextUnformatted(listener.AddonName is "" ? "GLOBAL" : listener.AddonName);
 
                         ImGui.TableNextColumn();
-                        ImGui.Text($"{listener.FunctionDelegate.Method.DeclaringType?.FullName ?? "Unknown Declaring Type"}::{listener.FunctionDelegate.Method.Name}");
+                        ImGui.TextUnformatted($"{listener.FunctionDelegate.Method.DeclaringType?.FullName ?? "Unknown Declaring Type"}::{listener.FunctionDelegate.Method.Name}");
                     }
 
                     ImGui.EndTable();
@@ -108,7 +108,7 @@ public class AddonLifecycleWidget : IDataWindowWidget
 
         if (listeners.Count == 0)
         {
-            ImGui.Text("No ReceiveEvent Hooks are Registered");
+            ImGui.TextUnformatted("No ReceiveEvent Hooks are Registered"u8);
         }
 
         foreach (var receiveEventListener in this.AddonLifecycle.ReceiveEventListeners)
@@ -117,22 +117,22 @@ public class AddonLifecycleWidget : IDataWindowWidget
             {
                 ImGui.Columns(2);
 
-                ImGui.Text("Hook Address");
+                ImGui.TextUnformatted("Hook Address"u8);
                 ImGui.NextColumn();
-                ImGui.Text(receiveEventListener.FunctionAddress.ToString("X"));
+                ImGui.TextUnformatted(receiveEventListener.FunctionAddress.ToString("X"));
 
                 ImGui.NextColumn();
-                ImGui.Text("Hook Status");
+                ImGui.TextUnformatted("Hook Status"u8);
                 ImGui.NextColumn();
                 if (receiveEventListener.Hook is null)
                 {
-                    ImGui.Text("Hook is null");
+                    ImGui.TextUnformatted("Hook is null"u8);
                 }
                 else
                 {
                     var color = receiveEventListener.Hook.IsEnabled ? ImGuiColors.HealerGreen : ImGuiColors.DalamudRed;
-                    var text = receiveEventListener.Hook.IsEnabled ? "Enabled" : "Disabled";
-                    ImGui.TextColored(color, text);
+                    var text = receiveEventListener.Hook.IsEnabled ? "Enabled"u8 : "Disabled"u8;
+                    ImGuiHelpers.SafeTextColored(color, text);
                 }
 
                 ImGui.Columns(1);

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonLifecycleWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonLifecycleWidget.cs
@@ -132,7 +132,7 @@ public class AddonLifecycleWidget : IDataWindowWidget
                 {
                     var color = receiveEventListener.Hook.IsEnabled ? ImGuiColors.HealerGreen : ImGuiColors.DalamudRed;
                     var text = receiveEventListener.Hook.IsEnabled ? "Enabled"u8 : "Disabled"u8;
-                    ImGuiHelpers.SafeTextColored(color, text);
+                    ImGui.TextColored(color, text);
                 }
 
                 ImGui.Columns(1);

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonLifecycleWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonLifecycleWidget.cs
@@ -43,7 +43,7 @@ public class AddonLifecycleWidget : IDataWindowWidget
     {
         if (!this.Ready)
         {
-            ImGui.TextUnformatted("AddonLifecycle Reference is null, reload module."u8);
+            ImGui.Text("AddonLifecycle Reference is null, reload module."u8);
             return;
         }
 
@@ -75,7 +75,7 @@ public class AddonLifecycleWidget : IDataWindowWidget
 
                 if (listeners.Count == 0)
                 {
-                    ImGui.TextUnformatted("No Listeners Registered for Event"u8);
+                    ImGui.Text("No Listeners Registered for Event"u8);
                 }
 
                 if (ImGui.BeginTable("AddonLifecycleListenersTable"u8, 2))
@@ -86,10 +86,10 @@ public class AddonLifecycleWidget : IDataWindowWidget
                     foreach (var listener in listeners)
                     {
                         ImGui.TableNextColumn();
-                        ImGui.TextUnformatted(listener.AddonName is "" ? "GLOBAL" : listener.AddonName);
+                        ImGui.Text(listener.AddonName is "" ? "GLOBAL" : listener.AddonName);
 
                         ImGui.TableNextColumn();
-                        ImGui.TextUnformatted($"{listener.FunctionDelegate.Method.DeclaringType?.FullName ?? "Unknown Declaring Type"}::{listener.FunctionDelegate.Method.Name}");
+                        ImGui.Text($"{listener.FunctionDelegate.Method.DeclaringType?.FullName ?? "Unknown Declaring Type"}::{listener.FunctionDelegate.Method.Name}");
                     }
 
                     ImGui.EndTable();
@@ -108,7 +108,7 @@ public class AddonLifecycleWidget : IDataWindowWidget
 
         if (listeners.Count == 0)
         {
-            ImGui.TextUnformatted("No ReceiveEvent Hooks are Registered"u8);
+            ImGui.Text("No ReceiveEvent Hooks are Registered"u8);
         }
 
         foreach (var receiveEventListener in this.AddonLifecycle.ReceiveEventListeners)
@@ -117,16 +117,16 @@ public class AddonLifecycleWidget : IDataWindowWidget
             {
                 ImGui.Columns(2);
 
-                ImGui.TextUnformatted("Hook Address"u8);
+                ImGui.Text("Hook Address"u8);
                 ImGui.NextColumn();
-                ImGui.TextUnformatted(receiveEventListener.FunctionAddress.ToString("X"));
+                ImGui.Text(receiveEventListener.FunctionAddress.ToString("X"));
 
                 ImGui.NextColumn();
-                ImGui.TextUnformatted("Hook Status"u8);
+                ImGui.Text("Hook Status"u8);
                 ImGui.NextColumn();
                 if (receiveEventListener.Hook is null)
                 {
-                    ImGui.TextUnformatted("Hook is null"u8);
+                    ImGui.Text("Hook is null"u8);
                 }
                 else
                 {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonWidget.cs
@@ -43,11 +43,11 @@ internal unsafe class AddonWidget : IDataWindowWidget
         var addon = gameGui.GetAddonByName(this.inputAddonName, this.inputAddonIndex);
         if (addon.IsNull)
         {
-            ImGui.TextUnformatted("Null"u8);
+            ImGui.Text("Null"u8);
             return;
         }
 
-        ImGui.TextUnformatted($"{addon.Name} - {Util.DescribeAddress(addon)}\n    v:{addon.IsVisible} x:{addon.X} y:{addon.Y} s:{addon.Scale}, w:{addon.Width}, h:{addon.Height}");
+        ImGui.Text($"{addon.Name} - {Util.DescribeAddress(addon)}\n    v:{addon.IsVisible} x:{addon.X} y:{addon.Y} s:{addon.Scale}, w:{addon.Width}, h:{addon.Height}");
 
         if (ImGui.Button("Find Agent"u8))
         {
@@ -56,7 +56,7 @@ internal unsafe class AddonWidget : IDataWindowWidget
 
         if (!this.agentInterfacePtr.IsNull)
         {
-            ImGui.TextUnformatted($"Agent: {Util.DescribeAddress(this.agentInterfacePtr)}");
+            ImGui.Text($"Agent: {Util.DescribeAddress(this.agentInterfacePtr)}");
             ImGui.SameLine();
 
             if (ImGui.Button("C"u8))

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AddonWidget.cs
@@ -34,8 +34,8 @@ internal unsafe class AddonWidget : IDataWindowWidget
     {
         var gameGui = Service<GameGui>.Get();
 
-        ImGui.InputText("Addon Name", ref this.inputAddonName, 256);
-        ImGui.InputInt("Addon Index", ref this.inputAddonIndex);
+        ImGui.InputText("Addon Name"u8, ref this.inputAddonName, 256);
+        ImGui.InputInt("Addon Index"u8, ref this.inputAddonIndex);
 
         if (this.inputAddonName.IsNullOrEmpty())
             return;
@@ -43,13 +43,13 @@ internal unsafe class AddonWidget : IDataWindowWidget
         var addon = gameGui.GetAddonByName(this.inputAddonName, this.inputAddonIndex);
         if (addon.IsNull)
         {
-            ImGui.Text("Null");
+            ImGui.TextUnformatted("Null"u8);
             return;
         }
 
         ImGui.TextUnformatted($"{addon.Name} - {Util.DescribeAddress(addon)}\n    v:{addon.IsVisible} x:{addon.X} y:{addon.Y} s:{addon.Scale}, w:{addon.Width}, h:{addon.Height}");
 
-        if (ImGui.Button("Find Agent"))
+        if (ImGui.Button("Find Agent"u8))
         {
             this.agentInterfacePtr = gameGui.FindAgentInterface(addon);
         }
@@ -59,7 +59,7 @@ internal unsafe class AddonWidget : IDataWindowWidget
             ImGui.TextUnformatted($"Agent: {Util.DescribeAddress(this.agentInterfacePtr)}");
             ImGui.SameLine();
 
-            if (ImGui.Button("C"))
+            if (ImGui.Button("C"u8))
                 ImGui.SetClipboardText(this.agentInterfacePtr.Address.ToString("X"));
         }
     }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AddressesWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AddressesWidget.cs
@@ -46,17 +46,17 @@ internal class AddressesWidget : IDataWindowWidget
             }
         }
 
-        ImGui.TextUnformatted($"Result: {this.sigResult.ToInt64():X}");
+        ImGui.Text($"Result: {this.sigResult.ToInt64():X}");
         ImGui.SameLine();
         if (ImGui.Button($"C##{this.sigResult.ToInt64():X}"))
             ImGui.SetClipboardText(this.sigResult.ToInt64().ToString("X"));
 
         foreach (var debugScannedValue in BaseAddressResolver.DebugScannedValues)
         {
-            ImGui.TextUnformatted($"{debugScannedValue.Key}");
+            ImGui.Text($"{debugScannedValue.Key}");
             foreach (var valueTuple in debugScannedValue.Value)
             {
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $"      {valueTuple.ClassName} - {Util.DescribeAddress(valueTuple.Address)}");
                 ImGui.SameLine();
 

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AddressesWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AddressesWidget.cs
@@ -32,8 +32,8 @@ internal class AddressesWidget : IDataWindowWidget
     /// <inheritdoc/>
     public void Draw()
     {
-        ImGui.InputText(".text sig", ref this.inputSig, 400);
-        if (ImGui.Button("Resolve"))
+        ImGui.InputText(".text sig"u8, ref this.inputSig, 400);
+        if (ImGui.Button("Resolve"u8))
         {
             try
             {
@@ -46,7 +46,7 @@ internal class AddressesWidget : IDataWindowWidget
             }
         }
 
-        ImGui.Text($"Result: {this.sigResult.ToInt64():X}");
+        ImGui.TextUnformatted($"Result: {this.sigResult.ToInt64():X}");
         ImGui.SameLine();
         if (ImGui.Button($"C##{this.sigResult.ToInt64():X}"))
             ImGui.SetClipboardText(this.sigResult.ToInt64().ToString("X"));

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AetherytesWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AetherytesWidget.cs
@@ -26,21 +26,21 @@ internal class AetherytesWidget : IDataWindowWidget
     /// <inheritdoc/>
     public void Draw()
     {
-        if (!ImGui.BeginTable("##aetheryteTable", 11, ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders))
+        if (!ImGui.BeginTable("##aetheryteTable"u8, 11, ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders))
             return;
 
         ImGui.TableSetupScrollFreeze(0, 1);
-        ImGui.TableSetupColumn("Idx", ImGuiTableColumnFlags.WidthFixed);
-        ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthFixed);
-        ImGui.TableSetupColumn("ID", ImGuiTableColumnFlags.WidthFixed);
-        ImGui.TableSetupColumn("Zone", ImGuiTableColumnFlags.WidthFixed);
-        ImGui.TableSetupColumn("Ward", ImGuiTableColumnFlags.WidthFixed);
-        ImGui.TableSetupColumn("Plot", ImGuiTableColumnFlags.WidthFixed);
-        ImGui.TableSetupColumn("Sub", ImGuiTableColumnFlags.WidthFixed);
-        ImGui.TableSetupColumn("Gil", ImGuiTableColumnFlags.WidthFixed);
-        ImGui.TableSetupColumn("Fav", ImGuiTableColumnFlags.WidthFixed);
-        ImGui.TableSetupColumn("Shared", ImGuiTableColumnFlags.WidthFixed);
-        ImGui.TableSetupColumn("Apartment", ImGuiTableColumnFlags.WidthFixed);
+        ImGui.TableSetupColumn("Idx"u8, ImGuiTableColumnFlags.WidthFixed);
+        ImGui.TableSetupColumn("Name"u8, ImGuiTableColumnFlags.WidthFixed);
+        ImGui.TableSetupColumn("ID"u8, ImGuiTableColumnFlags.WidthFixed);
+        ImGui.TableSetupColumn("Zone"u8, ImGuiTableColumnFlags.WidthFixed);
+        ImGui.TableSetupColumn("Ward"u8, ImGuiTableColumnFlags.WidthFixed);
+        ImGui.TableSetupColumn("Plot"u8, ImGuiTableColumnFlags.WidthFixed);
+        ImGui.TableSetupColumn("Sub"u8, ImGuiTableColumnFlags.WidthFixed);
+        ImGui.TableSetupColumn("Gil"u8, ImGuiTableColumnFlags.WidthFixed);
+        ImGui.TableSetupColumn("Fav"u8, ImGuiTableColumnFlags.WidthFixed);
+        ImGui.TableSetupColumn("Shared"u8, ImGuiTableColumnFlags.WidthFixed);
+        ImGui.TableSetupColumn("Apartment"u8, ImGuiTableColumnFlags.WidthFixed);
         ImGui.TableHeadersRow();
 
         var tpList = Service<AetheryteList>.Get();

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AetherytesWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AetherytesWidget.cs
@@ -52,37 +52,37 @@ internal class AetherytesWidget : IDataWindowWidget
                 continue;
 
             ImGui.TableNextColumn(); // Idx
-            ImGui.TextUnformatted($"{i}");
+            ImGui.Text($"{i}");
 
             ImGui.TableNextColumn(); // Name
-            ImGui.TextUnformatted($"{info.AetheryteData.ValueNullable?.PlaceName.ValueNullable?.Name}");
+            ImGui.Text($"{info.AetheryteData.ValueNullable?.PlaceName.ValueNullable?.Name}");
 
             ImGui.TableNextColumn(); // ID
-            ImGui.TextUnformatted($"{info.AetheryteId}");
+            ImGui.Text($"{info.AetheryteId}");
 
             ImGui.TableNextColumn(); // Zone
-            ImGui.TextUnformatted($"{info.TerritoryId}");
+            ImGui.Text($"{info.TerritoryId}");
 
             ImGui.TableNextColumn(); // Ward
-            ImGui.TextUnformatted($"{info.Ward}");
+            ImGui.Text($"{info.Ward}");
 
             ImGui.TableNextColumn(); // Plot
-            ImGui.TextUnformatted($"{info.Plot}");
+            ImGui.Text($"{info.Plot}");
 
             ImGui.TableNextColumn(); // Sub
-            ImGui.TextUnformatted($"{info.SubIndex}");
+            ImGui.Text($"{info.SubIndex}");
 
             ImGui.TableNextColumn(); // Gil
-            ImGui.TextUnformatted($"{info.GilCost}");
+            ImGui.Text($"{info.GilCost}");
 
             ImGui.TableNextColumn(); // Favourite
-            ImGui.TextUnformatted($"{info.IsFavourite}");
+            ImGui.Text($"{info.IsFavourite}");
 
             ImGui.TableNextColumn(); // Shared
-            ImGui.TextUnformatted($"{info.IsSharedHouse}");
+            ImGui.Text($"{info.IsSharedHouse}");
 
             ImGui.TableNextColumn(); // Apartment
-            ImGui.TextUnformatted($"{info.IsApartment}");
+            ImGui.Text($"{info.IsApartment}");
         }
 
         ImGui.EndTable();

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AtkArrayDataBrowserWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AtkArrayDataBrowserWidget.cs
@@ -46,7 +46,7 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
     /// <inheritdoc/>
     public void Draw()
     {
-        using var tabs = ImRaii.TabBar("AtkArrayDataTabs");
+        using var tabs = ImRaii.TabBar("AtkArrayDataTabs"u8);
         if (!tabs) return;
 
         this.DrawNumberArrayTab();
@@ -56,12 +56,12 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
 
     private void DrawArrayList(Type? arrayType, int arrayCount, short* arrayKeys, AtkArrayData** arrays, ref int selectedIndex)
     {
-        using var table = ImRaii.Table("ArkArrayTable", 3, ImGuiTableFlags.ScrollY | ImGuiTableFlags.Borders, new Vector2(300, -1));
+        using var table = ImRaii.Table("ArkArrayTable"u8, 3, ImGuiTableFlags.ScrollY | ImGuiTableFlags.Borders, new Vector2(300, -1));
         if (!table) return;
 
-        ImGui.TableSetupColumn("Index", ImGuiTableColumnFlags.WidthFixed, 30);
-        ImGui.TableSetupColumn("Type", ImGuiTableColumnFlags.WidthStretch);
-        ImGui.TableSetupColumn("Size", ImGuiTableColumnFlags.WidthFixed, 40);
+        ImGui.TableSetupColumn("Index"u8, ImGuiTableColumnFlags.WidthFixed, 30);
+        ImGui.TableSetupColumn("Type"u8, ImGuiTableColumnFlags.WidthStretch);
+        ImGui.TableSetupColumn("Size"u8, ImGuiTableColumnFlags.WidthFixed, 40);
         ImGui.TableSetupScrollFreeze(3, 1);
         ImGui.TableHeadersRow();
 
@@ -137,16 +137,16 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
         }
 
         ImGui.SameLine();
-        ImGui.TextUnformatted("–");
+        ImGui.TextUnformatted("–"u8);
         ImGui.SameLine();
-        ImGui.TextUnformatted("Address: ");
+        ImGui.TextUnformatted("Address: "u8);
         ImGui.SameLine(0, 0);
         WidgetUtil.DrawCopyableText($"0x{(nint)array:X}", "Copy address");
 
         if (array->SubscribedAddonsCount > 0)
         {
             ImGui.SameLine();
-            ImGui.TextUnformatted("–");
+            ImGui.TextUnformatted("–"u8);
             ImGui.SameLine();
             using (ImRaii.PushColor(ImGuiCol.Text, 0xFF00FFFF))
                 ImGui.TextUnformatted($"{array->SubscribedAddonsCount} Subscribed Addon" + (array->SubscribedAddonsCount > 1 ? 's' : string.Empty));
@@ -174,7 +174,7 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
     {
         var atkArrayDataHolder = RaptureAtkModule.Instance()->AtkArrayDataHolder;
 
-        using var tab = ImRaii.TabItem("Number Arrays");
+        using var tab = ImRaii.TabItem("Number Arrays"u8);
         if (!tab) return;
 
         this.DrawArrayList(
@@ -189,22 +189,22 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
 
         ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 
-        using var child = ImRaii.Child("AtkArrayContent", new Vector2(-1), true, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoSavedSettings);
+        using var child = ImRaii.Child("AtkArrayContent"u8, new Vector2(-1), true, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoSavedSettings);
         if (!child) return;
 
         var array = atkArrayDataHolder.NumberArrays[this.selectedNumberArray];
         this.DrawArrayHeader(this.numberType, "Number", this.selectedNumberArray, (AtkArrayData*)array);
 
-        using var table = ImRaii.Table("NumberArrayDataTable", 7, ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders);
+        using var table = ImRaii.Table("NumberArrayDataTable"u8, 7, ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders);
         if (!table) return;
 
-        ImGui.TableSetupColumn("Index", ImGuiTableColumnFlags.WidthFixed, 40);
-        ImGui.TableSetupColumn("Entry Address", ImGuiTableColumnFlags.WidthFixed, 120);
-        ImGui.TableSetupColumn("Integer", ImGuiTableColumnFlags.WidthFixed, 100);
-        ImGui.TableSetupColumn("Short", ImGuiTableColumnFlags.WidthFixed, 100);
-        ImGui.TableSetupColumn("Byte", ImGuiTableColumnFlags.WidthFixed, 100);
-        ImGui.TableSetupColumn("Float", ImGuiTableColumnFlags.WidthFixed, 100);
-        ImGui.TableSetupColumn("Hex", ImGuiTableColumnFlags.WidthFixed, 100);
+        ImGui.TableSetupColumn("Index"u8, ImGuiTableColumnFlags.WidthFixed, 40);
+        ImGui.TableSetupColumn("Entry Address"u8, ImGuiTableColumnFlags.WidthFixed, 120);
+        ImGui.TableSetupColumn("Integer"u8, ImGuiTableColumnFlags.WidthFixed, 100);
+        ImGui.TableSetupColumn("Short"u8, ImGuiTableColumnFlags.WidthFixed, 100);
+        ImGui.TableSetupColumn("Byte"u8, ImGuiTableColumnFlags.WidthFixed, 100);
+        ImGui.TableSetupColumn("Float"u8, ImGuiTableColumnFlags.WidthFixed, 100);
+        ImGui.TableSetupColumn("Hex"u8, ImGuiTableColumnFlags.WidthFixed, 100);
         ImGui.TableSetupScrollFreeze(7, 1);
         ImGui.TableHeadersRow();
 
@@ -238,17 +238,17 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
 
     private void DrawStringArrayTab()
     {
-        using var tab = ImRaii.TabItem("String Arrays");
+        using var tab = ImRaii.TabItem("String Arrays"u8);
         if (!tab) return;
 
         var atkArrayDataHolder = RaptureAtkModule.Instance()->AtkArrayDataHolder;
 
-        using (var sidebarchild = ImRaii.Child("StringArraySidebar", new Vector2(300, -1), false, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoSavedSettings))
+        using (var sidebarchild = ImRaii.Child("StringArraySidebar"u8, new Vector2(300, -1), false, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoSavedSettings))
         {
             if (sidebarchild)
             {
                 ImGui.SetNextItemWidth(-1);
-                ImGui.InputTextWithHint("##TextSearch", "Search...", ref this.searchTerm, 256, ImGuiInputTextFlags.AutoSelectAll);
+                ImGui.InputTextWithHint("##TextSearch"u8, "Search..."u8, ref this.searchTerm, 256, ImGuiInputTextFlags.AutoSelectAll);
 
                 this.DrawArrayList(
                     this.stringType,
@@ -264,24 +264,24 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
 
         ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 
-        using var child = ImRaii.Child("AtkArrayContent", new Vector2(-1), true, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoSavedSettings);
+        using var child = ImRaii.Child("AtkArrayContent"u8, new Vector2(-1), true, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoSavedSettings);
         if (!child) return;
 
         var array = atkArrayDataHolder.StringArrays[this.selectedStringArray];
         this.DrawArrayHeader(this.stringType, "String", this.selectedStringArray, (AtkArrayData*)array);
-        ImGui.Checkbox("Hide unset entries##HideUnsetStringArrayEntriesCheckbox", ref this.hideUnsetStringArrayEntries);
+        ImGui.Checkbox("Hide unset entries##HideUnsetStringArrayEntriesCheckbox"u8, ref this.hideUnsetStringArrayEntries);
         ImGui.SameLine();
-        ImGui.Checkbox("Show text address##WordWrapCheckbox", ref this.showTextAddress);
+        ImGui.Checkbox("Show text address##WordWrapCheckbox"u8, ref this.showTextAddress);
         ImGui.SameLine();
-        ImGui.Checkbox("Show macro string##RenderStringsCheckbox", ref this.showMacroString);
+        ImGui.Checkbox("Show macro string##RenderStringsCheckbox"u8, ref this.showMacroString);
 
-        using var table = ImRaii.Table("StringArrayDataTable", 4, ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders);
+        using var table = ImRaii.Table("StringArrayDataTable"u8, 4, ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders);
         if (!table) return;
 
-        ImGui.TableSetupColumn("Index", ImGuiTableColumnFlags.WidthFixed, 40);
-        ImGui.TableSetupColumn(this.showTextAddress ? "Text Address" : "Entry Address", ImGuiTableColumnFlags.WidthFixed, 120);
-        ImGui.TableSetupColumn("Managed", ImGuiTableColumnFlags.WidthFixed, 60);
-        ImGui.TableSetupColumn("Text", ImGuiTableColumnFlags.WidthStretch);
+        ImGui.TableSetupColumn("Index"u8, ImGuiTableColumnFlags.WidthFixed, 40);
+        ImGui.TableSetupColumn(this.showTextAddress ? "Text Address"u8 : "Entry Address"u8, ImGuiTableColumnFlags.WidthFixed, 120);
+        ImGui.TableSetupColumn("Managed"u8, ImGuiTableColumnFlags.WidthFixed, 60);
+        ImGui.TableSetupColumn("Text"u8, ImGuiTableColumnFlags.WidthStretch);
         ImGui.TableSetupScrollFreeze(4, 1);
         ImGui.TableHeadersRow();
 
@@ -342,7 +342,7 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
 
     private void DrawExtendArrayTab()
     {
-        using var tab = ImRaii.TabItem("Extend Arrays");
+        using var tab = ImRaii.TabItem("Extend Arrays"u8);
         if (!tab) return;
 
         var atkArrayDataHolder = RaptureAtkModule.Instance()->AtkArrayDataHolder;
@@ -359,18 +359,18 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
 
         ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 
-        using var child = ImRaii.Child("AtkArrayContent", new Vector2(-1), true, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoSavedSettings);
+        using var child = ImRaii.Child("AtkArrayContent"u8, new Vector2(-1), true, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoSavedSettings);
 
         var array = atkArrayDataHolder.ExtendArrays[this.selectedExtendArray];
         this.DrawArrayHeader(null, "Extend", this.selectedExtendArray, (AtkArrayData*)array);
-        ImGui.Checkbox("Hide unset entries##HideUnsetExtendArrayEntriesCheckbox", ref this.hideUnsetExtendArrayEntries);
+        ImGui.Checkbox("Hide unset entries##HideUnsetExtendArrayEntriesCheckbox"u8, ref this.hideUnsetExtendArrayEntries);
 
-        using var table = ImRaii.Table("ExtendArrayDataTable", 3, ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders);
+        using var table = ImRaii.Table("ExtendArrayDataTable"u8, 3, ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders);
         if (!table) return;
 
-        ImGui.TableSetupColumn("Index", ImGuiTableColumnFlags.WidthFixed, 40);
-        ImGui.TableSetupColumn("Entry Address", ImGuiTableColumnFlags.WidthFixed, 120);
-        ImGui.TableSetupColumn("Pointer", ImGuiTableColumnFlags.WidthStretch);
+        ImGui.TableSetupColumn("Index"u8, ImGuiTableColumnFlags.WidthFixed, 40);
+        ImGui.TableSetupColumn("Entry Address"u8, ImGuiTableColumnFlags.WidthFixed, 120);
+        ImGui.TableSetupColumn("Pointer"u8, ImGuiTableColumnFlags.WidthStretch);
         ImGui.TableSetupScrollFreeze(3, 1);
         ImGui.TableHeadersRow();
 

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/AtkArrayDataBrowserWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/AtkArrayDataBrowserWidget.cs
@@ -103,7 +103,7 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
             ImGui.TableNextColumn(); // Type
             if (arrayType != null && Enum.IsDefined(arrayType, arrayIndex))
             {
-                ImGui.TextUnformatted(Enum.GetName(arrayType, arrayIndex));
+                ImGui.Text(Enum.GetName(arrayType, arrayIndex));
             }
             else if (inUse && arrays[arrayIndex]->SubscribedAddonsCount > 0)
             {
@@ -115,41 +115,41 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
                         continue;
 
                     using (ImRaii.PushColor(ImGuiCol.Text, 0xFF00FFFF))
-                        ImGui.TextUnformatted(raptureAtkUnitManager->GetAddonById(arrays[arrayIndex]->SubscribedAddons[j])->NameString);
+                        ImGui.Text(raptureAtkUnitManager->GetAddonById(arrays[arrayIndex]->SubscribedAddons[j])->NameString);
                     break;
                 }
             }
 
             ImGui.TableNextColumn(); // Size
             if (inUse)
-                ImGui.TextUnformatted((rowsFound > 0 ? rowsFound : arrays[arrayIndex]->Size).ToString());
+                ImGui.Text((rowsFound > 0 ? rowsFound : arrays[arrayIndex]->Size).ToString());
         }
     }
 
     private void DrawArrayHeader(Type? arrayType, string type, int index, AtkArrayData* array)
     {
-        ImGui.TextUnformatted($"{type} Array #{index}");
+        ImGui.Text($"{type} Array #{index}");
 
         if (arrayType != null && Enum.IsDefined(arrayType, index))
         {
             ImGui.SameLine(0, 0);
-            ImGui.TextUnformatted($" ({Enum.GetName(arrayType, index)})");
+            ImGui.Text($" ({Enum.GetName(arrayType, index)})");
         }
 
         ImGui.SameLine();
-        ImGui.TextUnformatted("–"u8);
+        ImGui.Text("–"u8);
         ImGui.SameLine();
-        ImGui.TextUnformatted("Address: "u8);
+        ImGui.Text("Address: "u8);
         ImGui.SameLine(0, 0);
         WidgetUtil.DrawCopyableText($"0x{(nint)array:X}", "Copy address");
 
         if (array->SubscribedAddonsCount > 0)
         {
             ImGui.SameLine();
-            ImGui.TextUnformatted("–"u8);
+            ImGui.Text("–"u8);
             ImGui.SameLine();
             using (ImRaii.PushColor(ImGuiCol.Text, 0xFF00FFFF))
-                ImGui.TextUnformatted($"{array->SubscribedAddonsCount} Subscribed Addon" + (array->SubscribedAddonsCount > 1 ? 's' : string.Empty));
+                ImGui.Text($"{array->SubscribedAddonsCount} Subscribed Addon" + (array->SubscribedAddonsCount > 1 ? 's' : string.Empty));
 
             if (ImGui.IsItemHovered())
             {
@@ -163,7 +163,7 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
                         if (array->SubscribedAddons[j] == 0)
                             continue;
 
-                        ImGui.TextUnformatted(raptureAtkUnitManager->GetAddonById(array->SubscribedAddons[j])->NameString);
+                        ImGui.Text(raptureAtkUnitManager->GetAddonById(array->SubscribedAddons[j])->NameString);
                     }
                 }
             }
@@ -212,7 +212,7 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
         {
             ImGui.TableNextRow();
             ImGui.TableNextColumn(); // Index
-            ImGui.TextUnformatted($"#{i}");
+            ImGui.Text($"#{i}");
 
             var ptr = &array->IntArray[i];
 
@@ -306,7 +306,7 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
 
             ImGui.TableNextRow();
             ImGui.TableNextColumn(); // Index
-            ImGui.TextUnformatted($"#{i}");
+            ImGui.Text($"#{i}");
 
             ImGui.TableNextColumn(); // Address
             if (this.showTextAddress)
@@ -322,7 +322,7 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
             ImGui.TableNextColumn(); // Managed
             if (!isNull)
             {
-                ImGui.TextUnformatted(((nint)array->StringArray[i] != 0 && array->ManagedStringArray[i] == array->StringArray[i]).ToString());
+                ImGui.Text(((nint)array->StringArray[i] != 0 && array->ManagedStringArray[i] == array->StringArray[i]).ToString());
             }
 
             ImGui.TableNextColumn(); // Text
@@ -384,7 +384,7 @@ internal unsafe class AtkArrayDataBrowserWidget : IDataWindowWidget
 
             ImGui.TableNextRow();
             ImGui.TableNextColumn(); // Index
-            ImGui.TextUnformatted($"#{i}");
+            ImGui.Text($"#{i}");
 
             ImGui.TableNextColumn(); // Address
             WidgetUtil.DrawCopyableText($"0x{(nint)(&array->DataArray[i]):X}", "Copy entry address");

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/BuddyListWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/BuddyListWidget.cs
@@ -36,17 +36,17 @@ internal class BuddyListWidget : IDataWindowWidget
             var member = buddyList.CompanionBuddy;
             if (member == null)
             {
-                ImGui.TextUnformatted("[Companion] null"u8);
+                ImGui.Text("[Companion] null"u8);
             }
             else
             {
-                ImGui.TextUnformatted($"[Companion] {member.Address.ToInt64():X} - {member.ObjectId} - {member.DataID}");
+                ImGui.Text($"[Companion] {member.Address.ToInt64():X} - {member.ObjectId} - {member.DataID}");
                 if (this.resolveGameData)
                 {
                     var gameObject = member.GameObject;
                     if (gameObject == null)
                     {
-                        ImGui.TextUnformatted("GameObject was null"u8);
+                        ImGui.Text("GameObject was null"u8);
                     }
                     else
                     {
@@ -60,17 +60,17 @@ internal class BuddyListWidget : IDataWindowWidget
             var member = buddyList.PetBuddy;
             if (member == null)
             {
-                ImGui.TextUnformatted("[Pet] null"u8);
+                ImGui.Text("[Pet] null"u8);
             }
             else
             {
-                ImGui.TextUnformatted($"[Pet] {member.Address.ToInt64():X} - {member.ObjectId} - {member.DataID}");
+                ImGui.Text($"[Pet] {member.Address.ToInt64():X} - {member.ObjectId} - {member.DataID}");
                 if (this.resolveGameData)
                 {
                     var gameObject = member.GameObject;
                     if (gameObject == null)
                     {
-                        ImGui.TextUnformatted("GameObject was null"u8);
+                        ImGui.Text("GameObject was null"u8);
                     }
                     else
                     {
@@ -84,20 +84,20 @@ internal class BuddyListWidget : IDataWindowWidget
             var count = buddyList.Length;
             if (count == 0)
             {
-                ImGui.TextUnformatted("[BattleBuddy] None present"u8);
+                ImGui.Text("[BattleBuddy] None present"u8);
             }
             else
             {
                 for (var i = 0; i < count; i++)
                 {
                     var member = buddyList[i];
-                    ImGui.TextUnformatted($"[BattleBuddy] [{i}] {member?.Address.ToInt64():X} - {member?.ObjectId} - {member?.DataID}");
+                    ImGui.Text($"[BattleBuddy] [{i}] {member?.Address.ToInt64():X} - {member?.ObjectId} - {member?.DataID}");
                     if (this.resolveGameData)
                     {
                         var gameObject = member?.GameObject;
                         if (gameObject == null)
                         {
-                            ImGui.TextUnformatted("GameObject was null"u8);
+                            ImGui.Text("GameObject was null"u8);
                         }
                         else
                         {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/BuddyListWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/BuddyListWidget.cs
@@ -31,22 +31,22 @@ internal class BuddyListWidget : IDataWindowWidget
     {
         var buddyList = Service<BuddyList>.Get();
 
-        ImGui.Checkbox("Resolve GameData", ref this.resolveGameData);
+        ImGui.Checkbox("Resolve GameData"u8, ref this.resolveGameData);
         {
             var member = buddyList.CompanionBuddy;
             if (member == null)
             {
-                ImGui.Text("[Companion] null");
+                ImGui.TextUnformatted("[Companion] null"u8);
             }
             else
             {
-                ImGui.Text($"[Companion] {member.Address.ToInt64():X} - {member.ObjectId} - {member.DataID}");
+                ImGui.TextUnformatted($"[Companion] {member.Address.ToInt64():X} - {member.ObjectId} - {member.DataID}");
                 if (this.resolveGameData)
                 {
                     var gameObject = member.GameObject;
                     if (gameObject == null)
                     {
-                        ImGui.Text("GameObject was null");
+                        ImGui.TextUnformatted("GameObject was null"u8);
                     }
                     else
                     {
@@ -60,17 +60,17 @@ internal class BuddyListWidget : IDataWindowWidget
             var member = buddyList.PetBuddy;
             if (member == null)
             {
-                ImGui.Text("[Pet] null");
+                ImGui.TextUnformatted("[Pet] null"u8);
             }
             else
             {
-                ImGui.Text($"[Pet] {member.Address.ToInt64():X} - {member.ObjectId} - {member.DataID}");
+                ImGui.TextUnformatted($"[Pet] {member.Address.ToInt64():X} - {member.ObjectId} - {member.DataID}");
                 if (this.resolveGameData)
                 {
                     var gameObject = member.GameObject;
                     if (gameObject == null)
                     {
-                        ImGui.Text("GameObject was null");
+                        ImGui.TextUnformatted("GameObject was null"u8);
                     }
                     else
                     {
@@ -84,20 +84,20 @@ internal class BuddyListWidget : IDataWindowWidget
             var count = buddyList.Length;
             if (count == 0)
             {
-                ImGui.Text("[BattleBuddy] None present");
+                ImGui.TextUnformatted("[BattleBuddy] None present"u8);
             }
             else
             {
                 for (var i = 0; i < count; i++)
                 {
                     var member = buddyList[i];
-                    ImGui.Text($"[BattleBuddy] [{i}] {member?.Address.ToInt64():X} - {member?.ObjectId} - {member?.DataID}");
+                    ImGui.TextUnformatted($"[BattleBuddy] [{i}] {member?.Address.ToInt64():X} - {member?.ObjectId} - {member?.DataID}");
                     if (this.resolveGameData)
                     {
                         var gameObject = member?.GameObject;
                         if (gameObject == null)
                         {
-                            ImGui.Text("GameObject was null");
+                            ImGui.TextUnformatted("GameObject was null"u8);
                         }
                         else
                         {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/CommandWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/CommandWidget.cs
@@ -1,7 +1,8 @@
-﻿using System.Linq;
+using System.Linq;
 
 using Dalamud.Bindings.ImGui;
 using Dalamud.Game.Command;
+using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 
 namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
@@ -33,15 +34,15 @@ internal class CommandWidget : IDataWindowWidget
 
         var tableFlags = ImGuiTableFlags.ScrollY | ImGuiTableFlags.Borders | ImGuiTableFlags.SizingStretchProp |
                          ImGuiTableFlags.Sortable | ImGuiTableFlags.SortTristate;
-        using var table = ImRaii.Table("CommandList", 4, tableFlags);
+        using var table = ImRaii.Table("CommandList"u8, 4, tableFlags);
         if (table)
         {
             ImGui.TableSetupScrollFreeze(0, 1);
 
-            ImGui.TableSetupColumn("Command");
-            ImGui.TableSetupColumn("Plugin");
-            ImGui.TableSetupColumn("HelpMessage", ImGuiTableColumnFlags.NoSort);
-            ImGui.TableSetupColumn("In Help?", ImGuiTableColumnFlags.NoSort);
+            ImGui.TableSetupColumn("Command"u8);
+            ImGui.TableSetupColumn("Plugin"u8);
+            ImGui.TableSetupColumn("HelpMessage"u8, ImGuiTableColumnFlags.NoSort);
+            ImGui.TableSetupColumn("In Help?"u8, ImGuiTableColumnFlags.NoSort);
             ImGui.TableHeadersRow();
 
             var sortSpecs = ImGui.TableGetSortSpecs();
@@ -66,16 +67,16 @@ internal class CommandWidget : IDataWindowWidget
                 ImGui.TableNextRow();
 
                 ImGui.TableSetColumnIndex(0);
-                ImGui.Text(command.Key);
+                ImGui.TextUnformatted(command.Key);
 
                 ImGui.TableNextColumn();
-                ImGui.Text(commandManager.GetHandlerAssemblyName(command.Key, command.Value));
+                ImGui.TextUnformatted(commandManager.GetHandlerAssemblyName(command.Key, command.Value));
 
                 ImGui.TableNextColumn();
-                ImGui.TextWrapped(command.Value.HelpMessage);
+                ImGuiHelpers.SafeTextWrapped(command.Value.HelpMessage);
 
                 ImGui.TableNextColumn();
-                ImGui.Text(command.Value.ShowInHelp ? "Yes" : "No");
+                ImGui.TextUnformatted(command.Value.ShowInHelp ? "Yes" : "No");
             }
         }
     }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/CommandWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/CommandWidget.cs
@@ -67,16 +67,16 @@ internal class CommandWidget : IDataWindowWidget
                 ImGui.TableNextRow();
 
                 ImGui.TableSetColumnIndex(0);
-                ImGui.TextUnformatted(command.Key);
+                ImGui.Text(command.Key);
 
                 ImGui.TableNextColumn();
-                ImGui.TextUnformatted(commandManager.GetHandlerAssemblyName(command.Key, command.Value));
+                ImGui.Text(commandManager.GetHandlerAssemblyName(command.Key, command.Value));
 
                 ImGui.TableNextColumn();
                 ImGuiHelpers.SafeTextWrapped(command.Value.HelpMessage);
 
                 ImGui.TableNextColumn();
-                ImGui.TextUnformatted(command.Value.ShowInHelp ? "Yes" : "No");
+                ImGui.Text(command.Value.ShowInHelp ? "Yes" : "No");
             }
         }
     }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/CommandWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/CommandWidget.cs
@@ -73,7 +73,7 @@ internal class CommandWidget : IDataWindowWidget
                 ImGui.Text(commandManager.GetHandlerAssemblyName(command.Key, command.Value));
 
                 ImGui.TableNextColumn();
-                ImGuiHelpers.SafeTextWrapped(command.Value.HelpMessage);
+                ImGui.TextWrapped(command.Value.HelpMessage);
 
                 ImGui.TableNextColumn();
                 ImGui.Text(command.Value.ShowInHelp ? "Yes" : "No");

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ConditionWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ConditionWidget.cs
@@ -30,10 +30,10 @@ internal class ConditionWidget : IDataWindowWidget
         var condition = Service<Condition>.Get();
 
 #if DEBUG
-        ImGui.Text($"ptr: {Util.DescribeAddress(condition.Address)}");
+        ImGui.TextUnformatted($"ptr: {Util.DescribeAddress(condition.Address)}");
 #endif
 
-        ImGui.Text("Current Conditions:");
+        ImGui.TextUnformatted("Current Conditions:"u8);
         ImGui.Separator();
 
         var didAny = false;
@@ -47,10 +47,10 @@ internal class ConditionWidget : IDataWindowWidget
 
             didAny = true;
 
-            ImGui.Text($"ID: {i} Enum: {typedCondition}");
+            ImGui.TextUnformatted($"ID: {i} Enum: {typedCondition}");
         }
 
         if (!didAny)
-            ImGui.Text("None. Talk to a shop NPC or visit a market board to find out more!");
+            ImGui.TextUnformatted("None. Talk to a shop NPC or visit a market board to find out more!"u8);
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ConditionWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ConditionWidget.cs
@@ -30,10 +30,10 @@ internal class ConditionWidget : IDataWindowWidget
         var condition = Service<Condition>.Get();
 
 #if DEBUG
-        ImGui.TextUnformatted($"ptr: {Util.DescribeAddress(condition.Address)}");
+        ImGui.Text($"ptr: {Util.DescribeAddress(condition.Address)}");
 #endif
 
-        ImGui.TextUnformatted("Current Conditions:"u8);
+        ImGui.Text("Current Conditions:"u8);
         ImGui.Separator();
 
         var didAny = false;
@@ -47,10 +47,10 @@ internal class ConditionWidget : IDataWindowWidget
 
             didAny = true;
 
-            ImGui.TextUnformatted($"ID: {i} Enum: {typedCondition}");
+            ImGui.Text($"ID: {i} Enum: {typedCondition}");
         }
 
         if (!didAny)
-            ImGui.TextUnformatted("None. Talk to a shop NPC or visit a market board to find out more!"u8);
+            ImGui.Text("None. Talk to a shop NPC or visit a market board to find out more!"u8);
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/DataShareWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/DataShareWidget.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
@@ -224,7 +224,7 @@ internal class DataShareWidget : IDataWindowWidget
             using (ImRaii.Tooltip())
             {
                 ImGui.PushTextWrapPos(wrx);
-                ImGui.TextWrapped((tooltip?.Invoke() ?? s).Replace("%", "%%"));
+                ImGui.TextWrapped(tooltip?.Invoke() ?? s);
                 ImGui.PopTextWrapPos();
             }
         }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/DataShareWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/DataShareWidget.cs
@@ -51,13 +51,13 @@ internal class DataShareWidget : IDataWindowWidget
     /// <inheritdoc/>
     public unsafe void Draw()
     {
-        using var tabbar = ImRaii.TabBar("##tabbar");
+        using var tabbar = ImRaii.TabBar("##tabbar"u8);
         if (!tabbar.Success)
             return;
 
         var d = true;
         using (var tabitem = ImRaii.TabItem(
-                   "Data Share##tabbar-datashare",
+                   "Data Share##tabbar-datashare"u8,
                    ref d,
                    NoCloseButton | (this.nextTab == 0 ? ImGuiTabItemFlags.SetSelected : 0)))
         {
@@ -66,7 +66,7 @@ internal class DataShareWidget : IDataWindowWidget
         }
 
         using (var tabitem = ImRaii.TabItem(
-                   "Call Gate##tabbar-callgate",
+                   "Call Gate##tabbar-callgate"u8,
                    ref d,
                    NoCloseButton | (this.nextTab == 1 ? ImGuiTabItemFlags.SetSelected : 0)))
         {
@@ -88,7 +88,7 @@ internal class DataShareWidget : IDataWindowWidget
             if (!tabitem.Success)
                 continue;
 
-            if (ImGui.Button("Refresh"))
+            if (ImGui.Button("Refresh"u8))
                 data = null;
 
             if (data is null)
@@ -119,7 +119,7 @@ internal class DataShareWidget : IDataWindowWidget
             }
 
             ImGui.SameLine();
-            if (ImGui.Button("Copy"))
+            if (ImGui.Button("Copy"u8))
                 ImGui.SetClipboardText(data);
 
             ImGui.InputTextMultiline(
@@ -224,7 +224,7 @@ internal class DataShareWidget : IDataWindowWidget
             using (ImRaii.Tooltip())
             {
                 ImGui.PushTextWrapPos(wrx);
-                ImGui.TextWrapped((tooltip?.Invoke() ?? s).Replace("%", "%%"));
+                ImGuiHelpers.SafeTextWrapped((tooltip?.Invoke() ?? s).Replace("%", "%%"));
                 ImGui.PopTextWrapPos();
             }
         }
@@ -242,15 +242,15 @@ internal class DataShareWidget : IDataWindowWidget
     private void DrawCallGate()
     {
         var callGate = Service<CallGate>.Get();
-        if (ImGui.Button("Purge empty call gates"))
+        if (ImGui.Button("Purge empty call gates"u8))
             callGate.PurgeEmptyGates();
 
-        using var table = ImRaii.Table("##callgate-table", 5);
-        ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.DefaultSort);
-        ImGui.TableSetupColumn("Action");
-        ImGui.TableSetupColumn("Func");
-        ImGui.TableSetupColumn("#", ImGuiTableColumnFlags.WidthFixed, 30 * ImGuiHelpers.GlobalScale);
-        ImGui.TableSetupColumn("Subscriber");
+        using var table = ImRaii.Table("##callgate-table"u8, 5);
+        ImGui.TableSetupColumn("Name"u8, ImGuiTableColumnFlags.DefaultSort);
+        ImGui.TableSetupColumn("Action"u8);
+        ImGui.TableSetupColumn("Func"u8);
+        ImGui.TableSetupColumn("#"u8, ImGuiTableColumnFlags.WidthFixed, 30 * ImGuiHelpers.GlobalScale);
+        ImGui.TableSetupColumn("Subscriber"u8);
         ImGui.TableHeadersRow();
 
         var gates2 = callGate.Gates;
@@ -287,16 +287,16 @@ internal class DataShareWidget : IDataWindowWidget
 
     private void DrawDataShare()
     {
-        if (!ImGui.BeginTable("###DataShareTable", 5, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg))
+        if (!ImGui.BeginTable("###DataShareTable"u8, 5, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg))
             return;
 
         try
         {
-            ImGui.TableSetupColumn("Shared Tag");
-            ImGui.TableSetupColumn("Show");
-            ImGui.TableSetupColumn("Creator Assembly");
-            ImGui.TableSetupColumn("#", ImGuiTableColumnFlags.WidthFixed, 30 * ImGuiHelpers.GlobalScale);
-            ImGui.TableSetupColumn("Consumers");
+            ImGui.TableSetupColumn("Shared Tag"u8);
+            ImGui.TableSetupColumn("Show"u8);
+            ImGui.TableSetupColumn("Creator Assembly"u8);
+            ImGui.TableSetupColumn("#"u8, ImGuiTableColumnFlags.WidthFixed, 30 * ImGuiHelpers.GlobalScale);
+            ImGui.TableSetupColumn("Consumers"u8);
             ImGui.TableHeadersRow();
             foreach (var share in Service<DataShare>.Get().GetAllShares())
             {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/DataShareWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/DataShareWidget.cs
@@ -214,7 +214,7 @@ internal class DataShareWidget : IDataWindowWidget
         var offset = ImGui.GetCursorScreenPos() + new Vector2(0, framepad ? ImGui.GetStyle().FramePadding.Y : 0);
         if (framepad)
             ImGui.AlignTextToFramePadding();
-        ImGui.TextUnformatted(s);
+        ImGui.Text(s);
         if (ImGui.IsItemHovered())
         {
             ImGui.SetNextWindowPos(offset - ImGui.GetStyle().WindowPadding);

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/DataShareWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/DataShareWidget.cs
@@ -224,7 +224,7 @@ internal class DataShareWidget : IDataWindowWidget
             using (ImRaii.Tooltip())
             {
                 ImGui.PushTextWrapPos(wrx);
-                ImGuiHelpers.SafeTextWrapped((tooltip?.Invoke() ?? s).Replace("%", "%%"));
+                ImGui.TextWrapped((tooltip?.Invoke() ?? s).Replace("%", "%%"));
                 ImGui.PopTextWrapPos();
             }
         }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/DtrBarWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/DtrBarWidget.cs
@@ -44,7 +44,7 @@ internal class DtrBarWidget : IDataWindowWidget, IDisposable
     {
         if (this.loadTestThread?.IsAlive is not true)
         {
-            if (ImGui.Button("Do multithreaded add/remove operation"))
+            if (ImGui.Button("Do multithreaded add/remove operation"u8))
             {
                 var ct = this.loadTestThreadCt = new();
                 var dbar = Service<DtrBar>.Get();
@@ -135,7 +135,7 @@ internal class DtrBarWidget : IDataWindowWidget, IDisposable
         }
         else
         {
-            if (ImGui.Button("Stop multithreaded add/remove operation"))
+            if (ImGui.Button("Stop multithreaded add/remove operation"u8))
                 this.ClearState();
         }
 
@@ -149,17 +149,17 @@ internal class DtrBarWidget : IDataWindowWidget, IDisposable
         this.DrawDtrTestEntry(ref this.dtrTest3, "DTR Test #3");
 
         ImGui.Separator();
-        ImGui.Text("IDtrBar.Entries:");
+        ImGui.TextUnformatted("IDtrBar.Entries:"u8);
         foreach (var e in Service<DtrBar>.Get().Entries)
-            ImGui.Text(e.Title);
+            ImGui.TextUnformatted(e.Title);
 
         var configuration = Service<DalamudConfiguration>.Get();
         if (configuration.DtrOrder != null)
         {
             ImGui.Separator();
-            ImGui.Text("DtrOrder:");
+            ImGui.TextUnformatted("DtrOrder:"u8);
             foreach (var order in configuration.DtrOrder)
-                ImGui.Text(order);
+                ImGui.TextUnformatted(order);
         }
     }
 
@@ -177,7 +177,7 @@ internal class DtrBarWidget : IDataWindowWidget, IDisposable
 
         if (entry != null)
         {
-            ImGui.Text(title);
+            ImGui.TextUnformatted(title);
 
             var text = entry.Text?.TextValue ?? string.Empty;
             if (ImGui.InputText($"Text###{entry.Title}t", ref text, 255))

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/DtrBarWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/DtrBarWidget.cs
@@ -149,17 +149,17 @@ internal class DtrBarWidget : IDataWindowWidget, IDisposable
         this.DrawDtrTestEntry(ref this.dtrTest3, "DTR Test #3");
 
         ImGui.Separator();
-        ImGui.TextUnformatted("IDtrBar.Entries:"u8);
+        ImGui.Text("IDtrBar.Entries:"u8);
         foreach (var e in Service<DtrBar>.Get().Entries)
-            ImGui.TextUnformatted(e.Title);
+            ImGui.Text(e.Title);
 
         var configuration = Service<DalamudConfiguration>.Get();
         if (configuration.DtrOrder != null)
         {
             ImGui.Separator();
-            ImGui.TextUnformatted("DtrOrder:"u8);
+            ImGui.Text("DtrOrder:"u8);
             foreach (var order in configuration.DtrOrder)
-                ImGui.TextUnformatted(order);
+                ImGui.Text(order);
         }
     }
 
@@ -177,7 +177,7 @@ internal class DtrBarWidget : IDataWindowWidget, IDisposable
 
         if (entry != null)
         {
-            ImGui.TextUnformatted(title);
+            ImGui.Text(title);
 
             var text = entry.Text?.TextValue ?? string.Empty;
             if (ImGui.InputText($"Text###{entry.Title}t", ref text, 255))

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/FateTableWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/FateTableWidget.cs
@@ -34,26 +34,26 @@ internal class FateTableWidget : IDataWindowWidget
 
         if (fateTable.Length == 0)
         {
-            ImGui.TextUnformatted("No fates or data not ready.");
+            ImGui.TextUnformatted("No fates or data not ready."u8);
             return;
         }
 
-        using var table = ImRaii.Table("FateTable", 13, ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.NoSavedSettings);
+        using var table = ImRaii.Table("FateTable"u8, 13, ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.NoSavedSettings);
         if (!table) return;
 
-        ImGui.TableSetupColumn("Index", ImGuiTableColumnFlags.WidthFixed, 40);
-        ImGui.TableSetupColumn("Address", ImGuiTableColumnFlags.WidthFixed, 120);
-        ImGui.TableSetupColumn("FateId", ImGuiTableColumnFlags.WidthFixed, 40);
-        ImGui.TableSetupColumn("State", ImGuiTableColumnFlags.WidthFixed, 80);
-        ImGui.TableSetupColumn("Level", ImGuiTableColumnFlags.WidthFixed, 50);
-        ImGui.TableSetupColumn("Icon", ImGuiTableColumnFlags.WidthFixed, 30);
-        ImGui.TableSetupColumn("MapIcon", ImGuiTableColumnFlags.WidthFixed, 30);
-        ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthStretch);
-        ImGui.TableSetupColumn("Progress", ImGuiTableColumnFlags.WidthFixed, 55);
-        ImGui.TableSetupColumn("Duration", ImGuiTableColumnFlags.WidthFixed, 80);
-        ImGui.TableSetupColumn("Bonus", ImGuiTableColumnFlags.WidthFixed, 40);
-        ImGui.TableSetupColumn("Position", ImGuiTableColumnFlags.WidthFixed, 240);
-        ImGui.TableSetupColumn("Radius", ImGuiTableColumnFlags.WidthFixed, 40);
+        ImGui.TableSetupColumn("Index"u8, ImGuiTableColumnFlags.WidthFixed, 40);
+        ImGui.TableSetupColumn("Address"u8, ImGuiTableColumnFlags.WidthFixed, 120);
+        ImGui.TableSetupColumn("FateId"u8, ImGuiTableColumnFlags.WidthFixed, 40);
+        ImGui.TableSetupColumn("State"u8, ImGuiTableColumnFlags.WidthFixed, 80);
+        ImGui.TableSetupColumn("Level"u8, ImGuiTableColumnFlags.WidthFixed, 50);
+        ImGui.TableSetupColumn("Icon"u8, ImGuiTableColumnFlags.WidthFixed, 30);
+        ImGui.TableSetupColumn("MapIcon"u8, ImGuiTableColumnFlags.WidthFixed, 30);
+        ImGui.TableSetupColumn("Name"u8, ImGuiTableColumnFlags.WidthStretch);
+        ImGui.TableSetupColumn("Progress"u8, ImGuiTableColumnFlags.WidthFixed, 55);
+        ImGui.TableSetupColumn("Duration"u8, ImGuiTableColumnFlags.WidthFixed, 80);
+        ImGui.TableSetupColumn("Bonus"u8, ImGuiTableColumnFlags.WidthFixed, 40);
+        ImGui.TableSetupColumn("Position"u8, ImGuiTableColumnFlags.WidthFixed, 240);
+        ImGui.TableSetupColumn("Radius"u8, ImGuiTableColumnFlags.WidthFixed, 40);
         ImGui.TableSetupScrollFreeze(7, 1);
         ImGui.TableHeadersRow();
 
@@ -99,7 +99,7 @@ internal class FateTableWidget : IDataWindowWidget
                     {
                         ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                         ImGui.BeginTooltip();
-                        ImGui.TextUnformatted("Click to copy IconId");
+                        ImGui.TextUnformatted("Click to copy IconId"u8);
                         ImGui.TextUnformatted($"ID: {fate.IconId} – Size: {texture.Width}x{texture.Height}");
                         ImGui.Image(texture.Handle, new(texture.Width, texture.Height));
                         ImGui.EndTooltip();
@@ -124,7 +124,7 @@ internal class FateTableWidget : IDataWindowWidget
                     {
                         ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                         ImGui.BeginTooltip();
-                        ImGui.TextUnformatted("Click to copy MapIconId");
+                        ImGui.TextUnformatted("Click to copy MapIconId"u8);
                         ImGui.TextUnformatted($"ID: {fate.MapIconId} – Size: {texture.Width}x{texture.Height}");
                         ImGui.Image(texture.Handle, new(texture.Width, texture.Height));
                         ImGui.EndTooltip();

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/FateTableWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/FateTableWidget.cs
@@ -34,7 +34,7 @@ internal class FateTableWidget : IDataWindowWidget
 
         if (fateTable.Length == 0)
         {
-            ImGui.TextUnformatted("No fates or data not ready."u8);
+            ImGui.Text("No fates or data not ready."u8);
             return;
         }
 
@@ -65,7 +65,7 @@ internal class FateTableWidget : IDataWindowWidget
 
             ImGui.TableNextRow();
             ImGui.TableNextColumn(); // Index
-            ImGui.TextUnformatted($"#{i}");
+            ImGui.Text($"#{i}");
 
             ImGui.TableNextColumn(); // Address
             WidgetUtil.DrawCopyableText($"0x{fate.Address:X}", "Click to copy Address");
@@ -74,17 +74,17 @@ internal class FateTableWidget : IDataWindowWidget
             WidgetUtil.DrawCopyableText(fate.FateId.ToString(), "Click to copy FateId (RowId of Fate sheet)");
 
             ImGui.TableNextColumn(); // State
-            ImGui.TextUnformatted(fate.State.ToString());
+            ImGui.Text(fate.State.ToString());
 
             ImGui.TableNextColumn(); // Level
 
             if (fate.Level == fate.MaxLevel)
             {
-                ImGui.TextUnformatted($"{fate.Level}");
+                ImGui.Text($"{fate.Level}");
             }
             else
             {
-                ImGui.TextUnformatted($"{fate.Level}-{fate.MaxLevel}");
+                ImGui.Text($"{fate.Level}-{fate.MaxLevel}");
             }
 
             ImGui.TableNextColumn(); // Icon
@@ -99,8 +99,8 @@ internal class FateTableWidget : IDataWindowWidget
                     {
                         ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                         ImGui.BeginTooltip();
-                        ImGui.TextUnformatted("Click to copy IconId"u8);
-                        ImGui.TextUnformatted($"ID: {fate.IconId} – Size: {texture.Width}x{texture.Height}");
+                        ImGui.Text("Click to copy IconId"u8);
+                        ImGui.Text($"ID: {fate.IconId} – Size: {texture.Width}x{texture.Height}");
                         ImGui.Image(texture.Handle, new(texture.Width, texture.Height));
                         ImGui.EndTooltip();
                     }
@@ -124,8 +124,8 @@ internal class FateTableWidget : IDataWindowWidget
                     {
                         ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                         ImGui.BeginTooltip();
-                        ImGui.TextUnformatted("Click to copy MapIconId"u8);
-                        ImGui.TextUnformatted($"ID: {fate.MapIconId} – Size: {texture.Width}x{texture.Height}");
+                        ImGui.Text("Click to copy MapIconId"u8);
+                        ImGui.Text($"ID: {fate.MapIconId} – Size: {texture.Width}x{texture.Height}");
                         ImGui.Image(texture.Handle, new(texture.Width, texture.Height));
                         ImGui.EndTooltip();
                     }
@@ -142,17 +142,17 @@ internal class FateTableWidget : IDataWindowWidget
             WidgetUtil.DrawCopyableText(fate.Name.ToString(), "Click to copy Name");
 
             ImGui.TableNextColumn(); // Progress
-            ImGui.TextUnformatted($"{fate.Progress}%");
+            ImGui.Text($"{fate.Progress}%");
 
             ImGui.TableNextColumn(); // TimeRemaining
 
             if (fate.State == FateState.Running)
             {
-                ImGui.TextUnformatted($"{TimeSpan.FromSeconds(fate.TimeRemaining):mm\\:ss} / {TimeSpan.FromSeconds(fate.Duration):mm\\:ss}");
+                ImGui.Text($"{TimeSpan.FromSeconds(fate.TimeRemaining):mm\\:ss} / {TimeSpan.FromSeconds(fate.Duration):mm\\:ss}");
             }
 
             ImGui.TableNextColumn(); // HasExpBonus
-            ImGui.TextUnformatted(fate.HasBonus.ToString());
+            ImGui.Text(fate.HasBonus.ToString());
 
             ImGui.TableNextColumn(); // Position
             WidgetUtil.DrawCopyableText(fate.Position.ToString(), "Click to copy Position");

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/FlyTextWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/FlyTextWidget.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Numerics;
 
 using Dalamud.Bindings.ImGui;
@@ -39,7 +39,7 @@ internal class FlyTextWidget : IDataWindowWidget
     /// <inheritdoc/>
     public void Draw()
     {
-        if (ImGui.BeginCombo("Kind", $"{this.flyKind} ({(int)this.flyKind})"))
+        if (ImGui.BeginCombo("Kind"u8, $"{this.flyKind} ({(int)this.flyKind})"))
         {
             var values = Enum.GetValues<FlyTextKind>().Distinct();
             foreach (var value in values)
@@ -53,19 +53,19 @@ internal class FlyTextWidget : IDataWindowWidget
             ImGui.EndCombo();
         }
 
-        ImGui.InputText("Text1", ref this.flyText1, 200);
-        ImGui.InputText("Text2", ref this.flyText2, 200);
+        ImGui.InputText("Text1"u8, ref this.flyText1, 200);
+        ImGui.InputText("Text2"u8, ref this.flyText2, 200);
 
-        ImGui.InputInt("Val1", ref this.flyVal1);
-        ImGui.InputInt("Val2", ref this.flyVal2);
+        ImGui.InputInt("Val1"u8, ref this.flyVal1);
+        ImGui.InputInt("Val2"u8, ref this.flyVal2);
 
-        ImGui.InputInt("Icon ID", ref this.flyIcon);
-        ImGui.InputInt("Damage Icon ID", ref this.flyDmgIcon);
+        ImGui.InputInt("Icon ID"u8, ref this.flyIcon);
+        ImGui.InputInt("Damage Icon ID"u8, ref this.flyDmgIcon);
         ImGui.ColorEdit4("Color", ref this.flyColor);
-        ImGui.InputInt("Actor Index", ref this.flyActor);
+        ImGui.InputInt("Actor Index"u8, ref this.flyActor);
         var sendColor = ImGui.ColorConvertFloat4ToU32(this.flyColor);
 
-        if (ImGui.Button("Send"))
+        if (ImGui.Button("Send"u8))
         {
             Service<FlyTextGui>.Get().AddFlyText(
                 this.flyKind,

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/FontAwesomeTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/FontAwesomeTestWidget.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 
@@ -77,22 +77,22 @@ internal class FontAwesomeTestWidget : IDataWindowWidget
 
         ImGui.SameLine(170f);
         ImGui.SetNextItemWidth(180f);
-        if (ImGui.InputTextWithHint($"###FontAwesomeInputSearch", "search icons", ref this.iconSearchInput, 50))
+        if (ImGui.InputTextWithHint($"###FontAwesomeInputSearch", "search icons"u8, ref this.iconSearchInput, 50))
         {
             this.iconSearchChanged = true;
         }
 
-        ImGui.Checkbox("Use fixed width font", ref this.useFixedWidth);
+        ImGui.Checkbox("Use fixed width font"u8, ref this.useFixedWidth);
 
         ImGuiHelpers.ScaledDummy(10f);
         for (var i = 0; i < this.icons?.Count; i++)
         {
-            ImGui.Text($"0x{(int)this.icons[i].ToIconChar():X}");
+            ImGui.TextUnformatted($"0x{(int)this.icons[i].ToIconChar():X}");
             ImGuiHelpers.ScaledRelativeSameLine(50f);
-            ImGui.Text($"{this.iconNames?[i]}");
+            ImGui.TextUnformatted($"{this.iconNames?[i]}");
             ImGuiHelpers.ScaledRelativeSameLine(280f);
             ImGui.PushFont(this.useFixedWidth ? InterfaceManager.IconFontFixedWidth : InterfaceManager.IconFont);
-            ImGui.Text(this.icons[i].ToIconString());
+            ImGui.TextUnformatted(this.icons[i].ToIconString());
             ImGui.PopFont();
             ImGuiHelpers.ScaledDummy(2f);
         }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/FontAwesomeTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/FontAwesomeTestWidget.cs
@@ -87,12 +87,12 @@ internal class FontAwesomeTestWidget : IDataWindowWidget
         ImGuiHelpers.ScaledDummy(10f);
         for (var i = 0; i < this.icons?.Count; i++)
         {
-            ImGui.TextUnformatted($"0x{(int)this.icons[i].ToIconChar():X}");
+            ImGui.Text($"0x{(int)this.icons[i].ToIconChar():X}");
             ImGuiHelpers.ScaledRelativeSameLine(50f);
-            ImGui.TextUnformatted($"{this.iconNames?[i]}");
+            ImGui.Text($"{this.iconNames?[i]}");
             ImGuiHelpers.ScaledRelativeSameLine(280f);
             ImGui.PushFont(this.useFixedWidth ? InterfaceManager.IconFontFixedWidth : InterfaceManager.IconFont);
-            ImGui.TextUnformatted(this.icons[i].ToIconString());
+            ImGui.Text(this.icons[i].ToIconString());
             ImGui.PopFont();
             ImGuiHelpers.ScaledDummy(2f);
         }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/GamePrebakedFontsTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/GamePrebakedFontsTestWidget.cs
@@ -150,7 +150,7 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
         if (this.chooserDialog is not null)
         {
             ImGui.SameLine();
-            ImGui.TextUnformatted($"{this.chooserDialog.PopupPosition}, {this.chooserDialog.PopupSize}");
+            ImGui.Text($"{this.chooserDialog.PopupPosition}, {this.chooserDialog.PopupSize}");
 
             ImGui.SameLine();
             if (ImGui.Button("Random Location"u8))
@@ -246,18 +246,18 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
 
             foreach (var (gfs, handle) in items)
             {
-                ImGui.TextUnformatted($"{gfs.SizePt}pt");
+                ImGui.Text($"{gfs.SizePt}pt");
                 ImGui.SameLine(offsetX);
                 ImGui.PushTextWrapPos(this.useWordWrap ? 0f : -1f);
                 try
                 {
                     if (handle.Value.LoadException is { } exc)
                     {
-                        ImGui.TextUnformatted(exc.ToString());
+                        ImGui.Text(exc.ToString());
                     }
                     else if (!handle.Value.Available)
                     {
-                        ImGui.TextUnformatted("Loading..."u8[..(8 + ((Environment.TickCount / 200) % 3))]);
+                        ImGui.Text("Loading..."u8[..(8 + ((Environment.TickCount / 200) % 3))]);
                     }
                     else
                     {
@@ -266,12 +266,12 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
                         if (counter++ % 2 == 0)
                         {
                             using var pushPop = handle.Value.Push();
-                            ImGui.TextUnformatted(this.testStringBuffer.DataSpan);
+                            ImGui.Text(this.testStringBuffer.DataSpan);
                         }
                         else
                         {
                             handle.Value.Push();
-                            ImGui.TextUnformatted(this.testStringBuffer.DataSpan);
+                            ImGui.Text(this.testStringBuffer.DataSpan);
                             handle.Value.Pop();
                         }
                     }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/GamePrebakedFontsTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/GamePrebakedFontsTestWidget.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
@@ -63,6 +63,7 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
         ImGui.AlignTextToFramePadding();
         if (ImGui.Combo("Global Scale per Font"u8, ref this.fontScaleMode, FontScaleModes))
             this.ClearAtlas();
+
         if (ImGui.Checkbox("Global Scale for Atlas"u8, ref this.atlasScaleMode))
             this.ClearAtlas();
 
@@ -82,7 +83,7 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
             this.ClearAtlas();
 
         ImGui.SameLine();
-        if (ImGui.Button("Reset Text") || this.testStringBuffer.IsDisposed)
+        if (ImGui.Button("Reset Text"u8) || this.testStringBuffer.IsDisposed)
         {
             this.testStringBuffer.Dispose();
             this.testStringBuffer = ImVectorWrapper.CreateFromSpan(
@@ -91,10 +92,10 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
         }
 
         ImGui.SameLine();
-        if (ImGui.Button("Test Lock"))
+        if (ImGui.Button("Test Lock"u8))
             Task.Run(this.TestLock);
 
-        if (ImGui.Button("Choose Editor Font"))
+        if (ImGui.Button("Choose Editor Font"u8))
         {
             if (this.chooserDialog is null)
             {
@@ -152,7 +153,7 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
             ImGui.TextUnformatted($"{this.chooserDialog.PopupPosition}, {this.chooserDialog.PopupSize}");
 
             ImGui.SameLine();
-            if (ImGui.Button("Random Location"))
+            if (ImGui.Button("Random Location"u8))
             {
                 var monitors = ImGui.GetPlatformIO().Monitors;
                 var monitor = monitors[Random.Shared.Next() % monitors.Size];
@@ -236,7 +237,7 @@ internal class GamePrebakedFontsTestWidget : IDataWindowWidget, IDisposable
                               })
                           .ToArray());
 
-        var offsetX = ImGui.CalcTextSize("99.9pt").X + (ImGui.GetStyle().FramePadding.X * 2);
+        var offsetX = ImGui.CalcTextSize("99.9pt"u8).X + (ImGui.GetStyle().FramePadding.X * 2);
         var counter = 0;
         foreach (var (family, items) in this.fontHandles)
         {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/GamepadWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/GamepadWidget.cs
@@ -29,7 +29,7 @@ internal class GamepadWidget : IDataWindowWidget
     {
         var gamepadState = Service<GamepadState>.Get();
 
-        ImGui.TextUnformatted($"GamepadInput {Util.DescribeAddress(gamepadState.GamepadInputAddress)}");
+        ImGui.Text($"GamepadInput {Util.DescribeAddress(gamepadState.GamepadInputAddress)}");
 
 #if DEBUG
         if (ImGui.IsItemHovered())
@@ -55,26 +55,26 @@ internal class GamepadWidget : IDataWindowWidget
             "Buttons Released",
             (uint)gamepadState.ButtonsReleased,
             gamepadState.Released);
-        ImGui.TextUnformatted($"LeftStick {gamepadState.LeftStick}");
-        ImGui.TextUnformatted($"RightStick {gamepadState.RightStick}");
+        ImGui.Text($"LeftStick {gamepadState.LeftStick}");
+        ImGui.Text($"RightStick {gamepadState.RightStick}");
     }
 
     private void DrawHelper(string text, uint mask, Func<GamepadButtons, float> resolve)
     {
-        ImGui.TextUnformatted($"{text} {mask:X4}");
-        ImGui.TextUnformatted($"DPadLeft {resolve(GamepadButtons.DpadLeft)} " +
+        ImGui.Text($"{text} {mask:X4}");
+        ImGui.Text($"DPadLeft {resolve(GamepadButtons.DpadLeft)} " +
                    $"DPadUp {resolve(GamepadButtons.DpadUp)} " +
                    $"DPadRight {resolve(GamepadButtons.DpadRight)} " +
                    $"DPadDown {resolve(GamepadButtons.DpadDown)} ");
-        ImGui.TextUnformatted($"West {resolve(GamepadButtons.West)} " +
+        ImGui.Text($"West {resolve(GamepadButtons.West)} " +
                    $"North {resolve(GamepadButtons.North)} " +
                    $"East {resolve(GamepadButtons.East)} " +
                    $"South {resolve(GamepadButtons.South)} ");
-        ImGui.TextUnformatted($"L1 {resolve(GamepadButtons.L1)} " +
+        ImGui.Text($"L1 {resolve(GamepadButtons.L1)} " +
                    $"L2 {resolve(GamepadButtons.L2)} " +
                    $"R1 {resolve(GamepadButtons.R1)} " +
                    $"R2 {resolve(GamepadButtons.R2)} ");
-        ImGui.TextUnformatted($"Select {resolve(GamepadButtons.Select)} " +
+        ImGui.Text($"Select {resolve(GamepadButtons.Select)} " +
                    $"Start {resolve(GamepadButtons.Start)} " +
                    $"L3 {resolve(GamepadButtons.L3)} " +
                    $"R3 {resolve(GamepadButtons.R3)} ");

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/GamepadWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/GamepadWidget.cs
@@ -29,7 +29,7 @@ internal class GamepadWidget : IDataWindowWidget
     {
         var gamepadState = Service<GamepadState>.Get();
 
-        ImGui.Text($"GamepadInput {Util.DescribeAddress(gamepadState.GamepadInputAddress)}");
+        ImGui.TextUnformatted($"GamepadInput {Util.DescribeAddress(gamepadState.GamepadInputAddress)}");
 
 #if DEBUG
         if (ImGui.IsItemHovered())
@@ -55,26 +55,26 @@ internal class GamepadWidget : IDataWindowWidget
             "Buttons Released",
             (uint)gamepadState.ButtonsReleased,
             gamepadState.Released);
-        ImGui.Text($"LeftStick {gamepadState.LeftStick}");
-        ImGui.Text($"RightStick {gamepadState.RightStick}");
+        ImGui.TextUnformatted($"LeftStick {gamepadState.LeftStick}");
+        ImGui.TextUnformatted($"RightStick {gamepadState.RightStick}");
     }
 
     private void DrawHelper(string text, uint mask, Func<GamepadButtons, float> resolve)
     {
-        ImGui.Text($"{text} {mask:X4}");
-        ImGui.Text($"DPadLeft {resolve(GamepadButtons.DpadLeft)} " +
+        ImGui.TextUnformatted($"{text} {mask:X4}");
+        ImGui.TextUnformatted($"DPadLeft {resolve(GamepadButtons.DpadLeft)} " +
                    $"DPadUp {resolve(GamepadButtons.DpadUp)} " +
                    $"DPadRight {resolve(GamepadButtons.DpadRight)} " +
                    $"DPadDown {resolve(GamepadButtons.DpadDown)} ");
-        ImGui.Text($"West {resolve(GamepadButtons.West)} " +
+        ImGui.TextUnformatted($"West {resolve(GamepadButtons.West)} " +
                    $"North {resolve(GamepadButtons.North)} " +
                    $"East {resolve(GamepadButtons.East)} " +
                    $"South {resolve(GamepadButtons.South)} ");
-        ImGui.Text($"L1 {resolve(GamepadButtons.L1)} " +
+        ImGui.TextUnformatted($"L1 {resolve(GamepadButtons.L1)} " +
                    $"L2 {resolve(GamepadButtons.L2)} " +
                    $"R1 {resolve(GamepadButtons.R1)} " +
                    $"R2 {resolve(GamepadButtons.R2)} ");
-        ImGui.Text($"Select {resolve(GamepadButtons.Select)} " +
+        ImGui.TextUnformatted($"Select {resolve(GamepadButtons.Select)} " +
                    $"Start {resolve(GamepadButtons.Start)} " +
                    $"L3 {resolve(GamepadButtons.L3)} " +
                    $"R3 {resolve(GamepadButtons.R3)} ");

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/GaugeWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/GaugeWidget.cs
@@ -35,7 +35,7 @@ internal class GaugeWidget : IDataWindowWidget
         var player = clientState.LocalPlayer;
         if (player == null)
         {
-            ImGui.Text("Player is not present");
+            ImGui.TextUnformatted("Player is not present"u8);
             return;
         }
 
@@ -68,7 +68,7 @@ internal class GaugeWidget : IDataWindowWidget
 
         if (gauge == null)
         {
-            ImGui.Text("No supported gauge exists for this job.");
+            ImGui.TextUnformatted("No supported gauge exists for this job."u8);
             return;
         }
 

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/GaugeWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/GaugeWidget.cs
@@ -35,7 +35,7 @@ internal class GaugeWidget : IDataWindowWidget
         var player = clientState.LocalPlayer;
         if (player == null)
         {
-            ImGui.TextUnformatted("Player is not present"u8);
+            ImGui.Text("Player is not present"u8);
             return;
         }
 
@@ -68,7 +68,7 @@ internal class GaugeWidget : IDataWindowWidget
 
         if (gauge == null)
         {
-            ImGui.TextUnformatted("No supported gauge exists for this job."u8);
+            ImGui.Text("No supported gauge exists for this job."u8);
             return;
         }
 

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/HookWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/HookWidget.cs
@@ -74,46 +74,46 @@ internal unsafe class HookWidget : IDataWindowWidget
     {
         try
         {
-            ImGui.Checkbox("Use MinHook (only for regular hooks, AsmHook is Reloaded-only)", ref this.hookUseMinHook);
+            ImGui.Checkbox("Use MinHook (only for regular hooks, AsmHook is Reloaded-only)"u8, ref this.hookUseMinHook);
 
             ImGui.Separator();
 
-            if (ImGui.Button("Create"))
+            if (ImGui.Button("Create"u8))
                 this.messageBoxMinHook = Hook<MessageBoxWDelegate>.FromSymbol("User32", "MessageBoxW", this.MessageBoxWDetour, this.hookUseMinHook);
 
-            if (ImGui.Button("Enable"))
+            if (ImGui.Button("Enable"u8))
                 this.messageBoxMinHook?.Enable();
 
-            if (ImGui.Button("Disable"))
+            if (ImGui.Button("Disable"u8))
                 this.messageBoxMinHook?.Disable();
 
-            if (ImGui.Button("Call Original"))
+            if (ImGui.Button("Call Original"u8))
                 this.messageBoxMinHook?.Original(IntPtr.Zero, "Hello from .Original", "Hook Test", MESSAGEBOX_STYLE.MB_OK);
 
-            if (ImGui.Button("Dispose"))
+            if (ImGui.Button("Dispose"u8))
             {
                 this.messageBoxMinHook?.Dispose();
                 this.messageBoxMinHook = null;
             }
 
-            if (ImGui.Button("Test"))
+            if (ImGui.Button("Test"u8))
                 _ = global::Windows.Win32.PInvoke.MessageBox(HWND.Null, "Hi", "Hello", MESSAGEBOX_STYLE.MB_OK);
 
             if (this.messageBoxMinHook != null)
-                ImGui.Text("Enabled: " + this.messageBoxMinHook?.IsEnabled);
+                ImGui.TextUnformatted("Enabled: " + this.messageBoxMinHook?.IsEnabled);
 
             ImGui.Separator();
 
             ImGui.BeginDisabled(this.hookStressTestRunning);
-            ImGui.Text("Stress Test");
+            ImGui.TextUnformatted("Stress Test"u8);
 
-            if (ImGui.InputInt("Max", ref this.hookStressTestMax))
+            if (ImGui.InputInt("Max"u8, ref this.hookStressTestMax))
                 this.hookStressTestCount = 0;
 
-            ImGui.InputInt("Wait (ms)", ref this.hookStressTestWait);
-            ImGui.InputInt("Max Degree of Parallelism", ref this.hookStressTestMaxDegreeOfParallelism);
+            ImGui.InputInt("Wait (ms)"u8, ref this.hookStressTestWait);
+            ImGui.InputInt("Max Degree of Parallelism"u8, ref this.hookStressTestMaxDegreeOfParallelism);
 
-            if (ImGui.BeginCombo("Target", HookTargetToString(this.hookStressTestHookTarget)))
+            if (ImGui.BeginCombo("Target"u8, HookTargetToString(this.hookStressTestHookTarget)))
             {
                 foreach (var target in Enum.GetValues<StressTestHookTarget>())
                 {
@@ -124,7 +124,7 @@ internal unsafe class HookWidget : IDataWindowWidget
                 ImGui.EndCombo();
             }
 
-            if (ImGui.Button("Stress Test"))
+            if (ImGui.Button("Stress Test"u8))
             {
                 Task.Run(() =>
                 {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/HookWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/HookWidget.cs
@@ -100,12 +100,12 @@ internal unsafe class HookWidget : IDataWindowWidget
                 _ = global::Windows.Win32.PInvoke.MessageBox(HWND.Null, "Hi", "Hello", MESSAGEBOX_STYLE.MB_OK);
 
             if (this.messageBoxMinHook != null)
-                ImGui.TextUnformatted("Enabled: " + this.messageBoxMinHook?.IsEnabled);
+                ImGui.Text("Enabled: " + this.messageBoxMinHook?.IsEnabled);
 
             ImGui.Separator();
 
             ImGui.BeginDisabled(this.hookStressTestRunning);
-            ImGui.TextUnformatted("Stress Test"u8);
+            ImGui.Text("Stress Test"u8);
 
             if (ImGui.InputInt("Max"u8, ref this.hookStressTestMax))
                 this.hookStressTestCount = 0;
@@ -165,7 +165,7 @@ internal unsafe class HookWidget : IDataWindowWidget
 
             ImGui.EndDisabled();
 
-            ImGui.TextUnformatted("Status: " + (this.hookStressTestRunning ? "Running" : "Idle"));
+            ImGui.Text("Status: " + (this.hookStressTestRunning ? "Running" : "Idle"));
             ImGui.ProgressBar(this.hookStressTestCount / (float)this.hookStressTestMax, new System.Numerics.Vector2(0, 0), $"{this.hookStressTestCount}/{this.hookStressTestMax}");
         }
         catch (Exception ex)

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/IconBrowserWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/IconBrowserWidget.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Numerics;
 using System.Threading.Tasks;
 
@@ -72,7 +72,7 @@ public class IconBrowserWidget : IDataWindowWidget
 
         if (!this.iconIdsTask.IsCompleted)
         {
-            ImGui.TextUnformatted("Loading...");
+            ImGui.TextUnformatted("Loading..."u8);
         }
         else if (!this.iconIdsTask.IsCompletedSuccessfully)
         {
@@ -82,7 +82,7 @@ public class IconBrowserWidget : IDataWindowWidget
         {
             this.RecalculateIndexRange();
 
-            if (ImGui.BeginChild("ScrollableSection", ImGui.GetContentRegionAvail(), false, ImGuiWindowFlags.NoMove))
+            if (ImGui.BeginChild("ScrollableSection"u8, ImGui.GetContentRegionAvail(), false, ImGuiWindowFlags.NoMove))
             {
                 var itemsPerRow = (int)MathF.Floor(
                     ImGui.GetContentRegionMax().X / (this.iconSize.X + ImGui.GetStyle().ItemSpacing.X));
@@ -119,7 +119,7 @@ public class IconBrowserWidget : IDataWindowWidget
         ImGui.Columns(2);
 
         ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X);
-        if (ImGui.InputInt("##StartRange", ref this.startRange, 0, 0))
+        if (ImGui.InputInt("##StartRange"u8, ref this.startRange, 0, 0))
         {
             this.startRange = Math.Clamp(this.startRange, 0, MaxIconId);
             this.valueRange = null;
@@ -127,14 +127,14 @@ public class IconBrowserWidget : IDataWindowWidget
 
         ImGui.NextColumn();
         ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X);
-        if (ImGui.InputInt("##StopRange", ref this.stopRange, 0, 0))
+        if (ImGui.InputInt("##StopRange"u8, ref this.stopRange, 0, 0))
         {
             this.stopRange = Math.Clamp(this.stopRange, 0, MaxIconId);
             this.valueRange = null;
         }
 
         ImGui.NextColumn();
-        ImGui.Checkbox("Show Image in Tooltip", ref this.showTooltipImage);
+        ImGui.Checkbox("Show Image in Tooltip"u8, ref this.showTooltipImage);
 
         ImGui.NextColumn();
         ImGui.InputFloat2("Icon Size", ref this.editIconSize);
@@ -165,7 +165,7 @@ public class IconBrowserWidget : IDataWindowWidget
                 var textSize = ImGui.CalcTextSize(iconId.ToString());
                 ImGui.SetCursorPosX(
                     texture.Size.X * scale / 2.0f - textSize.X / 2.0f + ImGui.GetStyle().FramePadding.X * 2.0f);
-                ImGui.Text(iconId.ToString());
+                ImGui.TextUnformatted(iconId.ToString());
 
                 ImGui.Image(texture.Handle, texture.Size * scale);
                 ImGui.EndTooltip();

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/IconBrowserWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/IconBrowserWidget.cs
@@ -204,7 +204,7 @@ public class IconBrowserWidget : IDataWindowWidget
             }
 
             if (ImGui.IsItemHovered())
-                ImGui.SetTooltip($"{iconId}\n{exc}".Replace("%", "%%"));
+                ImGui.SetTooltip($"{iconId}\n{exc}");
 
             ImGui.GetWindowDrawList().AddRect(
                 cursor,

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/IconBrowserWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/IconBrowserWidget.cs
@@ -72,11 +72,11 @@ public class IconBrowserWidget : IDataWindowWidget
 
         if (!this.iconIdsTask.IsCompleted)
         {
-            ImGui.TextUnformatted("Loading..."u8);
+            ImGui.Text("Loading..."u8);
         }
         else if (!this.iconIdsTask.IsCompletedSuccessfully)
         {
-            ImGui.TextUnformatted(this.iconIdsTask.Exception?.ToString() ?? "Unknown error");
+            ImGui.Text(this.iconIdsTask.Exception?.ToString() ?? "Unknown error");
         }
         else
         {
@@ -165,7 +165,7 @@ public class IconBrowserWidget : IDataWindowWidget
                 var textSize = ImGui.CalcTextSize(iconId.ToString());
                 ImGui.SetCursorPosX(
                     texture.Size.X * scale / 2.0f - textSize.X / 2.0f + ImGui.GetStyle().FramePadding.X * 2.0f);
-                ImGui.TextUnformatted(iconId.ToString());
+                ImGui.Text(iconId.ToString());
 
                 ImGui.Image(texture.Handle, texture.Size * scale);
                 ImGui.EndTooltip();

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ImGuiWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ImGuiWidget.cs
@@ -46,15 +46,15 @@ internal class ImGuiWidget : IDataWindowWidget
         var interfaceManager = Service<InterfaceManager>.Get();
         var nm = Service<NotificationManager>.Get();
 
-        ImGui.TextUnformatted("Monitor count: " + ImGui.GetPlatformIO().Monitors.Size);
-        ImGui.TextUnformatted("OverrideGameCursor: " + interfaceManager.OverrideGameCursor);
+        ImGui.Text("Monitor count: " + ImGui.GetPlatformIO().Monitors.Size);
+        ImGui.Text("OverrideGameCursor: " + interfaceManager.OverrideGameCursor);
 
         ImGui.Button("THIS IS A BUTTON###hoverTestButton"u8);
         interfaceManager.OverrideGameCursor = !ImGui.IsItemHovered();
 
         ImGui.Separator();
 
-        ImGui.TextUnformatted(
+        ImGui.Text(
             $"WindowSystem.TimeSinceLastAnyFocus: {WindowSystem.TimeSinceLastAnyFocus.TotalMilliseconds:0}ms");
 
         ImGui.Separator();
@@ -266,7 +266,7 @@ internal class ImGuiWidget : IDataWindowWidget
                 n.DrawActions += an =>
                 {
                     ImGui.AlignTextToFramePadding();
-                    ImGui.TextUnformatted($"{nclick}");
+                    ImGui.Text($"{nclick}");
 
                     ImGui.SameLine();
                     if (ImGui.Button("Update"u8))

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ImGuiWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ImGuiWidget.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -46,10 +46,10 @@ internal class ImGuiWidget : IDataWindowWidget
         var interfaceManager = Service<InterfaceManager>.Get();
         var nm = Service<NotificationManager>.Get();
 
-        ImGui.Text("Monitor count: " + ImGui.GetPlatformIO().Monitors.Size);
-        ImGui.Text("OverrideGameCursor: " + interfaceManager.OverrideGameCursor);
+        ImGui.TextUnformatted("Monitor count: " + ImGui.GetPlatformIO().Monitors.Size);
+        ImGui.TextUnformatted("OverrideGameCursor: " + interfaceManager.OverrideGameCursor);
 
-        ImGui.Button("THIS IS A BUTTON###hoverTestButton");
+        ImGui.Button("THIS IS A BUTTON###hoverTestButton"u8);
         interfaceManager.OverrideGameCursor = !ImGui.IsItemHovered();
 
         ImGui.Separator();
@@ -59,19 +59,19 @@ internal class ImGuiWidget : IDataWindowWidget
 
         ImGui.Separator();
 
-        ImGui.Checkbox("##manualContent", ref this.notificationTemplate.ManualContent);
+        ImGui.Checkbox("##manualContent"u8, ref this.notificationTemplate.ManualContent);
         ImGui.SameLine();
-        ImGui.InputText("Content##content", ref this.notificationTemplate.Content, 255);
+        ImGui.InputText("Content##content"u8, ref this.notificationTemplate.Content, 255);
 
-        ImGui.Checkbox("##manualTitle", ref this.notificationTemplate.ManualTitle);
+        ImGui.Checkbox("##manualTitle"u8, ref this.notificationTemplate.ManualTitle);
         ImGui.SameLine();
-        ImGui.InputText("Title##title", ref this.notificationTemplate.Title, 255);
+        ImGui.InputText("Title##title"u8, ref this.notificationTemplate.Title, 255);
 
-        ImGui.Checkbox("##manualMinimizedText", ref this.notificationTemplate.ManualMinimizedText);
+        ImGui.Checkbox("##manualMinimizedText"u8, ref this.notificationTemplate.ManualMinimizedText);
         ImGui.SameLine();
-        ImGui.InputText("MinimizedText##minimizedText", ref this.notificationTemplate.MinimizedText, 255);
+        ImGui.InputText("MinimizedText##minimizedText"u8, ref this.notificationTemplate.MinimizedText, 255);
 
-        ImGui.Checkbox("##manualType", ref this.notificationTemplate.ManualType);
+        ImGui.Checkbox("##manualType"u8, ref this.notificationTemplate.ManualType);
         ImGui.SameLine();
         ImGui.Combo("Type##type", ref this.notificationTemplate.TypeInt, NotificationTemplate.TypeTitles);
 
@@ -80,7 +80,7 @@ internal class ImGuiWidget : IDataWindowWidget
         {
             case 1 or 2:
                 ImGui.InputText(
-                    "Icon Text##iconText",
+                    "Icon Text##iconText"u8,
                     ref this.notificationTemplate.IconText,
                     255);
                 break;
@@ -92,13 +92,13 @@ internal class ImGuiWidget : IDataWindowWidget
                 break;
             case 3 or 7:
                 ImGui.InputText(
-                    "Game Path##iconText",
+                    "Game Path##iconText"u8,
                     ref this.notificationTemplate.IconText,
                     255);
                 break;
             case 4 or 8:
                 ImGui.InputText(
-                    "File Path##iconText",
+                    "File Path##iconText"u8,
                     ref this.notificationTemplate.IconText,
                     255);
                 break;
@@ -119,19 +119,19 @@ internal class ImGuiWidget : IDataWindowWidget
             ref this.notificationTemplate.ProgressMode,
             NotificationTemplate.ProgressModeTitles);
 
-        ImGui.Checkbox("Respect UI Hidden", ref this.notificationTemplate.RespectUiHidden);
+        ImGui.Checkbox("Respect UI Hidden"u8, ref this.notificationTemplate.RespectUiHidden);
 
-        ImGui.Checkbox("Minimized", ref this.notificationTemplate.Minimized);
+        ImGui.Checkbox("Minimized"u8, ref this.notificationTemplate.Minimized);
 
-        ImGui.Checkbox("Show Indeterminate If No Expiry", ref this.notificationTemplate.ShowIndeterminateIfNoExpiry);
+        ImGui.Checkbox("Show Indeterminate If No Expiry"u8, ref this.notificationTemplate.ShowIndeterminateIfNoExpiry);
 
-        ImGui.Checkbox("User Dismissable", ref this.notificationTemplate.UserDismissable);
+        ImGui.Checkbox("User Dismissable"u8, ref this.notificationTemplate.UserDismissable);
 
         ImGui.Checkbox(
-            "Action Bar (always on if not user dismissable for the example)",
+            "Action Bar (always on if not user dismissable for the example)"u8,
             ref this.notificationTemplate.ActionBar);
 
-        if (ImGui.Button("Add notification"))
+        if (ImGui.Button("Add notification"u8))
         {
             var text =
                 "Bla bla bla bla bla bla bla bla bla bla bla.\nBla bla bla bla bla bla bla bla bla bla bla bla bla bla.";
@@ -269,7 +269,7 @@ internal class ImGuiWidget : IDataWindowWidget
                     ImGui.TextUnformatted($"{nclick}");
 
                     ImGui.SameLine();
-                    if (ImGui.Button("Update"))
+                    if (ImGui.Button("Update"u8))
                     {
                         NewRandom(out title, out type, out progress);
                         an.Notification.Title = title;
@@ -278,18 +278,18 @@ internal class ImGuiWidget : IDataWindowWidget
                     }
 
                     ImGui.SameLine();
-                    if (ImGui.Button("Dismiss"))
+                    if (ImGui.Button("Dismiss"u8))
                         an.Notification.DismissNow();
 
                     ImGui.SameLine();
                     ImGui.SetNextItemWidth(an.MaxCoord.X - ImGui.GetCursorPosX());
-                    ImGui.InputText("##input", ref testString, 255);
+                    ImGui.InputText("##input"u8, ref testString, 255);
                 };
             }
         }
 
         ImGui.SameLine();
-        if (ImGui.Button("Replace images using setter"))
+        if (ImGui.Button("Replace images using setter"u8))
         {
             foreach (var n in this.notifications)
             {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/InventoryWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/InventoryWidget.cs
@@ -101,7 +101,7 @@ internal class InventoryWidget : IDataWindowWidget
             }
 
             ImGui.TableNextColumn(); // Size
-            ImGui.TextUnformatted(items.Length.ToString());
+            ImGui.Text(items.Length.ToString());
         }
     }
 
@@ -110,7 +110,7 @@ internal class InventoryWidget : IDataWindowWidget
         var items = GameInventoryItem.GetReadOnlySpanOfInventory(inventoryType);
         if (items.IsEmpty)
         {
-            ImGui.TextUnformatted($"{inventoryType} is empty.");
+            ImGui.Text($"{inventoryType} is empty.");
             return;
         }
 
@@ -131,7 +131,7 @@ internal class InventoryWidget : IDataWindowWidget
 
             ImGui.TableNextRow();
             ImGui.TableNextColumn(); // Slot
-            ImGui.TextUnformatted(slotIndex.ToString());
+            ImGui.Text(slotIndex.ToString());
 
             ImGui.TableNextColumn(); // ItemId
             ImGuiHelpers.ClickToCopyText(item.ItemId.ToString());
@@ -153,8 +153,8 @@ internal class InventoryWidget : IDataWindowWidget
                     {
                         ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                         ImGui.BeginTooltip();
-                        ImGui.TextUnformatted("Click to copy IconId"u8);
-                        ImGui.TextUnformatted($"ID: {iconId} – Size: {texture.Width}x{texture.Height}");
+                        ImGui.Text("Click to copy IconId"u8);
+                        ImGui.Text($"ID: {iconId} – Size: {texture.Width}x{texture.Height}");
                         ImGui.Image(texture.Handle, new(texture.Width, texture.Height));
                         ImGui.EndTooltip();
                     }
@@ -193,7 +193,7 @@ internal class InventoryWidget : IDataWindowWidget
                 {
                     ImGui.TableNextRow();
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted(fieldName);
+                    ImGui.Text(fieldName);
                     ImGui.TableNextColumn();
                     ImGuiHelpers.ClickToCopyText(value);
                 }
@@ -261,7 +261,7 @@ internal class InventoryWidget : IDataWindowWidget
                     {
                         ImGui.TableNextRow();
                         ImGui.TableNextColumn();
-                        ImGui.TextUnformatted("Stains"u8);
+                        ImGui.Text("Stains"u8);
                         ImGui.TableNextColumn();
 
                         using var stainTable = ImRaii.Table($"{inventoryType}_{slotIndex}_StainTable", 2, ImGuiTableFlags.BordersInner | ImGuiTableFlags.NoSavedSettings);
@@ -282,7 +282,7 @@ internal class InventoryWidget : IDataWindowWidget
                     {
                         ImGui.TableNextRow();
                         ImGui.TableNextColumn();
-                        ImGui.TextUnformatted("Materia"u8);
+                        ImGui.Text("Materia"u8);
                         ImGui.TableNextColumn();
 
                         using var materiaTable = ImRaii.Table($"{inventoryType}_{slotIndex}_MateriaTable", 2, ImGuiTableFlags.BordersInner | ImGuiTableFlags.NoSavedSettings);

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/InventoryWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/InventoryWidget.cs
@@ -5,7 +5,6 @@ using System.Text;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Data;
 using Dalamud.Game.Inventory;
-using Dalamud.Game.Text;
 using Dalamud.Interface.Textures;
 using Dalamud.Interface.Textures.Internal;
 using Dalamud.Interface.Utility;
@@ -63,11 +62,11 @@ internal class InventoryWidget : IDataWindowWidget
 
     private unsafe void DrawInventoryTypeList()
     {
-        using var table = ImRaii.Table("InventoryTypeTable", 2, ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.ScrollY | ImGuiTableFlags.NoSavedSettings, new Vector2(300, -1));
+        using var table = ImRaii.Table("InventoryTypeTable"u8, 2, ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.ScrollY | ImGuiTableFlags.NoSavedSettings, new Vector2(300, -1));
         if (!table) return;
 
-        ImGui.TableSetupColumn("Type");
-        ImGui.TableSetupColumn("Size", ImGuiTableColumnFlags.WidthFixed, 40);
+        ImGui.TableSetupColumn("Type"u8);
+        ImGui.TableSetupColumn("Size"u8, ImGuiTableColumnFlags.WidthFixed, 40);
         ImGui.TableSetupScrollFreeze(2, 1);
         ImGui.TableHeadersRow();
 
@@ -88,12 +87,12 @@ internal class InventoryWidget : IDataWindowWidget
             {
                 if (contextMenu)
                 {
-                    if (ImGui.MenuItem("Copy Name"))
+                    if (ImGui.MenuItem("Copy Name"u8))
                     {
                         ImGui.SetClipboardText(inventoryType.ToString());
                     }
 
-                    if (ImGui.MenuItem("Copy Address"))
+                    if (ImGui.MenuItem("Copy Address"u8))
                     {
                         var container = InventoryManager.Instance()->GetInventoryContainer((InventoryType)inventoryType);
                         ImGui.SetClipboardText($"0x{(nint)container:X}");
@@ -115,12 +114,12 @@ internal class InventoryWidget : IDataWindowWidget
             return;
         }
 
-        using var itemTable = ImRaii.Table("InventoryItemTable", 4, ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.ScrollY | ImGuiTableFlags.NoSavedSettings);
+        using var itemTable = ImRaii.Table("InventoryItemTable"u8, 4, ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.ScrollY | ImGuiTableFlags.NoSavedSettings);
         if (!itemTable) return;
-        ImGui.TableSetupColumn("Slot", ImGuiTableColumnFlags.WidthFixed, 40);
-        ImGui.TableSetupColumn("ItemId", ImGuiTableColumnFlags.WidthFixed, 70);
-        ImGui.TableSetupColumn("Quantity", ImGuiTableColumnFlags.WidthFixed, 70);
-        ImGui.TableSetupColumn("Item");
+        ImGui.TableSetupColumn("Slot"u8, ImGuiTableColumnFlags.WidthFixed, 40);
+        ImGui.TableSetupColumn("ItemId"u8, ImGuiTableColumnFlags.WidthFixed, 70);
+        ImGui.TableSetupColumn("Quantity"u8, ImGuiTableColumnFlags.WidthFixed, 70);
+        ImGui.TableSetupColumn("Item"u8);
         ImGui.TableSetupScrollFreeze(0, 1);
         ImGui.TableHeadersRow();
 
@@ -154,7 +153,7 @@ internal class InventoryWidget : IDataWindowWidget
                     {
                         ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                         ImGui.BeginTooltip();
-                        ImGui.TextUnformatted("Click to copy IconId");
+                        ImGui.TextUnformatted("Click to copy IconId"u8);
                         ImGui.TextUnformatted($"ID: {iconId} – Size: {texture.Width}x{texture.Height}");
                         ImGui.Image(texture.Handle, new(texture.Width, texture.Height));
                         ImGui.EndTooltip();
@@ -174,7 +173,7 @@ internal class InventoryWidget : IDataWindowWidget
                 {
                     if (contextMenu)
                     {
-                        if (ImGui.MenuItem("Copy Name"))
+                        if (ImGui.MenuItem("Copy Name"u8))
                         {
                             ImGui.SetClipboardText(itemName);
                         }
@@ -186,8 +185,8 @@ internal class InventoryWidget : IDataWindowWidget
                 using var itemInfoTable = ImRaii.Table($"{inventoryType}_{slotIndex}_Table", 2, ImGuiTableFlags.BordersInner | ImGuiTableFlags.NoSavedSettings);
                 if (!itemInfoTable) continue;
 
-                ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthFixed, 150);
-                ImGui.TableSetupColumn("Value");
+                ImGui.TableSetupColumn("Name"u8, ImGuiTableColumnFlags.WidthFixed, 150);
+                ImGui.TableSetupColumn("Value"u8);
                 // ImGui.TableHeadersRow();
 
                 static void AddKeyValueRow(string fieldName, string value)
@@ -262,14 +261,14 @@ internal class InventoryWidget : IDataWindowWidget
                     {
                         ImGui.TableNextRow();
                         ImGui.TableNextColumn();
-                        ImGui.TextUnformatted("Stains");
+                        ImGui.TextUnformatted("Stains"u8);
                         ImGui.TableNextColumn();
 
                         using var stainTable = ImRaii.Table($"{inventoryType}_{slotIndex}_StainTable", 2, ImGuiTableFlags.BordersInner | ImGuiTableFlags.NoSavedSettings);
                         if (!stainTable) continue;
 
-                        ImGui.TableSetupColumn("Stain Id", ImGuiTableColumnFlags.WidthFixed, 80);
-                        ImGui.TableSetupColumn("Name");
+                        ImGui.TableSetupColumn("Stain Id"u8, ImGuiTableColumnFlags.WidthFixed, 80);
+                        ImGui.TableSetupColumn("Name"u8);
                         ImGui.TableHeadersRow();
 
                         for (var i = 0; i < itemRow.DyeCount; i++)
@@ -283,14 +282,14 @@ internal class InventoryWidget : IDataWindowWidget
                     {
                         ImGui.TableNextRow();
                         ImGui.TableNextColumn();
-                        ImGui.TextUnformatted("Materia");
+                        ImGui.TextUnformatted("Materia"u8);
                         ImGui.TableNextColumn();
 
                         using var materiaTable = ImRaii.Table($"{inventoryType}_{slotIndex}_MateriaTable", 2, ImGuiTableFlags.BordersInner | ImGuiTableFlags.NoSavedSettings);
                         if (!materiaTable) continue;
 
-                        ImGui.TableSetupColumn("Materia Id", ImGuiTableColumnFlags.WidthFixed, 80);
-                        ImGui.TableSetupColumn("MateriaGrade Id");
+                        ImGui.TableSetupColumn("Materia Id"u8, ImGuiTableColumnFlags.WidthFixed, 80);
+                        ImGui.TableSetupColumn("MateriaGrade Id"u8);
                         ImGui.TableHeadersRow();
 
                         for (var i = 0; i < Math.Min(itemRow.MateriaSlotCount, item.Materia.Length); i++)

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/KeyStateWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/KeyStateWidget.cs
@@ -39,7 +39,7 @@ internal class KeyStateWidget : IDataWindowWidget
 
             ImGui.PushStyleColor(ImGuiCol.Text, value ? ImGuiColors.HealerGreen : ImGuiColors.DPSRed);
 
-            ImGui.Text($"{vkCode} ({code})");
+            ImGui.TextUnformatted($"{vkCode} ({code})");
 
             ImGui.PopStyleColor();
 

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/KeyStateWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/KeyStateWidget.cs
@@ -39,7 +39,7 @@ internal class KeyStateWidget : IDataWindowWidget
 
             ImGui.PushStyleColor(ImGuiCol.Text, value ? ImGuiColors.HealerGreen : ImGuiColors.DPSRed);
 
-            ImGui.TextUnformatted($"{vkCode} ({code})");
+            ImGui.Text($"{vkCode} ({code})");
 
             ImGui.PopStyleColor();
 

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/MarketBoardWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/MarketBoardWidget.cs
@@ -69,7 +69,7 @@ internal class MarketBoardWidget : IDataWindowWidget
     public void Draw()
     {
         var marketBoard = Service<MarketBoard>.Get();
-        if (ImGui.Checkbox("Track MarketBoard Events", ref this.trackMarketBoard))
+        if (ImGui.Checkbox("Track MarketBoard Events"u8, ref this.trackMarketBoard))
         {
             if (this.trackMarketBoard)
             {
@@ -90,21 +90,21 @@ internal class MarketBoardWidget : IDataWindowWidget
         }
 
         ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X / 2);
-        if (ImGui.DragInt("Stored Number of Events", ref this.trackedEvents, 0.1f, 1, 512))
+        if (ImGui.DragInt("Stored Number of Events"u8, ref this.trackedEvents, 0.1f, 1, 512))
         {
             this.trackedEvents = Math.Clamp(this.trackedEvents, 1, 512);
         }
 
-        if (ImGui.Button("Clear Stored Events"))
+        if (ImGui.Button("Clear Stored Events"u8))
         {
             this.marketBoardHistoryQueue.Clear();
         }
 
-        using (var tabBar = ImRaii.TabBar("marketTabs"))
+        using (var tabBar = ImRaii.TabBar("marketTabs"u8))
         {
             if (tabBar)
             {
-                using (var tabItem = ImRaii.TabItem("History"))
+                using (var tabItem = ImRaii.TabItem("History"u8))
                 {
                     if (tabItem)
                     {
@@ -112,7 +112,7 @@ internal class MarketBoardWidget : IDataWindowWidget
                     }
                 }
 
-                using (var tabItem = ImRaii.TabItem("Offerings"))
+                using (var tabItem = ImRaii.TabItem("Offerings"u8))
                 {
                     if (tabItem)
                     {
@@ -120,7 +120,7 @@ internal class MarketBoardWidget : IDataWindowWidget
                     }
                 }
 
-                using (var tabItem = ImRaii.TabItem("Purchases"))
+                using (var tabItem = ImRaii.TabItem("Purchases"u8))
                 {
                     if (tabItem)
                     {
@@ -128,7 +128,7 @@ internal class MarketBoardWidget : IDataWindowWidget
                     }
                 }
 
-                using (var tabItem = ImRaii.TabItem("Purchase Requests"))
+                using (var tabItem = ImRaii.TabItem("Purchase Requests"u8))
                 {
                     if (tabItem)
                     {
@@ -136,7 +136,7 @@ internal class MarketBoardWidget : IDataWindowWidget
                     }
                 }
 
-                using (var tabItem = ImRaii.TabItem("Taxes"))
+                using (var tabItem = ImRaii.TabItem("Taxes"u8))
                 {
                     if (tabItem)
                     {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/MarketBoardWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/MarketBoardWidget.cs
@@ -206,105 +206,105 @@ internal class MarketBoardWidget : IDataWindowWidget
     private void DrawMarketBoardHistory((IMarketBoardHistory History, IMarketBoardHistoryListing Listing) data)
     {
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.History.ItemId.ToString());
+        ImGui.Text(data.History.ItemId.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.Listing.Quantity.ToString());
+        ImGui.Text(data.Listing.Quantity.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.Listing.IsHq.ToString());
+        ImGui.Text(data.Listing.IsHq.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.Listing.SalePrice.ToString());
+        ImGui.Text(data.Listing.SalePrice.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.Listing.BuyerName);
+        ImGui.Text(data.Listing.BuyerName);
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.Listing.PurchaseTime.ToString(CultureInfo.InvariantCulture));
+        ImGui.Text(data.Listing.PurchaseTime.ToString(CultureInfo.InvariantCulture));
     }
 
     private void DrawMarketBoardCurrentOfferings((IMarketBoardCurrentOfferings MarketBoardCurrentOfferings, IMarketBoardItemListing Listing) data)
     {
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.Listing.ItemId.ToString());
+        ImGui.Text(data.Listing.ItemId.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.Listing.ItemQuantity.ToString());
+        ImGui.Text(data.Listing.ItemQuantity.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.Listing.IsHq.ToString());
+        ImGui.Text(data.Listing.IsHq.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.Listing.PricePerUnit.ToString());
+        ImGui.Text(data.Listing.PricePerUnit.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.Listing.RetainerName);
+        ImGui.Text(data.Listing.RetainerName);
     }
 
     private void DrawMarketBoardPurchases(IMarketBoardPurchase data)
     {
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.CatalogId.ToString());
+        ImGui.Text(data.CatalogId.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.ItemQuantity.ToString());
+        ImGui.Text(data.ItemQuantity.ToString());
     }
 
     private void DrawMarketBoardPurchaseRequests(IMarketBoardPurchaseHandler data)
     {
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.CatalogId.ToString());
+        ImGui.Text(data.CatalogId.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.IsHq.ToString());
+        ImGui.Text(data.IsHq.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.ItemQuantity.ToString());
+        ImGui.Text(data.ItemQuantity.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.PricePerUnit.ToString());
+        ImGui.Text(data.PricePerUnit.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.TotalTax.ToString());
+        ImGui.Text(data.TotalTax.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.RetainerCityId.ToString());
+        ImGui.Text(data.RetainerCityId.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.ListingId.ToString());
+        ImGui.Text(data.ListingId.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.RetainerId.ToString());
+        ImGui.Text(data.RetainerId.ToString());
     }
 
     private void DrawMarketTaxRates(IMarketTaxRates data)
     {
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.UldahTax.ToString());
+        ImGui.Text(data.UldahTax.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.LimsaLominsaTax.ToString());
+        ImGui.Text(data.LimsaLominsaTax.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.GridaniaTax.ToString());
+        ImGui.Text(data.GridaniaTax.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.IshgardTax.ToString());
+        ImGui.Text(data.IshgardTax.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.KuganeTax.ToString());
+        ImGui.Text(data.KuganeTax.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.CrystariumTax.ToString());
+        ImGui.Text(data.CrystariumTax.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.SharlayanTax.ToString());
+        ImGui.Text(data.SharlayanTax.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.TuliyollalTax.ToString());
+        ImGui.Text(data.TuliyollalTax.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.ValidUntil.ToString(CultureInfo.InvariantCulture));
+        ImGui.Text(data.ValidUntil.ToString(CultureInfo.InvariantCulture));
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/NetworkMonitorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/NetworkMonitorWidget.cs
@@ -65,7 +65,7 @@ internal class NetworkMonitorWidget : IDataWindowWidget
     public void Draw()
     {
         var network = Service<GameNetwork>.Get();
-        if (ImGui.Checkbox("Track Network Packets", ref this.trackNetwork))
+        if (ImGui.Checkbox("Track Network Packets"u8, ref this.trackNetwork))
         {
             if (this.trackNetwork)
             {
@@ -78,12 +78,12 @@ internal class NetworkMonitorWidget : IDataWindowWidget
         }
 
         ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X / 2);
-        if (ImGui.DragInt("Stored Number of Packets", ref this.trackedPackets, 0.1f, 1, 512))
+        if (ImGui.DragInt("Stored Number of Packets"u8, ref this.trackedPackets, 0.1f, 1, 512))
         {
             this.trackedPackets = Math.Clamp(this.trackedPackets, 1, 512);
         }
 
-        if (ImGui.Button("Clear Stored Packets"))
+        if (ImGui.Button("Clear Stored Packets"u8))
         {
             this.packets.Clear();
         }
@@ -128,7 +128,7 @@ internal class NetworkMonitorWidget : IDataWindowWidget
         using var style = ImRaii.PushStyle(ImGuiStyleVar.FrameBorderSize, 2 * ImGuiHelpers.GlobalScale, invalidRegEx);
         using var color = ImRaii.PushColor(ImGuiCol.Border, 0xFF0000FF, invalidRegEx);
         ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
-        if (!ImGui.InputTextWithHint("##Filter", "Regex Filter OpCodes...", ref this.filterString, 1024))
+        if (!ImGui.InputTextWithHint("##Filter"u8, "Regex Filter OpCodes..."u8, ref this.filterString, 1024))
         {
             return;
         }
@@ -156,7 +156,7 @@ internal class NetworkMonitorWidget : IDataWindowWidget
         using var style = ImRaii.PushStyle(ImGuiStyleVar.FrameBorderSize, 2 * ImGuiHelpers.GlobalScale, invalidRegEx);
         using var color = ImRaii.PushColor(ImGuiCol.Border, 0xFF0000FF, invalidRegEx);
         ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
-        if (!ImGui.InputTextWithHint("##NegativeFilter", "Regex Filter Against OpCodes...", ref this.negativeFilterString, 1024))
+        if (!ImGui.InputTextWithHint("##NegativeFilter"u8, "Regex Filter Against OpCodes..."u8, ref this.negativeFilterString, 1024))
         {
             return;
         }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/NetworkMonitorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/NetworkMonitorWidget.cs
@@ -97,24 +97,24 @@ internal class NetworkMonitorWidget : IDataWindowWidget
     private void DrawNetworkPacket(NetworkPacketData data)
     {
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.Direction.ToString());
+        ImGui.Text(data.Direction.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.OpCode.ToString());
+        ImGui.Text(data.OpCode.ToString());
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted($"0x{data.OpCode:X4}");
+        ImGui.Text($"0x{data.OpCode:X4}");
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.TargetActorId > 0 ? $"0x{data.TargetActorId:X}" : string.Empty);
+        ImGui.Text(data.TargetActorId > 0 ? $"0x{data.TargetActorId:X}" : string.Empty);
 
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(data.SourceActorId > 0 ? $"0x{data.SourceActorId:X}" : string.Empty);
+        ImGui.Text(data.SourceActorId > 0 ? $"0x{data.SourceActorId:X}" : string.Empty);
 
         ImGui.TableNextColumn();
         if (data.Data.Count > 0)
         {
-            ImGui.TextUnformatted(string.Join(" ", data.Data.Select(b => b.ToString("X2"))));
+            ImGui.Text(string.Join(" ", data.Data.Select(b => b.ToString("X2"))));
         }
         else
         {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/NounProcessorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/NounProcessorWidget.cs
@@ -137,7 +137,7 @@ internal class NounProcessorWidget : IDataWindowWidget
         var numCases = language == ClientLanguage.German ? 4 : 1;
 
 #if DEBUG
-        if (ImGui.Button("Copy as self-test entry"))
+        if (ImGui.Button("Copy as self-test entry"u8))
         {
             var sb = new StringBuilder();
 
@@ -164,10 +164,10 @@ internal class NounProcessorWidget : IDataWindowWidget
         }
 #endif
 
-        using var table = ImRaii.Table("TextDecoderTable", 1 + numCases, ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.NoSavedSettings);
+        using var table = ImRaii.Table("TextDecoderTable"u8, 1 + numCases, ImGuiTableFlags.ScrollY | ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.NoSavedSettings);
         if (!table) return;
 
-        ImGui.TableSetupColumn("ArticleType", ImGuiTableColumnFlags.WidthFixed, 150);
+        ImGui.TableSetupColumn("ArticleType"u8, ImGuiTableColumnFlags.WidthFixed, 150);
         for (var i = 0; i < numCases; i++)
             ImGui.TableSetupColumn(language == ClientLanguage.German ? GermanCases[i] : "Text");
         ImGui.TableSetupScrollFreeze(6, 1);

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/NounProcessorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/NounProcessorWidget.cs
@@ -117,7 +117,7 @@ internal class NounProcessorWidget : IDataWindowWidget
         }
 
         ImGui.SameLine();
-        ImGui.TextUnformatted($"(Range: {minRowId} - {maxRowId})");
+        ImGui.Text($"(Range: {minRowId} - {maxRowId})");
 
         ImGui.SetNextItemWidth(120);
         if (ImGui.InputInt("Amount###Amount", ref this.amount, 1, 10, flags: ImGuiInputTextFlags.AutoSelectAll))
@@ -194,11 +194,11 @@ internal class NounProcessorWidget : IDataWindowWidget
                         ArticleType = (int)articleType,
                         GrammaticalCase = currentCase,
                     };
-                    ImGui.TextUnformatted(nounProcessor.ProcessNoun(nounParams).ExtractText());
+                    ImGui.Text(nounProcessor.ProcessNoun(nounParams).ExtractText());
                 }
                 catch (Exception ex)
                 {
-                    ImGui.TextUnformatted(ex.ToString());
+                    ImGui.Text(ex.ToString());
                 }
             }
         }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ObjectTableWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ObjectTableWidget.cs
@@ -35,7 +35,7 @@ internal class ObjectTableWidget : IDataWindowWidget
     /// <inheritdoc/>
     public void Draw()
     {
-        ImGui.Checkbox("Resolve GameData", ref this.resolveGameData);
+        ImGui.Checkbox("Resolve GameData"u8, ref this.resolveGameData);
 
         var chatGui = Service<ChatGui>.Get();
         var clientState = Service<ClientState>.Get();
@@ -46,11 +46,11 @@ internal class ObjectTableWidget : IDataWindowWidget
 
         if (clientState.LocalPlayer == null)
         {
-            ImGui.TextUnformatted("LocalPlayer null.");
+            ImGui.TextUnformatted("LocalPlayer null."u8);
         }
         else if (clientState.IsPvPExcludingDen)
         {
-            ImGui.TextUnformatted("Cannot access object table while in PvP.");
+            ImGui.TextUnformatted("Cannot access object table while in PvP."u8);
         }
         else
         {
@@ -64,8 +64,8 @@ internal class ObjectTableWidget : IDataWindowWidget
 
             ImGui.TextUnformatted(stateString);
 
-            ImGui.Checkbox("Draw characters on screen", ref this.drawCharacters);
-            ImGui.SliderFloat("Draw Distance", ref this.maxCharaDrawDistance, 2f, 40f);
+            ImGui.Checkbox("Draw characters on screen"u8, ref this.drawCharacters);
+            ImGui.SliderFloat("Draw Distance"u8, ref this.maxCharaDrawDistance, 2f, 40f);
 
             for (var i = 0; i < objectTable.Length; i++)
             {
@@ -112,7 +112,7 @@ internal class ObjectTableWidget : IDataWindowWidget
                             ImGuiWindowFlags.NoDocking |
                             ImGuiWindowFlags.NoFocusOnAppearing |
                             ImGuiWindowFlags.NoNav))
-                        ImGui.Text(objectText);
+                        ImGui.TextUnformatted(objectText);
                     ImGui.End();
                 }
             }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ObjectTableWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ObjectTableWidget.cs
@@ -46,11 +46,11 @@ internal class ObjectTableWidget : IDataWindowWidget
 
         if (clientState.LocalPlayer == null)
         {
-            ImGui.TextUnformatted("LocalPlayer null."u8);
+            ImGui.Text("LocalPlayer null."u8);
         }
         else if (clientState.IsPvPExcludingDen)
         {
-            ImGui.TextUnformatted("Cannot access object table while in PvP."u8);
+            ImGui.Text("Cannot access object table while in PvP."u8);
         }
         else
         {
@@ -62,7 +62,7 @@ internal class ObjectTableWidget : IDataWindowWidget
             stateString += $"LastLinkedItem: {chatGui.LastLinkedItemId}\n";
             stateString += $"TerritoryType: {clientState.TerritoryType}\n\n";
 
-            ImGui.TextUnformatted(stateString);
+            ImGui.Text(stateString);
 
             ImGui.Checkbox("Draw characters on screen"u8, ref this.drawCharacters);
             ImGui.SliderFloat("Draw Distance"u8, ref this.maxCharaDrawDistance, 2f, 40f);
@@ -112,7 +112,7 @@ internal class ObjectTableWidget : IDataWindowWidget
                             ImGuiWindowFlags.NoDocking |
                             ImGuiWindowFlags.NoFocusOnAppearing |
                             ImGuiWindowFlags.NoNav))
-                        ImGui.TextUnformatted(objectText);
+                        ImGui.Text(objectText);
                     ImGui.End();
                 }
             }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/PartyListWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/PartyListWidget.cs
@@ -31,30 +31,30 @@ internal class PartyListWidget : IDataWindowWidget
     {
         var partyList = Service<PartyList>.Get();
 
-        ImGui.Checkbox("Resolve GameData", ref this.resolveGameData);
+        ImGui.Checkbox("Resolve GameData"u8, ref this.resolveGameData);
 
-        ImGui.Text($"GroupManager: {partyList.GroupManagerAddress.ToInt64():X}");
-        ImGui.Text($"GroupList: {partyList.GroupListAddress.ToInt64():X}");
-        ImGui.Text($"AllianceList: {partyList.AllianceListAddress.ToInt64():X}");
+        ImGui.TextUnformatted($"GroupManager: {partyList.GroupManagerAddress.ToInt64():X}");
+        ImGui.TextUnformatted($"GroupList: {partyList.GroupListAddress.ToInt64():X}");
+        ImGui.TextUnformatted($"AllianceList: {partyList.AllianceListAddress.ToInt64():X}");
 
-        ImGui.Text($"{partyList.Length} Members");
+        ImGui.TextUnformatted($"{partyList.Length} Members");
 
         for (var i = 0; i < partyList.Length; i++)
         {
             var member = partyList[i];
             if (member == null)
             {
-                ImGui.Text($"[{i}] was null");
+                ImGui.TextUnformatted($"[{i}] was null");
                 continue;
             }
 
-            ImGui.Text($"[{i}] {member.Address.ToInt64():X} - {member.Name} - {member.GameObject?.GameObjectId}");
+            ImGui.TextUnformatted($"[{i}] {member.Address.ToInt64():X} - {member.Name} - {member.GameObject?.GameObjectId}");
             if (this.resolveGameData)
             {
                 var actor = member.GameObject;
                 if (actor == null)
                 {
-                    ImGui.Text("Actor was null");
+                    ImGui.TextUnformatted("Actor was null"u8);
                 }
                 else
                 {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/PartyListWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/PartyListWidget.cs
@@ -33,28 +33,28 @@ internal class PartyListWidget : IDataWindowWidget
 
         ImGui.Checkbox("Resolve GameData"u8, ref this.resolveGameData);
 
-        ImGui.TextUnformatted($"GroupManager: {partyList.GroupManagerAddress.ToInt64():X}");
-        ImGui.TextUnformatted($"GroupList: {partyList.GroupListAddress.ToInt64():X}");
-        ImGui.TextUnformatted($"AllianceList: {partyList.AllianceListAddress.ToInt64():X}");
+        ImGui.Text($"GroupManager: {partyList.GroupManagerAddress.ToInt64():X}");
+        ImGui.Text($"GroupList: {partyList.GroupListAddress.ToInt64():X}");
+        ImGui.Text($"AllianceList: {partyList.AllianceListAddress.ToInt64():X}");
 
-        ImGui.TextUnformatted($"{partyList.Length} Members");
+        ImGui.Text($"{partyList.Length} Members");
 
         for (var i = 0; i < partyList.Length; i++)
         {
             var member = partyList[i];
             if (member == null)
             {
-                ImGui.TextUnformatted($"[{i}] was null");
+                ImGui.Text($"[{i}] was null");
                 continue;
             }
 
-            ImGui.TextUnformatted($"[{i}] {member.Address.ToInt64():X} - {member.Name} - {member.GameObject?.GameObjectId}");
+            ImGui.Text($"[{i}] {member.Address.ToInt64():X} - {member.Name} - {member.GameObject?.GameObjectId}");
             if (this.resolveGameData)
             {
                 var actor = member.GameObject;
                 if (actor == null)
                 {
-                    ImGui.TextUnformatted("Actor was null"u8);
+                    ImGui.Text("Actor was null"u8);
                 }
                 else
                 {

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/PluginIpcWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/PluginIpcWidget.cs
@@ -120,6 +120,6 @@ internal class PluginIpcWidget : IDataWindowWidget
         }
 
         if (!this.callGateResponse.IsNullOrEmpty())
-            ImGui.TextUnformatted($"Response: {this.callGateResponse}");
+            ImGui.Text($"Response: {this.callGateResponse}");
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/PluginIpcWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/PluginIpcWidget.cs
@@ -94,32 +94,32 @@ internal class PluginIpcWidget : IDataWindowWidget
             this.ipcSubGo.Subscribe(go => { Log.Information("GO: {Name}", go.Name); });
         }
 
-        if (ImGui.Button("PING"))
+        if (ImGui.Button("PING"u8))
         {
             this.ipcPub.SendMessage("PING");
         }
 
-        if (ImGui.Button("Action"))
+        if (ImGui.Button("Action"u8))
         {
             this.ipcSub.InvokeAction("button1");
         }
 
-        if (ImGui.Button("Func"))
+        if (ImGui.Button("Func"u8))
         {
             this.callGateResponse = this.ipcSub.InvokeFunc("button2");
         }
 
-        if (ImGui.Button("Action GO"))
+        if (ImGui.Button("Action GO"u8))
         {
             this.ipcSubGo.InvokeAction(Service<ClientState>.Get().LocalPlayer);
         }
 
-        if (ImGui.Button("Func GO"))
+        if (ImGui.Button("Func GO"u8))
         {
             this.callGateResponse = this.ipcSubGo.InvokeFunc(Service<ClientState>.Get().LocalPlayer);
         }
 
         if (!this.callGateResponse.IsNullOrEmpty())
-            ImGui.Text($"Response: {this.callGateResponse}");
+            ImGui.TextUnformatted($"Response: {this.callGateResponse}");
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeFontTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeFontTestWidget.cs
@@ -36,6 +36,6 @@ internal class SeFontTestWidget : IDataWindowWidget
         for (var i = min; i <= max; i++)
             specialChars += $"0x{(int)i:X} - {(SeIconChar)i} - {i}\n";
 
-        ImGui.TextUnformatted(specialChars);
+        ImGui.Text(specialChars);
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
@@ -592,7 +592,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
             if (!sheet.TryGetRow((uint)this.importRowId, out var row))
             {
-                ImGuiHelpers.SafeTextColored(new Vector4(1, 0, 0, 1), "Row not found"u8);
+                ImGui.TextColored(new Vector4(1, 0, 0, 1), "Row not found"u8);
                 return;
             }
 

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
@@ -272,10 +272,10 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
             ImGui.TableNextRow();
             ImGui.TableNextColumn(); // Id
-            ImGui.TextUnformatted(i.ToString());
+            ImGui.Text(i.ToString());
 
             ImGui.TableNextColumn(); // Type
-            ImGui.TextUnformatted(item.Type.ToString());
+            ImGui.Text(item.Type.ToString());
 
             ImGui.TableNextColumn(); // ValuePtr
             WidgetUtil.DrawCopyableText($"0x{(nint)item.ValuePtr:X}");
@@ -293,7 +293,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
                     if (item.ReferencedUtf8StringValue != null)
                         WidgetUtil.DrawCopyableText(new ReadOnlySeStringSpan(item.ReferencedUtf8StringValue->Utf8String).ToString());
                     else
-                        ImGui.TextUnformatted("null"u8);
+                        ImGui.Text("null"u8);
 
                     break;
 
@@ -301,12 +301,12 @@ internal class SeStringCreatorWidget : IDataWindowWidget
                     if (item.StringValue.Value != null)
                         WidgetUtil.DrawCopyableText(item.StringValue.ToString());
                     else
-                        ImGui.TextUnformatted("null"u8);
+                        ImGui.Text("null"u8);
                     break;
             }
 
             ImGui.TableNextColumn();
-            ImGui.TextUnformatted(i switch
+            ImGui.Text(i switch
             {
                 0 => "Player Name",
                 1 => "Temp Player 1 Name",
@@ -522,7 +522,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
         if (!raptureTextModule->MacroEncoder.EncoderError.IsEmpty)
         {
             ImGui.SameLine();
-            ImGui.TextUnformatted(raptureTextModule->MacroEncoder.EncoderError.ToString()); // TODO: EncoderError doesn't clear
+            ImGui.Text(raptureTextModule->MacroEncoder.EncoderError.ToString()); // TODO: EncoderError doesn't clear
         }
 
         ImGui.SameLine();
@@ -579,7 +579,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
             var rowIdChanged = ImGui.InputInt("RowId"u8, ref this.importRowId, 1, 10);
 
             ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
-            ImGui.TextUnformatted($"(Range: {minRowId} - {maxRowId})");
+            ImGui.Text($"(Range: {minRowId} - {maxRowId})");
 
             if (sheetChanged || rowIdChanged)
             {
@@ -596,7 +596,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
                 return;
             }
 
-            ImGui.TextUnformatted("Select string to add:"u8);
+            ImGui.Text("Select string to add:"u8);
 
             using var table = ImRaii.Table("StringSelectionTable"u8, 2, ImGuiTableFlags.Borders | ImGuiTableFlags.NoSavedSettings);
             if (!table) return;
@@ -618,7 +618,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
                 ImGui.TableNextRow();
                 ImGui.TableNextColumn();
-                ImGui.TextUnformatted(i.ToString());
+                ImGui.Text(i.ToString());
 
                 ImGui.TableNextColumn();
                 if (ImGui.Selectable($"{value.ToString().Truncate(100)}###Column{i}"))
@@ -644,7 +644,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
         }
         catch (Exception e)
         {
-            ImGui.TextUnformatted(e.Message);
+            ImGui.Text(e.Message);
             return;
         }
     }
@@ -904,7 +904,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
             ImGui.TableNextRow();
             ImGui.TableNextColumn();
-            ImGui.TextUnformatted(payload.Type == ReadOnlySePayloadType.Text ? "Text" : "ToString()");
+            ImGui.Text(payload.Type == ReadOnlySePayloadType.Text ? "Text" : "ToString()");
             ImGui.TableNextColumn();
             var text = payload.ToString();
             WidgetUtil.DrawCopyableText($"\"{text}\"", text);
@@ -944,13 +944,13 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
         ImGui.TableNextColumn();
         var expressionName = this.GetExpressionName(macroCode, subType, exprIdx, expr);
-        ImGui.TextUnformatted($"[{exprIdx}] " + (string.IsNullOrEmpty(expressionName) ? $"Expr {exprIdx}" : expressionName));
+        ImGui.Text($"[{exprIdx}] " + (string.IsNullOrEmpty(expressionName) ? $"Expr {exprIdx}" : expressionName));
 
         ImGui.TableNextColumn();
 
         if (expr.Body.IsEmpty)
         {
-            ImGui.TextUnformatted("(?)"u8);
+            ImGui.Text("(?)"u8);
             return;
         }
 
@@ -994,7 +994,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
                 if (!string.IsNullOrEmpty(name))
                 {
                     ImGui.SameLine();
-                    ImGui.TextUnformatted(name);
+                    ImGui.Text(name);
                 }
             }
 
@@ -1015,13 +1015,13 @@ internal class SeStringCreatorWidget : IDataWindowWidget
                     _ => typeof(EnglishArticleType),
                 };
                 ImGui.SameLine();
-                ImGui.TextUnformatted(Enum.GetName(articleTypeEnumType, u32));
+                ImGui.Text(Enum.GetName(articleTypeEnumType, u32));
             }
 
             if (macroCode is MacroCode.DeNoun && exprIdx == 4 && u32 is >= 0 and <= 4)
             {
                 ImGui.SameLine();
-                ImGui.TextUnformatted(NounProcessorWidget.GermanCases[u32]);
+                ImGui.Text(NounProcessorWidget.GermanCases[u32]);
             }
 
             if (macroCode is MacroCode.Fixed && subType != null && fixedType != null && fixedType is 100 or 200 && subType == 5 && exprIdx == 2)
@@ -1041,34 +1041,34 @@ internal class SeStringCreatorWidget : IDataWindowWidget
                 {
                     case LinkMacroPayloadType.Item when dataManager.GetExcelSheet<Item>(this.language).TryGetRow(u32, out var itemRow):
                         ImGui.SameLine();
-                        ImGui.TextUnformatted(itemRow.Name.ExtractText());
+                        ImGui.Text(itemRow.Name.ExtractText());
                         break;
 
                     case LinkMacroPayloadType.Quest when dataManager.GetExcelSheet<Quest>(this.language).TryGetRow(u32, out var questRow):
                         ImGui.SameLine();
-                        ImGui.TextUnformatted(questRow.Name.ExtractText());
+                        ImGui.Text(questRow.Name.ExtractText());
                         break;
 
                     case LinkMacroPayloadType.Achievement when dataManager.GetExcelSheet<Achievement>(this.language).TryGetRow(u32, out var achievementRow):
                         ImGui.SameLine();
-                        ImGui.TextUnformatted(achievementRow.Name.ExtractText());
+                        ImGui.Text(achievementRow.Name.ExtractText());
                         break;
 
                     case LinkMacroPayloadType.HowTo when dataManager.GetExcelSheet<HowTo>(this.language).TryGetRow(u32, out var howToRow):
                         ImGui.SameLine();
-                        ImGui.TextUnformatted(howToRow.Name.ExtractText());
+                        ImGui.Text(howToRow.Name.ExtractText());
                         break;
 
                     case LinkMacroPayloadType.Status when dataManager.GetExcelSheet<Status>(this.language).TryGetRow(u32, out var statusRow):
                         ImGui.SameLine();
-                        ImGui.TextUnformatted(statusRow.Name.ExtractText());
+                        ImGui.Text(statusRow.Name.ExtractText());
                         break;
 
                     case LinkMacroPayloadType.AkatsukiNote when
                         dataManager.GetSubrowExcelSheet<AkatsukiNote>(this.language).TryGetRow(u32, out var akatsukiNoteRow) &&
                         dataManager.GetExcelSheet<AkatsukiNoteString>(this.language).TryGetRow((uint)akatsukiNoteRow[0].Unknown2, out var akatsukiNoteStringRow):
                         ImGui.SameLine();
-                        ImGui.TextUnformatted(akatsukiNoteStringRow.Unknown0.ExtractText());
+                        ImGui.Text(akatsukiNoteStringRow.Unknown0.ExtractText());
                         break;
                 }
             }
@@ -1086,11 +1086,11 @@ internal class SeStringCreatorWidget : IDataWindowWidget
         {
             if (((ExpressionType)exprType).GetNativeName() is { } nativeName)
             {
-                ImGui.TextUnformatted(nativeName);
+                ImGui.Text(nativeName);
                 return;
             }
 
-            ImGui.TextUnformatted($"?x{exprType:X02}");
+            ImGui.Text($"?x{exprType:X02}");
             return;
         }
 
@@ -1098,7 +1098,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
         {
             if (((ExpressionType)exprType).GetNativeName() is { } nativeName)
             {
-                ImGui.TextUnformatted($"{nativeName}({e1.ToString()})");
+                ImGui.Text($"{nativeName}({e1.ToString()})");
                 return;
             }
 
@@ -1109,7 +1109,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
         {
             if (((ExpressionType)exprType).GetNativeName() is { } nativeName)
             {
-                ImGui.TextUnformatted($"{e1.ToString()} {nativeName} {e2.ToString()}");
+                ImGui.Text($"{e1.ToString()} {nativeName} {e2.ToString()}");
                 return;
             }
 
@@ -1122,7 +1122,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
         for (var i = 1; i < expr.Body.Length; i++)
             sb.Append($" {expr.Body[i]:X02}");
         sb.Append(')');
-        ImGui.TextUnformatted(sb.ToString());
+        ImGui.Text(sb.ToString());
     }
 
     private string GetExpressionName(MacroCode macroCode, uint? subType, int idx, ReadOnlySeExpressionSpan expr)
@@ -1258,7 +1258,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
         if (ImGui.IsItemHovered())
         {
             ImGui.BeginTooltip();
-            ImGui.TextUnformatted(tooltip);
+            ImGui.Text(tooltip);
             ImGui.EndTooltip();
         }
 

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
@@ -191,7 +191,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
             this.lastContentWidth = contentWidth;
         }
 
-        using var tabBar = ImRaii.TabBar("SeStringCreatorWidgetTabBar");
+        using var tabBar = ImRaii.TabBar("SeStringCreatorWidgetTabBar"u8);
         if (!tabBar) return;
 
         this.DrawCreatorTab(contentWidth);
@@ -200,7 +200,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
     private void DrawCreatorTab(float contentWidth)
     {
-        using var tab = ImRaii.TabItem("Creator");
+        using var tab = ImRaii.TabItem("Creator"u8);
         if (!tab) return;
 
         this.DrawControls();
@@ -216,7 +216,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
         ImGui.SameLine(0, 0);
 
-        ImGui.Button("###InputPanelResizer", new Vector2(4, -1));
+        ImGui.Button("###InputPanelResizer"u8, new Vector2(4, -1));
         if (ImGui.IsItemActive())
         {
             this.inputsWidth += ImGui.GetIO().MouseDelta.X;
@@ -234,7 +234,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
         ImGui.SameLine();
 
-        using var child = ImRaii.Child("Preview", new Vector2(ImGui.GetContentRegionAvail().X, -1));
+        using var child = ImRaii.Child("Preview"u8, new Vector2(ImGui.GetContentRegionAvail().X, -1));
         if (!child) return;
 
         if (this.localParameters!.Length != 0)
@@ -251,17 +251,17 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
     private unsafe void DrawGlobalParametersTab()
     {
-        using var tab = ImRaii.TabItem("Global Parameters");
+        using var tab = ImRaii.TabItem("Global Parameters"u8);
         if (!tab) return;
 
-        using var table = ImRaii.Table("GlobalParametersTable", 5, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY | ImGuiTableFlags.NoSavedSettings);
+        using var table = ImRaii.Table("GlobalParametersTable"u8, 5, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY | ImGuiTableFlags.NoSavedSettings);
         if (!table) return;
 
-        ImGui.TableSetupColumn("Id", ImGuiTableColumnFlags.WidthFixed, 40);
-        ImGui.TableSetupColumn("Type", ImGuiTableColumnFlags.WidthFixed, 100);
-        ImGui.TableSetupColumn("ValuePtr", ImGuiTableColumnFlags.WidthFixed, 120);
-        ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthStretch);
-        ImGui.TableSetupColumn("Description", ImGuiTableColumnFlags.WidthStretch);
+        ImGui.TableSetupColumn("Id"u8, ImGuiTableColumnFlags.WidthFixed, 40);
+        ImGui.TableSetupColumn("Type"u8, ImGuiTableColumnFlags.WidthFixed, 100);
+        ImGui.TableSetupColumn("ValuePtr"u8, ImGuiTableColumnFlags.WidthFixed, 120);
+        ImGui.TableSetupColumn("Value"u8, ImGuiTableColumnFlags.WidthStretch);
+        ImGui.TableSetupColumn("Description"u8, ImGuiTableColumnFlags.WidthStretch);
         ImGui.TableSetupScrollFreeze(5, 1);
         ImGui.TableHeadersRow();
 
@@ -293,7 +293,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
                     if (item.ReferencedUtf8StringValue != null)
                         WidgetUtil.DrawCopyableText(new ReadOnlySeStringSpan(item.ReferencedUtf8StringValue->Utf8String).ToString());
                     else
-                        ImGui.TextUnformatted("null");
+                        ImGui.TextUnformatted("null"u8);
 
                     break;
 
@@ -301,7 +301,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
                     if (item.StringValue.Value != null)
                         WidgetUtil.DrawCopyableText(item.StringValue.ToString());
                     else
-                        ImGui.TextUnformatted("null");
+                        ImGui.TextUnformatted("null"u8);
                     break;
             }
 
@@ -399,23 +399,23 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
     private unsafe void DrawControls()
     {
-        if (ImGui.Button("Add entry"))
+        if (ImGui.Button("Add entry"u8))
         {
             this.entries.Add(new(TextEntryType.String, string.Empty));
         }
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Add from Sheet"))
+        if (ImGui.Button("Add from Sheet"u8))
         {
-            ImGui.OpenPopup("AddFromSheetPopup");
+            ImGui.OpenPopup("AddFromSheetPopup"u8);
         }
 
         this.DrawAddFromSheetPopup();
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Print"))
+        if (ImGui.Button("Print"u8))
         {
             var output = Utf8String.CreateEmpty();
             var temp = Utf8String.CreateEmpty();
@@ -456,7 +456,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Print Evaluated"))
+        if (ImGui.Button("Print Evaluated"u8))
         {
             var sb = new LSeStringBuilder();
 
@@ -487,7 +487,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
         {
             ImGui.SameLine();
 
-            if (ImGui.Button("Copy MacroString"))
+            if (ImGui.Button("Copy MacroString"u8))
             {
                 var sb = new LSeStringBuilder();
 
@@ -511,7 +511,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
             ImGui.SameLine();
 
-            if (ImGui.Button("Clear entries"))
+            if (ImGui.Button("Clear entries"u8))
             {
                 this.entries.Clear();
                 this.UpdateInputString();
@@ -527,7 +527,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
         ImGui.SameLine();
         ImGui.SetNextItemWidth(90 * ImGuiHelpers.GlobalScale);
-        using (var dropdown = ImRaii.Combo("##Language", this.language.ToString() ?? "Language..."))
+        using (var dropdown = ImRaii.Combo("##Language"u8, this.language.ToString() ?? "Language..."))
         {
             if (dropdown)
             {
@@ -546,7 +546,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
     private void DrawAddFromSheetPopup()
     {
-        using var popup = ImRaii.Popup("AddFromSheetPopup");
+        using var popup = ImRaii.Popup("AddFromSheetPopup"u8);
         if (!popup) return;
 
         var dataManager = Service<DataManager>.Get();
@@ -576,7 +576,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
             var minRowId = (int)sheet.FirstOrDefault().RowId;
             var maxRowId = (int)sheet.LastOrDefault().RowId;
 
-            var rowIdChanged = ImGui.InputInt("RowId", ref this.importRowId, 1, 10);
+            var rowIdChanged = ImGui.InputInt("RowId"u8, ref this.importRowId, 1, 10);
 
             ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
             ImGui.TextUnformatted($"(Range: {minRowId} - {maxRowId})");
@@ -592,17 +592,17 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
             if (!sheet.TryGetRow((uint)this.importRowId, out var row))
             {
-                ImGui.TextColored(new Vector4(1, 0, 0, 1), "Row not found");
+                ImGuiHelpers.SafeTextColored(new Vector4(1, 0, 0, 1), "Row not found"u8);
                 return;
             }
 
-            ImGui.TextUnformatted("Select string to add:");
+            ImGui.TextUnformatted("Select string to add:"u8);
 
-            using var table = ImRaii.Table("StringSelectionTable", 2, ImGuiTableFlags.Borders | ImGuiTableFlags.NoSavedSettings);
+            using var table = ImRaii.Table("StringSelectionTable"u8, 2, ImGuiTableFlags.Borders | ImGuiTableFlags.NoSavedSettings);
             if (!table) return;
 
-            ImGui.TableSetupColumn("Column", ImGuiTableColumnFlags.WidthFixed, 50);
-            ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthStretch);
+            ImGui.TableSetupColumn("Column"u8, ImGuiTableColumnFlags.WidthFixed, 50);
+            ImGui.TableSetupColumn("Value"u8, ImGuiTableColumnFlags.WidthStretch);
             ImGui.TableSetupScrollFreeze(0, 1);
             ImGui.TableHeadersRow();
 
@@ -651,15 +651,15 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
     private unsafe void DrawInputs()
     {
-        using var child = ImRaii.Child("Inputs", new Vector2(this.inputsWidth, -1));
+        using var child = ImRaii.Child("Inputs"u8, new Vector2(this.inputsWidth, -1));
         if (!child) return;
 
-        using var table = ImRaii.Table("StringMakerTable", 3, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY | ImGuiTableFlags.NoSavedSettings);
+        using var table = ImRaii.Table("StringMakerTable"u8, 3, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY | ImGuiTableFlags.NoSavedSettings);
         if (!table) return;
 
-        ImGui.TableSetupColumn("Type", ImGuiTableColumnFlags.WidthFixed, 100);
-        ImGui.TableSetupColumn("Text", ImGuiTableColumnFlags.WidthStretch);
-        ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthFixed, 80);
+        ImGui.TableSetupColumn("Type"u8, ImGuiTableColumnFlags.WidthFixed, 100);
+        ImGui.TableSetupColumn("Text"u8, ImGuiTableColumnFlags.WidthStretch);
+        ImGui.TableSetupColumn("Actions"u8, ImGuiTableColumnFlags.WidthFixed, 80);
         ImGui.TableSetupScrollFreeze(3, 1);
         ImGui.TableHeadersRow();
 
@@ -803,7 +803,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
     private void DrawPreview(ReadOnlySeString str)
     {
         using var nodeColor = ImRaii.PushColor(ImGuiCol.Text, 0xFF00FF00);
-        using var node = ImRaii.TreeNode("Preview", ImGuiTreeNodeFlags.DefaultOpen);
+        using var node = ImRaii.TreeNode("Preview"u8, ImGuiTreeNodeFlags.DefaultOpen);
         nodeColor.Pop();
         if (!node) return;
 
@@ -815,7 +815,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
     private void DrawParameters()
     {
         using var nodeColor = ImRaii.PushColor(ImGuiCol.Text, 0xFF00FF00);
-        using var node = ImRaii.TreeNode("Parameters", ImGuiTreeNodeFlags.DefaultOpen);
+        using var node = ImRaii.TreeNode("Parameters"u8, ImGuiTreeNodeFlags.DefaultOpen);
         nodeColor.Pop();
         if (!node) return;
 
@@ -843,7 +843,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
     private void DrawPayloads(ReadOnlySeString evaluated)
     {
         using (var nodeColor = ImRaii.PushColor(ImGuiCol.Text, 0xFF00FF00))
-        using (var node = ImRaii.TreeNode("Payloads", ImGuiTreeNodeFlags.DefaultOpen | ImGuiTreeNodeFlags.SpanAvailWidth))
+        using (var node = ImRaii.TreeNode("Payloads"u8, ImGuiTreeNodeFlags.DefaultOpen | ImGuiTreeNodeFlags.SpanAvailWidth))
         {
             nodeColor.Pop();
             if (node) this.DrawSeString("payloads", this.input.AsSpan(), treeNodeFlags: ImGuiTreeNodeFlags.DefaultOpen | ImGuiTreeNodeFlags.SpanAvailWidth);
@@ -853,7 +853,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
             return;
 
         using (var nodeColor = ImRaii.PushColor(ImGuiCol.Text, 0xFF00FF00))
-        using (var node = ImRaii.TreeNode("Payloads (Evaluated)", ImGuiTreeNodeFlags.DefaultOpen | ImGuiTreeNodeFlags.SpanAvailWidth))
+        using (var node = ImRaii.TreeNode("Payloads (Evaluated)"u8, ImGuiTreeNodeFlags.DefaultOpen | ImGuiTreeNodeFlags.SpanAvailWidth))
         {
             nodeColor.Pop();
             if (node) this.DrawSeString("payloads-evaluated", evaluated.AsSpan(), treeNodeFlags: ImGuiTreeNodeFlags.DefaultOpen | ImGuiTreeNodeFlags.SpanAvailWidth);
@@ -899,8 +899,8 @@ internal class SeStringCreatorWidget : IDataWindowWidget
             using var table = ImRaii.Table($"##Payload{payloadIdx}Table", 2);
             if (!table) return;
 
-            ImGui.TableSetupColumn("Label", ImGuiTableColumnFlags.WidthFixed, 120);
-            ImGui.TableSetupColumn("Tree", ImGuiTableColumnFlags.WidthStretch);
+            ImGui.TableSetupColumn("Label"u8, ImGuiTableColumnFlags.WidthFixed, 120);
+            ImGui.TableSetupColumn("Tree"u8, ImGuiTableColumnFlags.WidthStretch);
 
             ImGui.TableNextRow();
             ImGui.TableNextColumn();
@@ -950,7 +950,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
 
         if (expr.Body.IsEmpty)
         {
-            ImGui.TextUnformatted("(?)");
+            ImGui.TextUnformatted("(?)"u8);
             return;
         }
 
@@ -1027,7 +1027,7 @@ internal class SeStringCreatorWidget : IDataWindowWidget
             if (macroCode is MacroCode.Fixed && subType != null && fixedType != null && fixedType is 100 or 200 && subType == 5 && exprIdx == 2)
             {
                 ImGui.SameLine();
-                if (ImGui.SmallButton("Play"))
+                if (ImGui.SmallButton("Play"u8))
                 {
                     UIGlobals.PlayChatSoundEffect(u32 + 1);
                 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringRendererTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringRendererTestWidget.cs
@@ -203,7 +203,7 @@ internal unsafe class SeStringRendererTestWidget : IDataWindowWidget
 
                         ImGui.TableNextColumn();
                         ImGui.AlignTextToFramePadding();
-                        ImGui.TextUnformatted($"{row.RowId}");
+                        ImGui.Text($"{row.RowId}");
 
                         ImGui.TableNextColumn();
                         ImGui.AlignTextToFramePadding();
@@ -299,7 +299,7 @@ internal unsafe class SeStringRendererTestWidget : IDataWindowWidget
                 ImGui.Separator();
                 if (this.alignToFramePadding)
                     ImGui.AlignTextToFramePadding();
-                ImGui.TextUnformatted($"Hovered[{offset}]: {new ReadOnlySeStringSpan(envelope).ToString()}; {payload}");
+                ImGui.Text($"Hovered[{offset}]: {new ReadOnlySeStringSpan(envelope).ToString()}; {payload}");
                 if (clicked && payload is DalamudLinkPayload { Plugin: "test" } dlp)
                     Util.OpenLink(dlp.ExtraString);
             }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringRendererTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringRendererTestWidget.cs
@@ -66,7 +66,7 @@ internal unsafe class SeStringRendererTestWidget : IDataWindowWidget
 
         ImGui.SameLine();
         var t = this.style.ForceEdgeColor;
-        if (ImGui.Checkbox("Forced", ref t))
+        if (ImGui.Checkbox("Forced"u8, ref t))
             this.style.ForceEdgeColor = t;
 
         t2 = ImGui.ColorConvertU32ToFloat4(this.style.ShadowColor ?? 0xFF000000u);
@@ -82,67 +82,67 @@ internal unsafe class SeStringRendererTestWidget : IDataWindowWidget
             this.style.LinkActiveBackColor = ImGui.ColorConvertFloat4ToU32(t2);
 
         var t3 = this.style.LineHeight ?? 1f;
-        if (ImGui.DragFloat("Line Height", ref t3, 0.01f, 0.4f, 3f, "%.02f"))
+        if (ImGui.DragFloat("Line Height"u8, ref t3, 0.01f, 0.4f, 3f, "%.02f"))
             this.style.LineHeight = t3;
 
         t3 = this.style.Opacity ?? ImGui.GetStyle().Alpha;
-        if (ImGui.DragFloat("Opacity", ref t3, 0.005f, 0f, 1f, "%.02f"))
+        if (ImGui.DragFloat("Opacity"u8, ref t3, 0.005f, 0f, 1f, "%.02f"))
             this.style.Opacity = t3;
 
         t3 = this.style.EdgeStrength ?? 0.25f;
-        if (ImGui.DragFloat("Edge Strength", ref t3, 0.005f, 0f, 1f, "%.02f"))
+        if (ImGui.DragFloat("Edge Strength"u8, ref t3, 0.005f, 0f, 1f, "%.02f"))
             this.style.EdgeStrength = t3;
 
         t = this.style.Edge;
-        if (ImGui.Checkbox("Edge", ref t))
+        if (ImGui.Checkbox("Edge"u8, ref t))
             this.style.Edge = t;
 
         ImGui.SameLine();
         t = this.style.Bold;
-        if (ImGui.Checkbox("Bold", ref t))
+        if (ImGui.Checkbox("Bold"u8, ref t))
             this.style.Bold = t;
 
         ImGui.SameLine();
         t = this.style.Italic;
-        if (ImGui.Checkbox("Italic", ref t))
+        if (ImGui.Checkbox("Italic"u8, ref t))
             this.style.Italic = t;
 
         ImGui.SameLine();
         t = this.style.Shadow;
-        if (ImGui.Checkbox("Shadow", ref t))
+        if (ImGui.Checkbox("Shadow"u8, ref t))
             this.style.Shadow = t;
 
         ImGui.SameLine();
         var t4 = this.style.ThemeIndex ?? AtkStage.Instance()->AtkUIColorHolder->ActiveColorThemeType;
-        ImGui.PushItemWidth(ImGui.CalcTextSize("WWWWWWWWWWWWWW").X);
+        ImGui.PushItemWidth(ImGui.CalcTextSize("WWWWWWWWWWWWWW"u8).X);
         if (ImGui.Combo("##theme", ref t4, ThemeNames))
             this.style.ThemeIndex = t4;
 
         ImGui.SameLine();
         t = this.style.LinkUnderlineThickness > 0f;
-        if (ImGui.Checkbox("Link Underline", ref t))
+        if (ImGui.Checkbox("Link Underline"u8, ref t))
             this.style.LinkUnderlineThickness = t ? 1f : 0f;
 
         ImGui.SameLine();
         t = this.style.WrapWidth is null;
-        if (ImGui.Checkbox("Word Wrap", ref t))
+        if (ImGui.Checkbox("Word Wrap"u8, ref t))
             this.style.WrapWidth = t ? null : float.PositiveInfinity;
 
         t = this.interactable;
-        if (ImGui.Checkbox("Interactable", ref t))
+        if (ImGui.Checkbox("Interactable"u8, ref t))
             this.interactable = t;
 
         ImGui.SameLine();
         t = this.useEntity;
-        if (ImGui.Checkbox("Use Entity Replacements", ref t))
+        if (ImGui.Checkbox("Use Entity Replacements"u8, ref t))
             this.useEntity = t;
 
         ImGui.SameLine();
         t = this.alignToFramePadding;
-        if (ImGui.Checkbox("Align to Frame Padding", ref t))
+        if (ImGui.Checkbox("Align to Frame Padding"u8, ref t))
             this.alignToFramePadding = t;
 
-        if (ImGui.CollapsingHeader("LogKind Preview"))
+        if (ImGui.CollapsingHeader("LogKind Preview"u8))
         {
             if (this.logkind is null)
             {
@@ -174,17 +174,17 @@ internal unsafe class SeStringRendererTestWidget : IDataWindowWidget
             ImGuiHelpers.SeStringWrapped(this.logkind.Value.Data.Span, this.style);
         }
 
-        if (ImGui.CollapsingHeader("Addon Table"))
+        if (ImGui.CollapsingHeader("Addon Table"u8))
         {
-            if (ImGui.BeginTable("Addon Sheet", 3))
+            if (ImGui.BeginTable("Addon Sheet"u8, 3))
             {
                 ImGui.TableSetupScrollFreeze(0, 1);
-                ImGui.TableSetupColumn("Row ID", ImGuiTableColumnFlags.WidthFixed, ImGui.CalcTextSize("0000000").X);
-                ImGui.TableSetupColumn("Text", ImGuiTableColumnFlags.WidthStretch);
+                ImGui.TableSetupColumn("Row ID"u8, ImGuiTableColumnFlags.WidthFixed, ImGui.CalcTextSize("0000000"u8).X);
+                ImGui.TableSetupColumn("Text"u8, ImGuiTableColumnFlags.WidthStretch);
                 ImGui.TableSetupColumn(
-                    "Misc",
+                    "Misc"u8,
                     ImGuiTableColumnFlags.WidthFixed,
-                    ImGui.CalcTextSize("AAAAAAAAAAAAAAAAA").X);
+                    ImGui.CalcTextSize("AAAAAAAAAAAAAAAAA"u8).X);
                 ImGui.TableHeadersRow();
 
                 var addon = Service<DataManager>.GetNullable()?.GetExcelSheet<Addon>() ??
@@ -210,7 +210,7 @@ internal unsafe class SeStringRendererTestWidget : IDataWindowWidget
                         ImGuiHelpers.SeStringWrapped(row.Text, this.style);
 
                         ImGui.TableNextColumn();
-                        if (ImGui.Button("Print to Chat"))
+                        if (ImGui.Button("Print to Chat"u8))
                             Service<ChatGui>.Get().Print(row.Text.ToDalamudString());
 
                         ImGui.PopID();
@@ -222,7 +222,7 @@ internal unsafe class SeStringRendererTestWidget : IDataWindowWidget
             }
         }
 
-        if (ImGui.Button("Reset Text") || this.testStringBuffer.IsDisposed)
+        if (ImGui.Button("Reset Text"u8) || this.testStringBuffer.IsDisposed)
         {
             this.testStringBuffer.Dispose();
             this.testStringBuffer = ImVectorWrapper.CreateFromSpan(
@@ -233,7 +233,7 @@ internal unsafe class SeStringRendererTestWidget : IDataWindowWidget
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Print to Chat Log"))
+        if (ImGui.Button("Print to Chat Log"u8))
         {
             Service<ChatGui>.Get().Print(
                 Game.Text.SeStringHandling.SeString.Parse(

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ServicesWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ServicesWidget.cs
@@ -196,10 +196,10 @@ internal class ServicesWidget : IDataWindowWidget
 
                         ImGui.SetCursorPos((new Vector2(rc.X, rc.Y) - pos) + ((cellSize - textSize) / 2));
                         ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, Vector2.Zero);
-                        ImGui.TextUnformatted(node.DisplayedName);
+                        ImGui.Text(node.DisplayedName);
                         ImGui.SameLine();
                         ImGui.PushStyleColor(ImGuiCol.Text, node.TypeSuffixColor);
-                        ImGui.TextUnformatted(node.TypeSuffix);
+                        ImGui.Text(node.TypeSuffix);
                         ImGui.PopStyleVar();
                         ImGui.PopStyleColor();
                     }
@@ -248,21 +248,21 @@ internal class ServicesWidget : IDataWindowWidget
                 if (isPublic)
                 {
                     using var color = ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-                    ImGui.TextUnformatted("\t => PUBLIC!!!"u8);
+                    ImGui.Text("\t => PUBLIC!!!"u8);
                 }
 
                 switch (instance.Value.Visibility)
                 {
                     case ObjectInstanceVisibility.Internal:
-                        ImGui.TextUnformatted("\t => Internally resolved"u8);
+                        ImGui.Text("\t => Internally resolved"u8);
                         break;
 
                     case ObjectInstanceVisibility.ExposedToPlugins:
                         var hasInterface = container.InterfaceToTypeMap.Values.Any(x => x == instance.Key);
                         using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed, !hasInterface))
                         {
-                            ImGui.TextUnformatted("\t => Exposed to plugins!"u8);
-                            ImGui.TextUnformatted(
+                            ImGui.Text("\t => Exposed to plugins!"u8);
+                            ImGui.Text(
                                 hasInterface
                                     ? $"\t => Provided via interface: {container.InterfaceToTypeMap.First(x => x.Value == instance.Key).Key.FullName}"
                                     : "\t => NO INTERFACE!!!");

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ServicesWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ServicesWidget.cs
@@ -43,31 +43,31 @@ internal class ServicesWidget : IDataWindowWidget
     {
         var container = Service<ServiceContainer>.Get();
 
-        if (ImGui.CollapsingHeader("Dependencies"))
+        if (ImGui.CollapsingHeader("Dependencies"u8))
         {
-            if (ImGui.Button("Clear selection"))
+            if (ImGui.Button("Clear selection"u8))
                 this.selectedNodes.Clear();
 
             ImGui.SameLine();
             switch (this.includeUnloadDependencies)
             {
-                case true when ImGui.Button("Show load-time dependencies"):
+                case true when ImGui.Button("Show load-time dependencies"u8):
                     this.includeUnloadDependencies = false;
                     this.dependencyNodes = null;
                     break;
-                case false when ImGui.Button("Show unload-time dependencies"):
+                case false when ImGui.Button("Show unload-time dependencies"u8):
                     this.includeUnloadDependencies = true;
                     this.dependencyNodes = null;
                     break;
             }
 
             this.dependencyNodes ??= ServiceDependencyNode.CreateTreeByLevel(this.includeUnloadDependencies);
-            var cellPad = ImGui.CalcTextSize("WW");
-            var margin = ImGui.CalcTextSize("W\nW\nW");
+            var cellPad = ImGui.CalcTextSize("WW"u8);
+            var margin = ImGui.CalcTextSize("W\nW\nW"u8);
             var rowHeight = cellPad.Y * 3;
             var width = ImGui.GetContentRegionAvail().X;
             if (ImGui.BeginChild(
-                    "dependency-graph",
+                    "dependency-graph"u8,
                     new(width, (this.dependencyNodes.Count * (rowHeight + margin.Y)) + cellPad.Y),
                     false,
                     ImGuiWindowFlags.HorizontalScrollbar))
@@ -237,7 +237,7 @@ internal class ServicesWidget : IDataWindowWidget
             }
         }
 
-        if (ImGui.CollapsingHeader("Singleton Services"))
+        if (ImGui.CollapsingHeader("Singleton Services"u8))
         {
             foreach (var instance in container.Instances)
             {
@@ -248,21 +248,21 @@ internal class ServicesWidget : IDataWindowWidget
                 if (isPublic)
                 {
                     using var color = ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-                    ImGui.Text("\t => PUBLIC!!!");
+                    ImGui.TextUnformatted("\t => PUBLIC!!!"u8);
                 }
 
                 switch (instance.Value.Visibility)
                 {
                     case ObjectInstanceVisibility.Internal:
-                        ImGui.Text("\t => Internally resolved");
+                        ImGui.TextUnformatted("\t => Internally resolved"u8);
                         break;
 
                     case ObjectInstanceVisibility.ExposedToPlugins:
                         var hasInterface = container.InterfaceToTypeMap.Values.Any(x => x == instance.Key);
                         using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed, !hasInterface))
                         {
-                            ImGui.Text("\t => Exposed to plugins!");
-                            ImGui.Text(
+                            ImGui.TextUnformatted("\t => Exposed to plugins!"u8);
+                            ImGui.TextUnformatted(
                                 hasInterface
                                     ? $"\t => Provided via interface: {container.InterfaceToTypeMap.First(x => x.Value == instance.Key).Key.FullName}"
                                     : "\t => NO INTERFACE!!!");

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/StartInfoWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/StartInfoWidget.cs
@@ -28,6 +28,6 @@ internal class StartInfoWidget : IDataWindowWidget
     {
         var startInfo = Service<Dalamud>.Get().StartInfo;
 
-        ImGui.TextUnformatted(JsonConvert.SerializeObject(startInfo, Formatting.Indented));
+        ImGui.Text(JsonConvert.SerializeObject(startInfo, Formatting.Indented));
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/StartInfoWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/StartInfoWidget.cs
@@ -28,6 +28,6 @@ internal class StartInfoWidget : IDataWindowWidget
     {
         var startInfo = Service<Dalamud>.Get().StartInfo;
 
-        ImGui.Text(JsonConvert.SerializeObject(startInfo, Formatting.Indented));
+        ImGui.TextUnformatted(JsonConvert.SerializeObject(startInfo, Formatting.Indented));
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TargetWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TargetWidget.cs
@@ -40,7 +40,7 @@ internal class TargetWidget : IDataWindowWidget
         {
             Util.PrintGameObject(targetMgr.Target, "CurrentTarget", this.resolveGameData);
 
-            ImGui.TextUnformatted("Target"u8);
+            ImGui.Text("Target"u8);
             Util.ShowGameObjectStruct(targetMgr.Target);
 
             var tot = targetMgr.Target.TargetObject;
@@ -49,7 +49,7 @@ internal class TargetWidget : IDataWindowWidget
                 ImGuiHelpers.ScaledDummy(10);
 
                 ImGui.Separator();
-                ImGui.TextUnformatted("ToT"u8);
+                ImGui.Text("ToT"u8);
                 Util.ShowGameObjectStruct(tot);
             }
 
@@ -92,7 +92,7 @@ internal class TargetWidget : IDataWindowWidget
         }
         else
         {
-            ImGui.TextUnformatted("LocalPlayer is null."u8);
+            ImGui.Text("LocalPlayer is null."u8);
         }
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TargetWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TargetWidget.cs
@@ -31,7 +31,7 @@ internal class TargetWidget : IDataWindowWidget
     /// <inheritdoc/>
     public void Draw()
     {
-        ImGui.Checkbox("Resolve GameData", ref this.resolveGameData);
+        ImGui.Checkbox("Resolve GameData"u8, ref this.resolveGameData);
 
         var clientState = Service<ClientState>.Get();
         var targetMgr = Service<TargetManager>.Get();
@@ -40,7 +40,7 @@ internal class TargetWidget : IDataWindowWidget
         {
             Util.PrintGameObject(targetMgr.Target, "CurrentTarget", this.resolveGameData);
 
-            ImGui.Text("Target");
+            ImGui.TextUnformatted("Target"u8);
             Util.ShowGameObjectStruct(targetMgr.Target);
 
             var tot = targetMgr.Target.TargetObject;
@@ -49,7 +49,7 @@ internal class TargetWidget : IDataWindowWidget
                 ImGuiHelpers.ScaledDummy(10);
 
                 ImGui.Separator();
-                ImGui.Text("ToT");
+                ImGui.TextUnformatted("ToT"u8);
                 Util.ShowGameObjectStruct(tot);
             }
 
@@ -74,25 +74,25 @@ internal class TargetWidget : IDataWindowWidget
         if (targetMgr.MouseOverNameplateTarget != null)
             Util.PrintGameObject(targetMgr.MouseOverNameplateTarget, "MouseOverNameplateTarget", this.resolveGameData);
 
-        if (ImGui.Button("Clear CT"))
+        if (ImGui.Button("Clear CT"u8))
             targetMgr.Target = null;
 
-        if (ImGui.Button("Clear FT"))
+        if (ImGui.Button("Clear FT"u8))
             targetMgr.FocusTarget = null;
 
         var localPlayer = clientState.LocalPlayer;
 
         if (localPlayer != null)
         {
-            if (ImGui.Button("Set CT"))
+            if (ImGui.Button("Set CT"u8))
                 targetMgr.Target = localPlayer;
 
-            if (ImGui.Button("Set FT"))
+            if (ImGui.Button("Set FT"u8))
                 targetMgr.FocusTarget = localPlayer;
         }
         else
         {
-            ImGui.Text("LocalPlayer is null.");
+            ImGui.TextUnformatted("LocalPlayer is null."u8);
         }
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TaskSchedulerWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TaskSchedulerWidget.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable MethodSupportsCancellation // Using alternative method of cancelling tasks by throwing exceptions.
+// ReSharper disable MethodSupportsCancellation // Using alternative method of cancelling tasks by throwing exceptions.
 
 using System.IO;
 using System.Linq;
@@ -54,7 +54,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
     {
         var framework = Service<Framework>.Get();
 
-        if (ImGui.Button("Clear list"))
+        if (ImGui.Button("Clear list"u8))
         {
             TaskTracker.Clear();
         }
@@ -63,23 +63,23 @@ internal class TaskSchedulerWidget : IDataWindowWidget
         ImGuiHelpers.ScaledDummy(10);
         ImGui.SameLine();
 
-        if (ImGui.Button("Cancel using CancellationTokenSource"))
+        if (ImGui.Button("Cancel using CancellationTokenSource"u8))
         {
             this.taskSchedulerCancelSource.Cancel();
             this.taskSchedulerCancelSource = new();
         }
 
-        ImGui.Text("Run in any thread: ");
+        ImGui.TextUnformatted("Run in any thread: "u8);
         ImGui.SameLine();
 
-        if (ImGui.Button("Short Task.Run"))
+        if (ImGui.Button("Short Task.Run"u8))
         {
             Task.Run(() => { Thread.Sleep(500); });
         }
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Task in task(Delay)"))
+        if (ImGui.Button("Task in task(Delay)"u8))
         {
             var token = this.taskSchedulerCancelSource.Token;
             Task.Run(async () => await this.TestTaskInTaskDelay(token), token);
@@ -87,14 +87,14 @@ internal class TaskSchedulerWidget : IDataWindowWidget
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Task in task(Sleep)"))
+        if (ImGui.Button("Task in task(Sleep)"u8))
         {
             Task.Run(async () => await this.TestTaskInTaskSleep());
         }
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Faulting task"))
+        if (ImGui.Button("Faulting task"u8))
         {
             Task.Run(() =>
             {
@@ -104,43 +104,43 @@ internal class TaskSchedulerWidget : IDataWindowWidget
             });
         }
 
-        ImGui.Text("Run in Framework.Update: ");
+        ImGui.TextUnformatted("Run in Framework.Update: "u8);
         ImGui.SameLine();
 
-        if (ImGui.Button("ASAP"))
+        if (ImGui.Button("ASAP"u8))
         {
             _ = framework.RunOnTick(() => Log.Information("Framework.Update - ASAP"), cancellationToken: this.taskSchedulerCancelSource.Token);
         }
 
         ImGui.SameLine();
 
-        if (ImGui.Button("In 1s"))
+        if (ImGui.Button("In 1s"u8))
         {
             _ = framework.RunOnTick(() => Log.Information("Framework.Update - In 1s"), cancellationToken: this.taskSchedulerCancelSource.Token, delay: TimeSpan.FromSeconds(1));
         }
 
         ImGui.SameLine();
 
-        if (ImGui.Button("In 60f"))
+        if (ImGui.Button("In 60f"u8))
         {
             _ = framework.RunOnTick(() => Log.Information("Framework.Update - In 60f"), cancellationToken: this.taskSchedulerCancelSource.Token, delayTicks: 60);
         }
 
         ImGui.SameLine();
 
-        if (ImGui.Button("In 1s+120f"))
+        if (ImGui.Button("In 1s+120f"u8))
         {
             _ = framework.RunOnTick(() => Log.Information("Framework.Update - In 1s+120f"), cancellationToken: this.taskSchedulerCancelSource.Token, delay: TimeSpan.FromSeconds(1), delayTicks: 120);
         }
 
         ImGui.SameLine();
 
-        if (ImGui.Button("In 2s+60f"))
+        if (ImGui.Button("In 2s+60f"u8))
         {
             _ = framework.RunOnTick(() => Log.Information("Framework.Update - In 2s+60f"), cancellationToken: this.taskSchedulerCancelSource.Token, delay: TimeSpan.FromSeconds(2), delayTicks: 60);
         }
 
-        if (ImGui.Button("Every 60f"))
+        if (ImGui.Button("Every 60f"u8))
         {
             _ = framework.RunOnTick(
                 async () =>
@@ -158,7 +158,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Every 1s"))
+        if (ImGui.Button("Every 1s"u8))
         {
             _ = framework.RunOnTick(
                 async () =>
@@ -176,7 +176,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Every 60f (Await)"))
+        if (ImGui.Button("Every 60f (Await)"u8))
         {
             _ = framework.Run(
                 async () =>
@@ -194,7 +194,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Every 1s (Await)"))
+        if (ImGui.Button("Every 1s (Await)"u8))
         {
             _ = framework.Run(
                 async () =>
@@ -212,7 +212,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
 
         ImGui.SameLine();
 
-        if (ImGui.Button("As long as it's in Framework Thread"))
+        if (ImGui.Button("As long as it's in Framework Thread"u8))
         {
             Task.Run(async () => await framework.RunOnFrameworkThread(() => { Log.Information("Task dispatched from non-framework.update thread"); }));
             framework.RunOnFrameworkThread(() => { Log.Information("Task dispatched from framework.update thread"); }).Wait();
@@ -220,14 +220,14 @@ internal class TaskSchedulerWidget : IDataWindowWidget
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Error in 1s"))
+        if (ImGui.Button("Error in 1s"u8))
         {
             _ = framework.RunOnTick(() => throw new Exception("Test Exception"), cancellationToken: this.taskSchedulerCancelSource.Token, delay: TimeSpan.FromSeconds(1));
         }
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Freeze 1s"))
+        if (ImGui.Button("Freeze 1s"u8))
         {
             _ = framework.RunOnFrameworkThread(() => Helper().Wait());
             static async Task Helper() => await Task.Delay(1000);
@@ -235,16 +235,16 @@ internal class TaskSchedulerWidget : IDataWindowWidget
 
         ImGui.SameLine();
 
-        if (ImGui.Button("Freeze Completely"))
+        if (ImGui.Button("Freeze Completely"u8))
         {
             _ = framework.Run(() => Helper().Wait());
             static async Task Helper() => await Task.Delay(1000);
         }
 
-        if (ImGui.CollapsingHeader("Download"))
+        if (ImGui.CollapsingHeader("Download"u8))
         {
-            ImGui.InputText("URL", ref this.url);
-            ImGui.InputText("Local Path", ref this.localPath);
+            ImGui.InputText("URL"u8, ref this.url);
+            ImGui.InputText("Local Path"u8, ref this.localPath);
             ImGui.SameLine();
 
             if (ImGuiComponents.IconButton("##localpathpicker", FontAwesomeIcon.File))
@@ -269,11 +269,11 @@ internal class TaskSchedulerWidget : IDataWindowWidget
             using var disabled =
                 ImRaii.Disabled(this.downloadTask?.IsCompleted is false || this.localPath[0] == 0);
             ImGui.AlignTextToFramePadding();
-            ImGui.TextUnformatted("Download");
+            ImGui.TextUnformatted("Download"u8);
             ImGui.SameLine();
-            var downloadUsingGlobalScheduler = ImGui.Button("using default scheduler");
+            var downloadUsingGlobalScheduler = ImGui.Button("using default scheduler"u8);
             ImGui.SameLine();
-            var downloadUsingFramework = ImGui.Button("using Framework.Update");
+            var downloadUsingFramework = ImGui.Button("using Framework.Update"u8);
             if (downloadUsingGlobalScheduler || downloadUsingFramework)
             {
                 var ct = this.taskSchedulerCancelSource.Token;
@@ -328,7 +328,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
             }
         }
 
-        if (ImGui.Button("Drown in tasks"))
+        if (ImGui.Button("Drown in tasks"u8))
         {
             var token = this.taskSchedulerCancelSource.Token;
             Task.Run(
@@ -414,7 +414,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
             {
                 task.IsBeingViewed = true;
 
-                if (ImGui.Button("CANCEL (May not work)"))
+                if (ImGui.Button("CANCEL (May not work)"u8))
                 {
                     try
                     {
@@ -435,7 +435,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
                 if (task.Exception != null)
                 {
                     ImGuiHelpers.ScaledDummy(15);
-                    ImGui.TextColored(ImGuiColors.DalamudRed, "EXCEPTION:");
+                    ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, "EXCEPTION:"u8);
                     ImGui.TextUnformatted(task.Exception.ToString());
                 }
             }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TaskSchedulerWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TaskSchedulerWidget.cs
@@ -435,7 +435,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
                 if (task.Exception != null)
                 {
                     ImGuiHelpers.ScaledDummy(15);
-                    ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, "EXCEPTION:"u8);
+                    ImGui.TextColored(ImGuiColors.DalamudRed, "EXCEPTION:"u8);
                     ImGui.Text(task.Exception.ToString());
                 }
             }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TaskSchedulerWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TaskSchedulerWidget.cs
@@ -69,7 +69,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
             this.taskSchedulerCancelSource = new();
         }
 
-        ImGui.TextUnformatted("Run in any thread: "u8);
+        ImGui.Text("Run in any thread: "u8);
         ImGui.SameLine();
 
         if (ImGui.Button("Short Task.Run"u8))
@@ -104,7 +104,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
             });
         }
 
-        ImGui.TextUnformatted("Run in Framework.Update: "u8);
+        ImGui.Text("Run in Framework.Update: "u8);
         ImGui.SameLine();
 
         if (ImGui.Button("ASAP"u8))
@@ -264,12 +264,12 @@ internal class TaskSchedulerWidget : IDataWindowWidget
                     });
             }
 
-            ImGui.TextUnformatted($"{this.downloadState.Downloaded:##,###}/{this.downloadState.Total:##,###} ({this.downloadState.Percentage:0.00}%)");
+            ImGui.Text($"{this.downloadState.Downloaded:##,###}/{this.downloadState.Total:##,###} ({this.downloadState.Percentage:0.00}%)");
 
             using var disabled =
                 ImRaii.Disabled(this.downloadTask?.IsCompleted is false || this.localPath[0] == 0);
             ImGui.AlignTextToFramePadding();
-            ImGui.TextUnformatted("Download"u8);
+            ImGui.Text("Download"u8);
             ImGui.SameLine();
             var downloadUsingGlobalScheduler = ImGui.Button("using default scheduler"u8);
             ImGui.SameLine();
@@ -430,13 +430,13 @@ internal class TaskSchedulerWidget : IDataWindowWidget
 
                 ImGuiHelpers.ScaledDummy(10);
 
-                ImGui.TextUnformatted(task.StackTrace?.ToString());
+                ImGui.Text(task.StackTrace?.ToString());
 
                 if (task.Exception != null)
                 {
                     ImGuiHelpers.ScaledDummy(15);
                     ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, "EXCEPTION:"u8);
-                    ImGui.TextUnformatted(task.Exception.ToString());
+                    ImGui.Text(task.Exception.ToString());
                 }
             }
             else

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TexWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TexWidget.cs
@@ -127,11 +127,11 @@ internal class TexWidget : IDataWindowWidget
         this.textureManager = Service<TextureManager>.Get();
         var conf = Service<DalamudConfiguration>.Get();
 
-        if (ImGui.Button("GC"))
+        if (ImGui.Button("GC"u8))
             GC.Collect();
 
         var useTexturePluginTracking = conf.UseTexturePluginTracking;
-        if (ImGui.Checkbox("Enable Texture Tracking", ref useTexturePluginTracking))
+        if (ImGui.Checkbox("Enable Texture Tracking"u8, ref useTexturePluginTracking))
         {
             conf.UseTexturePluginTracking = useTexturePluginTracking;
             conf.QueueSave();
@@ -140,7 +140,7 @@ internal class TexWidget : IDataWindowWidget
         var allBlames = this.textureManager.BlameTracker;
         lock (allBlames)
         {
-            ImGui.PushID("blames");
+            ImGui.PushID("blames"u8);
             var sizeSum = allBlames.Sum(static x => Math.Max(0, x.RawSpecs.EstimatedBytes));
             if (ImGui.CollapsingHeader(
                     $"All Loaded Textures: {allBlames.Count:n0} ({Util.FormatBytes(sizeSum)})###header"))
@@ -148,19 +148,19 @@ internal class TexWidget : IDataWindowWidget
             ImGui.PopID();
         }
 
-        ImGui.PushID("loadedGameTextures");
+        ImGui.PushID("loadedGameTextures"u8);
         if (ImGui.CollapsingHeader(
                 $"Loaded Game Textures: {this.textureManager.Shared.ForDebugGamePathTextures.Count:n0}###header"))
             this.DrawLoadedTextures(this.textureManager.Shared.ForDebugGamePathTextures);
         ImGui.PopID();
 
-        ImGui.PushID("loadedFileTextures");
+        ImGui.PushID("loadedFileTextures"u8);
         if (ImGui.CollapsingHeader(
                 $"Loaded File Textures: {this.textureManager.Shared.ForDebugFileSystemTextures.Count:n0}###header"))
             this.DrawLoadedTextures(this.textureManager.Shared.ForDebugFileSystemTextures);
         ImGui.PopID();
 
-        ImGui.PushID("loadedManifestResourceTextures");
+        ImGui.PushID("loadedManifestResourceTextures"u8);
         if (ImGui.CollapsingHeader(
                 $"Loaded Manifest Resource Textures: {this.textureManager.Shared.ForDebugManifestResourceTextures.Count:n0}###header"))
             this.DrawLoadedTextures(this.textureManager.Shared.ForDebugManifestResourceTextures);
@@ -168,7 +168,7 @@ internal class TexWidget : IDataWindowWidget
 
         lock (this.textureManager.Shared.ForDebugInvalidatedTextures)
         {
-            ImGui.PushID("invalidatedTextures");
+            ImGui.PushID("invalidatedTextures"u8);
             if (ImGui.CollapsingHeader(
                     $"Invalidated: {this.textureManager.Shared.ForDebugInvalidatedTextures.Count:n0}###header"))
             {
@@ -184,7 +184,7 @@ internal class TexWidget : IDataWindowWidget
         {
             ImGuiComponents.DisabledButton("Paste from Clipboard");
         }
-        else if (ImGui.Button("Paste from Clipboard"))
+        else if (ImGui.Button("Paste from Clipboard"u8))
         {
             this.addedTextures.Add(new(Api10: this.textureManager.CreateFromClipboardAsync()));
         }
@@ -224,7 +224,7 @@ internal class TexWidget : IDataWindowWidget
             ImGui.PopID();
         }
 
-        if (ImGui.CollapsingHeader("UV"))
+        if (ImGui.CollapsingHeader("UV"u8))
         {
             ImGui.PushID(nameof(this.DrawUvInput));
             this.DrawUvInput();
@@ -246,7 +246,7 @@ internal class TexWidget : IDataWindowWidget
             ImGui.PushID(t.Id);
             if (ImGui.CollapsingHeader($"Tex #{t.Id} {t}###header", ImGuiTreeNodeFlags.DefaultOpen))
             {
-                if (ImGui.Button("X"))
+                if (ImGui.Button("X"u8))
                 {
                     runLater = () =>
                     {
@@ -256,7 +256,7 @@ internal class TexWidget : IDataWindowWidget
                 }
 
                 ImGui.SameLine();
-                if (ImGui.Button("Save"))
+                if (ImGui.Button("Save"u8))
                 {
                     _ = Service<DevTextureSaveMenu>.Get().ShowTextureSaveMenuAsync(
                         this.DisplayName,
@@ -265,11 +265,11 @@ internal class TexWidget : IDataWindowWidget
                 }
 
                 ImGui.SameLine();
-                if (ImGui.Button("Copy Reference"))
+                if (ImGui.Button("Copy Reference"u8))
                     runLater = () => this.addedTextures.Add(t.CreateFromSharedLowLevelResource(this.textureManager));
 
                 ImGui.SameLine();
-                if (ImGui.Button("CropCopy"))
+                if (ImGui.Button("CropCopy"u8))
                 {
                     runLater = () =>
                     {
@@ -310,8 +310,8 @@ internal class TexWidget : IDataWindowWidget
                     }
                     else
                     {
-                        ImGui.TextUnformatted("RC: -");
-                        ImGui.TextUnformatted(" ");
+                        ImGui.TextUnformatted("RC: -"u8);
+                        ImGui.TextUnformatted(" "u8);
                     }
                 }
 
@@ -346,10 +346,10 @@ internal class TexWidget : IDataWindowWidget
     {
         var im = Service<InterfaceManager>.Get();
 
-        var shouldSortAgain = ImGui.Button("Sort again");
+        var shouldSortAgain = ImGui.Button("Sort again"u8);
 
         ImGui.SameLine();
-        if (ImGui.Button("Reset Columns"))
+        if (ImGui.Button("Reset Columns"u8))
             this.allLoadedTexturesTableName = "##table" + Environment.TickCount64;
 
         if (!ImGui.BeginTable(
@@ -367,46 +367,46 @@ internal class TexWidget : IDataWindowWidget
 
         ImGui.TableSetupScrollFreeze(0, 1);
         ImGui.TableSetupColumn(
-            "Address",
+            "Address"u8,
             ImGuiTableColumnFlags.WidthFixed,
-            ImGui.CalcTextSize("0x7F0000000000").X,
+            ImGui.CalcTextSize("0x7F0000000000"u8).X,
             (uint)DrawBlameTableColumnUserId.NativeAddress);
         ImGui.TableSetupColumn(
-            "Actions",
+            "Actions"u8,
             ImGuiTableColumnFlags.WidthFixed | ImGuiTableColumnFlags.NoSort,
             iconWidths +
             (ImGui.GetStyle().FramePadding.X * 2 * numIcons) +
             (ImGui.GetStyle().ItemSpacing.X * 1 * numIcons),
             (uint)DrawBlameTableColumnUserId.Actions);
         ImGui.TableSetupColumn(
-            "Name",
+            "Name"u8,
             ImGuiTableColumnFlags.WidthStretch,
             0f,
             (uint)DrawBlameTableColumnUserId.Name);
         ImGui.TableSetupColumn(
-            "Width",
+            "Width"u8,
             ImGuiTableColumnFlags.WidthFixed,
-            ImGui.CalcTextSize("000000").X,
+            ImGui.CalcTextSize("000000"u8).X,
             (uint)DrawBlameTableColumnUserId.Width);
         ImGui.TableSetupColumn(
-            "Height",
+            "Height"u8,
             ImGuiTableColumnFlags.WidthFixed,
-            ImGui.CalcTextSize("000000").X,
+            ImGui.CalcTextSize("000000"u8).X,
             (uint)DrawBlameTableColumnUserId.Height);
         ImGui.TableSetupColumn(
-            "Format",
+            "Format"u8,
             ImGuiTableColumnFlags.WidthFixed,
-            ImGui.CalcTextSize("R32G32B32A32_TYPELESS").X,
+            ImGui.CalcTextSize("R32G32B32A32_TYPELESS"u8).X,
             (uint)DrawBlameTableColumnUserId.Format);
         ImGui.TableSetupColumn(
-            "Size",
+            "Size"u8,
             ImGuiTableColumnFlags.WidthFixed,
-            ImGui.CalcTextSize("123.45 MB").X,
+            ImGui.CalcTextSize("123.45 MB"u8).X,
             (uint)DrawBlameTableColumnUserId.Size);
         ImGui.TableSetupColumn(
-            "Plugins",
+            "Plugins"u8,
             ImGuiTableColumnFlags.WidthFixed,
-            ImGui.CalcTextSize("Aaaaaaaaaa Aaaaaaaaaa Aaaaaaaaaa").X,
+            ImGui.CalcTextSize("Aaaaaaaaaa Aaaaaaaaaa Aaaaaaaaaa"u8).X,
             (uint)DrawBlameTableColumnUserId.Plugins);
         ImGui.TableHeadersRow();
 
@@ -513,7 +513,7 @@ internal class TexWidget : IDataWindowWidget
     private unsafe void DrawLoadedTextures(ICollection<SharedImmediateTexture> textures)
     {
         var im = Service<InterfaceManager>.Get();
-        if (!ImGui.BeginTable("##table", 6))
+        if (!ImGui.BeginTable("##table"u8, 6))
             return;
 
         const int numIcons = 4;
@@ -526,12 +526,12 @@ internal class TexWidget : IDataWindowWidget
         }
 
         ImGui.TableSetupScrollFreeze(0, 1);
-        ImGui.TableSetupColumn("ID", ImGuiTableColumnFlags.WidthFixed, ImGui.CalcTextSize("000000").X);
-        ImGui.TableSetupColumn("Source", ImGuiTableColumnFlags.WidthStretch);
-        ImGui.TableSetupColumn("RefCount", ImGuiTableColumnFlags.WidthFixed, ImGui.CalcTextSize("RefCount__").X);
-        ImGui.TableSetupColumn("SelfRef", ImGuiTableColumnFlags.WidthFixed, ImGui.CalcTextSize("00.000___").X);
+        ImGui.TableSetupColumn("ID"u8, ImGuiTableColumnFlags.WidthFixed, ImGui.CalcTextSize("000000"u8).X);
+        ImGui.TableSetupColumn("Source"u8, ImGuiTableColumnFlags.WidthStretch);
+        ImGui.TableSetupColumn("RefCount"u8, ImGuiTableColumnFlags.WidthFixed, ImGui.CalcTextSize("RefCount__"u8).X);
+        ImGui.TableSetupColumn("SelfRef"u8, ImGuiTableColumnFlags.WidthFixed, ImGui.CalcTextSize("00.000___"u8).X);
         ImGui.TableSetupColumn(
-            "Actions",
+            "Actions"u8,
             ImGuiTableColumnFlags.WidthFixed,
             iconWidths +
             (ImGui.GetStyle().FramePadding.X * 2 * numIcons) +
@@ -566,7 +566,7 @@ internal class TexWidget : IDataWindowWidget
                         // Should not happen
                         ImGui.TableNextColumn();
                         ImGui.AlignTextToFramePadding();
-                        ImGui.TextUnformatted("?");
+                        ImGui.TextUnformatted("?"u8);
                         continue;
                     }
 
@@ -615,7 +615,7 @@ internal class TexWidget : IDataWindowWidget
                     if (ImGuiComponents.IconButton(FontAwesomeIcon.Trash))
                         texture.ReleaseSelfReference(true);
                     if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                        ImGui.SetTooltip("Release self-reference immediately.");
+                        ImGui.SetTooltip("Release self-reference immediately."u8);
                     if (remain <= 0)
                         ImGui.EndDisabled();
 
@@ -635,12 +635,12 @@ internal class TexWidget : IDataWindowWidget
 
     private void DrawGetFromGameIcon()
     {
-        ImGui.InputText("Icon ID", ref this.iconId, 32);
-        ImGui.Checkbox("HQ Item", ref this.hq);
-        ImGui.Checkbox("Hi-Res", ref this.hiRes);
+        ImGui.InputText("Icon ID"u8, ref this.iconId, 32);
+        ImGui.Checkbox("HQ Item"u8, ref this.hq);
+        ImGui.Checkbox("Hi-Res"u8, ref this.hiRes);
 
         ImGui.SameLine();
-        if (ImGui.Button("Load Icon (Async)"))
+        if (ImGui.Button("Load Icon (Async)"u8))
         {
             this.addedTextures.Add(
                 new(
@@ -651,7 +651,7 @@ internal class TexWidget : IDataWindowWidget
         }
 
         ImGui.SameLine();
-        if (ImGui.Button("Load Icon (Immediate)"))
+        if (ImGui.Button("Load Icon (Immediate)"u8))
             this.addedTextures.Add(new(Api10ImmGameIcon: new(uint.Parse(this.iconId), this.hq, this.hiRes)));
 
         ImGuiHelpers.ScaledDummy(10);
@@ -659,14 +659,14 @@ internal class TexWidget : IDataWindowWidget
 
     private void DrawGetFromGame()
     {
-        ImGui.InputText("Tex Path", ref this.inputTexPath, 255);
+        ImGui.InputText("Tex Path"u8, ref this.inputTexPath, 255);
 
         ImGui.SameLine();
-        if (ImGui.Button("Load Tex (Async)"))
+        if (ImGui.Button("Load Tex (Async)"u8))
             this.addedTextures.Add(new(Api10: this.textureManager.Shared.GetFromGame(this.inputTexPath).RentAsync()));
 
         ImGui.SameLine();
-        if (ImGui.Button("Load Tex (Immediate)"))
+        if (ImGui.Button("Load Tex (Immediate)"u8))
             this.addedTextures.Add(new(Api10ImmGamePath: this.inputTexPath));
 
         ImGuiHelpers.ScaledDummy(10);
@@ -674,14 +674,14 @@ internal class TexWidget : IDataWindowWidget
 
     private void DrawGetFromFile()
     {
-        ImGui.InputText("File Path", ref this.inputFilePath, 255);
+        ImGui.InputText("File Path"u8, ref this.inputFilePath, 255);
 
         ImGui.SameLine();
-        if (ImGui.Button("Load File (Async)"))
+        if (ImGui.Button("Load File (Async)"u8))
             this.addedTextures.Add(new(Api10: this.textureManager.Shared.GetFromFile(this.inputFilePath).RentAsync()));
 
         ImGui.SameLine();
-        if (ImGui.Button("Load File (Immediate)"))
+        if (ImGui.Button("Load File (Immediate)"u8))
             this.addedTextures.Add(new(Api10ImmFile: this.inputFilePath));
 
         ImGuiHelpers.ScaledDummy(10);
@@ -734,7 +734,7 @@ internal class TexWidget : IDataWindowWidget
                 ? this.inputManifestResourceNameCandidates[this.inputManifestResourceNameIndex]
                 : null;
 
-        if (ImGui.Button("Refresh Assemblies"))
+        if (ImGui.Button("Refresh Assemblies"u8))
         {
             this.inputManifestResourceAssemblyIndex = 0;
             this.inputManifestResourceAssemblyCandidates = null;
@@ -746,14 +746,14 @@ internal class TexWidget : IDataWindowWidget
         if (assembly is not null && name is not null)
         {
             ImGui.SameLine();
-            if (ImGui.Button("Load File (Async)"))
+            if (ImGui.Button("Load File (Async)"u8))
             {
                 this.addedTextures.Add(
                     new(Api10: this.textureManager.Shared.GetFromManifestResource(assembly, name).RentAsync()));
             }
 
             ImGui.SameLine();
-            if (ImGui.Button("Load File (Immediate)"))
+            if (ImGui.Button("Load File (Immediate)"u8))
                 this.addedTextures.Add(new(Api10ImmManifestResource: (assembly, name)));
         }
 
@@ -800,7 +800,7 @@ internal class TexWidget : IDataWindowWidget
         if (ImGui.InputFloat2(nameof(this.viewportTextureArgs.Uv1), ref vec2))
             this.viewportTextureArgs.Uv1 = vec2;
 
-        if (ImGui.Button("Create") && this.viewportIndexInt >= 0 && this.viewportIndexInt < viewports.Size)
+        if (ImGui.Button("Create"u8) && this.viewportIndexInt >= 0 && this.viewportIndexInt < viewports.Size)
         {
             this.addedTextures.Add(
                 new()

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TexWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TexWidget.cs
@@ -305,13 +305,13 @@ internal class TexWidget : IDataWindowWidget
                         pres->Release();
                         pres->Release();
 
-                        ImGui.TextUnformatted($"RC: Resource({rcres})/View({rcsrv})");
-                        ImGui.TextUnformatted(source.ToString());
+                        ImGui.Text($"RC: Resource({rcres})/View({rcsrv})");
+                        ImGui.Text(source.ToString());
                     }
                     else
                     {
-                        ImGui.TextUnformatted("RC: -"u8);
-                        ImGui.TextUnformatted(" "u8);
+                        ImGui.Text("RC: -"u8);
+                        ImGui.Text(" "u8);
                     }
                 }
 
@@ -327,12 +327,12 @@ internal class TexWidget : IDataWindowWidget
                     }
                     else
                     {
-                        ImGui.TextUnformatted(t.DescribeError() ?? "Loading");
+                        ImGui.Text(t.DescribeError() ?? "Loading");
                     }
                 }
                 catch (Exception e)
                 {
-                    ImGui.TextUnformatted(e.ToString());
+                    ImGui.Text(e.ToString());
                 }
             }
 
@@ -566,7 +566,7 @@ internal class TexWidget : IDataWindowWidget
                         // Should not happen
                         ImGui.TableNextColumn();
                         ImGui.AlignTextToFramePadding();
-                        ImGui.TextUnformatted("?"u8);
+                        ImGui.Text("?"u8);
                         continue;
                     }
 

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/ToastWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/ToastWidget.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 
 using Dalamud.Bindings.ImGui;
 using Dalamud.Game.Gui.Toast;
@@ -39,18 +39,18 @@ internal class ToastWidget : IDataWindowWidget
     {
         var toastGui = Service<ToastGui>.Get();
 
-        ImGui.InputText("Toast text", ref this.inputTextToast, 200);
+        ImGui.InputText("Toast text"u8, ref this.inputTextToast, 200);
 
-        ImGui.Combo("Toast Position", ref this.toastPosition, ["Bottom", "Top"]);
-        ImGui.Combo("Toast Speed", ref this.toastSpeed, ["Slow", "Fast"]);
-        ImGui.Combo("Quest Toast Position", ref this.questToastPosition, ["Centre", "Right", "Left"]);
-        ImGui.Checkbox("Quest Checkmark", ref this.questToastCheckmark);
-        ImGui.Checkbox("Quest Play Sound", ref this.questToastSound);
-        ImGui.InputInt("Quest Icon ID", ref this.questToastIconId);
+        ImGui.Combo("Toast Position", ref this.toastPosition, ["Bottom", "Top",], 2);
+        ImGui.Combo("Toast Speed", ref this.toastSpeed, ["Slow", "Fast",], 2);
+        ImGui.Combo("Quest Toast Position", ref this.questToastPosition, ["Centre", "Right", "Left"], 3);
+        ImGui.Checkbox("Quest Checkmark"u8, ref this.questToastCheckmark);
+        ImGui.Checkbox("Quest Play Sound"u8, ref this.questToastSound);
+        ImGui.InputInt("Quest Icon ID"u8, ref this.questToastIconId);
 
         ImGuiHelpers.ScaledDummy(new Vector2(10, 10));
 
-        if (ImGui.Button("Show toast"))
+        if (ImGui.Button("Show toast"u8))
         {
             toastGui.ShowNormal(this.inputTextToast, new ToastOptions
             {
@@ -59,7 +59,7 @@ internal class ToastWidget : IDataWindowWidget
             });
         }
 
-        if (ImGui.Button("Show Quest toast"))
+        if (ImGui.Button("Show Quest toast"u8))
         {
             toastGui.ShowQuest(this.inputTextToast, new QuestToastOptions
             {
@@ -70,7 +70,7 @@ internal class ToastWidget : IDataWindowWidget
             });
         }
 
-        if (ImGui.Button("Show Error toast"))
+        if (ImGui.Button("Show Error toast"u8))
         {
             toastGui.ShowError(this.inputTextToast);
         }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/UIColorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/UIColorWidget.cs
@@ -87,7 +87,7 @@ internal class UiColorWidget : IDataWindowWidget
 
                 ImGui.TableNextColumn();
                 ImGui.AlignTextToFramePadding();
-                ImGui.TextUnformatted($"{id}");
+                ImGui.Text($"{id}");
 
                 ImGui.TableNextColumn();
                 ImGui.AlignTextToFramePadding();

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/UIColorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/UIColorWidget.cs
@@ -44,24 +44,24 @@ internal class UiColorWidget : IDataWindowWidget
             "<edgecolor(0xEEEEFF)><color(0x0000FF)>BB<color(stackcolor)><edgecolor(stackcolor)>.<br>" +
             "· Click on a color to copy the color code.<br>" +
             "· Hover on a color to preview the text with edge, when the next color has been used together.");
-        if (!ImGui.BeginTable("UIColor", 5))
+        if (!ImGui.BeginTable("UIColor"u8, 5))
             return;
 
         ImGui.TableSetupScrollFreeze(0, 1);
-        var rowidw = ImGui.CalcTextSize("9999999").X;
-        var colorw = ImGui.CalcTextSize("#999999").X;
-        colorw = Math.Max(colorw, ImGui.CalcTextSize("#AAAAAA").X);
-        colorw = Math.Max(colorw, ImGui.CalcTextSize("#BBBBBB").X);
-        colorw = Math.Max(colorw, ImGui.CalcTextSize("#CCCCCC").X);
-        colorw = Math.Max(colorw, ImGui.CalcTextSize("#DDDDDD").X);
-        colorw = Math.Max(colorw, ImGui.CalcTextSize("#EEEEEE").X);
-        colorw = Math.Max(colorw, ImGui.CalcTextSize("#FFFFFF").X);
+        var rowidw = ImGui.CalcTextSize("9999999"u8).X;
+        var colorw = ImGui.CalcTextSize("#999999"u8).X;
+        colorw = Math.Max(colorw, ImGui.CalcTextSize("#AAAAAA"u8).X);
+        colorw = Math.Max(colorw, ImGui.CalcTextSize("#BBBBBB"u8).X);
+        colorw = Math.Max(colorw, ImGui.CalcTextSize("#CCCCCC"u8).X);
+        colorw = Math.Max(colorw, ImGui.CalcTextSize("#DDDDDD"u8).X);
+        colorw = Math.Max(colorw, ImGui.CalcTextSize("#EEEEEE"u8).X);
+        colorw = Math.Max(colorw, ImGui.CalcTextSize("#FFFFFF"u8).X);
         colorw += ImGui.GetFrameHeight() + ImGui.GetStyle().FramePadding.X;
-        ImGui.TableSetupColumn("Row ID", ImGuiTableColumnFlags.WidthFixed, rowidw);
-        ImGui.TableSetupColumn("Dark", ImGuiTableColumnFlags.WidthFixed, colorw);
-        ImGui.TableSetupColumn("Light", ImGuiTableColumnFlags.WidthFixed, colorw);
-        ImGui.TableSetupColumn("Classic FF", ImGuiTableColumnFlags.WidthFixed, colorw);
-        ImGui.TableSetupColumn("Clear Blue", ImGuiTableColumnFlags.WidthFixed, colorw);
+        ImGui.TableSetupColumn("Row ID"u8, ImGuiTableColumnFlags.WidthFixed, rowidw);
+        ImGui.TableSetupColumn("Dark"u8, ImGuiTableColumnFlags.WidthFixed, colorw);
+        ImGui.TableSetupColumn("Light"u8, ImGuiTableColumnFlags.WidthFixed, colorw);
+        ImGui.TableSetupColumn("Classic FF"u8, ImGuiTableColumnFlags.WidthFixed, colorw);
+        ImGui.TableSetupColumn("Clear Blue"u8, ImGuiTableColumnFlags.WidthFixed, colorw);
         ImGui.TableHeadersRow();
 
         var clipper = ImGui.ImGuiListClipper();
@@ -186,7 +186,7 @@ internal class UiColorWidget : IDataWindowWidget
             ImGui.GetColorU32(ImGuiCol.Text),
             rgbtext);
 
-        if (ImGui.InvisibleButton("##copy", size))
+        if (ImGui.InvisibleButton("##copy"u8, size))
         {
             ImGui.SetClipboardText(rgbtext);
             Service<NotificationManager>.Get().AddNotification(

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/UldWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/UldWidget.cs
@@ -96,7 +96,7 @@ internal class UldWidget : IDataWindowWidget
                 ClearTask(ref this.uldNamesTask);
                 goto default;
             default:
-                ImGui.TextUnformatted("Loading...");
+                ImGui.TextUnformatted("Loading..."u8);
                 return;
         }
 
@@ -109,7 +109,7 @@ internal class UldWidget : IDataWindowWidget
         if (ImGuiComponents.IconButton("selectUldRight", FontAwesomeIcon.AngleRight))
             this.selectedUld = (this.selectedUld + 1) % uldNames.Length;
         ImGui.SameLine();
-        ImGui.TextUnformatted("Select ULD File");
+        ImGui.TextUnformatted("Select ULD File"u8);
         if (selectedUldPrev != this.selectedUld)
         {
             // reset selected parts when changing ULD
@@ -125,7 +125,7 @@ internal class UldWidget : IDataWindowWidget
         if (ImGuiComponents.IconButton("selectThemeRight", FontAwesomeIcon.AngleRight))
             this.selectedTheme = (this.selectedTheme + 1) % ThemeDisplayNames.Length;
         ImGui.SameLine();
-        ImGui.TextUnformatted("Select Theme");
+        ImGui.TextUnformatted("Select Theme"u8);
 
         var dataManager = Service<DataManager>.Get();
         var textureManager = Service<TextureManager>.Get();
@@ -146,11 +146,11 @@ internal class UldWidget : IDataWindowWidget
                 this.selectedUldFileTask = null;
                 goto default;
             default:
-                ImGui.TextUnformatted("Loading...");
+                ImGui.TextUnformatted("Loading..."u8);
                 return;
         }
 
-        if (ImGui.CollapsingHeader("Texture Entries"))
+        if (ImGui.CollapsingHeader("Texture Entries"u8))
         {
             if (ForceNullable(uld.AssetData) is null)
             {
@@ -158,11 +158,11 @@ internal class UldWidget : IDataWindowWidget
                     ImGuiColors.DalamudRed,
                     $"Error: {nameof(UldFile.AssetData)} is not populated.");
             }
-            else if (ImGui.BeginTable("##uldTextureEntries", 3, ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders))
+            else if (ImGui.BeginTable("##uldTextureEntries"u8, 3, ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders))
             {
-                ImGui.TableSetupColumn("Id", ImGuiTableColumnFlags.WidthFixed, ImGui.CalcTextSize("000000").X);
-                ImGui.TableSetupColumn("Path", ImGuiTableColumnFlags.WidthStretch);
-                ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthFixed, ImGui.CalcTextSize("Preview___").X);
+                ImGui.TableSetupColumn("Id"u8, ImGuiTableColumnFlags.WidthFixed, ImGui.CalcTextSize("000000"u8).X);
+                ImGui.TableSetupColumn("Path"u8, ImGuiTableColumnFlags.WidthStretch);
+                ImGui.TableSetupColumn("Actions"u8, ImGuiTableColumnFlags.WidthFixed, ImGui.CalcTextSize("Preview___"u8).X);
                 ImGui.TableHeadersRow();
 
                 foreach (var textureEntry in uld.AssetData)
@@ -172,7 +172,7 @@ internal class UldWidget : IDataWindowWidget
             }
         }
 
-        if (ImGui.CollapsingHeader("Timeline##TimelineCollapsingHeader"))
+        if (ImGui.CollapsingHeader("Timeline##TimelineCollapsingHeader"u8))
         {
             if (ForceNullable(uld.Timelines) is null)
             {
@@ -182,16 +182,16 @@ internal class UldWidget : IDataWindowWidget
             }
             else if (uld.Timelines.Length == 0)
             {
-                ImGui.TextUnformatted("No entry exists.");
+                ImGui.TextUnformatted("No entry exists."u8);
             }
             else
             {
-                ImGui.SliderInt("Timeline##TimelineSlider", ref this.selectedTimeline, 0, uld.Timelines.Length - 1);
+                ImGui.SliderInt("Timeline##TimelineSlider"u8, ref this.selectedTimeline, 0, uld.Timelines.Length - 1);
                 this.DrawTimelines(uld.Timelines[this.selectedTimeline]);
             }
         }
 
-        if (ImGui.CollapsingHeader("Parts##PartsCollapsingHeader"))
+        if (ImGui.CollapsingHeader("Parts##PartsCollapsingHeader"u8))
         {
             if (ForceNullable(uld.Parts) is null)
             {
@@ -201,11 +201,11 @@ internal class UldWidget : IDataWindowWidget
             }
             else if (uld.Parts.Length == 0)
             {
-                ImGui.TextUnformatted("No entry exists.");
+                ImGui.TextUnformatted("No entry exists."u8);
             }
             else
             {
-                ImGui.SliderInt("Parts##PartsSlider", ref this.selectedParts, 0, uld.Parts.Length - 1);
+                ImGui.SliderInt("Parts##PartsSlider"u8, ref this.selectedParts, 0, uld.Parts.Length - 1);
                 this.DrawParts(uld.Parts[this.selectedParts], uld.AssetData, textureManager);
             }
         }
@@ -278,7 +278,7 @@ internal class UldWidget : IDataWindowWidget
         if (string.IsNullOrWhiteSpace(path))
             return;
 
-        ImGui.TextUnformatted("Preview");
+        ImGui.TextUnformatted("Preview"u8);
 
         if (ImGui.IsItemHovered())
         {
@@ -307,7 +307,7 @@ internal class UldWidget : IDataWindowWidget
 
     private void DrawTimelines(UldRoot.Timeline timeline)
     {
-        ImGui.SliderInt("FrameData", ref this.selectedFrameData, 0, timeline.FrameData.Length - 1);
+        ImGui.SliderInt("FrameData"u8, ref this.selectedFrameData, 0, timeline.FrameData.Length - 1);
         var frameData = timeline.FrameData[this.selectedFrameData];
         ImGui.TextUnformatted($"FrameInfo: {frameData.StartFrame} -> {frameData.EndFrame}");
         ImGui.Indent();
@@ -501,7 +501,7 @@ internal class UldWidget : IDataWindowWidget
             var texturePath = GetStringNullTerminated(path);
             if (string.IsNullOrWhiteSpace(texturePath))
             {
-                ImGui.TextUnformatted("Texture path is empty.");
+                ImGui.TextUnformatted("Texture path is empty."u8);
                 continue;
             }
 
@@ -542,7 +542,7 @@ internal class UldWidget : IDataWindowWidget
             if (ImGui.IsItemHovered())
             {
                 ImGui.BeginTooltip();
-                ImGui.TextUnformatted("Click to copy:");
+                ImGui.TextUnformatted("Click to copy:"u8);
                 ImGui.TextUnformatted(texturePath);
                 ImGui.EndTooltip();
             }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/UldWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/UldWidget.cs
@@ -90,7 +90,7 @@ internal class UldWidget : IDataWindowWidget
                 uldNames = t.Result;
                 break;
             case { Exception: { } loadException }:
-                ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, loadException.ToString());
+                ImGui.TextColoredWrapped(ImGuiColors.DalamudRed, loadException.ToString());
                 return;
             case { IsCanceled: true }:
                 ClearTask(ref this.uldNamesTask);
@@ -138,7 +138,7 @@ internal class UldWidget : IDataWindowWidget
                 uld = this.selectedUldFileTask.Result;
                 break;
             case { Exception: { } loadException }:
-                ImGuiHelpers.SafeTextColoredWrapped(
+                ImGui.TextColoredWrapped(
                     ImGuiColors.DalamudRed,
                     $"Failed to load ULD file.\n{loadException}");
                 return;
@@ -154,7 +154,7 @@ internal class UldWidget : IDataWindowWidget
         {
             if (ForceNullable(uld.AssetData) is null)
             {
-                ImGuiHelpers.SafeTextColoredWrapped(
+                ImGui.TextColoredWrapped(
                     ImGuiColors.DalamudRed,
                     $"Error: {nameof(UldFile.AssetData)} is not populated.");
             }
@@ -176,7 +176,7 @@ internal class UldWidget : IDataWindowWidget
         {
             if (ForceNullable(uld.Timelines) is null)
             {
-                ImGuiHelpers.SafeTextColoredWrapped(
+                ImGui.TextColoredWrapped(
                     ImGuiColors.DalamudRed,
                     $"Error: {nameof(UldFile.Timelines)} is not populated.");
             }
@@ -195,7 +195,7 @@ internal class UldWidget : IDataWindowWidget
         {
             if (ForceNullable(uld.Parts) is null)
             {
-                ImGuiHelpers.SafeTextColoredWrapped(
+                ImGui.TextColoredWrapped(
                     ImGuiColors.DalamudRed,
                     $"Error: {nameof(UldFile.Parts)} is not populated.");
             }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/UldWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/UldWidget.cs
@@ -96,7 +96,7 @@ internal class UldWidget : IDataWindowWidget
                 ClearTask(ref this.uldNamesTask);
                 goto default;
             default:
-                ImGui.TextUnformatted("Loading..."u8);
+                ImGui.Text("Loading..."u8);
                 return;
         }
 
@@ -109,7 +109,7 @@ internal class UldWidget : IDataWindowWidget
         if (ImGuiComponents.IconButton("selectUldRight", FontAwesomeIcon.AngleRight))
             this.selectedUld = (this.selectedUld + 1) % uldNames.Length;
         ImGui.SameLine();
-        ImGui.TextUnformatted("Select ULD File"u8);
+        ImGui.Text("Select ULD File"u8);
         if (selectedUldPrev != this.selectedUld)
         {
             // reset selected parts when changing ULD
@@ -125,7 +125,7 @@ internal class UldWidget : IDataWindowWidget
         if (ImGuiComponents.IconButton("selectThemeRight", FontAwesomeIcon.AngleRight))
             this.selectedTheme = (this.selectedTheme + 1) % ThemeDisplayNames.Length;
         ImGui.SameLine();
-        ImGui.TextUnformatted("Select Theme"u8);
+        ImGui.Text("Select Theme"u8);
 
         var dataManager = Service<DataManager>.Get();
         var textureManager = Service<TextureManager>.Get();
@@ -146,7 +146,7 @@ internal class UldWidget : IDataWindowWidget
                 this.selectedUldFileTask = null;
                 goto default;
             default:
-                ImGui.TextUnformatted("Loading..."u8);
+                ImGui.Text("Loading..."u8);
                 return;
         }
 
@@ -182,7 +182,7 @@ internal class UldWidget : IDataWindowWidget
             }
             else if (uld.Timelines.Length == 0)
             {
-                ImGui.TextUnformatted("No entry exists."u8);
+                ImGui.Text("No entry exists."u8);
             }
             else
             {
@@ -201,7 +201,7 @@ internal class UldWidget : IDataWindowWidget
             }
             else if (uld.Parts.Length == 0)
             {
-                ImGui.TextUnformatted("No entry exists."u8);
+                ImGui.Text("No entry exists."u8);
             }
             else
             {
@@ -269,7 +269,7 @@ internal class UldWidget : IDataWindowWidget
     {
         var path = GetStringNullTerminated(textureEntry.Path);
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted(textureEntry.Id.ToString());
+        ImGui.Text(textureEntry.Id.ToString());
 
         ImGui.TableNextColumn();
         this.TextColumnCopiable(path, false, false);
@@ -278,27 +278,27 @@ internal class UldWidget : IDataWindowWidget
         if (string.IsNullOrWhiteSpace(path))
             return;
 
-        ImGui.TextUnformatted("Preview"u8);
+        ImGui.Text("Preview"u8);
 
         if (ImGui.IsItemHovered())
         {
             ImGui.BeginTooltip();
 
             var texturePath = GetStringNullTerminated(textureEntry.Path);
-            ImGui.TextUnformatted($"Base path at {texturePath}:");
+            ImGui.Text($"Base path at {texturePath}:");
             if (textureManager.Shared.GetFromGame(texturePath).TryGetWrap(out var wrap, out var e))
                 ImGui.Image(wrap.Handle, wrap.Size);
             else if (e is not null)
-                ImGui.TextUnformatted(e.ToString());
+                ImGui.Text(e.ToString());
 
             if (this.selectedTheme != 0)
             {
                 var texturePathThemed = this.ToThemedPath(texturePath);
-                ImGui.TextUnformatted($"Themed path at {texturePathThemed}:");
+                ImGui.Text($"Themed path at {texturePathThemed}:");
                 if (textureManager.Shared.GetFromGame(texturePathThemed).TryGetWrap(out wrap, out e))
                     ImGui.Image(wrap.Handle, wrap.Size);
                 else if (e is not null)
-                    ImGui.TextUnformatted(e.ToString());
+                    ImGui.Text(e.ToString());
             }
 
             ImGui.EndTooltip();
@@ -309,11 +309,11 @@ internal class UldWidget : IDataWindowWidget
     {
         ImGui.SliderInt("FrameData"u8, ref this.selectedFrameData, 0, timeline.FrameData.Length - 1);
         var frameData = timeline.FrameData[this.selectedFrameData];
-        ImGui.TextUnformatted($"FrameInfo: {frameData.StartFrame} -> {frameData.EndFrame}");
+        ImGui.Text($"FrameInfo: {frameData.StartFrame} -> {frameData.EndFrame}");
         ImGui.Indent();
         foreach (var frameDataKeyGroup in frameData.KeyGroups)
         {
-            ImGui.TextUnformatted($"{frameDataKeyGroup.Usage:G} {frameDataKeyGroup.Type:G}");
+            ImGui.Text($"{frameDataKeyGroup.Usage:G} {frameDataKeyGroup.Type:G}");
             foreach (var keyframe in frameDataKeyGroup.Frames)
                 this.DrawTimelineKeyGroupFrame(keyframe);
         }
@@ -326,147 +326,147 @@ internal class UldWidget : IDataWindowWidget
         switch (frame)
         {
             case BaseKeyframeData baseKeyframeData:
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $"Time: {baseKeyframeData.Time} | Interpolation: {baseKeyframeData.Interpolation} | Acceleration: {baseKeyframeData.Acceleration} | Deceleration: {baseKeyframeData.Deceleration}");
                 break;
             case Float1Keyframe float1Keyframe:
                 this.DrawTimelineKeyGroupFrame(float1Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value: {float1Keyframe.Value}");
+                ImGui.Text($" | Value: {float1Keyframe.Value}");
                 break;
             case Float2Keyframe float2Keyframe:
                 this.DrawTimelineKeyGroupFrame(float2Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value1: {float2Keyframe.Value[0]} | Value2: {float2Keyframe.Value[1]}");
+                ImGui.Text($" | Value1: {float2Keyframe.Value[0]} | Value2: {float2Keyframe.Value[1]}");
                 break;
             case Float3Keyframe float3Keyframe:
                 this.DrawTimelineKeyGroupFrame(float3Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $" | Value1: {float3Keyframe.Value[0]} | Value2: {float3Keyframe.Value[1]} | Value3: {float3Keyframe.Value[2]}");
                 break;
             case SByte1Keyframe sbyte1Keyframe:
                 this.DrawTimelineKeyGroupFrame(sbyte1Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value: {sbyte1Keyframe.Value}");
+                ImGui.Text($" | Value: {sbyte1Keyframe.Value}");
                 break;
             case SByte2Keyframe sbyte2Keyframe:
                 this.DrawTimelineKeyGroupFrame(sbyte2Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value1: {sbyte2Keyframe.Value[0]} | Value2: {sbyte2Keyframe.Value[1]}");
+                ImGui.Text($" | Value1: {sbyte2Keyframe.Value[0]} | Value2: {sbyte2Keyframe.Value[1]}");
                 break;
             case SByte3Keyframe sbyte3Keyframe:
                 this.DrawTimelineKeyGroupFrame(sbyte3Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $" | Value1: {sbyte3Keyframe.Value[0]} | Value2: {sbyte3Keyframe.Value[1]} | Value3: {sbyte3Keyframe.Value[2]}");
                 break;
             case Byte1Keyframe byte1Keyframe:
                 this.DrawTimelineKeyGroupFrame(byte1Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value: {byte1Keyframe.Value}");
+                ImGui.Text($" | Value: {byte1Keyframe.Value}");
                 break;
             case Byte2Keyframe byte2Keyframe:
                 this.DrawTimelineKeyGroupFrame(byte2Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value1: {byte2Keyframe.Value[0]} | Value2: {byte2Keyframe.Value[1]}");
+                ImGui.Text($" | Value1: {byte2Keyframe.Value[0]} | Value2: {byte2Keyframe.Value[1]}");
                 break;
             case Byte3Keyframe byte3Keyframe:
                 this.DrawTimelineKeyGroupFrame(byte3Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $" | Value1: {byte3Keyframe.Value[0]} | Value2: {byte3Keyframe.Value[1]} | Value3: {byte3Keyframe.Value[2]}");
                 break;
             case Short1Keyframe short1Keyframe:
                 this.DrawTimelineKeyGroupFrame(short1Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value: {short1Keyframe.Value}");
+                ImGui.Text($" | Value: {short1Keyframe.Value}");
                 break;
             case Short2Keyframe short2Keyframe:
                 this.DrawTimelineKeyGroupFrame(short2Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value1: {short2Keyframe.Value[0]} | Value2: {short2Keyframe.Value[1]}");
+                ImGui.Text($" | Value1: {short2Keyframe.Value[0]} | Value2: {short2Keyframe.Value[1]}");
                 break;
             case Short3Keyframe short3Keyframe:
                 this.DrawTimelineKeyGroupFrame(short3Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $" | Value1: {short3Keyframe.Value[0]} | Value2: {short3Keyframe.Value[1]} | Value3: {short3Keyframe.Value[2]}");
                 break;
             case UShort1Keyframe ushort1Keyframe:
                 this.DrawTimelineKeyGroupFrame(ushort1Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value: {ushort1Keyframe.Value}");
+                ImGui.Text($" | Value: {ushort1Keyframe.Value}");
                 break;
             case UShort2Keyframe ushort2Keyframe:
                 this.DrawTimelineKeyGroupFrame(ushort2Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value1: {ushort2Keyframe.Value[0]} | Value2: {ushort2Keyframe.Value[1]}");
+                ImGui.Text($" | Value1: {ushort2Keyframe.Value[0]} | Value2: {ushort2Keyframe.Value[1]}");
                 break;
             case UShort3Keyframe ushort3Keyframe:
                 this.DrawTimelineKeyGroupFrame(ushort3Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $" | Value1: {ushort3Keyframe.Value[0]} | Value2: {ushort3Keyframe.Value[1]} | Value3: {ushort3Keyframe.Value[2]}");
                 break;
             case Int1Keyframe int1Keyframe:
                 this.DrawTimelineKeyGroupFrame(int1Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value: {int1Keyframe.Value}");
+                ImGui.Text($" | Value: {int1Keyframe.Value}");
                 break;
             case Int2Keyframe int2Keyframe:
                 this.DrawTimelineKeyGroupFrame(int2Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value1: {int2Keyframe.Value[0]} | Value2: {int2Keyframe.Value[1]}");
+                ImGui.Text($" | Value1: {int2Keyframe.Value[0]} | Value2: {int2Keyframe.Value[1]}");
                 break;
             case Int3Keyframe int3Keyframe:
                 this.DrawTimelineKeyGroupFrame(int3Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $" | Value1: {int3Keyframe.Value[0]} | Value2: {int3Keyframe.Value[1]} | Value3: {int3Keyframe.Value[2]}");
                 break;
             case UInt1Keyframe uint1Keyframe:
                 this.DrawTimelineKeyGroupFrame(uint1Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value: {uint1Keyframe.Value}");
+                ImGui.Text($" | Value: {uint1Keyframe.Value}");
                 break;
             case UInt2Keyframe uint2Keyframe:
                 this.DrawTimelineKeyGroupFrame(uint2Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value1: {uint2Keyframe.Value[0]} | Value2: {uint2Keyframe.Value[1]}");
+                ImGui.Text($" | Value1: {uint2Keyframe.Value[0]} | Value2: {uint2Keyframe.Value[1]}");
                 break;
             case UInt3Keyframe uint3Keyframe:
                 this.DrawTimelineKeyGroupFrame(uint3Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $" | Value1: {uint3Keyframe.Value[0]} | Value2: {uint3Keyframe.Value[1]} | Value3: {uint3Keyframe.Value[2]}");
                 break;
             case Bool1Keyframe bool1Keyframe:
                 this.DrawTimelineKeyGroupFrame(bool1Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value: {bool1Keyframe.Value}");
+                ImGui.Text($" | Value: {bool1Keyframe.Value}");
                 break;
             case Bool2Keyframe bool2Keyframe:
                 this.DrawTimelineKeyGroupFrame(bool2Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted($" | Value1: {bool2Keyframe.Value[0]} | Value2: {bool2Keyframe.Value[1]}");
+                ImGui.Text($" | Value1: {bool2Keyframe.Value[0]} | Value2: {bool2Keyframe.Value[1]}");
                 break;
             case Bool3Keyframe bool3Keyframe:
                 this.DrawTimelineKeyGroupFrame(bool3Keyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $" | Value1: {bool3Keyframe.Value[0]} | Value2: {bool3Keyframe.Value[1]} | Value3: {bool3Keyframe.Value[2]}");
                 break;
             case ColorKeyframe colorKeyframe:
                 this.DrawTimelineKeyGroupFrame(colorKeyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $" | Add: {colorKeyframe.AddRed} {colorKeyframe.AddGreen} {colorKeyframe.AddBlue} | Multiply: {colorKeyframe.MultiplyRed} {colorKeyframe.MultiplyGreen} {colorKeyframe.MultiplyBlue}");
                 break;
             case LabelKeyframe labelKeyframe:
                 this.DrawTimelineKeyGroupFrame(labelKeyframe.Keyframe);
                 ImGui.SameLine(0, 0);
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     $" | LabelCommand: {labelKeyframe.LabelCommand} | JumpId: {labelKeyframe.JumpId} | LabelId: {labelKeyframe.LabelId}");
                 break;
         }
@@ -479,7 +479,7 @@ internal class UldWidget : IDataWindowWidget
     {
         for (var index = 0; index < partsData.Parts.Length; index++)
         {
-            ImGui.TextUnformatted($"Index: {index}");
+            ImGui.Text($"Index: {index}");
             var partsDataPart = partsData.Parts[index];
             ImGui.SameLine();
 
@@ -494,14 +494,14 @@ internal class UldWidget : IDataWindowWidget
 
             if (path is null)
             {
-                ImGui.TextUnformatted($"Could not find texture for id {partsDataPart.TextureId}");
+                ImGui.Text($"Could not find texture for id {partsDataPart.TextureId}");
                 continue;
             }
 
             var texturePath = GetStringNullTerminated(path);
             if (string.IsNullOrWhiteSpace(texturePath))
             {
-                ImGui.TextUnformatted("Texture path is empty."u8);
+                ImGui.Text("Texture path is empty."u8);
                 continue;
             }
 
@@ -518,7 +518,7 @@ internal class UldWidget : IDataWindowWidget
                     // neither the supposedly original path nor themed path had a file we could load.
                     if (e is not null && e2 is not null)
                     {
-                        ImGui.TextUnformatted($"{texturePathThemed}: {e}\n{texturePath}: {e2}");
+                        ImGui.Text($"{texturePathThemed}: {e}\n{texturePath}: {e2}");
                         continue;
                     }
                 }
@@ -542,8 +542,8 @@ internal class UldWidget : IDataWindowWidget
             if (ImGui.IsItemHovered())
             {
                 ImGui.BeginTooltip();
-                ImGui.TextUnformatted("Click to copy:"u8);
-                ImGui.TextUnformatted(texturePath);
+                ImGui.Text("Click to copy:"u8);
+                ImGui.Text(texturePath);
                 ImGui.EndTooltip();
             }
         }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/VfsWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/VfsWidget.cs
@@ -37,12 +37,12 @@ internal class VfsWidget : IDataWindowWidget
         var service = Service<ReliableFileStorage>.Get();
         var dalamud = Service<Dalamud>.Get();
 
-        ImGui.InputInt("Num bytes", ref this.numBytes);
-        ImGui.InputInt("Reps", ref this.reps);
+        ImGui.InputInt("Num bytes"u8, ref this.numBytes);
+        ImGui.InputInt("Reps"u8, ref this.reps);
 
         var path = Path.Combine(dalamud.StartInfo.WorkingDirectory!, "test.bin");
 
-        if (ImGui.Button("Write"))
+        if (ImGui.Button("Write"u8))
         {
             Log.Information("=== WRITING ===");
             var data = new byte[this.numBytes];
@@ -61,7 +61,7 @@ internal class VfsWidget : IDataWindowWidget
             Log.Information("Took {Ms}ms in total", acc);
         }
 
-        if (ImGui.Button("Read"))
+        if (ImGui.Button("Read"u8))
         {
             Log.Information("=== READING ===");
             var stopwatch = new Stopwatch();
@@ -79,7 +79,7 @@ internal class VfsWidget : IDataWindowWidget
             Log.Information("Took {Ms}ms in total", acc);
         }
 
-        if (ImGui.Button("Test Config"))
+        if (ImGui.Button("Test Config"u8))
         {
             var config = Service<DalamudConfiguration>.Get();
 

--- a/Dalamud/Interface/Internal/Windows/HitchSettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/HitchSettingsWindow.cs
@@ -28,28 +28,28 @@ public class HitchSettingsWindow : Window
         var config = Service<DalamudConfiguration>.Get();
 
         var uiBuilderHitch = (float)config.UiBuilderHitch;
-        if (ImGui.SliderFloat("UiBuilderHitch", ref uiBuilderHitch, MinHitch, MaxHitch))
+        if (ImGui.SliderFloat("UiBuilderHitch"u8, ref uiBuilderHitch, MinHitch, MaxHitch))
         {
             config.UiBuilderHitch = uiBuilderHitch;
             config.QueueSave();
         }
 
         var frameworkUpdateHitch = (float)config.FrameworkUpdateHitch;
-        if (ImGui.SliderFloat("FrameworkUpdateHitch", ref frameworkUpdateHitch, MinHitch, MaxHitch))
+        if (ImGui.SliderFloat("FrameworkUpdateHitch"u8, ref frameworkUpdateHitch, MinHitch, MaxHitch))
         {
             config.FrameworkUpdateHitch = frameworkUpdateHitch;
             config.QueueSave();
         }
 
         var gameNetworkUpHitch = (float)config.GameNetworkUpHitch;
-        if (ImGui.SliderFloat("GameNetworkUpHitch", ref gameNetworkUpHitch, MinHitch, MaxHitch))
+        if (ImGui.SliderFloat("GameNetworkUpHitch"u8, ref gameNetworkUpHitch, MinHitch, MaxHitch))
         {
             config.GameNetworkUpHitch = gameNetworkUpHitch;
             config.QueueSave();
         }
 
         var gameNetworkDownHitch = (float)config.GameNetworkDownHitch;
-        if (ImGui.SliderFloat("GameNetworkDownHitch", ref gameNetworkDownHitch, MinHitch, MaxHitch))
+        if (ImGui.SliderFloat("GameNetworkDownHitch"u8, ref gameNetworkDownHitch, MinHitch, MaxHitch))
         {
             config.GameNetworkDownHitch = gameNetworkDownHitch;
             config.QueueSave();

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -3424,7 +3424,7 @@ internal class PluginInstallerWindow : Window, IDisposable
     {
         if (!devPlugin.IsLoaded)
         {
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, "You have to load this plugin to see validation issues."u8);
+            ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, "You have to load this plugin to see validation issues."u8);
         }
         else
         {
@@ -3435,7 +3435,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 ImGui.TextUnformatted(FontAwesomeIcon.Check.ToIconString());
                 ImGui.PopFont();
                 ImGui.SameLine();
-                ImGuiHelpers.SafeTextColored(ImGuiColors.HealerGreen, "No validation issues found in this plugin!"u8);
+                ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.HealerGreen, "No validation issues found in this plugin!"u8);
             }
             else
             {

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -3006,7 +3006,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 if (repoManifest?.IsTestingExclusive == true)
                     ImGui.BeginDisabled();
 
-                if (ImGui.MenuItem(Locs.PluginContext_TestingOptIn, (byte*)null, optIn != null))
+                if (ImGui.MenuItem(Locs.PluginContext_TestingOptIn, optIn != null))
                 {
                     if (optIn != null)
                     {

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -566,7 +566,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         var windowSize = ImGui.GetWindowSize();
         var titleHeight = ImGui.GetFontSize() + (ImGui.GetStyle().FramePadding.Y * 2);
 
-        using var loadingChild = ImRaii.Child("###installerLoadingFrame", new Vector2(-1, -1), false);
+        using var loadingChild = ImRaii.Child("###installerLoadingFrame"u8, new Vector2(-1, -1), false);
         if (loadingChild)
         {
             ImGui.GetWindowDrawList().PushClipRectFullScreen();
@@ -692,7 +692,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         var headerText = Locs.Header_Hint;
         var headerTextSize = ImGui.CalcTextSize(headerText);
-        ImGui.Text(headerText);
+        ImGui.TextUnformatted(headerText);
 
         ImGui.SameLine();
 
@@ -713,7 +713,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             var prevSearchText = this.searchText;
             ImGui.SetNextItemWidth(searchInputWidth);
             searchTextChanged |= ImGui.InputTextWithHint(
-                "###XlPluginInstaller_Search",
+                "###XlPluginInstaller_Search"u8,
                 Locs.Header_SearchPlaceholder,
                 ref this.searchText,
                 100,
@@ -925,7 +925,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (ImGui.BeginPopupModal(modalTitle, ref this.errorModalDrawing, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar))
         {
-            ImGui.Text(this.errorModalMessage);
+            ImGui.TextUnformatted(this.errorModalMessage);
             ImGui.Spacing();
 
             var buttonWidth = 120f;
@@ -961,7 +961,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (ImGui.BeginPopupModal(modalTitle, ref this.updateModalDrawing, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar))
         {
-            ImGui.Text(Locs.UpdateModal_UpdateAvailable(this.updateModalPlugin.Name));
+            ImGui.TextUnformatted(Locs.UpdateModal_UpdateAvailable(this.updateModalPlugin.Name));
             ImGui.Spacing();
 
             var buttonWidth = 120f;
@@ -1002,7 +1002,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (ImGui.BeginPopupModal(modalTitle, ref this.testingWarningModalDrawing, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar))
         {
-            ImGui.Text(Locs.TestingWarningModal_DowngradeBody);
+            ImGui.TextUnformatted(Locs.TestingWarningModal_DowngradeBody);
 
             ImGuiHelpers.ScaledDummy(10);
 
@@ -1047,11 +1047,11 @@ internal class PluginInstallerWindow : Window, IDisposable
             if (this.deletePluginConfigWarningModalExplainTesting)
             {
                 ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudOrange);
-                ImGui.Text(Locs.DeletePluginConfigWarningModal_ExplainTesting());
+                ImGui.TextUnformatted(Locs.DeletePluginConfigWarningModal_ExplainTesting());
                 ImGui.PopStyleColor();
             }
 
-            ImGui.Text(Locs.DeletePluginConfigWarningModal_Body(this.deletePluginConfigWarningModalPluginName));
+            ImGui.TextUnformatted(Locs.DeletePluginConfigWarningModal_Body(this.deletePluginConfigWarningModalPluginName));
             ImGui.Spacing();
 
             var buttonWidth = 120f;
@@ -1102,12 +1102,12 @@ internal class PluginInstallerWindow : Window, IDisposable
             if (this.pluginListUpdatable.Any(
                     up => up.InstalledPlugin.Manifest.InternalName == this.feedbackPlugin?.InternalName))
             {
-                ImGui.TextColored(ImGuiColors.DalamudRed, Locs.FeedbackModal_HasUpdate);
+                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, Locs.FeedbackModal_HasUpdate);
             }
 
             ImGui.Spacing();
 
-            ImGui.InputTextMultiline("###FeedbackContent", ref this.feedbackModalBody, 1000, new Vector2(400, 200));
+            ImGui.InputTextMultiline("###FeedbackContent"u8, ref this.feedbackModalBody, 1000, new Vector2(400, 200));
 
             ImGui.Spacing();
 
@@ -1123,18 +1123,18 @@ internal class PluginInstallerWindow : Window, IDisposable
                 });
             }
 
-            ImGui.Text(Locs.FeedbackModal_ContactInformationHelp);
+            ImGui.TextUnformatted(Locs.FeedbackModal_ContactInformationHelp);
 
-            ImGui.TextColored(ImGuiColors.DalamudRed, Locs.FeedbackModal_ContactInformationWarning);
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, Locs.FeedbackModal_ContactInformationWarning);
 
             ImGui.Spacing();
 
             ImGui.Checkbox(Locs.FeedbackModal_IncludeLastError, ref this.feedbackModalIncludeException);
-            ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.FeedbackModal_IncludeLastErrorHint);
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.FeedbackModal_IncludeLastErrorHint);
 
             ImGui.Spacing();
 
-            ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.FeedbackModal_Hint);
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.FeedbackModal_Hint);
 
             var buttonWidth = 120f;
             ImGui.SetCursorPosX((ImGui.GetWindowWidth() - buttonWidth) / 2);
@@ -1219,20 +1219,20 @@ internal class PluginInstallerWindow : Window, IDisposable
     {
         if (this.pluginListInstalled.Count == 0)
         {
-            ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.TabBody_SearchNoInstalled);
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.TabBody_SearchNoInstalled);
             return;
         }
 
         if (this.dalamudChangelogRefreshTask?.IsFaulted == true ||
             this.dalamudChangelogRefreshTask?.IsCanceled == true)
         {
-            ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.TabBody_ChangelogError);
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.TabBody_ChangelogError);
             return;
         }
 
         if (this.dalamudChangelogManager?.Changelogs == null)
         {
-            ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.TabBody_LoadingPlugins);
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.TabBody_LoadingPlugins);
 
             if (this.dalamudChangelogManager != null &&
                 this.dalamudChangelogRefreshTask == null)
@@ -1269,9 +1269,9 @@ internal class PluginInstallerWindow : Window, IDisposable
         var sortedChangelogs = changelogs?.Where(x => this.searchText.IsNullOrWhitespace() || new FuzzyMatcher(this.searchText.ToLowerInvariant(), MatchMode.FuzzyParts).Matches(x.Title.ToLowerInvariant()) > 0)
                                                             .OrderByDescending(x => x.Date).ToList();
 
-        if (sortedChangelogs == null || !sortedChangelogs.Any())
+        if (sortedChangelogs == null || sortedChangelogs.Count == 0)
         {
-            ImGui.TextColored(
+            ImGuiHelpers.SafeTextColored(
                 ImGuiColors.DalamudGrey2,
                 this.pluginListInstalled.Any(plugin => !plugin.Manifest.Changelog.IsNullOrEmpty())
                     ? Locs.TabBody_SearchNoMatching
@@ -1298,7 +1298,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (availableManifests.Count == 0)
         {
-            ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.TabBody_SearchNoCompatible);
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.TabBody_SearchNoCompatible);
             return proxies;
         }
 
@@ -1513,14 +1513,14 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         var useContentWidth = ImGui.GetContentRegionAvail().X;
 
-        using var installerMainChild = ImRaii.Child("InstallerCategories", new Vector2(useContentWidth, useContentHeight * ImGuiHelpers.GlobalScale));
+        using var installerMainChild = ImRaii.Child("InstallerCategories"u8, new Vector2(useContentWidth, useContentHeight * ImGuiHelpers.GlobalScale));
         if (installerMainChild)
         {
             using var style = ImRaii.PushStyle(ImGuiStyleVar.CellPadding, ImGuiHelpers.ScaledVector2(5, 0));
 
             try
             {
-                using (var categoriesChild = ImRaii.Child("InstallerCategoriesSelector", new Vector2(useMenuWidth * ImGuiHelpers.GlobalScale, -1), false))
+                using (var categoriesChild = ImRaii.Child("InstallerCategoriesSelector"u8, new Vector2(useMenuWidth * ImGuiHelpers.GlobalScale, -1), false))
                 {
                     if (categoriesChild)
                     {
@@ -1531,7 +1531,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 ImGui.SameLine();
 
                 using var scrollingChild =
-                    ImRaii.Child("ScrollingPlugins", new Vector2(-1, -1), false, ImGuiWindowFlags.NoBackground);
+                    ImRaii.Child("ScrollingPlugins"u8, new Vector2(-1, -1), false, ImGuiWindowFlags.NoBackground);
                 if (scrollingChild)
                 {
                     try
@@ -1706,7 +1706,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                         break;
 
                     default:
-                        ImGui.TextUnformatted("You found a mysterious category. Please keep it to yourself.");
+                        ImGui.TextUnformatted("You found a mysterious category. Please keep it to yourself."u8);
                         break;
                 }
 
@@ -1731,7 +1731,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                         break;
 
                     default:
-                        ImGui.TextUnformatted("You found a secret category. Please feel a sense of pride and accomplishment.");
+                        ImGui.TextUnformatted("You found a secret category. Please feel a sense of pride and accomplishment."u8);
                         break;
                 }
 
@@ -1752,7 +1752,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                         break;
 
                     default:
-                        ImGui.TextUnformatted("You found a quiet category. Please don't wake it up.");
+                        ImGui.TextUnformatted("You found a quiet category. Please don't wake it up."u8);
                         break;
                 }
 
@@ -1813,19 +1813,19 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         var cursor = ImGui.GetCursorPos();
         // Name
-        ImGui.Text("My Cool Plugin");
+        ImGui.TextUnformatted("My Cool Plugin"u8);
 
         // Download count
         var downloadCountText = Locs.PluginBody_AuthorWithDownloadCount("Plugin Enjoyer", 69420);
 
         ImGui.SameLine();
-        ImGui.TextColored(ImGuiColors.DalamudGrey3, downloadCountText);
+        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, downloadCountText);
 
         cursor.Y += ImGui.GetTextLineHeightWithSpacing();
         ImGui.SetCursorPos(cursor);
 
         // Description
-        ImGui.TextWrapped("This plugin does very many great things.");
+        ImGuiHelpers.SafeTextWrapped("This plugin does very many great things."u8);
 
         startCursor.Y += sectionSize;
         ImGui.SetCursorPos(startCursor);
@@ -1835,7 +1835,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         ImGui.Indent();
 
         // Description
-        ImGui.TextWrapped("This is a description.\nIt has multiple lines.\nTruly descriptive.");
+        ImGuiHelpers.SafeTextWrapped("This is a description.\nIt has multiple lines.\nTruly descriptive."u8);
 
         ImGuiHelpers.ScaledDummy(5);
 
@@ -1869,7 +1869,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             var width = ImGui.GetWindowWidth();
 
             if (ImGui.BeginChild(
-                    "pluginTestingImageScrolling",
+                    "pluginTestingImageScrolling"u8,
                     new Vector2(width - (70 * ImGuiHelpers.GlobalScale), (PluginImageCache.PluginImageHeight / thumbFactor) + scrollBarSize),
                     false,
                     ImGuiWindowFlags.HorizontalScrollbar |
@@ -1887,7 +1887,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
                         if (!imageTask.IsCompleted)
                         {
-                            ImGui.TextUnformatted("Loading...");
+                            ImGui.TextUnformatted("Loading..."u8);
                             continue;
                         }
 
@@ -1961,7 +1961,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
             if (!imageTask.IsCompleted)
             {
-                ImGui.Text("Loading...");
+                ImGui.TextUnformatted("Loading..."u8);
                 return;
             }
 
@@ -1987,27 +1987,27 @@ internal class PluginInstallerWindow : Window, IDisposable
             ImGui.PopStyleColor();
         }
 
-        ImGui.InputText("Icon Path", ref this.testerIconPath, 1000);
+        ImGui.InputText("Icon Path"u8, ref this.testerIconPath, 1000);
         if (this.testerIcon != null)
             CheckImageSize(this.testerIcon, PluginImageCache.PluginIconWidth, PluginImageCache.PluginIconHeight, true);
-        ImGui.InputText("Image 1 Path", ref this.testerImagePaths[0], 1000);
+        ImGui.InputText("Image 1 Path"u8, ref this.testerImagePaths[0], 1000);
         if (this.testerImages?.Length > 0)
             CheckImageSize(this.testerImages[0], PluginImageCache.PluginImageWidth, PluginImageCache.PluginImageHeight, false);
-        ImGui.InputText("Image 2 Path", ref this.testerImagePaths[1], 1000);
+        ImGui.InputText("Image 2 Path"u8, ref this.testerImagePaths[1], 1000);
         if (this.testerImages?.Length > 1)
             CheckImageSize(this.testerImages[1], PluginImageCache.PluginImageWidth, PluginImageCache.PluginImageHeight, false);
-        ImGui.InputText("Image 3 Path", ref this.testerImagePaths[2], 1000);
+        ImGui.InputText("Image 3 Path"u8, ref this.testerImagePaths[2], 1000);
         if (this.testerImages?.Length > 2)
             CheckImageSize(this.testerImages[2], PluginImageCache.PluginImageWidth, PluginImageCache.PluginImageHeight, false);
-        ImGui.InputText("Image 4 Path", ref this.testerImagePaths[3], 1000);
+        ImGui.InputText("Image 4 Path"u8, ref this.testerImagePaths[3], 1000);
         if (this.testerImages?.Length > 3)
             CheckImageSize(this.testerImages[3], PluginImageCache.PluginImageWidth, PluginImageCache.PluginImageHeight, false);
-        ImGui.InputText("Image 5 Path", ref this.testerImagePaths[4], 1000);
+        ImGui.InputText("Image 5 Path"u8, ref this.testerImagePaths[4], 1000);
         if (this.testerImages?.Length > 4)
             CheckImageSize(this.testerImages[4], PluginImageCache.PluginImageWidth, PluginImageCache.PluginImageHeight, false);
 
         var tm = Service<TextureManager>.Get();
-        if (ImGui.Button("Load"))
+        if (ImGui.Button("Load"u8))
         {
             try
             {
@@ -2039,8 +2039,8 @@ internal class PluginInstallerWindow : Window, IDisposable
             }
         }
 
-        ImGui.Checkbox("Failed", ref this.testerError);
-        ImGui.Checkbox("Has Update", ref this.testerUpdateAvailable);
+        ImGui.Checkbox("Failed"u8, ref this.testerError);
+        ImGui.Checkbox("Has Update"u8, ref this.testerUpdateAvailable);
     }
 
     private bool DrawPluginListLoading()
@@ -2051,7 +2051,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (!ready)
         {
-            ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.TabBody_LoadingPlugins);
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.TabBody_LoadingPlugins);
         }
 
         var failedRepos = pluginManager.Repos
@@ -2065,7 +2065,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                               .Select(repo => $"{failText} ({repo.PluginMasterUrl})")
                               .Aggregate((s1, s2) => $"{s1}\n{s2}");
 
-            ImGui.TextColored(ImGuiColors.DalamudRed, aggFailText);
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, aggFailText);
         }
 
         return ready;
@@ -2223,7 +2223,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         // Verified Checkmark or dev plugin wrench
         {
             ImGui.SameLine();
-            ImGui.Text(" ");
+            ImGui.TextUnformatted(" "u8);
             ImGui.SameLine();
 
             var verifiedOutlineColor = KnownColor.White.Vector() with { W = 0.75f };
@@ -2256,12 +2256,12 @@ internal class PluginInstallerWindow : Window, IDisposable
                                     : Locs.PluginBody_AuthorWithDownloadCountUnavailable(manifest.Author);
 
         ImGui.SameLine();
-        ImGui.TextColored(ImGuiColors.DalamudGrey3, downloadCountText);
+        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, downloadCountText);
 
         if (flags.HasFlag(PluginHeaderFlags.IsNew))
         {
             ImGui.SameLine();
-            ImGui.TextColored(ImGuiColors.TankBlue, Locs.PluginTitleMod_New);
+            ImGuiHelpers.SafeTextColored(ImGuiColors.TankBlue, Locs.PluginTitleMod_New);
         }
 
         cursor.Y += ImGui.GetTextLineHeightWithSpacing();
@@ -2271,7 +2271,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         if (flags.HasFlag(PluginHeaderFlags.IsIncompatible))
         {
             using var color = ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-            ImGui.TextWrapped(Locs.PluginBody_Incompatible);
+            ImGuiHelpers.SafeTextWrapped(Locs.PluginBody_Incompatible);
         }
         else if (plugin is { IsOutdated: true, IsBanned: false } || flags.HasFlag(PluginHeaderFlags.IsInstallableOutdated))
         {
@@ -2283,7 +2283,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             else
                 bodyText += Locs.PluginBody_Outdated_WaitForUpdate;
 
-            ImGui.TextWrapped(bodyText);
+            ImGuiHelpers.SafeTextWrapped(bodyText);
         }
         else if (plugin is { IsBanned: true })
         {
@@ -2307,20 +2307,20 @@ internal class PluginInstallerWindow : Window, IDisposable
         else if (plugin is { IsOrphaned: true })
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-            ImGui.TextWrapped(Locs.PluginBody_Orphaned);
+            ImGuiHelpers.SafeTextWrapped(Locs.PluginBody_Orphaned);
             ImGui.PopStyleColor();
         }
         else if (plugin is { IsDecommissioned: true, IsThirdParty: false })
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-            ImGui.TextWrapped(Locs.PluginBody_NoServiceOfficial);
+            ImGuiHelpers.SafeTextWrapped(Locs.PluginBody_NoServiceOfficial);
             ImGui.PopStyleColor();
         }
         else if (plugin is { IsDecommissioned: true, IsThirdParty: true })
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
 
-            ImGui.TextWrapped(
+            ImGuiHelpers.SafeTextWrapped(
                 flags.HasFlag(PluginHeaderFlags.MainRepoCrossUpdate)
                     ? Locs.PluginBody_NoServiceThirdCrossUpdate
                     : Locs.PluginBody_NoServiceThird);
@@ -2330,14 +2330,14 @@ internal class PluginInstallerWindow : Window, IDisposable
         else if (plugin != null && !plugin.CheckPolicy())
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-            ImGui.TextWrapped(Locs.PluginBody_Policy);
+            ImGuiHelpers.SafeTextWrapped(Locs.PluginBody_Policy);
             ImGui.PopStyleColor();
         }
         else if (plugin is { State: PluginState.LoadError or PluginState.DependencyResolutionFailed })
         {
             // Load failed warning
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-            ImGui.TextWrapped(Locs.PluginBody_LoadFailed);
+            ImGuiHelpers.SafeTextWrapped(Locs.PluginBody_LoadFailed);
             ImGui.PopStyleColor();
         }
 
@@ -2409,11 +2409,11 @@ internal class PluginInstallerWindow : Window, IDisposable
         ImGui.TextUnformatted(log.Title);
 
         ImGui.SameLine();
-        ImGui.TextColored(ImGuiColors.DalamudGrey3, $" v{log.Version}");
+        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, $" v{log.Version}");
         if (log.Author != null)
         {
             ImGui.SameLine();
-            ImGui.TextColored(ImGuiColors.DalamudGrey3, Locs.PluginBody_AuthorWithoutDownloadCount(log.Author));
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, Locs.PluginBody_AuthorWithoutDownloadCount(log.Author));
         }
 
         if (log.Date != DateTime.MinValue)
@@ -2421,7 +2421,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             var whenText = log.Date.LocRelativePastLong();
             var whenSize = ImGui.CalcTextSize(whenText);
             ImGui.SameLine(ImGui.GetWindowWidth() - whenSize.X - (25 * ImGuiHelpers.GlobalScale));
-            ImGui.TextColored(ImGuiColors.DalamudGrey3, whenText);
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, whenText);
             if (ImGui.IsItemHovered())
                 ImGui.SetTooltip("Published on " + log.Date.LocAbsolute());
         }
@@ -2518,7 +2518,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             if (manifest.SourceRepo.IsThirdParty)
             {
                 var repoText = Locs.PluginBody_Plugin3rdPartyRepo(manifest.SourceRepo.PluginMasterUrl);
-                ImGui.TextColored(ImGuiColors.DalamudGrey3, repoText);
+                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, repoText);
 
                 ImGuiHelpers.ScaledDummy(2);
             }
@@ -2588,7 +2588,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         var hasTestingVersionAvailable = configuration.DoPluginTest &&
                                          PluginManager.HasTestingVersion(manifest);
 
-        if (ImGui.BeginPopupContextItem("ItemContextMenu"))
+        if (ImGui.BeginPopupContextItem("ItemContextMenu"u8))
         {
             if (hasTestingVersionAvailable)
             {
@@ -2839,7 +2839,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                                        : Locs.PluginBody_AuthorWithDownloadCountUnavailable(manifest.Author);
 
             ImGui.SameLine();
-            ImGui.TextColored(ImGuiColors.DalamudGrey3, downloadText);
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, downloadText);
 
             var acceptsFeedback =
                 this.pluginListAvailable.Any(x => x.InternalName == plugin.InternalName && x.AcceptsFeedback);
@@ -2857,12 +2857,12 @@ internal class PluginInstallerWindow : Window, IDisposable
             if (plugin.IsDev)
             {
                 var fileText = Locs.PluginBody_DevPluginPath(plugin.DllFile.FullName);
-                ImGui.TextColored(ImGuiColors.DalamudGrey3, fileText);
+                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, fileText);
             }
             else if (isThirdParty)
             {
                 var repoText = Locs.PluginBody_Plugin3rdPartyRepo(manifest.InstalledFromUrl);
-                ImGui.TextColored(ImGuiColors.DalamudGrey3, repoText);
+                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, repoText);
             }
 
             // Description
@@ -2875,8 +2875,8 @@ internal class PluginInstallerWindow : Window, IDisposable
             if (this.hasDevPlugins)
             {
                 ImGuiHelpers.ScaledDummy(3);
-                ImGui.TextColored(ImGuiColors.DalamudGrey, $"WorkingPluginId: {plugin.EffectiveWorkingPluginId}");
-                ImGui.TextColored(ImGuiColors.DalamudGrey, $"Command prefix: {ConsoleManagerPluginUtil.GetSanitizedNamespaceName(plugin.InternalName)}");
+                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, $"WorkingPluginId: {plugin.EffectiveWorkingPluginId}");
+                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, $"Command prefix: {ConsoleManagerPluginUtil.GetSanitizedNamespaceName(plugin.InternalName)}");
                 ImGuiHelpers.ScaledDummy(3);
             }
 
@@ -2927,7 +2927,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             }
 
             ImGui.SameLine();
-            ImGui.TextColored(ImGuiColors.DalamudGrey3, $" v{plugin.EffectiveVersion}");
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, $" v{plugin.EffectiveVersion}");
 
             ImGuiHelpers.ScaledDummy(5);
 
@@ -2980,9 +2980,9 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(7, 5));
 
-        if (ImGui.BeginChild("##changelog", new Vector2(-1, 100), true, ImGuiWindowFlags.NoNavFocus | ImGuiWindowFlags.NoNavInputs | ImGuiWindowFlags.AlwaysAutoResize))
+        if (ImGui.BeginChild("##changelog"u8, new Vector2(-1, 100), true, ImGuiWindowFlags.NoNavFocus | ImGuiWindowFlags.NoNavInputs | ImGuiWindowFlags.AlwaysAutoResize))
         {
-            ImGui.Text("Changelog:");
+            ImGui.TextUnformatted("Changelog:"u8);
             ImGuiHelpers.ScaledDummy(2);
             ImGuiHelpers.SafeTextWrapped(changelog!);
         }
@@ -2993,12 +2993,12 @@ internal class PluginInstallerWindow : Window, IDisposable
         ImGui.PopStyleColor(2);
     }
 
-    private void DrawInstalledPluginContextMenu(LocalPlugin plugin, PluginTestingOptIn? optIn)
+    private unsafe void DrawInstalledPluginContextMenu(LocalPlugin plugin, PluginTestingOptIn? optIn)
     {
         var pluginManager = Service<PluginManager>.Get();
         var configuration = Service<DalamudConfiguration>.Get();
 
-        if (ImGui.BeginPopupContextItem("InstalledItemContextMenu"))
+        if (ImGui.BeginPopupContextItem("InstalledItemContextMenu"u8))
         {
             if (configuration.DoPluginTest)
             {
@@ -3006,7 +3006,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 if (repoManifest?.IsTestingExclusive == true)
                     ImGui.BeginDisabled();
 
-                if (ImGui.MenuItem(Locs.PluginContext_TestingOptIn, string.Empty, optIn != null))
+                if (ImGui.MenuItem(Locs.PluginContext_TestingOptIn, (byte*)null, optIn != null))
                 {
                     if (optIn != null)
                     {
@@ -3127,7 +3127,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             }
 
             if (!didAny)
-                ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.Profiles_None);
+                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.Profiles_None);
 
             ImGui.Separator();
 
@@ -3147,7 +3147,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             }
 
             ImGui.SameLine();
-            ImGui.Text(Locs.Profiles_RemoveFromAll);
+            ImGui.TextUnformatted(Locs.Profiles_RemoveFromAll);
 
             ImGui.EndPopup();
         }
@@ -3424,7 +3424,7 @@ internal class PluginInstallerWindow : Window, IDisposable
     {
         if (!devPlugin.IsLoaded)
         {
-            ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, "You have to load this plugin to see validation issues.");
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, "You have to load this plugin to see validation issues."u8);
         }
         else
         {
@@ -3432,10 +3432,10 @@ internal class PluginInstallerWindow : Window, IDisposable
             if (problems.Count == 0)
             {
                 ImGui.PushFont(InterfaceManager.IconFont);
-                ImGui.Text(FontAwesomeIcon.Check.ToIconString());
+                ImGui.TextUnformatted(FontAwesomeIcon.Check.ToIconString());
                 ImGui.PopFont();
                 ImGui.SameLine();
-                ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.HealerGreen, "No validation issues found in this plugin!");
+                ImGuiHelpers.SafeTextColored(ImGuiColors.HealerGreen, "No validation issues found in this plugin!"u8);
             }
             else
             {
@@ -3468,7 +3468,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
                                 if (ImGui.IsItemHovered())
                                 {
-                                    ImGui.SetTooltip("Dismiss this issue");
+                                    ImGui.SetTooltip("Dismiss this issue"u8);
                                 }
                             }
 
@@ -3489,13 +3489,13 @@ internal class PluginInstallerWindow : Window, IDisposable
                             switch (problem.Severity)
                             {
                                 case PluginValidator.ValidationSeverity.Fatal:
-                                    ImGui.Text(FontAwesomeIcon.TimesCircle.ToIconString());
+                                    ImGui.TextUnformatted(FontAwesomeIcon.TimesCircle.ToIconString());
                                     break;
                                 case PluginValidator.ValidationSeverity.Warning:
-                                    ImGui.Text(FontAwesomeIcon.ExclamationTriangle.ToIconString());
+                                    ImGui.TextUnformatted(FontAwesomeIcon.ExclamationTriangle.ToIconString());
                                     break;
                                 case PluginValidator.ValidationSeverity.Information:
-                                    ImGui.Text(FontAwesomeIcon.InfoCircle.ToIconString());
+                                    ImGui.TextUnformatted(FontAwesomeIcon.InfoCircle.ToIconString());
                                     break;
                                 default:
                                     throw new ArgumentOutOfRangeException();
@@ -3986,7 +3986,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 if (x is 0 && y is 0) continue;
 
                 ImGui.SetCursorPos(cursorStart + new Vector2(x, y));
-                ImGui.Text(icon.ToIconString());
+                ImGui.TextUnformatted(icon.ToIconString());
             }
         }
 
@@ -3994,7 +3994,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         ImGui.PushStyleColor(ImGuiCol.Text, iconColor);
         ImGui.SetCursorPos(cursorStart);
-        ImGui.Text(icon.ToIconString());
+        ImGui.TextUnformatted(icon.ToIconString());
         ImGui.PopStyleColor();
 
         ImGui.PopFont();

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -1096,13 +1096,13 @@ internal class PluginInstallerWindow : Window, IDisposable
 
             if (this.feedbackPlugin?.FeedbackMessage != null)
             {
-                ImGuiHelpers.SafeTextWrapped(this.feedbackPlugin.FeedbackMessage);
+                ImGui.TextWrapped(this.feedbackPlugin.FeedbackMessage);
             }
 
             if (this.pluginListUpdatable.Any(
                     up => up.InstalledPlugin.Manifest.InternalName == this.feedbackPlugin?.InternalName))
             {
-                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, Locs.FeedbackModal_HasUpdate);
+                ImGui.TextColored(ImGuiColors.DalamudRed, Locs.FeedbackModal_HasUpdate);
             }
 
             ImGui.Spacing();
@@ -1125,16 +1125,16 @@ internal class PluginInstallerWindow : Window, IDisposable
 
             ImGui.Text(Locs.FeedbackModal_ContactInformationHelp);
 
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, Locs.FeedbackModal_ContactInformationWarning);
+            ImGui.TextColored(ImGuiColors.DalamudRed, Locs.FeedbackModal_ContactInformationWarning);
 
             ImGui.Spacing();
 
             ImGui.Checkbox(Locs.FeedbackModal_IncludeLastError, ref this.feedbackModalIncludeException);
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.FeedbackModal_IncludeLastErrorHint);
+            ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.FeedbackModal_IncludeLastErrorHint);
 
             ImGui.Spacing();
 
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.FeedbackModal_Hint);
+            ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.FeedbackModal_Hint);
 
             var buttonWidth = 120f;
             ImGui.SetCursorPosX((ImGui.GetWindowWidth() - buttonWidth) / 2);
@@ -1219,20 +1219,20 @@ internal class PluginInstallerWindow : Window, IDisposable
     {
         if (this.pluginListInstalled.Count == 0)
         {
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.TabBody_SearchNoInstalled);
+            ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.TabBody_SearchNoInstalled);
             return;
         }
 
         if (this.dalamudChangelogRefreshTask?.IsFaulted == true ||
             this.dalamudChangelogRefreshTask?.IsCanceled == true)
         {
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.TabBody_ChangelogError);
+            ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.TabBody_ChangelogError);
             return;
         }
 
         if (this.dalamudChangelogManager?.Changelogs == null)
         {
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.TabBody_LoadingPlugins);
+            ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.TabBody_LoadingPlugins);
 
             if (this.dalamudChangelogManager != null &&
                 this.dalamudChangelogRefreshTask == null)
@@ -1271,7 +1271,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (sortedChangelogs == null || sortedChangelogs.Count == 0)
         {
-            ImGuiHelpers.SafeTextColored(
+            ImGui.TextColored(
                 ImGuiColors.DalamudGrey2,
                 this.pluginListInstalled.Any(plugin => !plugin.Manifest.Changelog.IsNullOrEmpty())
                     ? Locs.TabBody_SearchNoMatching
@@ -1298,7 +1298,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (availableManifests.Count == 0)
         {
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.TabBody_SearchNoCompatible);
+            ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.TabBody_SearchNoCompatible);
             return proxies;
         }
 
@@ -1819,13 +1819,13 @@ internal class PluginInstallerWindow : Window, IDisposable
         var downloadCountText = Locs.PluginBody_AuthorWithDownloadCount("Plugin Enjoyer", 69420);
 
         ImGui.SameLine();
-        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, downloadCountText);
+        ImGui.TextColored(ImGuiColors.DalamudGrey3, downloadCountText);
 
         cursor.Y += ImGui.GetTextLineHeightWithSpacing();
         ImGui.SetCursorPos(cursor);
 
         // Description
-        ImGuiHelpers.SafeTextWrapped("This plugin does very many great things."u8);
+        ImGui.TextWrapped("This plugin does very many great things."u8);
 
         startCursor.Y += sectionSize;
         ImGui.SetCursorPos(startCursor);
@@ -1835,7 +1835,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         ImGui.Indent();
 
         // Description
-        ImGuiHelpers.SafeTextWrapped("This is a description.\nIt has multiple lines.\nTruly descriptive."u8);
+        ImGui.TextWrapped("This is a description.\nIt has multiple lines.\nTruly descriptive."u8);
 
         ImGuiHelpers.ScaledDummy(5);
 
@@ -2051,7 +2051,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (!ready)
         {
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.TabBody_LoadingPlugins);
+            ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.TabBody_LoadingPlugins);
         }
 
         var failedRepos = pluginManager.Repos
@@ -2065,7 +2065,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                               .Select(repo => $"{failText} ({repo.PluginMasterUrl})")
                               .Aggregate((s1, s2) => $"{s1}\n{s2}");
 
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, aggFailText);
+            ImGui.TextColored(ImGuiColors.DalamudRed, aggFailText);
         }
 
         return ready;
@@ -2256,12 +2256,12 @@ internal class PluginInstallerWindow : Window, IDisposable
                                     : Locs.PluginBody_AuthorWithDownloadCountUnavailable(manifest.Author);
 
         ImGui.SameLine();
-        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, downloadCountText);
+        ImGui.TextColored(ImGuiColors.DalamudGrey3, downloadCountText);
 
         if (flags.HasFlag(PluginHeaderFlags.IsNew))
         {
             ImGui.SameLine();
-            ImGuiHelpers.SafeTextColored(ImGuiColors.TankBlue, Locs.PluginTitleMod_New);
+            ImGui.TextColored(ImGuiColors.TankBlue, Locs.PluginTitleMod_New);
         }
 
         cursor.Y += ImGui.GetTextLineHeightWithSpacing();
@@ -2271,7 +2271,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         if (flags.HasFlag(PluginHeaderFlags.IsIncompatible))
         {
             using var color = ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-            ImGuiHelpers.SafeTextWrapped(Locs.PluginBody_Incompatible);
+            ImGui.TextWrapped(Locs.PluginBody_Incompatible);
         }
         else if (plugin is { IsOutdated: true, IsBanned: false } || flags.HasFlag(PluginHeaderFlags.IsInstallableOutdated))
         {
@@ -2283,7 +2283,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             else
                 bodyText += Locs.PluginBody_Outdated_WaitForUpdate;
 
-            ImGuiHelpers.SafeTextWrapped(bodyText);
+            ImGui.TextWrapped(bodyText);
         }
         else if (plugin is { IsBanned: true })
         {
@@ -2300,27 +2300,27 @@ internal class PluginInstallerWindow : Window, IDisposable
             else
                 bodyText += Locs.PluginBody_Outdated_WaitForUpdate;
 
-            ImGuiHelpers.SafeTextWrapped(bodyText);
+            ImGui.TextWrapped(bodyText);
 
             ImGui.PopStyleColor();
         }
         else if (plugin is { IsOrphaned: true })
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-            ImGuiHelpers.SafeTextWrapped(Locs.PluginBody_Orphaned);
+            ImGui.TextWrapped(Locs.PluginBody_Orphaned);
             ImGui.PopStyleColor();
         }
         else if (plugin is { IsDecommissioned: true, IsThirdParty: false })
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-            ImGuiHelpers.SafeTextWrapped(Locs.PluginBody_NoServiceOfficial);
+            ImGui.TextWrapped(Locs.PluginBody_NoServiceOfficial);
             ImGui.PopStyleColor();
         }
         else if (plugin is { IsDecommissioned: true, IsThirdParty: true })
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
 
-            ImGuiHelpers.SafeTextWrapped(
+            ImGui.TextWrapped(
                 flags.HasFlag(PluginHeaderFlags.MainRepoCrossUpdate)
                     ? Locs.PluginBody_NoServiceThirdCrossUpdate
                     : Locs.PluginBody_NoServiceThird);
@@ -2330,14 +2330,14 @@ internal class PluginInstallerWindow : Window, IDisposable
         else if (plugin != null && !plugin.CheckPolicy())
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-            ImGuiHelpers.SafeTextWrapped(Locs.PluginBody_Policy);
+            ImGui.TextWrapped(Locs.PluginBody_Policy);
             ImGui.PopStyleColor();
         }
         else if (plugin is { State: PluginState.LoadError or PluginState.DependencyResolutionFailed })
         {
             // Load failed warning
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-            ImGuiHelpers.SafeTextWrapped(Locs.PluginBody_LoadFailed);
+            ImGui.TextWrapped(Locs.PluginBody_LoadFailed);
             ImGui.PopStyleColor();
         }
 
@@ -2348,14 +2348,14 @@ internal class PluginInstallerWindow : Window, IDisposable
         {
             if (!string.IsNullOrWhiteSpace(manifest.Punchline))
             {
-                ImGuiHelpers.SafeTextWrapped(manifest.Punchline);
+                ImGui.TextWrapped(manifest.Punchline);
             }
             else if (!string.IsNullOrWhiteSpace(manifest.Description))
             {
                 const int punchlineLen = 200;
                 var firstLine = manifest.Description.Split(new[] { '\r', '\n' })[0];
 
-                ImGuiHelpers.SafeTextWrapped(firstLine.Length < punchlineLen
+                ImGui.TextWrapped(firstLine.Length < punchlineLen
                                                  ? firstLine
                                                  : firstLine[..punchlineLen]);
             }
@@ -2409,11 +2409,11 @@ internal class PluginInstallerWindow : Window, IDisposable
         ImGui.Text(log.Title);
 
         ImGui.SameLine();
-        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, $" v{log.Version}");
+        ImGui.TextColored(ImGuiColors.DalamudGrey3, $" v{log.Version}");
         if (log.Author != null)
         {
             ImGui.SameLine();
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, Locs.PluginBody_AuthorWithoutDownloadCount(log.Author));
+            ImGui.TextColored(ImGuiColors.DalamudGrey3, Locs.PluginBody_AuthorWithoutDownloadCount(log.Author));
         }
 
         if (log.Date != DateTime.MinValue)
@@ -2421,7 +2421,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             var whenText = log.Date.LocRelativePastLong();
             var whenSize = ImGui.CalcTextSize(whenText);
             ImGui.SameLine(ImGui.GetWindowWidth() - whenSize.X - (25 * ImGuiHelpers.GlobalScale));
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, whenText);
+            ImGui.TextColored(ImGuiColors.DalamudGrey3, whenText);
             if (ImGui.IsItemHovered())
                 ImGui.SetTooltip("Published on " + log.Date.LocAbsolute());
         }
@@ -2429,7 +2429,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         cursor.Y += ImGui.GetTextLineHeightWithSpacing();
         ImGui.SetCursorPos(cursor);
 
-        ImGuiHelpers.SafeTextWrapped(log.Text);
+        ImGui.TextWrapped(log.Text);
 
         var endCursor = ImGui.GetCursorPos();
 
@@ -2518,7 +2518,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             if (manifest.SourceRepo.IsThirdParty)
             {
                 var repoText = Locs.PluginBody_Plugin3rdPartyRepo(manifest.SourceRepo.PluginMasterUrl);
-                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, repoText);
+                ImGui.TextColored(ImGuiColors.DalamudGrey3, repoText);
 
                 ImGuiHelpers.ScaledDummy(2);
             }
@@ -2526,7 +2526,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             // Description
             if (!string.IsNullOrWhiteSpace(manifest.Description))
             {
-                ImGuiHelpers.SafeTextWrapped(manifest.Description);
+                ImGui.TextWrapped(manifest.Description);
             }
 
             ImGuiHelpers.ScaledDummy(5);
@@ -2839,7 +2839,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                                        : Locs.PluginBody_AuthorWithDownloadCountUnavailable(manifest.Author);
 
             ImGui.SameLine();
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, downloadText);
+            ImGui.TextColored(ImGuiColors.DalamudGrey3, downloadText);
 
             var acceptsFeedback =
                 this.pluginListAvailable.Any(x => x.InternalName == plugin.InternalName && x.AcceptsFeedback);
@@ -2857,26 +2857,26 @@ internal class PluginInstallerWindow : Window, IDisposable
             if (plugin.IsDev)
             {
                 var fileText = Locs.PluginBody_DevPluginPath(plugin.DllFile.FullName);
-                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, fileText);
+                ImGui.TextColored(ImGuiColors.DalamudGrey3, fileText);
             }
             else if (isThirdParty)
             {
                 var repoText = Locs.PluginBody_Plugin3rdPartyRepo(manifest.InstalledFromUrl);
-                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, repoText);
+                ImGui.TextColored(ImGuiColors.DalamudGrey3, repoText);
             }
 
             // Description
             if (!string.IsNullOrWhiteSpace(manifest.Description))
             {
-                ImGuiHelpers.SafeTextWrapped(manifest.Description);
+                ImGui.TextWrapped(manifest.Description);
             }
 
             // Working Plugin ID
             if (this.hasDevPlugins)
             {
                 ImGuiHelpers.ScaledDummy(3);
-                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, $"WorkingPluginId: {plugin.EffectiveWorkingPluginId}");
-                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, $"Command prefix: {ConsoleManagerPluginUtil.GetSanitizedNamespaceName(plugin.InternalName)}");
+                ImGui.TextColored(ImGuiColors.DalamudGrey, $"WorkingPluginId: {plugin.EffectiveWorkingPluginId}");
+                ImGui.TextColored(ImGuiColors.DalamudGrey, $"Command prefix: {ConsoleManagerPluginUtil.GetSanitizedNamespaceName(plugin.InternalName)}");
                 ImGuiHelpers.ScaledDummy(3);
             }
 
@@ -2895,7 +2895,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                         .OrderBy(cInfo => cInfo.Value.DisplayOrder)
                         .ThenBy(cInfo => cInfo.Key))
                     {
-                        ImGuiHelpers.SafeTextWrapped($"{command.Key} → {command.Value.HelpMessage}");
+                        ImGui.TextWrapped($"{command.Key} → {command.Value.HelpMessage}");
                     }
 
                     ImGuiHelpers.ScaledDummy(3);
@@ -2927,7 +2927,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             }
 
             ImGui.SameLine();
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, $" v{plugin.EffectiveVersion}");
+            ImGui.TextColored(ImGuiColors.DalamudGrey3, $" v{plugin.EffectiveVersion}");
 
             ImGuiHelpers.ScaledDummy(5);
 
@@ -2984,7 +2984,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         {
             ImGui.Text("Changelog:"u8);
             ImGuiHelpers.ScaledDummy(2);
-            ImGuiHelpers.SafeTextWrapped(changelog!);
+            ImGui.TextWrapped(changelog!);
         }
 
         ImGui.EndChild();
@@ -3127,7 +3127,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             }
 
             if (!didAny)
-                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.Profiles_None);
+                ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.Profiles_None);
 
             ImGui.Separator();
 
@@ -3424,7 +3424,7 @@ internal class PluginInstallerWindow : Window, IDisposable
     {
         if (!devPlugin.IsLoaded)
         {
-            ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, "You have to load this plugin to see validation issues."u8);
+            ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, "You have to load this plugin to see validation issues."u8);
         }
         else
         {
@@ -3435,7 +3435,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 ImGui.Text(FontAwesomeIcon.Check.ToIconString());
                 ImGui.PopFont();
                 ImGui.SameLine();
-                ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.HealerGreen, "No validation issues found in this plugin!"u8);
+                ImGui.TextColoredWrapped(ImGuiColors.HealerGreen, "No validation issues found in this plugin!"u8);
             }
             else
             {
@@ -3506,7 +3506,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
                         using (ImRaii.PushColor(ImGuiCol.Text, thisProblemIsDismissed ? ImGuiColors.DalamudGrey : ImGuiColors.DalamudWhite))
                         {
-                            ImGuiHelpers.SafeTextWrapped(problem.GetLocalizedDescription());
+                            ImGui.TextWrapped(problem.GetLocalizedDescription());
                         }
                     }
                 }

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -692,7 +692,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         var headerText = Locs.Header_Hint;
         var headerTextSize = ImGui.CalcTextSize(headerText);
-        ImGui.TextUnformatted(headerText);
+        ImGui.Text(headerText);
 
         ImGui.SameLine();
 
@@ -925,7 +925,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (ImGui.BeginPopupModal(modalTitle, ref this.errorModalDrawing, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar))
         {
-            ImGui.TextUnformatted(this.errorModalMessage);
+            ImGui.Text(this.errorModalMessage);
             ImGui.Spacing();
 
             var buttonWidth = 120f;
@@ -961,7 +961,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (ImGui.BeginPopupModal(modalTitle, ref this.updateModalDrawing, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar))
         {
-            ImGui.TextUnformatted(Locs.UpdateModal_UpdateAvailable(this.updateModalPlugin.Name));
+            ImGui.Text(Locs.UpdateModal_UpdateAvailable(this.updateModalPlugin.Name));
             ImGui.Spacing();
 
             var buttonWidth = 120f;
@@ -1002,7 +1002,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (ImGui.BeginPopupModal(modalTitle, ref this.testingWarningModalDrawing, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar))
         {
-            ImGui.TextUnformatted(Locs.TestingWarningModal_DowngradeBody);
+            ImGui.Text(Locs.TestingWarningModal_DowngradeBody);
 
             ImGuiHelpers.ScaledDummy(10);
 
@@ -1047,11 +1047,11 @@ internal class PluginInstallerWindow : Window, IDisposable
             if (this.deletePluginConfigWarningModalExplainTesting)
             {
                 ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudOrange);
-                ImGui.TextUnformatted(Locs.DeletePluginConfigWarningModal_ExplainTesting());
+                ImGui.Text(Locs.DeletePluginConfigWarningModal_ExplainTesting());
                 ImGui.PopStyleColor();
             }
 
-            ImGui.TextUnformatted(Locs.DeletePluginConfigWarningModal_Body(this.deletePluginConfigWarningModalPluginName));
+            ImGui.Text(Locs.DeletePluginConfigWarningModal_Body(this.deletePluginConfigWarningModalPluginName));
             ImGui.Spacing();
 
             var buttonWidth = 120f;
@@ -1092,7 +1092,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (ImGui.BeginPopupModal(modalTitle, ref this.feedbackModalDrawing, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar))
         {
-            ImGui.TextUnformatted(Locs.FeedbackModal_Text(this.feedbackPlugin.Name));
+            ImGui.Text(Locs.FeedbackModal_Text(this.feedbackPlugin.Name));
 
             if (this.feedbackPlugin?.FeedbackMessage != null)
             {
@@ -1123,7 +1123,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 });
             }
 
-            ImGui.TextUnformatted(Locs.FeedbackModal_ContactInformationHelp);
+            ImGui.Text(Locs.FeedbackModal_ContactInformationHelp);
 
             ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, Locs.FeedbackModal_ContactInformationWarning);
 
@@ -1706,7 +1706,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                         break;
 
                     default:
-                        ImGui.TextUnformatted("You found a mysterious category. Please keep it to yourself."u8);
+                        ImGui.Text("You found a mysterious category. Please keep it to yourself."u8);
                         break;
                 }
 
@@ -1731,7 +1731,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                         break;
 
                     default:
-                        ImGui.TextUnformatted("You found a secret category. Please feel a sense of pride and accomplishment."u8);
+                        ImGui.Text("You found a secret category. Please feel a sense of pride and accomplishment."u8);
                         break;
                 }
 
@@ -1752,7 +1752,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                         break;
 
                     default:
-                        ImGui.TextUnformatted("You found a quiet category. Please don't wake it up."u8);
+                        ImGui.Text("You found a quiet category. Please don't wake it up."u8);
                         break;
                 }
 
@@ -1813,7 +1813,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         var cursor = ImGui.GetCursorPos();
         // Name
-        ImGui.TextUnformatted("My Cool Plugin"u8);
+        ImGui.Text("My Cool Plugin"u8);
 
         // Download count
         var downloadCountText = Locs.PluginBody_AuthorWithDownloadCount("Plugin Enjoyer", 69420);
@@ -1887,13 +1887,13 @@ internal class PluginInstallerWindow : Window, IDisposable
 
                         if (!imageTask.IsCompleted)
                         {
-                            ImGui.TextUnformatted("Loading..."u8);
+                            ImGui.Text("Loading..."u8);
                             continue;
                         }
 
                         if (imageTask.Exception is not null)
                         {
-                            ImGui.TextUnformatted(imageTask.Exception.ToString());
+                            ImGui.Text(imageTask.Exception.ToString());
                             continue;
                         }
 
@@ -1961,7 +1961,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
             if (!imageTask.IsCompleted)
             {
-                ImGui.TextUnformatted("Loading..."u8);
+                ImGui.Text("Loading..."u8);
                 return;
             }
 
@@ -1969,19 +1969,19 @@ internal class PluginInstallerWindow : Window, IDisposable
 
             if (imageTask.Exception is { } exc)
             {
-                ImGui.TextUnformatted(exc.ToString());
+                ImGui.Text(exc.ToString());
             }
             else
             {
                 var image = imageTask.Result;
                 if (image.Width > maxWidth || image.Height > maxHeight)
                 {
-                    ImGui.TextUnformatted(
+                    ImGui.Text(
                         $"Image is larger than the maximum allowed resolution ({image.Width}x{image.Height} > {maxWidth}x{maxHeight})");
                 }
 
                 if (requireSquare && image.Width != image.Height)
-                    ImGui.TextUnformatted($"Image must be square! Current size: {image.Width}x{image.Height}");
+                    ImGui.Text($"Image must be square! Current size: {image.Width}x{image.Height}");
             }
 
             ImGui.PopStyleColor();
@@ -2218,12 +2218,12 @@ internal class PluginInstallerWindow : Window, IDisposable
         var cursor = ImGui.GetCursorPos();
 
         // Name
-        ImGui.TextUnformatted(label);
+        ImGui.Text(label);
 
         // Verified Checkmark or dev plugin wrench
         {
             ImGui.SameLine();
-            ImGui.TextUnformatted(" "u8);
+            ImGui.Text(" "u8);
             ImGui.SameLine();
 
             var verifiedOutlineColor = KnownColor.White.Vector() with { W = 0.75f };
@@ -2406,7 +2406,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         ImGui.SameLine();
         var cursor = ImGui.GetCursorPos();
-        ImGui.TextUnformatted(log.Title);
+        ImGui.Text(log.Title);
 
         ImGui.SameLine();
         ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey3, $" v{log.Version}");
@@ -2829,7 +2829,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             ImGui.Indent();
 
             // Name
-            ImGui.TextUnformatted(manifest.Name);
+            ImGui.Text(manifest.Name);
 
             // Download count
             var downloadText = plugin.IsDev
@@ -2982,7 +2982,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (ImGui.BeginChild("##changelog"u8, new Vector2(-1, 100), true, ImGuiWindowFlags.NoNavFocus | ImGuiWindowFlags.NoNavInputs | ImGuiWindowFlags.AlwaysAutoResize))
         {
-            ImGui.TextUnformatted("Changelog:"u8);
+            ImGui.Text("Changelog:"u8);
             ImGuiHelpers.ScaledDummy(2);
             ImGuiHelpers.SafeTextWrapped(changelog!);
         }
@@ -3121,7 +3121,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
                 ImGui.SameLine();
 
-                ImGui.TextUnformatted(profile.Name);
+                ImGui.Text(profile.Name);
 
                 didAny = true;
             }
@@ -3147,7 +3147,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             }
 
             ImGui.SameLine();
-            ImGui.TextUnformatted(Locs.Profiles_RemoveFromAll);
+            ImGui.Text(Locs.Profiles_RemoveFromAll);
 
             ImGui.EndPopup();
         }
@@ -3432,7 +3432,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             if (problems.Count == 0)
             {
                 ImGui.PushFont(InterfaceManager.IconFont);
-                ImGui.TextUnformatted(FontAwesomeIcon.Check.ToIconString());
+                ImGui.Text(FontAwesomeIcon.Check.ToIconString());
                 ImGui.PopFont();
                 ImGui.SameLine();
                 ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.HealerGreen, "No validation issues found in this plugin!"u8);
@@ -3489,13 +3489,13 @@ internal class PluginInstallerWindow : Window, IDisposable
                             switch (problem.Severity)
                             {
                                 case PluginValidator.ValidationSeverity.Fatal:
-                                    ImGui.TextUnformatted(FontAwesomeIcon.TimesCircle.ToIconString());
+                                    ImGui.Text(FontAwesomeIcon.TimesCircle.ToIconString());
                                     break;
                                 case PluginValidator.ValidationSeverity.Warning:
-                                    ImGui.TextUnformatted(FontAwesomeIcon.ExclamationTriangle.ToIconString());
+                                    ImGui.Text(FontAwesomeIcon.ExclamationTriangle.ToIconString());
                                     break;
                                 case PluginValidator.ValidationSeverity.Information:
-                                    ImGui.TextUnformatted(FontAwesomeIcon.InfoCircle.ToIconString());
+                                    ImGui.Text(FontAwesomeIcon.InfoCircle.ToIconString());
                                     break;
                                 default:
                                     throw new ArgumentOutOfRangeException();
@@ -3986,7 +3986,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 if (x is 0 && y is 0) continue;
 
                 ImGui.SetCursorPos(cursorStart + new Vector2(x, y));
-                ImGui.TextUnformatted(icon.ToIconString());
+                ImGui.Text(icon.ToIconString());
             }
         }
 
@@ -3994,7 +3994,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         ImGui.PushStyleColor(ImGuiCol.Text, iconColor);
         ImGui.SetCursorPos(cursorStart);
-        ImGui.TextUnformatted(icon.ToIconString());
+        ImGui.Text(icon.ToIconString());
         ImGui.PopStyleColor();
 
         ImGui.PopFont();

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/ProfileManagerWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/ProfileManagerWidget.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
 
@@ -108,7 +108,7 @@ internal class ProfileManagerWidget
         {
             if (popup)
             {
-                using var scrolling = ImRaii.Child("###scrolling", new Vector2(-1, -1));
+                using var scrolling = ImRaii.Child("###scrolling"u8, new Vector2(-1, -1));
                 if (scrolling)
                 {
                     ImGuiHelpers.SafeTextWrapped(Locs.TutorialParagraphOne);
@@ -138,7 +138,7 @@ internal class ProfileManagerWidget
 
                     var buttonWidth = 120f;
                     ImGui.SetCursorPosX((ImGui.GetWindowWidth() - buttonWidth) / 2);
-                    if (ImGui.Button("OK", new Vector2(buttonWidth, 40)))
+                    if (ImGui.Button("OK"u8, new Vector2(buttonWidth, 40)))
                     {
                         ImGui.CloseCurrentPopup();
                     }
@@ -202,7 +202,7 @@ internal class ProfileManagerWidget
 
         var windowSize = ImGui.GetWindowSize();
 
-        using var profileChooserChild = ImRaii.Child("###profileChooserScrolling");
+        using var profileChooserChild = ImRaii.Child("###profileChooserScrolling"u8);
         if (profileChooserChild)
         {
             Guid? toCloneGuid = null;
@@ -227,7 +227,7 @@ internal class ProfileManagerWidget
                 // Center text in frame height
                 var textHeight = ImGui.CalcTextSize(profile.Name);
                 ImGui.SetCursorPosY(ImGui.GetCursorPosY() + (ImGui.GetFrameHeight() / 2) - (textHeight.Y / 2));
-                ImGui.Text(profile.Name);
+                ImGui.TextUnformatted(profile.Name);
 
                 ImGui.SameLine();
                 ImGui.SetCursorPosX(windowSize.X - (ImGuiHelpers.GlobalScale * 30));
@@ -378,7 +378,7 @@ internal class ProfileManagerWidget
         ImGui.SameLine();
 
         ImGui.SetNextItemWidth(windowSize.X / 3);
-        if (ImGui.InputText("###profileNameInput", ref this.profileNameEdit, 255))
+        if (ImGui.InputText("###profileNameInput"u8, ref this.profileNameEdit, 255))
         {
             profile.Name = this.profileNameEdit;
         }
@@ -401,7 +401,7 @@ internal class ProfileManagerWidget
         ImGuiHelpers.ScaledDummy(5);
 
         ImGui.TextUnformatted(Locs.StartupBehavior);
-        if (ImGui.BeginCombo("##startupBehaviorPicker", Locs.PolicyToLocalisedName(profile.StartupPolicy)))
+        if (ImGui.BeginCombo("##startupBehaviorPicker"u8, Locs.PolicyToLocalisedName(profile.StartupPolicy)))
         {
             foreach (var policy in Enum.GetValues(typeof(ProfileModelV1.ProfileStartupPolicy)).Cast<ProfileModelV1.ProfileStartupPolicy>())
             {
@@ -420,7 +420,7 @@ internal class ProfileManagerWidget
         ImGui.Separator();
         var wantPluginAddPopup = false;
 
-        using var pluginListChild = ImRaii.Child("###profileEditorPluginList");
+        using var pluginListChild = ImRaii.Child("###profileEditorPluginList"u8);
         if (pluginListChild)
         {
             var pluginLineHeight = 32 * ImGuiHelpers.GlobalScale;
@@ -479,7 +479,7 @@ internal class ProfileManagerWidget
 
                     if (firstAvailableInstalled != null)
                     {
-                        ImGui.Text($"Match to plugin '{firstAvailableInstalled.Name}'?");
+                        ImGui.TextUnformatted($"Match to plugin '{firstAvailableInstalled.Name}'?");
                         ImGui.SameLine();
                         if (ImGuiComponents.IconButtonWithText(
                                 FontAwesomeIcon.Check,
@@ -557,7 +557,7 @@ internal class ProfileManagerWidget
 
             if (!didAny)
             {
-                ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.NoPluginsInProfile);
+                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.NoPluginsInProfile);
             }
 
             ImGuiHelpers.ScaledDummy(10);

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/ProfileManagerWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/ProfileManagerWidget.cs
@@ -227,7 +227,7 @@ internal class ProfileManagerWidget
                 // Center text in frame height
                 var textHeight = ImGui.CalcTextSize(profile.Name);
                 ImGui.SetCursorPosY(ImGui.GetCursorPosY() + (ImGui.GetFrameHeight() / 2) - (textHeight.Y / 2));
-                ImGui.TextUnformatted(profile.Name);
+                ImGui.Text(profile.Name);
 
                 ImGui.SameLine();
                 ImGui.SetCursorPosX(windowSize.X - (ImGuiHelpers.GlobalScale * 30));
@@ -400,7 +400,7 @@ internal class ProfileManagerWidget
 
         ImGuiHelpers.ScaledDummy(5);
 
-        ImGui.TextUnformatted(Locs.StartupBehavior);
+        ImGui.Text(Locs.StartupBehavior);
         if (ImGui.BeginCombo("##startupBehaviorPicker"u8, Locs.PolicyToLocalisedName(profile.StartupPolicy)))
         {
             foreach (var policy in Enum.GetValues(typeof(ProfileModelV1.ProfileStartupPolicy)).Cast<ProfileModelV1.ProfileStartupPolicy>())
@@ -456,7 +456,7 @@ internal class ProfileManagerWidget
                     var before = ImGui.GetCursorPos();
 
                     ImGui.SetCursorPosY(ImGui.GetCursorPosY() + (pluginLineHeight / 2) - (textHeight.Y / 2));
-                    ImGui.TextUnformatted(text);
+                    ImGui.Text(text);
 
                     ImGui.SetCursorPos(before);
                 }
@@ -470,7 +470,7 @@ internal class ProfileManagerWidget
                     var before = ImGui.GetCursorPos();
 
                     ImGui.SetCursorPosY(ImGui.GetCursorPosY() + (pluginLineHeight / 2) - (textHeight.Y / 2));
-                    ImGui.TextUnformatted(text);
+                    ImGui.Text(text);
 
                     var firstAvailableInstalled = pm.InstalledPlugins.FirstOrDefault(x => x.InternalName == profileEntry.InternalName);
                     var installable =
@@ -479,7 +479,7 @@ internal class ProfileManagerWidget
 
                     if (firstAvailableInstalled != null)
                     {
-                        ImGui.TextUnformatted($"Match to plugin '{firstAvailableInstalled.Name}'?");
+                        ImGui.Text($"Match to plugin '{firstAvailableInstalled.Name}'?");
                         ImGui.SameLine();
                         if (ImGuiComponents.IconButtonWithText(
                                 FontAwesomeIcon.Check,
@@ -572,7 +572,7 @@ internal class ProfileManagerWidget
             ImGuiHelpers.ScaledDummy(5);
             ImGui.SameLine();
 
-            ImGui.TextUnformatted(addPluginsText);
+            ImGui.Text(addPluginsText);
 
             ImGuiHelpers.ScaledDummy(10);
         }

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/ProfileManagerWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/ProfileManagerWidget.cs
@@ -111,29 +111,29 @@ internal class ProfileManagerWidget
                 using var scrolling = ImRaii.Child("###scrolling"u8, new Vector2(-1, -1));
                 if (scrolling)
                 {
-                    ImGuiHelpers.SafeTextWrapped(Locs.TutorialParagraphOne);
+                    ImGui.TextWrapped(Locs.TutorialParagraphOne);
                     ImGuiHelpers.ScaledDummy(5);
-                    ImGuiHelpers.SafeTextWrapped(Locs.TutorialParagraphTwo);
+                    ImGui.TextWrapped(Locs.TutorialParagraphTwo);
                     ImGuiHelpers.ScaledDummy(5);
-                    ImGuiHelpers.SafeTextWrapped(Locs.TutorialParagraphThree);
+                    ImGui.TextWrapped(Locs.TutorialParagraphThree);
                     ImGuiHelpers.ScaledDummy(5);
-                    ImGuiHelpers.SafeTextWrapped(Locs.TutorialParagraphFour);
+                    ImGui.TextWrapped(Locs.TutorialParagraphFour);
                     ImGuiHelpers.ScaledDummy(5);
-                    ImGuiHelpers.SafeTextWrapped(Locs.TutorialCommands);
+                    ImGui.TextWrapped(Locs.TutorialCommands);
 
                     ImGui.Bullet();
                     ImGui.SameLine();
-                    ImGuiHelpers.SafeTextWrapped(Locs.TutorialCommandsEnable);
+                    ImGui.TextWrapped(Locs.TutorialCommandsEnable);
 
                     ImGui.Bullet();
                     ImGui.SameLine();
-                    ImGuiHelpers.SafeTextWrapped(Locs.TutorialCommandsDisable);
+                    ImGui.TextWrapped(Locs.TutorialCommandsDisable);
 
                     ImGui.Bullet();
                     ImGui.SameLine();
-                    ImGuiHelpers.SafeTextWrapped(Locs.TutorialCommandsToggle);
+                    ImGui.TextWrapped(Locs.TutorialCommandsToggle);
 
-                    ImGuiHelpers.SafeTextWrapped(Locs.TutorialCommandsEnd);
+                    ImGui.TextWrapped(Locs.TutorialCommandsEnd);
                     ImGuiHelpers.ScaledDummy(5);
 
                     var buttonWidth = 120f;
@@ -557,7 +557,7 @@ internal class ProfileManagerWidget
 
             if (!didAny)
             {
-                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, Locs.NoPluginsInProfile);
+                ImGui.TextColored(ImGuiColors.DalamudGrey, Locs.NoPluginsInProfile);
             }
 
             ImGuiHelpers.ScaledDummy(10);

--- a/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
@@ -45,17 +45,17 @@ internal class PluginStatWindow : Window
     {
         var pluginManager = Service<PluginManager>.Get();
 
-        using var tabBar = ImRaii.TabBar("Stat Tabs");
+        using var tabBar = ImRaii.TabBar("Stat Tabs"u8);
         if (!tabBar)
             return;
 
-        using (var tabItem = ImRaii.TabItem("Draw times"))
+        using (var tabItem = ImRaii.TabItem("Draw times"u8))
         {
             if (tabItem)
             {
                 var doStats = UiBuilder.DoStats;
 
-                if (ImGui.Checkbox("Enable Draw Time Tracking", ref doStats))
+                if (ImGui.Checkbox("Enable Draw Time Tracking"u8, ref doStats))
                 {
                     UiBuilder.DoStats = doStats;
                 }
@@ -63,7 +63,7 @@ internal class PluginStatWindow : Window
                 if (doStats)
                 {
                     ImGui.SameLine();
-                    if (ImGui.Button("Reset"))
+                    if (ImGui.Button("Reset"u8))
                     {
                         foreach (var plugin in pluginManager.InstalledPlugins)
                         {
@@ -87,13 +87,13 @@ internal class PluginStatWindow : Window
                     ImGuiComponents.TextWithLabel("Collective Average",  $"{(loadedPlugins.Any() ? totalAverage / loadedPlugins.Count() / 10000f : 0):F4}ms",  "Average of all average draw times");
 
                     ImGui.InputTextWithHint(
-                        "###PluginStatWindow_DrawSearch",
-                        "Search",
+                        "###PluginStatWindow_DrawSearch"u8,
+                        "Search"u8,
                         ref this.drawSearchText,
                         500);
 
                     using var table = ImRaii.Table(
-                        "##PluginStatsDrawTimes",
+                        "##PluginStatsDrawTimes"u8,
                         4,
                         ImGuiTableFlags.RowBg
                         | ImGuiTableFlags.SizingStretchProp
@@ -106,10 +106,10 @@ internal class PluginStatWindow : Window
                     if (table)
                     {
                         ImGui.TableSetupScrollFreeze(0, 1);
-                        ImGui.TableSetupColumn("Plugin");
-                        ImGui.TableSetupColumn("Last", ImGuiTableColumnFlags.NoSort); // Changes too fast to sort
-                        ImGui.TableSetupColumn("Longest");
-                        ImGui.TableSetupColumn("Average");
+                        ImGui.TableSetupColumn("Plugin"u8);
+                        ImGui.TableSetupColumn("Last"u8, ImGuiTableColumnFlags.NoSort); // Changes too fast to sort
+                        ImGui.TableSetupColumn("Longest"u8);
+                        ImGui.TableSetupColumn("Average"u8);
                         ImGui.TableHeadersRow();
 
                         var sortSpecs = ImGui.TableGetSortSpecs();
@@ -138,18 +138,18 @@ internal class PluginStatWindow : Window
                             ImGui.TableNextRow();
 
                             ImGui.TableNextColumn();
-                            ImGui.Text(plugin.Manifest.Name);
+                            ImGui.TextUnformatted(plugin.Manifest.Name);
 
                             if (plugin.DalamudInterface != null)
                             {
                                 ImGui.TableNextColumn();
-                                ImGui.Text($"{plugin.DalamudInterface.LocalUiBuilder.LastDrawTime / 10000f:F4}ms");
+                                ImGui.TextUnformatted($"{plugin.DalamudInterface.LocalUiBuilder.LastDrawTime / 10000f:F4}ms");
 
                                 ImGui.TableNextColumn();
-                                ImGui.Text($"{plugin.DalamudInterface.LocalUiBuilder.MaxDrawTime / 10000f:F4}ms");
+                                ImGui.TextUnformatted($"{plugin.DalamudInterface.LocalUiBuilder.MaxDrawTime / 10000f:F4}ms");
 
                                 ImGui.TableNextColumn();
-                                ImGui.Text(plugin.DalamudInterface.LocalUiBuilder.DrawTimeHistory.Count > 0
+                                ImGui.TextUnformatted(plugin.DalamudInterface.LocalUiBuilder.DrawTimeHistory.Count > 0
                                                ? $"{plugin.DalamudInterface.LocalUiBuilder.DrawTimeHistory.Average() / 10000f:F4}ms"
                                                : "-");
                             }
@@ -159,13 +159,13 @@ internal class PluginStatWindow : Window
             }
         }
 
-        using (var tabItem = ImRaii.TabItem("Framework times"))
+        using (var tabItem = ImRaii.TabItem("Framework times"u8))
         {
             if (tabItem)
             {
                 var doStats = Framework.StatsEnabled;
 
-                if (ImGui.Checkbox("Enable Framework Update Tracking", ref doStats))
+                if (ImGui.Checkbox("Enable Framework Update Tracking"u8, ref doStats))
                 {
                     Framework.StatsEnabled = doStats;
                 }
@@ -173,7 +173,7 @@ internal class PluginStatWindow : Window
                 if (doStats)
                 {
                     ImGui.SameLine();
-                    if (ImGui.Button("Reset"))
+                    if (ImGui.Button("Reset"u8))
                     {
                         Framework.StatsHistory.Clear();
                     }
@@ -189,13 +189,13 @@ internal class PluginStatWindow : Window
                     ImGuiComponents.TextWithLabel("Collective Average", $"{(statsHistory.Any() ? totalAverage / statsHistory.Length : 0):F4}ms", "Average of all average update times");
 
                     ImGui.InputTextWithHint(
-                        "###PluginStatWindow_FrameworkSearch",
-                        "Search",
+                        "###PluginStatWindow_FrameworkSearch"u8,
+                        "Search"u8,
                         ref this.frameworkSearchText,
                         500);
 
                     using var table = ImRaii.Table(
-                        "##PluginStatsFrameworkTimes",
+                        "##PluginStatsFrameworkTimes"u8,
                         4,
                         ImGuiTableFlags.RowBg
                         | ImGuiTableFlags.SizingStretchProp
@@ -207,10 +207,10 @@ internal class PluginStatWindow : Window
                     if (table)
                     {
                         ImGui.TableSetupScrollFreeze(0, 1);
-                        ImGui.TableSetupColumn("Method", ImGuiTableColumnFlags.None, 250);
-                        ImGui.TableSetupColumn("Last", ImGuiTableColumnFlags.NoSort, 50); // Changes too fast to sort
-                        ImGui.TableSetupColumn("Longest", ImGuiTableColumnFlags.None, 50);
-                        ImGui.TableSetupColumn("Average", ImGuiTableColumnFlags.None, 50);
+                        ImGui.TableSetupColumn("Method"u8, ImGuiTableColumnFlags.None, 250);
+                        ImGui.TableSetupColumn("Last"u8, ImGuiTableColumnFlags.NoSort, 50); // Changes too fast to sort
+                        ImGui.TableSetupColumn("Longest"u8, ImGuiTableColumnFlags.None, 50);
+                        ImGui.TableSetupColumn("Average"u8, ImGuiTableColumnFlags.None, 50);
                         ImGui.TableHeadersRow();
 
                         var sortSpecs = ImGui.TableGetSortSpecs();
@@ -245,36 +245,36 @@ internal class PluginStatWindow : Window
                             ImGui.TableNextRow();
 
                             ImGui.TableNextColumn();
-                            ImGui.Text($"{handlerHistory.Key}");
+                            ImGui.TextUnformatted($"{handlerHistory.Key}");
 
                             ImGui.TableNextColumn();
-                            ImGui.Text($"{handlerHistory.Value.Last():F4}ms");
+                            ImGui.TextUnformatted($"{handlerHistory.Value.Last():F4}ms");
 
                             ImGui.TableNextColumn();
-                            ImGui.Text($"{handlerHistory.Value.Max():F4}ms");
+                            ImGui.TextUnformatted($"{handlerHistory.Value.Max():F4}ms");
 
                             ImGui.TableNextColumn();
-                            ImGui.Text($"{handlerHistory.Value.Average():F4}ms");
+                            ImGui.TextUnformatted($"{handlerHistory.Value.Average():F4}ms");
                         }
                     }
                 }
             }
         }
 
-        using (var tabItem = ImRaii.TabItem("Hooks"))
+        using (var tabItem = ImRaii.TabItem("Hooks"u8))
         {
             if (tabItem)
             {
-                ImGui.Checkbox("Show Dalamud Hooks", ref this.showDalamudHooks);
+                ImGui.Checkbox("Show Dalamud Hooks"u8, ref this.showDalamudHooks);
 
                 ImGui.InputTextWithHint(
-                    "###PluginStatWindow_HookSearch",
-                    "Search",
+                    "###PluginStatWindow_HookSearch"u8,
+                    "Search"u8,
                     ref this.hookSearchText,
                     500);
 
                 using var table = ImRaii.Table(
-                    "##PluginStatsHooks",
+                    "##PluginStatsHooks"u8,
                     4,
                     ImGuiTableFlags.RowBg
                     | ImGuiTableFlags.SizingStretchProp
@@ -285,10 +285,10 @@ internal class PluginStatWindow : Window
                 if (table)
                 {
                     ImGui.TableSetupScrollFreeze(0, 1);
-                    ImGui.TableSetupColumn("Detour Method", ImGuiTableColumnFlags.None, 250);
-                    ImGui.TableSetupColumn("Address", ImGuiTableColumnFlags.None, 100);
-                    ImGui.TableSetupColumn("Status", ImGuiTableColumnFlags.None, 40);
-                    ImGui.TableSetupColumn("Backend", ImGuiTableColumnFlags.None, 40);
+                    ImGui.TableSetupColumn("Detour Method"u8, ImGuiTableColumnFlags.None, 250);
+                    ImGui.TableSetupColumn("Address"u8, ImGuiTableColumnFlags.None, 100);
+                    ImGui.TableSetupColumn("Status"u8, ImGuiTableColumnFlags.None, 40);
+                    ImGui.TableSetupColumn("Backend"u8, ImGuiTableColumnFlags.None, 40);
                     ImGui.TableHeadersRow();
 
                     foreach (var (guid, trackedHook) in HookManager.TrackedHooks)
@@ -309,7 +309,7 @@ internal class PluginStatWindow : Window
 
                             ImGui.TableNextColumn();
 
-                            ImGui.Text($"{trackedHook.Delegate.Target} :: {trackedHook.Delegate.Method.Name}");
+                            ImGui.TextUnformatted($"{trackedHook.Delegate.Target} :: {trackedHook.Delegate.Method.Name}");
                             ImGui.TextDisabled(trackedHook.Assembly.FullName);
                             ImGui.TableNextColumn();
                             if (!trackedHook.Hook.IsDisposed)
@@ -335,16 +335,16 @@ internal class PluginStatWindow : Window
 
                             if (trackedHook.Hook.IsDisposed)
                             {
-                                ImGui.Text("Disposed");
+                                ImGui.TextUnformatted("Disposed"u8);
                             }
                             else
                             {
-                                ImGui.Text(trackedHook.Hook.IsEnabled ? "Enabled" : "Disabled");
+                                ImGui.TextUnformatted(trackedHook.Hook.IsEnabled ? "Enabled" : "Disabled");
                             }
 
                             ImGui.TableNextColumn();
 
-                            ImGui.Text(trackedHook.Hook.BackendName);
+                            ImGui.TextUnformatted(trackedHook.Hook.BackendName);
                         }
                         catch (Exception ex)
                         {

--- a/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
@@ -138,18 +138,18 @@ internal class PluginStatWindow : Window
                             ImGui.TableNextRow();
 
                             ImGui.TableNextColumn();
-                            ImGui.TextUnformatted(plugin.Manifest.Name);
+                            ImGui.Text(plugin.Manifest.Name);
 
                             if (plugin.DalamudInterface != null)
                             {
                                 ImGui.TableNextColumn();
-                                ImGui.TextUnformatted($"{plugin.DalamudInterface.LocalUiBuilder.LastDrawTime / 10000f:F4}ms");
+                                ImGui.Text($"{plugin.DalamudInterface.LocalUiBuilder.LastDrawTime / 10000f:F4}ms");
 
                                 ImGui.TableNextColumn();
-                                ImGui.TextUnformatted($"{plugin.DalamudInterface.LocalUiBuilder.MaxDrawTime / 10000f:F4}ms");
+                                ImGui.Text($"{plugin.DalamudInterface.LocalUiBuilder.MaxDrawTime / 10000f:F4}ms");
 
                                 ImGui.TableNextColumn();
-                                ImGui.TextUnformatted(plugin.DalamudInterface.LocalUiBuilder.DrawTimeHistory.Count > 0
+                                ImGui.Text(plugin.DalamudInterface.LocalUiBuilder.DrawTimeHistory.Count > 0
                                                ? $"{plugin.DalamudInterface.LocalUiBuilder.DrawTimeHistory.Average() / 10000f:F4}ms"
                                                : "-");
                             }
@@ -245,16 +245,16 @@ internal class PluginStatWindow : Window
                             ImGui.TableNextRow();
 
                             ImGui.TableNextColumn();
-                            ImGui.TextUnformatted($"{handlerHistory.Key}");
+                            ImGui.Text($"{handlerHistory.Key}");
 
                             ImGui.TableNextColumn();
-                            ImGui.TextUnformatted($"{handlerHistory.Value.Last():F4}ms");
+                            ImGui.Text($"{handlerHistory.Value.Last():F4}ms");
 
                             ImGui.TableNextColumn();
-                            ImGui.TextUnformatted($"{handlerHistory.Value.Max():F4}ms");
+                            ImGui.Text($"{handlerHistory.Value.Max():F4}ms");
 
                             ImGui.TableNextColumn();
-                            ImGui.TextUnformatted($"{handlerHistory.Value.Average():F4}ms");
+                            ImGui.Text($"{handlerHistory.Value.Average():F4}ms");
                         }
                     }
                 }
@@ -309,7 +309,7 @@ internal class PluginStatWindow : Window
 
                             ImGui.TableNextColumn();
 
-                            ImGui.TextUnformatted($"{trackedHook.Delegate.Target} :: {trackedHook.Delegate.Method.Name}");
+                            ImGui.Text($"{trackedHook.Delegate.Target} :: {trackedHook.Delegate.Method.Name}");
                             ImGui.TextDisabled(trackedHook.Assembly.FullName);
                             ImGui.TableNextColumn();
                             if (!trackedHook.Hook.IsDisposed)
@@ -335,16 +335,16 @@ internal class PluginStatWindow : Window
 
                             if (trackedHook.Hook.IsDisposed)
                             {
-                                ImGui.TextUnformatted("Disposed"u8);
+                                ImGui.Text("Disposed"u8);
                             }
                             else
                             {
-                                ImGui.TextUnformatted(trackedHook.Hook.IsEnabled ? "Enabled" : "Disabled");
+                                ImGui.Text(trackedHook.Hook.IsEnabled ? "Enabled" : "Disabled");
                             }
 
                             ImGui.TableNextColumn();
 
-                            ImGui.TextUnformatted(trackedHook.Hook.BackendName);
+                            ImGui.Text(trackedHook.Hook.BackendName);
                         }
                         catch (Exception ex)
                         {

--- a/Dalamud/Interface/Internal/Windows/ProfilerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ProfilerWindow.cs
@@ -43,7 +43,7 @@ public class ProfilerWindow : Window
         var actualMin = Timings.AllTimings.Keys.Min(x => x.StartTime);
         var actualMax = Timings.AllTimings.Keys.Max(x => x.EndTime);
 
-        ImGui.TextUnformatted("Timings"u8);
+        ImGui.Text("Timings"u8);
 
         var childHeight = Math.Max(300, 20 * (2.5f + this.occupied.Count));
 
@@ -178,12 +178,12 @@ public class ProfilerWindow : Window
                 if (rectInfo.Hover)
                 {
                     ImGui.BeginTooltip();
-                    ImGui.TextUnformatted(rectInfo.Timing.Name);
-                    ImGui.TextUnformatted(rectInfo.Timing.MemberName);
-                    ImGui.TextUnformatted($"{rectInfo.Timing.FileName}:{rectInfo.Timing.LineNumber}");
-                    ImGui.TextUnformatted($"Duration: {rectInfo.Timing.Duration}ms");
+                    ImGui.Text(rectInfo.Timing.Name);
+                    ImGui.Text(rectInfo.Timing.MemberName);
+                    ImGui.Text($"{rectInfo.Timing.FileName}:{rectInfo.Timing.LineNumber}");
+                    ImGui.Text($"Duration: {rectInfo.Timing.Duration}ms");
                     if (rectInfo.Timing.Parent != null)
-                        ImGui.TextUnformatted($"Parent: {rectInfo.Timing.Parent.Name}");
+                        ImGui.Text($"Parent: {rectInfo.Timing.Parent.Name}");
                     ImGui.EndTooltip();
                 }
             }
@@ -254,9 +254,9 @@ public class ProfilerWindow : Window
             this.max = this.min + (sizeShown * 1000f);
         }
 
-        ImGui.TextUnformatted("Min: " + actualMin.ToString("0.000"));
-        ImGui.TextUnformatted("Max: " + actualMax.ToString("0.000"));
-        ImGui.TextUnformatted("Timings: " + Timings.AllTimings.Count);
+        ImGui.Text("Min: " + actualMin.ToString("0.000"));
+        ImGui.Text("Max: " + actualMax.ToString("0.000"));
+        ImGui.Text("Timings: " + Timings.AllTimings.Count);
     }
 
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:Fields should be private", Justification = "Internals")]

--- a/Dalamud/Interface/Internal/Windows/ProfilerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ProfilerWindow.cs
@@ -43,11 +43,11 @@ public class ProfilerWindow : Window
         var actualMin = Timings.AllTimings.Keys.Min(x => x.StartTime);
         var actualMax = Timings.AllTimings.Keys.Max(x => x.EndTime);
 
-        ImGui.Text("Timings");
+        ImGui.TextUnformatted("Timings"u8);
 
         var childHeight = Math.Max(300, 20 * (2.5f + this.occupied.Count));
 
-        if (ImGui.BeginChild("Timings", new Vector2(0, childHeight), true))
+        if (ImGui.BeginChild("Timings"u8, new Vector2(0, childHeight), true))
         {
             var pos = ImGui.GetCursorScreenPos();
 
@@ -236,27 +236,27 @@ public class ProfilerWindow : Window
         ImGui.EndChild();
 
         var sliderMin = (float)this.min / 1000f;
-        if (ImGui.SliderFloat("Start", ref sliderMin, (float)actualMin / 1000f, (float)this.max / 1000f, "%.2fs"))
+        if (ImGui.SliderFloat("Start"u8, ref sliderMin, (float)actualMin / 1000f, (float)this.max / 1000f, "%.2fs"))
         {
             this.min = sliderMin * 1000f;
         }
 
         var sliderMax = (float)this.max / 1000f;
-        if (ImGui.SliderFloat("End", ref sliderMax, (float)this.min / 1000f, (float)actualMax / 1000f, "%.2fs"))
+        if (ImGui.SliderFloat("End"u8, ref sliderMax, (float)this.min / 1000f, (float)actualMax / 1000f, "%.2fs"))
         {
             this.max = sliderMax * 1000f;
         }
 
         var sizeShown = (float)(this.max - this.min) / 1000f;
         var sizeActual = (float)(actualMax - actualMin) / 1000f;
-        if (ImGui.SliderFloat("Size", ref sizeShown, sizeActual / 10f, sizeActual, "%.2fs"))
+        if (ImGui.SliderFloat("Size"u8, ref sizeShown, sizeActual / 10f, sizeActual, "%.2fs"))
         {
             this.max = this.min + (sizeShown * 1000f);
         }
 
-        ImGui.Text("Min: " + actualMin.ToString("0.000"));
-        ImGui.Text("Max: " + actualMax.ToString("0.000"));
-        ImGui.Text("Timings: " + Timings.AllTimings.Count);
+        ImGui.TextUnformatted("Min: " + actualMin.ToString("0.000"));
+        ImGui.TextUnformatted("Max: " + actualMax.ToString("0.000"));
+        ImGui.TextUnformatted("Timings: " + Timings.AllTimings.Count);
     }
 
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:Fields should be private", Justification = "Internals")]

--- a/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
@@ -118,7 +118,7 @@ internal class SelfTestWindow : Window
 
         ImGui.SameLine();
 
-        ImGui.TextUnformatted($"Step: {this.currentStep} / {this.steps.Count}");
+        ImGui.Text($"Step: {this.currentStep} / {this.steps.Count}");
 
         ImGui.Spacing();
 
@@ -154,7 +154,7 @@ internal class SelfTestWindow : Window
         if (!resultChild) return;
 
         var step = this.steps[this.currentStep];
-        ImGui.TextUnformatted($"Current: {step.Name}");
+        ImGui.Text($"Current: {step.Name}");
 
         ImGuiHelpers.ScaledDummy(10);
 
@@ -214,7 +214,7 @@ internal class SelfTestWindow : Window
 
             ImGui.TableSetColumnIndex(0);
             ImGui.AlignTextToFramePadding();
-            ImGui.TextUnformatted(i.ToString());
+            ImGui.Text(i.ToString());
 
             if (this.selfTestRunning && this.scrollToStep == i)
             {
@@ -224,7 +224,7 @@ internal class SelfTestWindow : Window
 
             ImGui.TableSetColumnIndex(1);
             ImGui.AlignTextToFramePadding();
-            ImGui.TextUnformatted(step.Name);
+            ImGui.Text(step.Name);
 
             if (this.testIndexToResult.TryGetValue(i, out var result))
             {
@@ -248,7 +248,7 @@ internal class SelfTestWindow : Window
                 if (result.Duration.HasValue)
                 {
                     ImGui.AlignTextToFramePadding();
-                    ImGui.TextUnformatted(this.FormatTimeSpan(result.Duration.Value));
+                    ImGui.Text(this.FormatTimeSpan(result.Duration.Value));
                 }
             }
             else
@@ -268,7 +268,7 @@ internal class SelfTestWindow : Window
                 ImGui.AlignTextToFramePadding();
                 if (this.selfTestRunning && this.currentStep == i)
                 {
-                    ImGui.TextUnformatted(this.FormatTimeSpan(DateTimeOffset.Now - this.lastTestStart));
+                    ImGui.Text(this.FormatTimeSpan(DateTimeOffset.Now - this.lastTestStart));
                 }
             }
 

--- a/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
@@ -135,11 +135,11 @@ internal class SelfTestWindow : Window
 
             if (this.testIndexToResult.Any(x => x.Value.Result == SelfTestStepResult.Fail))
             {
-                ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, "One or more checks failed!"u8);
+                ImGui.TextColoredWrapped(ImGuiColors.DalamudRed, "One or more checks failed!"u8);
             }
             else
             {
-                ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.HealerGreen, "All checks passed!"u8);
+                ImGui.TextColoredWrapped(ImGuiColors.HealerGreen, "All checks passed!"u8);
             }
 
             return;
@@ -234,13 +234,13 @@ internal class SelfTestWindow : Window
                 switch (result.Result)
                 {
                     case SelfTestStepResult.Pass:
-                        ImGuiHelpers.SafeTextColored(ImGuiColors.HealerGreen, "PASS"u8);
+                        ImGui.TextColored(ImGuiColors.HealerGreen, "PASS"u8);
                         break;
                     case SelfTestStepResult.Fail:
-                        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, "FAIL"u8);
+                        ImGui.TextColored(ImGuiColors.DalamudRed, "FAIL"u8);
                         break;
                     default:
-                        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, "NR"u8);
+                        ImGui.TextColored(ImGuiColors.DalamudGrey, "NR"u8);
                         break;
                 }
 
@@ -257,11 +257,11 @@ internal class SelfTestWindow : Window
                 ImGui.AlignTextToFramePadding();
                 if (this.selfTestRunning && this.currentStep == i)
                 {
-                    ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, "WAIT"u8);
+                    ImGui.TextColored(ImGuiColors.DalamudGrey, "WAIT"u8);
                 }
                 else
                 {
-                    ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, "NR"u8);
+                    ImGui.TextColored(ImGuiColors.DalamudGrey, "NR"u8);
                 }
 
                 ImGui.TableSetColumnIndex(3);

--- a/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
@@ -135,11 +135,11 @@ internal class SelfTestWindow : Window
 
             if (this.testIndexToResult.Any(x => x.Value.Result == SelfTestStepResult.Fail))
             {
-                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, "One or more checks failed!"u8);
+                ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, "One or more checks failed!"u8);
             }
             else
             {
-                ImGuiHelpers.SafeTextColored(ImGuiColors.HealerGreen, "All checks passed!"u8);
+                ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.HealerGreen, "All checks passed!"u8);
             }
 
             return;

--- a/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
@@ -135,11 +135,11 @@ internal class SelfTestWindow : Window
 
             if (this.testIndexToResult.Any(x => x.Value.Result == SelfTestStepResult.Fail))
             {
-                ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, "One or more checks failed!");
+                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, "One or more checks failed!"u8);
             }
             else
             {
-                ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.HealerGreen, "All checks passed!");
+                ImGuiHelpers.SafeTextColored(ImGuiColors.HealerGreen, "All checks passed!"u8);
             }
 
             return;
@@ -150,7 +150,7 @@ internal class SelfTestWindow : Window
             return;
         }
 
-        using var resultChild = ImRaii.Child("SelfTestResultChild", ImGui.GetContentRegionAvail());
+        using var resultChild = ImRaii.Child("SelfTestResultChild"u8, ImGui.GetContentRegionAvail());
         if (!resultChild) return;
 
         var step = this.steps[this.currentStep];
@@ -189,14 +189,14 @@ internal class SelfTestWindow : Window
 
         tableSize.Y = Math.Min(tableSize.Y, ImGui.GetWindowViewport().Size.Y * 0.5f);
 
-        using var table = ImRaii.Table("agingResultTable", 5, ImGuiTableFlags.Borders | ImGuiTableFlags.ScrollY, tableSize);
+        using var table = ImRaii.Table("agingResultTable"u8, 5, ImGuiTableFlags.Borders | ImGuiTableFlags.ScrollY, tableSize);
         if (!table)
             return;
 
-        ImGui.TableSetupColumn("###index", ImGuiTableColumnFlags.WidthFixed, 12f * ImGuiHelpers.GlobalScale);
-        ImGui.TableSetupColumn("Name");
-        ImGui.TableSetupColumn("Result", ImGuiTableColumnFlags.WidthFixed, 40f * ImGuiHelpers.GlobalScale);
-        ImGui.TableSetupColumn("Duration", ImGuiTableColumnFlags.WidthFixed, 90f * ImGuiHelpers.GlobalScale);
+        ImGui.TableSetupColumn("###index"u8, ImGuiTableColumnFlags.WidthFixed, 12f * ImGuiHelpers.GlobalScale);
+        ImGui.TableSetupColumn("Name"u8);
+        ImGui.TableSetupColumn("Result"u8, ImGuiTableColumnFlags.WidthFixed, 40f * ImGuiHelpers.GlobalScale);
+        ImGui.TableSetupColumn("Duration"u8, ImGuiTableColumnFlags.WidthFixed, 90f * ImGuiHelpers.GlobalScale);
         ImGui.TableSetupColumn(string.Empty, ImGuiTableColumnFlags.WidthFixed, 30f * ImGuiHelpers.GlobalScale);
 
         ImGui.TableSetupScrollFreeze(0, 1);
@@ -234,13 +234,13 @@ internal class SelfTestWindow : Window
                 switch (result.Result)
                 {
                     case SelfTestStepResult.Pass:
-                        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.HealerGreen, "PASS");
+                        ImGuiHelpers.SafeTextColored(ImGuiColors.HealerGreen, "PASS"u8);
                         break;
                     case SelfTestStepResult.Fail:
-                        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudRed, "FAIL");
+                        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, "FAIL"u8);
                         break;
                     default:
-                        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, "NR");
+                        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, "NR"u8);
                         break;
                 }
 
@@ -257,11 +257,11 @@ internal class SelfTestWindow : Window
                 ImGui.AlignTextToFramePadding();
                 if (this.selfTestRunning && this.currentStep == i)
                 {
-                    ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, "WAIT");
+                    ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, "WAIT"u8);
                 }
                 else
                 {
-                    ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, "NR");
+                    ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, "NR"u8);
                 }
 
                 ImGui.TableSetColumnIndex(3);
@@ -285,7 +285,7 @@ internal class SelfTestWindow : Window
 
             if (ImGui.IsItemHovered())
             {
-                ImGui.SetTooltip("Jump to this test");
+                ImGui.SetTooltip("Jump to this test"u8);
             }
         }
     }

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ActorTableSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ActorTableSelfTestStep.cs
@@ -19,7 +19,7 @@ internal class ActorTableSelfTestStep : ISelfTestStep
     {
         var objectTable = Service<ObjectTable>.Get();
 
-        ImGui.Text("Checking actor table...");
+        ImGui.TextUnformatted("Checking actor table..."u8);
 
         if (this.index == objectTable.Length - 1)
         {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ActorTableSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ActorTableSelfTestStep.cs
@@ -19,7 +19,7 @@ internal class ActorTableSelfTestStep : ISelfTestStep
     {
         var objectTable = Service<ObjectTable>.Get();
 
-        ImGui.TextUnformatted("Checking actor table..."u8);
+        ImGui.Text("Checking actor table..."u8);
 
         if (this.index == objectTable.Length - 1)
         {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/AddonLifecycleSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/AddonLifecycleSelfTestStep.cs
@@ -66,19 +66,19 @@ internal class AddonLifecycleSelfTestStep : ISelfTestStep
         switch (this.currentStep)
         {
             case TestStep.CharacterRefresh:
-                ImGui.TextUnformatted("Open Character Window."u8);
+                ImGui.Text("Open Character Window."u8);
                 break;
 
             case TestStep.CharacterSetup:
-                ImGui.TextUnformatted("Open Character Window."u8);
+                ImGui.Text("Open Character Window."u8);
                 break;
 
             case TestStep.CharacterRequestedUpdate:
-                ImGui.TextUnformatted("Change tabs, or un-equip/equip gear."u8);
+                ImGui.Text("Change tabs, or un-equip/equip gear."u8);
                 break;
 
             case TestStep.CharacterFinalize:
-                ImGui.TextUnformatted("Close Character Window."u8);
+                ImGui.Text("Close Character Window."u8);
                 break;
 
             case TestStep.CharacterUpdate:

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/AddonLifecycleSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/AddonLifecycleSelfTestStep.cs
@@ -66,19 +66,19 @@ internal class AddonLifecycleSelfTestStep : ISelfTestStep
         switch (this.currentStep)
         {
             case TestStep.CharacterRefresh:
-                ImGui.Text("Open Character Window.");
+                ImGui.TextUnformatted("Open Character Window."u8);
                 break;
 
             case TestStep.CharacterSetup:
-                ImGui.Text("Open Character Window.");
+                ImGui.TextUnformatted("Open Character Window."u8);
                 break;
 
             case TestStep.CharacterRequestedUpdate:
-                ImGui.Text("Change tabs, or un-equip/equip gear.");
+                ImGui.TextUnformatted("Change tabs, or un-equip/equip gear."u8);
                 break;
 
             case TestStep.CharacterFinalize:
-                ImGui.Text("Close Character Window.");
+                ImGui.TextUnformatted("Close Character Window."u8);
                 break;
 
             case TestStep.CharacterUpdate:

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/AetheryteListSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/AetheryteListSelfTestStep.cs
@@ -19,7 +19,7 @@ internal class AetheryteListSelfTestStep : ISelfTestStep
     {
         var list = Service<AetheryteList>.Get();
 
-        ImGui.Text("Checking aetheryte list...");
+        ImGui.TextUnformatted("Checking aetheryte list..."u8);
 
         if (this.index == list.Length - 1)
         {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/AetheryteListSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/AetheryteListSelfTestStep.cs
@@ -19,7 +19,7 @@ internal class AetheryteListSelfTestStep : ISelfTestStep
     {
         var list = Service<AetheryteList>.Get();
 
-        ImGui.TextUnformatted("Checking aetheryte list..."u8);
+        ImGui.Text("Checking aetheryte list..."u8);
 
         if (this.index == list.Length - 1)
         {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ChatSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ChatSelfTestStep.cs
@@ -31,7 +31,7 @@ internal class ChatSelfTestStep : ISelfTestStep
                 break;
 
             case 1:
-                ImGui.TextUnformatted("Type \"/e DALAMUD\" in chat...");
+                ImGui.Text("Type \"/e DALAMUD\" in chat...");
 
                 if (!this.subscribed)
                 {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ChatSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ChatSelfTestStep.cs
@@ -31,7 +31,7 @@ internal class ChatSelfTestStep : ISelfTestStep
                 break;
 
             case 1:
-                ImGui.Text("Type \"/e DALAMUD\" in chat...");
+                ImGui.TextUnformatted("Type \"/e DALAMUD\" in chat...");
 
                 if (!this.subscribed)
                 {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/CompletionSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/CompletionSelfTestStep.cs
@@ -28,7 +28,7 @@ internal class CompletionSelfTestStep : ISelfTestStep
                 break;
 
             case 1:
-                ImGui.TextUnformatted("[Chat Log]"u8);
+                ImGui.Text("[Chat Log]"u8);
                 ImGuiHelpers.SafeTextWrapped("Use the category menus to navigate to [Dalamud], then complete a command from the list. Did it work?"u8);
                 if (ImGui.Button("Yes"u8))
                     this.step++;
@@ -38,8 +38,8 @@ internal class CompletionSelfTestStep : ISelfTestStep
                     return SelfTestStepResult.Fail;
                 break;
             case 2:
-                ImGui.TextUnformatted("[Chat Log]"u8);
-                ImGui.TextUnformatted("Type /xl into the chat log and tab-complete a dalamud command. Did it work?"u8);
+                ImGui.Text("[Chat Log]"u8);
+                ImGui.Text("Type /xl into the chat log and tab-complete a dalamud command. Did it work?"u8);
 
                 if (ImGui.Button("Yes"u8))
                     this.step++;
@@ -51,14 +51,14 @@ internal class CompletionSelfTestStep : ISelfTestStep
                 break;
 
             case 3:
-                ImGui.TextUnformatted("[Chat Log]"u8);
+                ImGui.Text("[Chat Log]"u8);
                 if (!this.registered)
                 {
                     cmdManager.AddHandler("/xlselftestcompletion", new CommandInfo((_, _) => this.commandRun = true));
                     this.registered = true;
                 }
 
-                ImGui.TextUnformatted("Tab-complete /xlselftestcompletion in the chat log and send the command"u8);
+                ImGui.Text("Tab-complete /xlselftestcompletion in the chat log and send the command"u8);
 
                 if (this.commandRun)
                     this.step++;
@@ -66,9 +66,9 @@ internal class CompletionSelfTestStep : ISelfTestStep
                 break;
 
             case 4:
-                ImGui.TextUnformatted("[Other text inputs]"u8);
-                ImGui.TextUnformatted("Open the party finder recruitment criteria dialog and try to tab-complete /xldev in the text box."u8);
-                ImGui.TextUnformatted("Did the command appear in the text box? (It should not have)"u8);
+                ImGui.Text("[Other text inputs]"u8);
+                ImGui.Text("Open the party finder recruitment criteria dialog and try to tab-complete /xldev in the text box."u8);
+                ImGui.Text("Did the command appear in the text box? (It should not have)"u8);
                 if (ImGui.Button("Yes"u8))
                     return SelfTestStepResult.Fail;
                 ImGui.SameLine();

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/CompletionSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/CompletionSelfTestStep.cs
@@ -29,7 +29,7 @@ internal class CompletionSelfTestStep : ISelfTestStep
 
             case 1:
                 ImGui.Text("[Chat Log]"u8);
-                ImGuiHelpers.SafeTextWrapped("Use the category menus to navigate to [Dalamud], then complete a command from the list. Did it work?"u8);
+                ImGui.TextWrapped("Use the category menus to navigate to [Dalamud], then complete a command from the list. Did it work?"u8);
                 if (ImGui.Button("Yes"u8))
                     this.step++;
                 ImGui.SameLine();

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/CompletionSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/CompletionSelfTestStep.cs
@@ -1,5 +1,6 @@
 using Dalamud.Bindings.ImGui;
 using Dalamud.Game.Command;
+using Dalamud.Interface.Utility;
 
 namespace Dalamud.Interface.Internal.Windows.SelfTest.Steps;
 
@@ -27,37 +28,37 @@ internal class CompletionSelfTestStep : ISelfTestStep
                 break;
 
             case 1:
-                ImGui.Text("[Chat Log]");
-                ImGui.TextWrapped("Use the category menus to navigate to [Dalamud], then complete a command from the list. Did it work?");
-                if (ImGui.Button("Yes"))
+                ImGui.TextUnformatted("[Chat Log]"u8);
+                ImGuiHelpers.SafeTextWrapped("Use the category menus to navigate to [Dalamud], then complete a command from the list. Did it work?"u8);
+                if (ImGui.Button("Yes"u8))
                     this.step++;
                 ImGui.SameLine();
 
-                if (ImGui.Button("No"))
+                if (ImGui.Button("No"u8))
                     return SelfTestStepResult.Fail;
                 break;
             case 2:
-                ImGui.Text("[Chat Log]");
-                ImGui.Text("Type /xl into the chat log and tab-complete a dalamud command. Did it work?");
+                ImGui.TextUnformatted("[Chat Log]"u8);
+                ImGui.TextUnformatted("Type /xl into the chat log and tab-complete a dalamud command. Did it work?"u8);
 
-                if (ImGui.Button("Yes"))
+                if (ImGui.Button("Yes"u8))
                     this.step++;
                 ImGui.SameLine();
 
-                if (ImGui.Button("No"))
+                if (ImGui.Button("No"u8))
                     return SelfTestStepResult.Fail;
 
                 break;
 
             case 3:
-                ImGui.Text("[Chat Log]");
+                ImGui.TextUnformatted("[Chat Log]"u8);
                 if (!this.registered)
                 {
                     cmdManager.AddHandler("/xlselftestcompletion", new CommandInfo((_, _) => this.commandRun = true));
                     this.registered = true;
                 }
 
-                ImGui.Text("Tab-complete /xlselftestcompletion in the chat log and send the command");
+                ImGui.TextUnformatted("Tab-complete /xlselftestcompletion in the chat log and send the command"u8);
 
                 if (this.commandRun)
                     this.step++;
@@ -65,14 +66,14 @@ internal class CompletionSelfTestStep : ISelfTestStep
                 break;
 
             case 4:
-                ImGui.Text("[Other text inputs]");
-                ImGui.Text("Open the party finder recruitment criteria dialog and try to tab-complete /xldev in the text box.");
-                ImGui.Text("Did the command appear in the text box? (It should not have)");
-                if (ImGui.Button("Yes"))
+                ImGui.TextUnformatted("[Other text inputs]"u8);
+                ImGui.TextUnformatted("Open the party finder recruitment criteria dialog and try to tab-complete /xldev in the text box."u8);
+                ImGui.TextUnformatted("Did the command appear in the text box? (It should not have)"u8);
+                if (ImGui.Button("Yes"u8))
                     return SelfTestStepResult.Fail;
                 ImGui.SameLine();
 
-                if (ImGui.Button("No"))
+                if (ImGui.Button("No"u8))
                     this.step++;
                 break;
             case 5:

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ConditionSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ConditionSelfTestStep.cs
@@ -23,7 +23,7 @@ internal class ConditionSelfTestStep : ISelfTestStep
             return SelfTestStepResult.Fail;
         }
 
-        ImGui.Text("Please jump...");
+        ImGui.TextUnformatted("Please jump..."u8);
 
         return condition[ConditionFlag.Jumping] ? SelfTestStepResult.Pass : SelfTestStepResult.Waiting;
     }

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ConditionSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ConditionSelfTestStep.cs
@@ -23,7 +23,7 @@ internal class ConditionSelfTestStep : ISelfTestStep
             return SelfTestStepResult.Fail;
         }
 
-        ImGui.TextUnformatted("Please jump..."u8);
+        ImGui.Text("Please jump..."u8);
 
         return condition[ConditionFlag.Jumping] ? SelfTestStepResult.Pass : SelfTestStepResult.Waiting;
     }

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ContextMenuSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ContextMenuSelfTestStep.cs
@@ -48,7 +48,7 @@ internal class ContextMenuSelfTestStep : ISelfTestStep
         this.materiaSheet = dataMgr.GetExcelSheet<Materia>();
         this.stainSheet = dataMgr.GetExcelSheet<Stain>();
 
-        ImGui.Text(this.currentSubStep.ToString());
+        ImGui.TextUnformatted(this.currentSubStep.ToString());
 
         switch (this.currentSubStep)
         {
@@ -59,21 +59,21 @@ internal class ContextMenuSelfTestStep : ISelfTestStep
             case SubStep.TestInventoryAndSubmenu:
                 if (this.targetInventorySubmenuOpened == true)
                 {
-                    ImGui.Text($"Is the data in the submenu correct?");
+                    ImGui.TextUnformatted($"Is the data in the submenu correct?");
 
-                    if (ImGui.Button("Yes"))
+                    if (ImGui.Button("Yes"u8))
                         this.currentSubStep++;
 
                     ImGui.SameLine();
 
-                    if (ImGui.Button("No"))
+                    if (ImGui.Button("No"u8))
                         return SelfTestStepResult.Fail;
                 }
                 else
                 {
-                    ImGui.Text("Right-click an item and select \"Self Test\".");
+                    ImGui.TextUnformatted("Right-click an item and select \"Self Test\".");
 
-                    if (ImGui.Button("Skip"))
+                    if (ImGui.Button("Skip"u8))
                         this.currentSubStep++;
                 }
 
@@ -82,21 +82,21 @@ internal class ContextMenuSelfTestStep : ISelfTestStep
             case SubStep.TestDefault:
                 if (this.targetCharacter is { } character)
                 {
-                    ImGui.Text($"Did you click \"{character.Name}\" ({character.ClassJob.Value.Abbreviation.ExtractText()})?");
+                    ImGui.TextUnformatted($"Did you click \"{character.Name}\" ({character.ClassJob.Value.Abbreviation.ExtractText()})?");
 
-                    if (ImGui.Button("Yes"))
+                    if (ImGui.Button("Yes"u8))
                         this.currentSubStep++;
 
                     ImGui.SameLine();
 
-                    if (ImGui.Button("No"))
+                    if (ImGui.Button("No"u8))
                         return SelfTestStepResult.Fail;
                 }
                 else
                 {
-                    ImGui.Text("Right-click a character.");
+                    ImGui.TextUnformatted("Right-click a character."u8);
 
-                    if (ImGui.Button("Skip"))
+                    if (ImGui.Button("Skip"u8))
                         this.currentSubStep++;
                 }
 

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ContextMenuSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ContextMenuSelfTestStep.cs
@@ -48,7 +48,7 @@ internal class ContextMenuSelfTestStep : ISelfTestStep
         this.materiaSheet = dataMgr.GetExcelSheet<Materia>();
         this.stainSheet = dataMgr.GetExcelSheet<Stain>();
 
-        ImGui.TextUnformatted(this.currentSubStep.ToString());
+        ImGui.Text(this.currentSubStep.ToString());
 
         switch (this.currentSubStep)
         {
@@ -59,7 +59,7 @@ internal class ContextMenuSelfTestStep : ISelfTestStep
             case SubStep.TestInventoryAndSubmenu:
                 if (this.targetInventorySubmenuOpened == true)
                 {
-                    ImGui.TextUnformatted($"Is the data in the submenu correct?");
+                    ImGui.Text($"Is the data in the submenu correct?");
 
                     if (ImGui.Button("Yes"u8))
                         this.currentSubStep++;
@@ -71,7 +71,7 @@ internal class ContextMenuSelfTestStep : ISelfTestStep
                 }
                 else
                 {
-                    ImGui.TextUnformatted("Right-click an item and select \"Self Test\".");
+                    ImGui.Text("Right-click an item and select \"Self Test\".");
 
                     if (ImGui.Button("Skip"u8))
                         this.currentSubStep++;
@@ -82,7 +82,7 @@ internal class ContextMenuSelfTestStep : ISelfTestStep
             case SubStep.TestDefault:
                 if (this.targetCharacter is { } character)
                 {
-                    ImGui.TextUnformatted($"Did you click \"{character.Name}\" ({character.ClassJob.Value.Abbreviation.ExtractText()})?");
+                    ImGui.Text($"Did you click \"{character.Name}\" ({character.ClassJob.Value.Abbreviation.ExtractText()})?");
 
                     if (ImGui.Button("Yes"u8))
                         this.currentSubStep++;
@@ -94,7 +94,7 @@ internal class ContextMenuSelfTestStep : ISelfTestStep
                 }
                 else
                 {
-                    ImGui.TextUnformatted("Right-click a character."u8);
+                    ImGui.Text("Right-click a character."u8);
 
                     if (ImGui.Button("Skip"u8))
                         this.currentSubStep++;

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/DutyStateSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/DutyStateSelfTestStep.cs
@@ -19,7 +19,7 @@ internal class DutyStateSelfTestStep : ISelfTestStep
     {
         var dutyState = Service<DutyState>.Get();
 
-        ImGui.TextUnformatted("Enter a duty now..."u8);
+        ImGui.Text("Enter a duty now..."u8);
 
         if (!this.subscribed)
         {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/DutyStateSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/DutyStateSelfTestStep.cs
@@ -19,7 +19,7 @@ internal class DutyStateSelfTestStep : ISelfTestStep
     {
         var dutyState = Service<DutyState>.Get();
 
-        ImGui.Text("Enter a duty now...");
+        ImGui.TextUnformatted("Enter a duty now..."u8);
 
         if (!this.subscribed)
         {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/EnterTerritorySelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/EnterTerritorySelfTestStep.cs
@@ -32,7 +32,7 @@ internal class EnterTerritorySelfTestStep : ISelfTestStep
     {
         var clientState = Service<ClientState>.Get();
 
-        ImGui.TextUnformatted(this.Name);
+        ImGui.Text(this.Name);
 
         if (!this.subscribed)
         {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/FateTableSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/FateTableSelfTestStep.cs
@@ -19,11 +19,11 @@ internal class FateTableSelfTestStep : ISelfTestStep
     {
         var fateTable = Service<FateTable>.Get();
 
-        ImGui.TextUnformatted("Checking fate table..."u8);
+        ImGui.Text("Checking fate table..."u8);
 
         if (fateTable.Length == 0)
         {
-            ImGui.TextUnformatted("Go to a zone that has FATEs currently up."u8);
+            ImGui.Text("Go to a zone that has FATEs currently up."u8);
             return SelfTestStepResult.Waiting;
         }
 

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/FateTableSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/FateTableSelfTestStep.cs
@@ -19,11 +19,11 @@ internal class FateTableSelfTestStep : ISelfTestStep
     {
         var fateTable = Service<FateTable>.Get();
 
-        ImGui.Text("Checking fate table...");
+        ImGui.TextUnformatted("Checking fate table..."u8);
 
         if (fateTable.Length == 0)
         {
-            ImGui.Text("Go to a zone that has FATEs currently up.");
+            ImGui.TextUnformatted("Go to a zone that has FATEs currently up."u8);
             return SelfTestStepResult.Waiting;
         }
 

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/GameConfigSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/GameConfigSelfTestStep.cs
@@ -43,7 +43,7 @@ internal class GameConfigSelfTestStep : ISelfTestStep
                 }
                 else
                 {
-                    ImGui.Text("Switch Movement Type to Standard");
+                    ImGui.TextUnformatted("Switch Movement Type to Standard"u8);
                 }
 
                 return SelfTestStepResult.Waiting;
@@ -57,7 +57,7 @@ internal class GameConfigSelfTestStep : ISelfTestStep
                 }
                 else
                 {
-                    ImGui.Text("Switch Movement Type to Legacy");
+                    ImGui.TextUnformatted("Switch Movement Type to Legacy"u8);
                 }
 
                 return SelfTestStepResult.Waiting;
@@ -73,7 +73,7 @@ internal class GameConfigSelfTestStep : ISelfTestStep
                  }
                  else
                  {
-                     ImGui.Text("Switch Movement Type to Legacy");
+                     ImGui.TextUnformatted("Switch Movement Type to Legacy"u8);
                  }
 
                  return SelfTestStepResult.Waiting;
@@ -87,7 +87,7 @@ internal class GameConfigSelfTestStep : ISelfTestStep
                  }
                  else
                  {
-                     ImGui.Text("Switch Movement Type to Standard");
+                     ImGui.TextUnformatted("Switch Movement Type to Standard"u8);
                  }
 
                  return SelfTestStepResult.Waiting;

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/GameConfigSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/GameConfigSelfTestStep.cs
@@ -43,7 +43,7 @@ internal class GameConfigSelfTestStep : ISelfTestStep
                 }
                 else
                 {
-                    ImGui.TextUnformatted("Switch Movement Type to Standard"u8);
+                    ImGui.Text("Switch Movement Type to Standard"u8);
                 }
 
                 return SelfTestStepResult.Waiting;
@@ -57,7 +57,7 @@ internal class GameConfigSelfTestStep : ISelfTestStep
                 }
                 else
                 {
-                    ImGui.TextUnformatted("Switch Movement Type to Legacy"u8);
+                    ImGui.Text("Switch Movement Type to Legacy"u8);
                 }
 
                 return SelfTestStepResult.Waiting;
@@ -73,7 +73,7 @@ internal class GameConfigSelfTestStep : ISelfTestStep
                  }
                  else
                  {
-                     ImGui.TextUnformatted("Switch Movement Type to Legacy"u8);
+                     ImGui.Text("Switch Movement Type to Legacy"u8);
                  }
 
                  return SelfTestStepResult.Waiting;
@@ -87,7 +87,7 @@ internal class GameConfigSelfTestStep : ISelfTestStep
                  }
                  else
                  {
-                     ImGui.TextUnformatted("Switch Movement Type to Standard"u8);
+                     ImGui.Text("Switch Movement Type to Standard"u8);
                  }
 
                  return SelfTestStepResult.Waiting;

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/HoverSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/HoverSelfTestStep.cs
@@ -21,7 +21,7 @@ internal class HoverSelfTestStep : ISelfTestStep
 
         if (!this.clearedItem)
         {
-            ImGui.TextUnformatted("Hover WHM soul crystal..."u8);
+            ImGui.Text("Hover WHM soul crystal..."u8);
 
             if (gameGui.HoveredItem == 4547)
             {
@@ -31,7 +31,7 @@ internal class HoverSelfTestStep : ISelfTestStep
 
         if (!this.clearedAction)
         {
-            ImGui.TextUnformatted("Hover \"Open Linkshells\" action...");
+            ImGui.Text("Hover \"Open Linkshells\" action...");
 
             if (gameGui.HoveredAction != null &&
                 gameGui.HoveredAction.ActionKind == HoverActionKind.MainCommand &&

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/HoverSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/HoverSelfTestStep.cs
@@ -21,7 +21,7 @@ internal class HoverSelfTestStep : ISelfTestStep
 
         if (!this.clearedItem)
         {
-            ImGui.Text("Hover WHM soul crystal...");
+            ImGui.TextUnformatted("Hover WHM soul crystal..."u8);
 
             if (gameGui.HoveredItem == 4547)
             {
@@ -31,7 +31,7 @@ internal class HoverSelfTestStep : ISelfTestStep
 
         if (!this.clearedAction)
         {
-            ImGui.Text("Hover \"Open Linkshells\" action...");
+            ImGui.TextUnformatted("Hover \"Open Linkshells\" action...");
 
             if (gameGui.HoveredAction != null &&
                 gameGui.HoveredAction.ActionKind == HoverActionKind.MainCommand &&

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ItemPayloadSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ItemPayloadSelfTestStep.cs
@@ -43,7 +43,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
 
         SeString? toPrint = null;
 
-        ImGui.Text(this.currentSubStep.ToString());
+        ImGui.TextUnformatted(this.currentSubStep.ToString());
 
         switch (this.currentSubStep)
         {
@@ -52,7 +52,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
                 this.currentSubStep++;
                 break;
             case SubStep.HoverNormalItem:
-                ImGui.Text("Hover the item.");
+                ImGui.TextUnformatted("Hover the item."u8);
                 if (gameGui.HoveredItem != normalItemId)
                     return SelfTestStepResult.Waiting;
                 this.currentSubStep++;
@@ -62,7 +62,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
                 this.currentSubStep++;
                 break;
             case SubStep.HoverHqItem:
-                ImGui.Text("Hover the item.");
+                ImGui.TextUnformatted("Hover the item."u8);
                 if (gameGui.HoveredItem != 1_000_000 + hqItemId)
                     return SelfTestStepResult.Waiting;
                 this.currentSubStep++;
@@ -72,7 +72,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
                 this.currentSubStep++;
                 break;
             case SubStep.HoverCollectable:
-                ImGui.Text("Hover the item.");
+                ImGui.TextUnformatted("Hover the item."u8);
                 if (gameGui.HoveredItem != 500_000 + collectableItemId)
                     return SelfTestStepResult.Waiting;
                 this.currentSubStep++;
@@ -82,7 +82,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
                 this.currentSubStep++;
                 break;
             case SubStep.HoverEventItem:
-                ImGui.Text("Hover the item.");
+                ImGui.TextUnformatted("Hover the item."u8);
                 if (gameGui.HoveredItem != eventItemId)
                     return SelfTestStepResult.Waiting;
                 this.currentSubStep++;
@@ -92,7 +92,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
                 this.currentSubStep++;
                 break;
             case SubStep.HoverNormalWithText:
-                ImGui.Text("Hover the item.");
+                ImGui.TextUnformatted("Hover the item."u8);
                 if (gameGui.HoveredItem != normalItemId)
                     return SelfTestStepResult.Waiting;
                 this.currentSubStep++;

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ItemPayloadSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ItemPayloadSelfTestStep.cs
@@ -43,7 +43,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
 
         SeString? toPrint = null;
 
-        ImGui.TextUnformatted(this.currentSubStep.ToString());
+        ImGui.Text(this.currentSubStep.ToString());
 
         switch (this.currentSubStep)
         {
@@ -52,7 +52,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
                 this.currentSubStep++;
                 break;
             case SubStep.HoverNormalItem:
-                ImGui.TextUnformatted("Hover the item."u8);
+                ImGui.Text("Hover the item."u8);
                 if (gameGui.HoveredItem != normalItemId)
                     return SelfTestStepResult.Waiting;
                 this.currentSubStep++;
@@ -62,7 +62,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
                 this.currentSubStep++;
                 break;
             case SubStep.HoverHqItem:
-                ImGui.TextUnformatted("Hover the item."u8);
+                ImGui.Text("Hover the item."u8);
                 if (gameGui.HoveredItem != 1_000_000 + hqItemId)
                     return SelfTestStepResult.Waiting;
                 this.currentSubStep++;
@@ -72,7 +72,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
                 this.currentSubStep++;
                 break;
             case SubStep.HoverCollectable:
-                ImGui.TextUnformatted("Hover the item."u8);
+                ImGui.Text("Hover the item."u8);
                 if (gameGui.HoveredItem != 500_000 + collectableItemId)
                     return SelfTestStepResult.Waiting;
                 this.currentSubStep++;
@@ -82,7 +82,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
                 this.currentSubStep++;
                 break;
             case SubStep.HoverEventItem:
-                ImGui.TextUnformatted("Hover the item."u8);
+                ImGui.Text("Hover the item."u8);
                 if (gameGui.HoveredItem != eventItemId)
                     return SelfTestStepResult.Waiting;
                 this.currentSubStep++;
@@ -92,7 +92,7 @@ internal class ItemPayloadSelfTestStep : ISelfTestStep
                 this.currentSubStep++;
                 break;
             case SubStep.HoverNormalWithText:
-                ImGui.TextUnformatted("Hover the item."u8);
+                ImGui.Text("Hover the item."u8);
                 if (gameGui.HoveredItem != normalItemId)
                     return SelfTestStepResult.Waiting;
                 this.currentSubStep++;

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/KeyStateSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/KeyStateSelfTestStep.cs
@@ -16,7 +16,7 @@ internal class KeyStateSelfTestStep : ISelfTestStep
     {
         var keyState = Service<KeyState>.Get();
 
-        ImGui.TextUnformatted("Hold down D,A,L,M,U"u8);
+        ImGui.Text("Hold down D,A,L,M,U"u8);
 
         if (keyState[VirtualKey.D]
             && keyState[VirtualKey.A]

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/KeyStateSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/KeyStateSelfTestStep.cs
@@ -16,7 +16,7 @@ internal class KeyStateSelfTestStep : ISelfTestStep
     {
         var keyState = Service<KeyState>.Get();
 
-        ImGui.Text("Hold down D,A,L,M,U");
+        ImGui.TextUnformatted("Hold down D,A,L,M,U"u8);
 
         if (keyState[VirtualKey.D]
             && keyState[VirtualKey.A]

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/LoginEventSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/LoginEventSelfTestStep.cs
@@ -19,7 +19,7 @@ internal class LoginEventSelfTestStep : ISelfTestStep
     {
         var clientState = Service<ClientState>.Get();
 
-        ImGui.Text("Log in now...");
+        ImGui.TextUnformatted("Log in now..."u8);
 
         if (!this.subscribed)
         {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/LoginEventSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/LoginEventSelfTestStep.cs
@@ -19,7 +19,7 @@ internal class LoginEventSelfTestStep : ISelfTestStep
     {
         var clientState = Service<ClientState>.Get();
 
-        ImGui.TextUnformatted("Log in now..."u8);
+        ImGui.Text("Log in now..."u8);
 
         if (!this.subscribed)
         {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/LogoutEventSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/LogoutEventSelfTestStep.cs
@@ -19,7 +19,7 @@ internal class LogoutEventSelfTestStep : ISelfTestStep
     {
         var clientState = Service<ClientState>.Get();
 
-        ImGui.Text("Log out now...");
+        ImGui.TextUnformatted("Log out now..."u8);
 
         if (!this.subscribed)
         {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/LogoutEventSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/LogoutEventSelfTestStep.cs
@@ -19,7 +19,7 @@ internal class LogoutEventSelfTestStep : ISelfTestStep
     {
         var clientState = Service<ClientState>.Get();
 
-        ImGui.TextUnformatted("Log out now..."u8);
+        ImGui.Text("Log out now..."u8);
 
         if (!this.subscribed)
         {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/MarketBoardSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/MarketBoardSelfTestStep.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Game.MarketBoard;
 using Dalamud.Game.Network.Structures;
+using Dalamud.Interface.Utility;
 
 namespace Dalamud.Interface.Internal.Windows.SelfTest.Steps;
 
@@ -42,7 +43,7 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
             this.SubscribeToEvents();
         }
 
-        ImGui.Text($"Testing: {this.currentSubStep.ToString()}");
+        ImGui.TextUnformatted($"Testing: {this.currentSubStep.ToString()}");
 
         switch (this.currentSubStep)
         {
@@ -50,24 +51,24 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
 
                 if (this.historyListing == null)
                 {
-                    ImGui.Text("Goto a Market Board. Open any item that has historical sale listings.");
+                    ImGui.TextUnformatted("Goto a Market Board. Open any item that has historical sale listings."u8);
                 }
                 else
                 {
-                    ImGui.Text("Does one of the historical sales match this information?");
+                    ImGui.TextUnformatted("Does one of the historical sales match this information?"u8);
                     ImGui.Separator();
-                    ImGui.Text($"Quantity: {this.historyListing.Quantity.ToString()}");
-                    ImGui.Text($"Buyer: {this.historyListing.BuyerName}");
-                    ImGui.Text($"Sale Price: {this.historyListing.SalePrice.ToString()}");
-                    ImGui.Text($"Purchase Time: {this.historyListing.PurchaseTime.ToLocalTime().ToString(CultureInfo.InvariantCulture)}");
+                    ImGui.TextUnformatted($"Quantity: {this.historyListing.Quantity.ToString()}");
+                    ImGui.TextUnformatted($"Buyer: {this.historyListing.BuyerName}");
+                    ImGui.TextUnformatted($"Sale Price: {this.historyListing.SalePrice.ToString()}");
+                    ImGui.TextUnformatted($"Purchase Time: {this.historyListing.PurchaseTime.ToLocalTime().ToString(CultureInfo.InvariantCulture)}");
                     ImGui.Separator();
-                    if (ImGui.Button("Looks Correct / Skip"))
+                    if (ImGui.Button("Looks Correct / Skip"u8))
                     {
                         this.currentSubStep++;
                     }
 
                     ImGui.SameLine();
-                    if (ImGui.Button("No"))
+                    if (ImGui.Button("No"u8))
                     {
                         return SelfTestStepResult.Fail;
                     }
@@ -78,24 +79,24 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
 
                 if (this.itemListing == null)
                 {
-                    ImGui.Text("Goto a Market Board. Open any item that has sale listings.");
+                    ImGui.TextUnformatted("Goto a Market Board. Open any item that has sale listings."u8);
                 }
                 else
                 {
-                    ImGui.Text("Does one of the sales match this information?");
+                    ImGui.TextUnformatted("Does one of the sales match this information?"u8);
                     ImGui.Separator();
-                    ImGui.Text($"Quantity: {this.itemListing.ItemQuantity.ToString()}");
-                    ImGui.Text($"Price Per Unit: {this.itemListing.PricePerUnit}");
-                    ImGui.Text($"Retainer Name: {this.itemListing.RetainerName}");
-                    ImGui.Text($"Is HQ?: {(this.itemListing.IsHq ? "Yes" : "No")}");
+                    ImGui.TextUnformatted($"Quantity: {this.itemListing.ItemQuantity.ToString()}");
+                    ImGui.TextUnformatted($"Price Per Unit: {this.itemListing.PricePerUnit}");
+                    ImGui.TextUnformatted($"Retainer Name: {this.itemListing.RetainerName}");
+                    ImGui.TextUnformatted($"Is HQ?: {(this.itemListing.IsHq ? "Yes" : "No")}");
                     ImGui.Separator();
-                    if (ImGui.Button("Looks Correct / Skip"))
+                    if (ImGui.Button("Looks Correct / Skip"u8))
                     {
                         this.currentSubStep++;
                     }
 
                     ImGui.SameLine();
-                    if (ImGui.Button("No"))
+                    if (ImGui.Button("No"u8))
                     {
                         return SelfTestStepResult.Fail;
                     }
@@ -105,23 +106,23 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
             case SubStep.PurchaseRequests:
                 if (this.marketBoardPurchaseRequest == null)
                 {
-                    ImGui.Text("Goto a Market Board. Purchase any item, the cheapest you can find.");
+                    ImGui.TextUnformatted("Goto a Market Board. Purchase any item, the cheapest you can find."u8);
                 }
                 else
                 {
-                    ImGui.TextWrapped("Does this information match the purchase you made? This is testing the request to the server.");
+                    ImGuiHelpers.SafeTextWrapped("Does this information match the purchase you made? This is testing the request to the server."u8);
                     ImGui.Separator();
-                    ImGui.Text($"Quantity: {this.marketBoardPurchaseRequest.ItemQuantity.ToString()}");
-                    ImGui.Text($"Item ID: {this.marketBoardPurchaseRequest.CatalogId}");
-                    ImGui.Text($"Price Per Unit: {this.marketBoardPurchaseRequest.PricePerUnit}");
+                    ImGui.TextUnformatted($"Quantity: {this.marketBoardPurchaseRequest.ItemQuantity.ToString()}");
+                    ImGui.TextUnformatted($"Item ID: {this.marketBoardPurchaseRequest.CatalogId}");
+                    ImGui.TextUnformatted($"Price Per Unit: {this.marketBoardPurchaseRequest.PricePerUnit}");
                     ImGui.Separator();
-                    if (ImGui.Button("Looks Correct / Skip"))
+                    if (ImGui.Button("Looks Correct / Skip"u8))
                     {
                         this.currentSubStep++;
                     }
 
                     ImGui.SameLine();
-                    if (ImGui.Button("No"))
+                    if (ImGui.Button("No"u8))
                     {
                         return SelfTestStepResult.Fail;
                     }
@@ -131,22 +132,22 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
             case SubStep.Purchases:
                 if (this.marketBoardPurchase == null)
                 {
-                    ImGui.Text("Goto a Market Board. Purchase any item, the cheapest you can find.");
+                    ImGui.TextUnformatted("Goto a Market Board. Purchase any item, the cheapest you can find."u8);
                 }
                 else
                 {
-                    ImGui.TextWrapped("Does this information match the purchase you made? This is testing the response from the server.");
+                    ImGuiHelpers.SafeTextWrapped("Does this information match the purchase you made? This is testing the response from the server."u8);
                     ImGui.Separator();
-                    ImGui.Text($"Quantity: {this.marketBoardPurchase.ItemQuantity.ToString()}");
-                    ImGui.Text($"Item ID: {this.marketBoardPurchase.CatalogId}");
+                    ImGui.TextUnformatted($"Quantity: {this.marketBoardPurchase.ItemQuantity.ToString()}");
+                    ImGui.TextUnformatted($"Item ID: {this.marketBoardPurchase.CatalogId}");
                     ImGui.Separator();
-                    if (ImGui.Button("Looks Correct / Skip"))
+                    if (ImGui.Button("Looks Correct / Skip"u8))
                     {
                         this.currentSubStep++;
                     }
 
                     ImGui.SameLine();
-                    if (ImGui.Button("No"))
+                    if (ImGui.Button("No"u8))
                     {
                         return SelfTestStepResult.Fail;
                     }
@@ -156,28 +157,28 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
             case SubStep.Taxes:
                 if (this.marketTaxRate == null)
                 {
-                    ImGui.TextWrapped("Goto a Retainer Vocate and talk to then. Click the 'View market tax rates' menu item.");
+                    ImGuiHelpers.SafeTextWrapped("Goto a Retainer Vocate and talk to then. Click the 'View market tax rates' menu item."u8);
                 }
                 else
                 {
-                    ImGui.Text("Does this market tax rate information look correct?");
+                    ImGui.TextUnformatted("Does this market tax rate information look correct?"u8);
                     ImGui.Separator();
-                    ImGui.Text($"Uldah: {this.marketTaxRate.UldahTax.ToString()}");
-                    ImGui.Text($"Gridania: {this.marketTaxRate.GridaniaTax.ToString()}");
-                    ImGui.Text($"Limsa Lominsa: {this.marketTaxRate.LimsaLominsaTax.ToString()}");
-                    ImGui.Text($"Ishgard: {this.marketTaxRate.IshgardTax.ToString()}");
-                    ImGui.Text($"Kugane: {this.marketTaxRate.KuganeTax.ToString()}");
-                    ImGui.Text($"Crystarium: {this.marketTaxRate.CrystariumTax.ToString()}");
-                    ImGui.Text($"Sharlayan: {this.marketTaxRate.SharlayanTax.ToString()}");
-                    ImGui.Text($"Tuliyollal: {this.marketTaxRate.TuliyollalTax.ToString()}");
+                    ImGui.TextUnformatted($"Uldah: {this.marketTaxRate.UldahTax.ToString()}");
+                    ImGui.TextUnformatted($"Gridania: {this.marketTaxRate.GridaniaTax.ToString()}");
+                    ImGui.TextUnformatted($"Limsa Lominsa: {this.marketTaxRate.LimsaLominsaTax.ToString()}");
+                    ImGui.TextUnformatted($"Ishgard: {this.marketTaxRate.IshgardTax.ToString()}");
+                    ImGui.TextUnformatted($"Kugane: {this.marketTaxRate.KuganeTax.ToString()}");
+                    ImGui.TextUnformatted($"Crystarium: {this.marketTaxRate.CrystariumTax.ToString()}");
+                    ImGui.TextUnformatted($"Sharlayan: {this.marketTaxRate.SharlayanTax.ToString()}");
+                    ImGui.TextUnformatted($"Tuliyollal: {this.marketTaxRate.TuliyollalTax.ToString()}");
                     ImGui.Separator();
-                    if (ImGui.Button("Looks Correct / Skip"))
+                    if (ImGui.Button("Looks Correct / Skip"u8))
                     {
                         this.currentSubStep++;
                     }
 
                     ImGui.SameLine();
-                    if (ImGui.Button("No"))
+                    if (ImGui.Button("No"u8))
                     {
                         return SelfTestStepResult.Fail;
                     }

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/MarketBoardSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/MarketBoardSelfTestStep.cs
@@ -43,7 +43,7 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
             this.SubscribeToEvents();
         }
 
-        ImGui.TextUnformatted($"Testing: {this.currentSubStep.ToString()}");
+        ImGui.Text($"Testing: {this.currentSubStep.ToString()}");
 
         switch (this.currentSubStep)
         {
@@ -51,16 +51,16 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
 
                 if (this.historyListing == null)
                 {
-                    ImGui.TextUnformatted("Goto a Market Board. Open any item that has historical sale listings."u8);
+                    ImGui.Text("Goto a Market Board. Open any item that has historical sale listings."u8);
                 }
                 else
                 {
-                    ImGui.TextUnformatted("Does one of the historical sales match this information?"u8);
+                    ImGui.Text("Does one of the historical sales match this information?"u8);
                     ImGui.Separator();
-                    ImGui.TextUnformatted($"Quantity: {this.historyListing.Quantity.ToString()}");
-                    ImGui.TextUnformatted($"Buyer: {this.historyListing.BuyerName}");
-                    ImGui.TextUnformatted($"Sale Price: {this.historyListing.SalePrice.ToString()}");
-                    ImGui.TextUnformatted($"Purchase Time: {this.historyListing.PurchaseTime.ToLocalTime().ToString(CultureInfo.InvariantCulture)}");
+                    ImGui.Text($"Quantity: {this.historyListing.Quantity.ToString()}");
+                    ImGui.Text($"Buyer: {this.historyListing.BuyerName}");
+                    ImGui.Text($"Sale Price: {this.historyListing.SalePrice.ToString()}");
+                    ImGui.Text($"Purchase Time: {this.historyListing.PurchaseTime.ToLocalTime().ToString(CultureInfo.InvariantCulture)}");
                     ImGui.Separator();
                     if (ImGui.Button("Looks Correct / Skip"u8))
                     {
@@ -79,16 +79,16 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
 
                 if (this.itemListing == null)
                 {
-                    ImGui.TextUnformatted("Goto a Market Board. Open any item that has sale listings."u8);
+                    ImGui.Text("Goto a Market Board. Open any item that has sale listings."u8);
                 }
                 else
                 {
-                    ImGui.TextUnformatted("Does one of the sales match this information?"u8);
+                    ImGui.Text("Does one of the sales match this information?"u8);
                     ImGui.Separator();
-                    ImGui.TextUnformatted($"Quantity: {this.itemListing.ItemQuantity.ToString()}");
-                    ImGui.TextUnformatted($"Price Per Unit: {this.itemListing.PricePerUnit}");
-                    ImGui.TextUnformatted($"Retainer Name: {this.itemListing.RetainerName}");
-                    ImGui.TextUnformatted($"Is HQ?: {(this.itemListing.IsHq ? "Yes" : "No")}");
+                    ImGui.Text($"Quantity: {this.itemListing.ItemQuantity.ToString()}");
+                    ImGui.Text($"Price Per Unit: {this.itemListing.PricePerUnit}");
+                    ImGui.Text($"Retainer Name: {this.itemListing.RetainerName}");
+                    ImGui.Text($"Is HQ?: {(this.itemListing.IsHq ? "Yes" : "No")}");
                     ImGui.Separator();
                     if (ImGui.Button("Looks Correct / Skip"u8))
                     {
@@ -106,15 +106,15 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
             case SubStep.PurchaseRequests:
                 if (this.marketBoardPurchaseRequest == null)
                 {
-                    ImGui.TextUnformatted("Goto a Market Board. Purchase any item, the cheapest you can find."u8);
+                    ImGui.Text("Goto a Market Board. Purchase any item, the cheapest you can find."u8);
                 }
                 else
                 {
                     ImGuiHelpers.SafeTextWrapped("Does this information match the purchase you made? This is testing the request to the server."u8);
                     ImGui.Separator();
-                    ImGui.TextUnformatted($"Quantity: {this.marketBoardPurchaseRequest.ItemQuantity.ToString()}");
-                    ImGui.TextUnformatted($"Item ID: {this.marketBoardPurchaseRequest.CatalogId}");
-                    ImGui.TextUnformatted($"Price Per Unit: {this.marketBoardPurchaseRequest.PricePerUnit}");
+                    ImGui.Text($"Quantity: {this.marketBoardPurchaseRequest.ItemQuantity.ToString()}");
+                    ImGui.Text($"Item ID: {this.marketBoardPurchaseRequest.CatalogId}");
+                    ImGui.Text($"Price Per Unit: {this.marketBoardPurchaseRequest.PricePerUnit}");
                     ImGui.Separator();
                     if (ImGui.Button("Looks Correct / Skip"u8))
                     {
@@ -132,14 +132,14 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
             case SubStep.Purchases:
                 if (this.marketBoardPurchase == null)
                 {
-                    ImGui.TextUnformatted("Goto a Market Board. Purchase any item, the cheapest you can find."u8);
+                    ImGui.Text("Goto a Market Board. Purchase any item, the cheapest you can find."u8);
                 }
                 else
                 {
                     ImGuiHelpers.SafeTextWrapped("Does this information match the purchase you made? This is testing the response from the server."u8);
                     ImGui.Separator();
-                    ImGui.TextUnformatted($"Quantity: {this.marketBoardPurchase.ItemQuantity.ToString()}");
-                    ImGui.TextUnformatted($"Item ID: {this.marketBoardPurchase.CatalogId}");
+                    ImGui.Text($"Quantity: {this.marketBoardPurchase.ItemQuantity.ToString()}");
+                    ImGui.Text($"Item ID: {this.marketBoardPurchase.CatalogId}");
                     ImGui.Separator();
                     if (ImGui.Button("Looks Correct / Skip"u8))
                     {
@@ -161,16 +161,16 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
                 }
                 else
                 {
-                    ImGui.TextUnformatted("Does this market tax rate information look correct?"u8);
+                    ImGui.Text("Does this market tax rate information look correct?"u8);
                     ImGui.Separator();
-                    ImGui.TextUnformatted($"Uldah: {this.marketTaxRate.UldahTax.ToString()}");
-                    ImGui.TextUnformatted($"Gridania: {this.marketTaxRate.GridaniaTax.ToString()}");
-                    ImGui.TextUnformatted($"Limsa Lominsa: {this.marketTaxRate.LimsaLominsaTax.ToString()}");
-                    ImGui.TextUnformatted($"Ishgard: {this.marketTaxRate.IshgardTax.ToString()}");
-                    ImGui.TextUnformatted($"Kugane: {this.marketTaxRate.KuganeTax.ToString()}");
-                    ImGui.TextUnformatted($"Crystarium: {this.marketTaxRate.CrystariumTax.ToString()}");
-                    ImGui.TextUnformatted($"Sharlayan: {this.marketTaxRate.SharlayanTax.ToString()}");
-                    ImGui.TextUnformatted($"Tuliyollal: {this.marketTaxRate.TuliyollalTax.ToString()}");
+                    ImGui.Text($"Uldah: {this.marketTaxRate.UldahTax.ToString()}");
+                    ImGui.Text($"Gridania: {this.marketTaxRate.GridaniaTax.ToString()}");
+                    ImGui.Text($"Limsa Lominsa: {this.marketTaxRate.LimsaLominsaTax.ToString()}");
+                    ImGui.Text($"Ishgard: {this.marketTaxRate.IshgardTax.ToString()}");
+                    ImGui.Text($"Kugane: {this.marketTaxRate.KuganeTax.ToString()}");
+                    ImGui.Text($"Crystarium: {this.marketTaxRate.CrystariumTax.ToString()}");
+                    ImGui.Text($"Sharlayan: {this.marketTaxRate.SharlayanTax.ToString()}");
+                    ImGui.Text($"Tuliyollal: {this.marketTaxRate.TuliyollalTax.ToString()}");
                     ImGui.Separator();
                     if (ImGui.Button("Looks Correct / Skip"u8))
                     {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/MarketBoardSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/MarketBoardSelfTestStep.cs
@@ -110,7 +110,7 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
                 }
                 else
                 {
-                    ImGuiHelpers.SafeTextWrapped("Does this information match the purchase you made? This is testing the request to the server."u8);
+                    ImGui.TextWrapped("Does this information match the purchase you made? This is testing the request to the server."u8);
                     ImGui.Separator();
                     ImGui.Text($"Quantity: {this.marketBoardPurchaseRequest.ItemQuantity.ToString()}");
                     ImGui.Text($"Item ID: {this.marketBoardPurchaseRequest.CatalogId}");
@@ -136,7 +136,7 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
                 }
                 else
                 {
-                    ImGuiHelpers.SafeTextWrapped("Does this information match the purchase you made? This is testing the response from the server."u8);
+                    ImGui.TextWrapped("Does this information match the purchase you made? This is testing the response from the server."u8);
                     ImGui.Separator();
                     ImGui.Text($"Quantity: {this.marketBoardPurchase.ItemQuantity.ToString()}");
                     ImGui.Text($"Item ID: {this.marketBoardPurchase.CatalogId}");
@@ -157,7 +157,7 @@ internal class MarketBoardSelfTestStep : ISelfTestStep
             case SubStep.Taxes:
                 if (this.marketTaxRate == null)
                 {
-                    ImGuiHelpers.SafeTextWrapped("Goto a Retainer Vocate and talk to then. Click the 'View market tax rates' menu item."u8);
+                    ImGui.TextWrapped("Goto a Retainer Vocate and talk to then. Click the 'View market tax rates' menu item."u8);
                 }
                 else
                 {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/NamePlateSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/NamePlateSelfTestStep.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 using Dalamud.Bindings.ImGui;
 using Dalamud.Game.Gui.NamePlate;
@@ -40,14 +40,14 @@ internal class NamePlateSelfTestStep : ISelfTestStep
                 break;
 
             case SubStep.Confirm:
-                ImGui.Text("Click to redraw all visible nameplates");
-                if (ImGui.Button("Request redraw"))
+                ImGui.TextUnformatted("Click to redraw all visible nameplates"u8);
+                if (ImGui.Button("Request redraw"u8))
                     namePlateGui.RequestRedraw();
 
                 ImGui.TextUnformatted("Can you see marker icons above nameplates, and does\n" +
                                       "the update count increase when using request redraw?");
 
-                if (ImGui.Button("Yes"))
+                if (ImGui.Button("Yes"u8))
                 {
                     this.CleanUp();
                     return SelfTestStepResult.Pass;
@@ -55,7 +55,7 @@ internal class NamePlateSelfTestStep : ISelfTestStep
 
                 ImGui.SameLine();
 
-                if (ImGui.Button("No"))
+                if (ImGui.Button("No"u8))
                 {
                     this.CleanUp();
                     return SelfTestStepResult.Fail;

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/NamePlateSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/NamePlateSelfTestStep.cs
@@ -40,11 +40,11 @@ internal class NamePlateSelfTestStep : ISelfTestStep
                 break;
 
             case SubStep.Confirm:
-                ImGui.TextUnformatted("Click to redraw all visible nameplates"u8);
+                ImGui.Text("Click to redraw all visible nameplates"u8);
                 if (ImGui.Button("Request redraw"u8))
                     namePlateGui.RequestRedraw();
 
-                ImGui.TextUnformatted("Can you see marker icons above nameplates, and does\n" +
+                ImGui.Text("Can you see marker icons above nameplates, and does\n" +
                                       "the update count increase when using request redraw?");
 
                 if (ImGui.Button("Yes"u8))

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/NounProcessorSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/NounProcessorSelfTestStep.cs
@@ -225,9 +225,9 @@ internal class NounProcessorSelfTestStep : ISelfTestStep
 
             if (e.ExpectedResult != output)
             {
-                ImGui.TextUnformatted($"Mismatch detected (Test #{i}):");
-                ImGui.TextUnformatted($"Got: {output}");
-                ImGui.TextUnformatted($"Expected: {e.ExpectedResult}");
+                ImGui.Text($"Mismatch detected (Test #{i}):");
+                ImGui.Text($"Got: {output}");
+                ImGui.Text($"Expected: {e.ExpectedResult}");
 
                 if (ImGui.Button("Continue"u8))
                     return SelfTestStepResult.Fail;

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/NounProcessorSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/NounProcessorSelfTestStep.cs
@@ -229,7 +229,7 @@ internal class NounProcessorSelfTestStep : ISelfTestStep
                 ImGui.TextUnformatted($"Got: {output}");
                 ImGui.TextUnformatted($"Expected: {e.ExpectedResult}");
 
-                if (ImGui.Button("Continue"))
+                if (ImGui.Button("Continue"u8))
                     return SelfTestStepResult.Fail;
 
                 return SelfTestStepResult.Waiting;

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/PartyFinderSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/PartyFinderSelfTestStep.cs
@@ -33,7 +33,7 @@ internal class PartyFinderSelfTestStep : ISelfTestStep
             return SelfTestStepResult.Pass;
         }
 
-        ImGui.TextUnformatted("Open Party Finder"u8);
+        ImGui.Text("Open Party Finder"u8);
 
         return SelfTestStepResult.Waiting;
     }

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/PartyFinderSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/PartyFinderSelfTestStep.cs
@@ -33,7 +33,7 @@ internal class PartyFinderSelfTestStep : ISelfTestStep
             return SelfTestStepResult.Pass;
         }
 
-        ImGui.Text("Open Party Finder");
+        ImGui.TextUnformatted("Open Party Finder"u8);
 
         return SelfTestStepResult.Waiting;
     }

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/SeStringEvaluatorSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/SeStringEvaluatorSelfTestStep.cs
@@ -23,13 +23,13 @@ internal class SeStringEvaluatorSelfTestStep : ISelfTestStep
         switch (this.step)
         {
             case 0:
-                ImGui.TextUnformatted("Is this the current time, and is it ticking?"u8);
+                ImGui.Text("Is this the current time, and is it ticking?"u8);
 
                 // This checks that EvaluateFromAddon fetches the correct Addon row,
                 // that MacroDecoder.GetMacroTime()->SetTime() has been called
                 // and that local and global parameters have been read correctly.
 
-                ImGui.TextUnformatted(seStringEvaluator.EvaluateFromAddon(31, [(uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds()]).ExtractText());
+                ImGui.Text(seStringEvaluator.EvaluateFromAddon(31, [(uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds()]).ExtractText());
 
                 if (ImGui.Button("Yes"u8))
                     this.step++;
@@ -42,7 +42,7 @@ internal class SeStringEvaluatorSelfTestStep : ISelfTestStep
                 break;
 
             case 1:
-                ImGui.TextUnformatted("Checking pcname macro using the local player name..."u8);
+                ImGui.Text("Checking pcname macro using the local player name..."u8);
 
                 // This makes sure that NameCache.Instance()->TryGetCharacterInfoByEntityId() has been called,
                 // that it returned the local players name by using its EntityId,
@@ -52,7 +52,7 @@ internal class SeStringEvaluatorSelfTestStep : ISelfTestStep
                 var localPlayer = clientState.LocalPlayer;
                 if (localPlayer is null)
                 {
-                    ImGui.TextUnformatted("You need to be logged in for this step."u8);
+                    ImGui.Text("You need to be logged in for this step."u8);
 
                     if (ImGui.Button("Skip"u8))
                         return SelfTestStepResult.NotRan;
@@ -65,9 +65,9 @@ internal class SeStringEvaluatorSelfTestStep : ISelfTestStep
 
                 if (evaluatedPlayerName != localPlayerName)
                 {
-                    ImGui.TextUnformatted("The player name doesn't match:"u8);
-                    ImGui.TextUnformatted($"Evaluated Player Name (got): {evaluatedPlayerName}");
-                    ImGui.TextUnformatted($"Local Player Name (expected): {localPlayerName}");
+                    ImGui.Text("The player name doesn't match:"u8);
+                    ImGui.Text($"Evaluated Player Name (got): {evaluatedPlayerName}");
+                    ImGui.Text($"Local Player Name (expected): {localPlayerName}");
 
                     if (ImGui.Button("Continue"u8))
                         return SelfTestStepResult.Fail;

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/SeStringEvaluatorSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/SeStringEvaluatorSelfTestStep.cs
@@ -23,7 +23,7 @@ internal class SeStringEvaluatorSelfTestStep : ISelfTestStep
         switch (this.step)
         {
             case 0:
-                ImGui.TextUnformatted("Is this the current time, and is it ticking?");
+                ImGui.TextUnformatted("Is this the current time, and is it ticking?"u8);
 
                 // This checks that EvaluateFromAddon fetches the correct Addon row,
                 // that MacroDecoder.GetMacroTime()->SetTime() has been called
@@ -31,18 +31,18 @@ internal class SeStringEvaluatorSelfTestStep : ISelfTestStep
 
                 ImGui.TextUnformatted(seStringEvaluator.EvaluateFromAddon(31, [(uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds()]).ExtractText());
 
-                if (ImGui.Button("Yes"))
+                if (ImGui.Button("Yes"u8))
                     this.step++;
 
                 ImGui.SameLine();
 
-                if (ImGui.Button("No"))
+                if (ImGui.Button("No"u8))
                     return SelfTestStepResult.Fail;
 
                 break;
 
             case 1:
-                ImGui.TextUnformatted("Checking pcname macro using the local player name...");
+                ImGui.TextUnformatted("Checking pcname macro using the local player name..."u8);
 
                 // This makes sure that NameCache.Instance()->TryGetCharacterInfoByEntityId() has been called,
                 // that it returned the local players name by using its EntityId,
@@ -52,9 +52,9 @@ internal class SeStringEvaluatorSelfTestStep : ISelfTestStep
                 var localPlayer = clientState.LocalPlayer;
                 if (localPlayer is null)
                 {
-                    ImGui.TextUnformatted("You need to be logged in for this step.");
+                    ImGui.TextUnformatted("You need to be logged in for this step."u8);
 
-                    if (ImGui.Button("Skip"))
+                    if (ImGui.Button("Skip"u8))
                         return SelfTestStepResult.NotRan;
 
                     return SelfTestStepResult.Waiting;
@@ -65,11 +65,11 @@ internal class SeStringEvaluatorSelfTestStep : ISelfTestStep
 
                 if (evaluatedPlayerName != localPlayerName)
                 {
-                    ImGui.TextUnformatted("The player name doesn't match:");
+                    ImGui.TextUnformatted("The player name doesn't match:"u8);
                     ImGui.TextUnformatted($"Evaluated Player Name (got): {evaluatedPlayerName}");
                     ImGui.TextUnformatted($"Local Player Name (expected): {localPlayerName}");
 
-                    if (ImGui.Button("Continue"))
+                    if (ImGui.Button("Continue"u8))
                         return SelfTestStepResult.Fail;
 
                     return SelfTestStepResult.Waiting;

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/SheetRedirectResolverSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/SheetRedirectResolverSelfTestStep.cs
@@ -107,7 +107,7 @@ internal class SheetRedirectResolverSelfTestStep : ISelfTestStep
                     ImGui.TextUnformatted($"Game: {utf8SheetName->ToString()}#{rowId1}-{colIndex1} ({flags1})");
                     ImGui.TextUnformatted($"Evaluated: {sheetName2}#{rowId2}-{colIndex2} ({flags2})");
 
-                    if (ImGui.Button("Continue"))
+                    if (ImGui.Button("Continue"u8))
                         return SelfTestStepResult.Fail;
 
                     return SelfTestStepResult.Waiting;

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/SheetRedirectResolverSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/SheetRedirectResolverSelfTestStep.cs
@@ -102,10 +102,10 @@ internal class SheetRedirectResolverSelfTestStep : ISelfTestStep
 
                 if (utf8SheetName->ToString() != sheetName2 || rowId1 != rowId2 || colIndex1 != colIndex2 || flags1 != flags2)
                 {
-                    ImGui.TextUnformatted($"Mismatch detected (Test #{i}):");
-                    ImGui.TextUnformatted($"Input: {redirect.SheetName}#{redirect.RowId}");
-                    ImGui.TextUnformatted($"Game: {utf8SheetName->ToString()}#{rowId1}-{colIndex1} ({flags1})");
-                    ImGui.TextUnformatted($"Evaluated: {sheetName2}#{rowId2}-{colIndex2} ({flags2})");
+                    ImGui.Text($"Mismatch detected (Test #{i}):");
+                    ImGui.Text($"Input: {redirect.SheetName}#{redirect.RowId}");
+                    ImGui.Text($"Game: {utf8SheetName->ToString()}#{rowId1}-{colIndex1} ({flags1})");
+                    ImGui.Text($"Evaluated: {sheetName2}#{rowId2}-{colIndex2} ({flags2})");
 
                     if (ImGui.Button("Continue"u8))
                         return SelfTestStepResult.Fail;

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/TargetSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/TargetSelfTestStep.cs
@@ -31,7 +31,7 @@ internal class TargetSelfTestStep : ISelfTestStep
                 break;
 
             case 1:
-                ImGui.TextUnformatted("Target a player..."u8);
+                ImGui.Text("Target a player..."u8);
 
                 var cTarget = targetManager.Target;
                 if (cTarget is PlayerCharacter)
@@ -42,7 +42,7 @@ internal class TargetSelfTestStep : ISelfTestStep
                 break;
 
             case 2:
-                ImGui.TextUnformatted("Focus-Target a Battle NPC..."u8);
+                ImGui.Text("Focus-Target a Battle NPC..."u8);
 
                 var fTarget = targetManager.FocusTarget;
                 if (fTarget is BattleNpc)
@@ -53,7 +53,7 @@ internal class TargetSelfTestStep : ISelfTestStep
                 break;
 
             case 3:
-                ImGui.TextUnformatted("Soft-Target an EventObj..."u8);
+                ImGui.Text("Soft-Target an EventObj..."u8);
 
                 var sTarget = targetManager.SoftTarget;
                 if (sTarget is EventObj)

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/TargetSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/TargetSelfTestStep.cs
@@ -31,7 +31,7 @@ internal class TargetSelfTestStep : ISelfTestStep
                 break;
 
             case 1:
-                ImGui.Text("Target a player...");
+                ImGui.TextUnformatted("Target a player..."u8);
 
                 var cTarget = targetManager.Target;
                 if (cTarget is PlayerCharacter)
@@ -42,7 +42,7 @@ internal class TargetSelfTestStep : ISelfTestStep
                 break;
 
             case 2:
-                ImGui.Text("Focus-Target a Battle NPC...");
+                ImGui.TextUnformatted("Focus-Target a Battle NPC..."u8);
 
                 var fTarget = targetManager.FocusTarget;
                 if (fTarget is BattleNpc)
@@ -53,7 +53,7 @@ internal class TargetSelfTestStep : ISelfTestStep
                 break;
 
             case 3:
-                ImGui.Text("Soft-Target an EventObj...");
+                ImGui.TextUnformatted("Soft-Target an EventObj..."u8);
 
                 var sTarget = targetManager.SoftTarget;
                 if (sTarget is EventObj)

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ToastSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ToastSelfTestStep.cs
@@ -25,7 +25,7 @@ internal class ToastSelfTestStep : ISelfTestStep
             this.sentToasts = true;
         }
 
-        ImGui.TextUnformatted("Did you see a normal toast, a quest toast and an error toast?"u8);
+        ImGui.Text("Did you see a normal toast, a quest toast and an error toast?"u8);
 
         if (ImGui.Button("Yes"u8))
         {

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ToastSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/ToastSelfTestStep.cs
@@ -25,15 +25,15 @@ internal class ToastSelfTestStep : ISelfTestStep
             this.sentToasts = true;
         }
 
-        ImGui.Text("Did you see a normal toast, a quest toast and an error toast?");
+        ImGui.TextUnformatted("Did you see a normal toast, a quest toast and an error toast?"u8);
 
-        if (ImGui.Button("Yes"))
+        if (ImGui.Button("Yes"u8))
         {
             return SelfTestStepResult.Pass;
         }
 
         ImGui.SameLine();
-        if (ImGui.Button("No"))
+        if (ImGui.Button("No"u8))
         {
             return SelfTestStepResult.Fail;
         }

--- a/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs
@@ -129,7 +129,7 @@ internal class SettingsWindow : Window
     {
         var windowSize = ImGui.GetWindowSize();
 
-        if (ImGui.BeginTabBar("###settingsTabs"))
+        if (ImGui.BeginTabBar("###settingsTabs"u8))
         {
             if (string.IsNullOrEmpty(this.searchInput))
             {
@@ -179,7 +179,7 @@ internal class SettingsWindow : Window
             }
             else
             {
-                if (ImGui.BeginTabItem("Search Results"))
+                if (ImGui.BeginTabItem("Search Results"u8))
                 {
                     var any = false;
 
@@ -192,7 +192,7 @@ internal class SettingsWindow : Window
 
                         any = true;
 
-                        ImGui.TextColored(ImGuiColors.DalamudGrey, settingsTab.Title);
+                        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, settingsTab.Title);
                         ImGui.Dummy(new Vector2(5));
 
                         foreach (var settingsTabEntry in eligible)
@@ -207,7 +207,7 @@ internal class SettingsWindow : Window
                     }
 
                     if (!any)
-                        ImGui.TextColored(ImGuiColors.DalamudGrey, "No results found...");
+                        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, "No results found..."u8);
 
                     ImGui.EndTabItem();
                 }
@@ -218,7 +218,7 @@ internal class SettingsWindow : Window
 
         ImGui.SetCursorPos(windowSize - ImGuiHelpers.ScaledVector2(70));
 
-        using (var buttonChild = ImRaii.Child("###settingsFinishButton"))
+        using (var buttonChild = ImRaii.Child("###settingsFinishButton"u8))
         {
             if (buttonChild)
             {
@@ -248,7 +248,7 @@ internal class SettingsWindow : Window
 
         ImGui.SetCursorPos(new Vector2(windowSize.X - 250, ImGui.GetTextLineHeightWithSpacing() + (ImGui.GetStyle().FramePadding.Y * 2)));
         ImGui.SetNextItemWidth(240);
-        ImGui.InputTextWithHint("###searchInput", "Search for settings...", ref this.searchInput, 100);
+        ImGui.InputTextWithHint("###searchInput"u8, "Search for settings..."u8, ref this.searchInput, 100);
     }
 
     private void Save()

--- a/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/SettingsWindow.cs
@@ -192,7 +192,7 @@ internal class SettingsWindow : Window
 
                         any = true;
 
-                        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, settingsTab.Title);
+                        ImGui.TextColored(ImGuiColors.DalamudGrey, settingsTab.Title);
                         ImGui.Dummy(new Vector2(5));
 
                         foreach (var settingsTabEntry in eligible)
@@ -207,7 +207,7 @@ internal class SettingsWindow : Window
                     }
 
                     if (!any)
-                        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey, "No results found..."u8);
+                        ImGui.TextColored(ImGuiColors.DalamudGrey, "No results found..."u8);
 
                     ImGui.EndTabItem();
                 }

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabAbout.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabAbout.cs
@@ -263,7 +263,7 @@ Contribute at: https://github.com/goatcorp/Dalamud
     {
         var windowSize = ImGui.GetWindowSize();
 
-        using var child = ImRaii.Child("scrolling", new Vector2(-1, -10 * ImGuiHelpers.GlobalScale), false, ImGuiWindowFlags.NoScrollbar);
+        using var child = ImRaii.Child("scrolling"u8, new Vector2(-1, -10 * ImGuiHelpers.GlobalScale), false, ImGuiWindowFlags.NoScrollbar);
         if (!child)
             return;
 
@@ -276,7 +276,7 @@ Contribute at: https://github.com/goatcorp/Dalamud
         using (ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, Vector2.Zero))
         {
             ImGuiHelpers.ScaledDummy(0, windowSize.Y + 20f);
-            ImGui.Text(string.Empty);
+            ImGui.TextUnformatted(string.Empty);
 
             const float imageSize = 190f;
             ImGui.SameLine((ImGui.GetWindowWidth() / 2) - (imageSize / 2));

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabAbout.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabAbout.cs
@@ -276,7 +276,7 @@ Contribute at: https://github.com/goatcorp/Dalamud
         using (ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, Vector2.Zero))
         {
             ImGuiHelpers.ScaledDummy(0, windowSize.Y + 20f);
-            ImGui.TextUnformatted(string.Empty);
+            ImGui.Text(string.Empty);
 
             const float imageSize = 190f;
             ImGui.SameLine((ImGui.GetWindowWidth() / 2) - (imageSize / 2));
@@ -293,7 +293,7 @@ Contribute at: https://github.com/goatcorp/Dalamud
 
                 ImGui.Dummy(new Vector2((windowX / 2) - (lineLenX / 2), 0f));
                 ImGui.SameLine();
-                ImGui.TextUnformatted(creditsLine);
+                ImGui.Text(creditsLine);
             }
 
             ImGuiHelpers.ScaledDummy(0, 40f);
@@ -305,7 +305,7 @@ Contribute at: https://github.com/goatcorp/Dalamud
 
                 ImGui.Dummy(new Vector2((windowX / 2) - (thankYouLenX / 2), 0f));
                 ImGui.SameLine();
-                ImGui.TextUnformatted(ThankYouText);
+                ImGui.Text(ThankYouText);
             }
 
             ImGuiHelpers.ScaledDummy(0, windowSize.Y + 50f);

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabAutoUpdate.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabAutoUpdate.cs
@@ -136,7 +136,7 @@ public class SettingsTabAutoUpdates : SettingsTab
                     var before = ImGui.GetCursorPos();
 
                     ImGui.SetCursorPosY(ImGui.GetCursorPosY() + (pluginLineHeight / 2) - (textHeight.Y / 2));
-                    ImGui.TextUnformatted(text);
+                    ImGui.Text(text);
 
                     ImGui.SetCursorPos(before);
                 }
@@ -150,7 +150,7 @@ public class SettingsTabAutoUpdates : SettingsTab
                     var before = ImGui.GetCursorPos();
 
                     ImGui.SetCursorPosY(ImGui.GetCursorPosY() + (pluginLineHeight / 2) - (textHeight.Y / 2));
-                    ImGui.TextUnformatted(text);
+                    ImGui.Text(text);
 
                     ImGui.SetCursorPos(before);
                 }

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabAutoUpdate.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabAutoUpdate.cs
@@ -33,20 +33,20 @@ public class SettingsTabAutoUpdates : SettingsTab
 
     public override void Draw()
     {
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudWhite, Loc.Localize("DalamudSettingsAutoUpdateHint",
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudWhite, Loc.Localize("DalamudSettingsAutoUpdateHint",
                                                 "Dalamud can update your plugins automatically, making sure that you always " +
                                                 "have the newest features and bug fixes. You can choose when and how auto-updates are run here."));
         ImGuiHelpers.ScaledDummy(2);
 
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsAutoUpdateDisclaimer1",
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsAutoUpdateDisclaimer1",
                                                 "You can always update your plugins manually by clicking the update button in the plugin list. " +
                                                 "You can also opt into updates for specific plugins by right-clicking them and selecting \"Always auto-update\"."));
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsAutoUpdateDisclaimer2",
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsAutoUpdateDisclaimer2",
                                                 "Dalamud will only notify you about updates while you are idle."));
 
         ImGuiHelpers.ScaledDummy(8);
 
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudWhite, Loc.Localize("DalamudSettingsAutoUpdateBehavior",
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudWhite, Loc.Localize("DalamudSettingsAutoUpdateBehavior",
                                                 "When the game starts..."));
         var behaviorInt = (int)this.behavior;
         ImGui.RadioButton(Loc.Localize("DalamudSettingsAutoUpdateNone", "Do not check for updates automatically"), ref behaviorInt, (int)AutoUpdateBehavior.None);
@@ -61,7 +61,7 @@ public class SettingsTabAutoUpdates : SettingsTab
                 "DalamudSettingsAutoUpdateAllWarning",
                 "Warning: This will update all plugins, including those not from the main repository.\n" +
                 "These updates are not reviewed by the Dalamud team and may contain malicious code.");
-            ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudOrange, warning);
+            ImGui.TextColoredWrapped(ImGuiColors.DalamudOrange, warning);
         }
 
         ImGuiHelpers.ScaledDummy(8);
@@ -69,17 +69,17 @@ public class SettingsTabAutoUpdates : SettingsTab
         ImGui.Checkbox(Loc.Localize("DalamudSettingsAutoUpdateDisabledPlugins", "Auto-Update plugins that are currently disabled"), ref this.updateDisabledPlugins);
         ImGui.Checkbox(Loc.Localize("DalamudSettingsAutoUpdateChatMessage", "Show notification about updates available in chat"), ref this.chatNotification);
         ImGui.Checkbox(Loc.Localize("DalamudSettingsAutoUpdatePeriodically", "Periodically check for new updates while playing"), ref this.checkPeriodically);
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsAutoUpdatePeriodicallyHint",
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsAutoUpdatePeriodicallyHint",
                                                 "Plugins won't update automatically after startup, you will only receive a notification while you are not actively playing."));
 
         ImGuiHelpers.ScaledDummy(5);
         ImGui.Separator();
         ImGuiHelpers.ScaledDummy(5);
 
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudWhite, Loc.Localize("DalamudSettingsAutoUpdateOptedIn",
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudWhite, Loc.Localize("DalamudSettingsAutoUpdateOptedIn",
                                                 "Per-plugin overrides"));
 
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudWhite, Loc.Localize("DalamudSettingsAutoUpdateOverrideHint",
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudWhite, Loc.Localize("DalamudSettingsAutoUpdateOverrideHint",
                                                 "Here, you can choose to receive or not to receive updates for specific plugins. " +
                                                 "This will override the settings above for the selected plugins."));
 

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabDtr.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabDtr.cs
@@ -101,7 +101,7 @@ public class SettingsTabDtr : SettingsTab
             ImGui.SameLine();
 
             // if (isRequired) {
-            //     ImGui.TextUnformatted($"Search in {name}");
+            //     ImGui.Text($"Search in {name}");
             // } else {
 
             var isShown = ignore.All(x => x != title);
@@ -133,11 +133,11 @@ public class SettingsTabDtr : SettingsTab
 
         ImGuiHelpers.ScaledDummy(10);
 
-        ImGui.TextUnformatted(Loc.Localize("DalamudSettingServerInfoBarSpacing", "Server Info Bar spacing"));
+        ImGui.Text(Loc.Localize("DalamudSettingServerInfoBarSpacing", "Server Info Bar spacing"));
         ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingServerInfoBarSpacingHint", "Configure the amount of space between entries in the server info bar here."));
         ImGui.SliderInt("Spacing"u8, ref this.dtrSpacing, 0, 40);
 
-        ImGui.TextUnformatted(Loc.Localize("DalamudSettingServerInfoBarDirection", "Server Info Bar direction"));
+        ImGui.Text(Loc.Localize("DalamudSettingServerInfoBarDirection", "Server Info Bar direction"));
         ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingServerInfoBarDirectionHint", "If checked, the Server Info Bar elements will expand to the right instead of the left."));
         ImGui.Checkbox("Swap Direction"u8, ref this.dtrSwapDirection);
 

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabDtr.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabDtr.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
@@ -133,13 +133,13 @@ public class SettingsTabDtr : SettingsTab
 
         ImGuiHelpers.ScaledDummy(10);
 
-        ImGui.Text(Loc.Localize("DalamudSettingServerInfoBarSpacing", "Server Info Bar spacing"));
+        ImGui.TextUnformatted(Loc.Localize("DalamudSettingServerInfoBarSpacing", "Server Info Bar spacing"));
         ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingServerInfoBarSpacingHint", "Configure the amount of space between entries in the server info bar here."));
-        ImGui.SliderInt("Spacing", ref this.dtrSpacing, 0, 40);
+        ImGui.SliderInt("Spacing"u8, ref this.dtrSpacing, 0, 40);
 
-        ImGui.Text(Loc.Localize("DalamudSettingServerInfoBarDirection", "Server Info Bar direction"));
+        ImGui.TextUnformatted(Loc.Localize("DalamudSettingServerInfoBarDirection", "Server Info Bar direction"));
         ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingServerInfoBarDirectionHint", "If checked, the Server Info Bar elements will expand to the right instead of the left."));
-        ImGui.Checkbox("Swap Direction", ref this.dtrSwapDirection);
+        ImGui.Checkbox("Swap Direction"u8, ref this.dtrSwapDirection);
 
         base.Draw();
     }

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabDtr.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabDtr.cs
@@ -27,7 +27,7 @@ public class SettingsTabDtr : SettingsTab
 
     public override void Draw()
     {
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingServerInfoBarHint", "Plugins can put additional information into your server information bar(where world & time can be seen).\nYou can reorder and disable these here."));
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingServerInfoBarHint", "Plugins can put additional information into your server information bar(where world & time can be seen).\nYou can reorder and disable these here."));
 
         ImGuiHelpers.ScaledDummy(10);
 
@@ -41,7 +41,7 @@ public class SettingsTabDtr : SettingsTab
 
         if (order.Count == 0)
         {
-            ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingServerInfoBarDidNone", "You have no plugins that use this feature."));
+            ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingServerInfoBarDidNone", "You have no plugins that use this feature."));
         }
 
         var isOrderChange = false;
@@ -134,11 +134,11 @@ public class SettingsTabDtr : SettingsTab
         ImGuiHelpers.ScaledDummy(10);
 
         ImGui.Text(Loc.Localize("DalamudSettingServerInfoBarSpacing", "Server Info Bar spacing"));
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingServerInfoBarSpacingHint", "Configure the amount of space between entries in the server info bar here."));
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingServerInfoBarSpacingHint", "Configure the amount of space between entries in the server info bar here."));
         ImGui.SliderInt("Spacing"u8, ref this.dtrSpacing, 0, 40);
 
         ImGui.Text(Loc.Localize("DalamudSettingServerInfoBarDirection", "Server Info Bar direction"));
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingServerInfoBarDirectionHint", "If checked, the Server Info Bar elements will expand to the right instead of the left."));
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingServerInfoBarDirectionHint", "If checked, the Server Info Bar elements will expand to the right instead of the left."));
         ImGui.Checkbox("Swap Direction"u8, ref this.dtrSwapDirection);
 
         base.Draw();

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabExperimental.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabExperimental.cs
@@ -1,7 +1,8 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 
 using CheapLoc;
 
+using Dalamud.Bindings.ImGui;
 using Dalamud.Configuration.Internal;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Internal.ReShadeHandling;
@@ -151,7 +152,7 @@ public class SettingsTabExperimental : SettingsTab
     {
         base.Draw();
 
-        ImGuiHelpers.SafeTextColoredWrapped(
+        ImGui.TextColoredWrapped(
             ImGuiColors.DalamudGrey,
             "Total memory used by Dalamud & Plugins: " + Util.FormatBytes(GC.GetTotalMemory(false)));
         ImGuiHelpers.ScaledDummy(15);

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
@@ -170,7 +170,7 @@ public class SettingsTabLook : SettingsTab
                 ImGui.SameLine();
 
                 ImGui.PushStyleVar(ImGuiStyleVar.Alpha, v / 100);
-                ImGui.TextUnformatted("\uE020\uE021\uE022\uE023\uE024\uE025\uE026\uE027"u8);
+                ImGui.Text("\uE020\uE021\uE022\uE023\uE024\uE025\uE026\uE027"u8);
                 ImGui.PopStyleVar(1);
             },
         }
@@ -184,7 +184,7 @@ public class SettingsTabLook : SettingsTab
         var fontBuildTask = interfaceManager.FontBuildTask;
 
         ImGui.AlignTextToFramePadding();
-        ImGui.TextUnformatted(Loc.Localize("DalamudSettingsGlobalUiScale", "Global Font Scale"));
+        ImGui.Text(Loc.Localize("DalamudSettingsGlobalUiScale", "Global Font Scale"));
 
         var buttonSize =
             GlobalUiScalePresets
@@ -210,7 +210,7 @@ public class SettingsTabLook : SettingsTab
                 var len = Encoding.UTF8.GetByteCount(buildingFonts);
                 var p = stackalloc byte[len];
                 Encoding.UTF8.GetBytes(buildingFonts, new(p, len));
-                ImGui.TextUnformatted(
+                ImGui.Text(
                     new ReadOnlySpan<byte>(p, len)[..((len + ((Environment.TickCount / 200) % 3)) - 2)]);
             }
         }
@@ -234,7 +234,7 @@ public class SettingsTabLook : SettingsTab
                 && ImGui.CollapsingHeader("##DalamudSetingsFontBuildFaultReason"u8))
             {
                 foreach (var e in fontBuildTask.Exception.InnerExceptions)
-                    ImGui.TextUnformatted(e.ToString());
+                    ImGui.Text(e.ToString());
             }
         }
 

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
@@ -162,7 +162,7 @@ public class SettingsTabLook : SettingsTab
         {
             CustomDraw = static e =>
             {
-                ImGuiHelpers.SafeTextWrapped(e.Name!);
+                ImGui.TextWrapped(e.Name!);
 
                 var v = e.Value * 100f;
                 if (ImGui.SliderFloat($"###{e}", ref v, 0f, 100f, "%.1f%%"))
@@ -223,11 +223,11 @@ public class SettingsTabLook : SettingsTab
             interfaceManager.RebuildFonts();
         }
 
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsGlobalUiScaleHint", "Scale text in all XIVLauncher UI elements - this is useful for 4K displays."));
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsGlobalUiScaleHint", "Scale text in all XIVLauncher UI elements - this is useful for 4K displays."));
 
         if (fontBuildTask.IsFaulted || fontBuildTask.IsCanceled)
         {
-            ImGuiHelpers.SafeTextColored(
+            ImGui.TextColored(
                 ImGuiColors.DalamudRed,
                 Loc.Localize("DalamudSettingsFontBuildFaulted", "Failed to load fonts as requested."));
             if (fontBuildTask.Exception is not null

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using System.Text;
@@ -170,7 +170,7 @@ public class SettingsTabLook : SettingsTab
                 ImGui.SameLine();
 
                 ImGui.PushStyleVar(ImGuiStyleVar.Alpha, v / 100);
-                ImGui.TextUnformatted("\uE020\uE021\uE022\uE023\uE024\uE025\uE026\uE027");
+                ImGui.TextUnformatted("\uE020\uE021\uE022\uE023\uE024\uE025\uE026\uE027"u8);
                 ImGui.PopStyleVar(1);
             },
         }
@@ -184,7 +184,7 @@ public class SettingsTabLook : SettingsTab
         var fontBuildTask = interfaceManager.FontBuildTask;
 
         ImGui.AlignTextToFramePadding();
-        ImGui.Text(Loc.Localize("DalamudSettingsGlobalUiScale", "Global Font Scale"));
+        ImGui.TextUnformatted(Loc.Localize("DalamudSettingsGlobalUiScale", "Global Font Scale"));
 
         var buttonSize =
             GlobalUiScalePresets
@@ -216,7 +216,7 @@ public class SettingsTabLook : SettingsTab
         }
 
         var globalUiScaleInPct = 100f * this.globalUiScale;
-        if (ImGui.DragFloat("##DalamudSettingsGlobalUiScaleDrag", ref globalUiScaleInPct, 1f, 80f, 300f, "%.0f%%", ImGuiSliderFlags.AlwaysClamp))
+        if (ImGui.DragFloat("##DalamudSettingsGlobalUiScaleDrag"u8, ref globalUiScaleInPct, 1f, 80f, 300f, "%.0f%%", ImGuiSliderFlags.AlwaysClamp))
         {
             this.globalUiScale = globalUiScaleInPct / 100f;
             ImGui.GetIO().FontGlobalScale = this.globalUiScale;
@@ -227,11 +227,11 @@ public class SettingsTabLook : SettingsTab
 
         if (fontBuildTask.IsFaulted || fontBuildTask.IsCanceled)
         {
-            ImGui.TextColored(
+            ImGuiHelpers.SafeTextColored(
                 ImGuiColors.DalamudRed,
                 Loc.Localize("DalamudSettingsFontBuildFaulted", "Failed to load fonts as requested."));
             if (fontBuildTask.Exception is not null
-                && ImGui.CollapsingHeader("##DalamudSetingsFontBuildFaultReason"))
+                && ImGui.CollapsingHeader("##DalamudSetingsFontBuildFaultReason"u8))
             {
                 foreach (var e in fontBuildTask.Exception.InnerExceptions)
                     ImGui.TextUnformatted(e.ToString());

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/ButtonSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/ButtonSettingsEntry.cs
@@ -36,6 +36,6 @@ public class ButtonSettingsEntry : SettingsEntry
             this.runs.Invoke();
         }
 
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, this.description);
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, this.description);
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
@@ -69,7 +69,7 @@ public class DevPluginsSettingsEntry : SettingsEntry
             }
         }
 
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsDevPluginLocationsHint", "Add dev plugin load locations.\nThis must be a path to the plugin DLL."));
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsDevPluginLocationsHint", "Add dev plugin load locations.\nThis must be a path to the plugin DLL."));
 
         var locationSelect = Loc.Localize("DalamudDevPluginLocationSelect", "Select Dev Plugin DLL");
         if (ImGuiComponents.IconButtonWithText(FontAwesomeIcon.Folder, locationSelect))
@@ -191,7 +191,7 @@ public class DevPluginsSettingsEntry : SettingsEntry
 
         if (!string.IsNullOrEmpty(this.devPluginLocationAddError))
         {
-            ImGuiHelpers.SafeTextColoredWrapped(new Vector4(1, 0, 0, 1), this.devPluginLocationAddError);
+            ImGui.TextColoredWrapped(new Vector4(1, 0, 0, 1), this.devPluginLocationAddError);
         }
     }
 

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
@@ -59,13 +59,13 @@ public class DevPluginsSettingsEntry : SettingsEntry
     public override void Draw()
     {
         using var id = ImRaii.PushId("devPluginLocation"u8);
-        ImGui.TextUnformatted(this.Name);
+        ImGui.Text(this.Name);
         if (this.devPluginLocationsChanged)
         {
             using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.HealerGreen))
             {
                 ImGui.SameLine();
-                ImGui.TextUnformatted(Loc.Localize("DalamudSettingsChanged", "(Changed)"));
+                ImGui.Text(Loc.Localize("DalamudSettingsChanged", "(Changed)"));
             }
         }
 
@@ -97,13 +97,13 @@ public class DevPluginsSettingsEntry : SettingsEntry
 
         ImGui.Separator();
 
-        ImGui.TextUnformatted("#"u8);
+        ImGui.Text("#"u8);
         ImGui.NextColumn();
-        ImGui.TextUnformatted("Path"u8);
+        ImGui.Text("Path"u8);
         ImGui.NextColumn();
-        ImGui.TextUnformatted("Enabled"u8);
+        ImGui.Text("Enabled"u8);
         ImGui.NextColumn();
-        ImGui.TextUnformatted(string.Empty);
+        ImGui.Text(string.Empty);
         ImGui.NextColumn();
 
         ImGui.Separator();
@@ -118,7 +118,7 @@ public class DevPluginsSettingsEntry : SettingsEntry
             id.Push(devPluginLocationSetting.Path);
 
             ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 8 - (ImGui.CalcTextSize(locNumber.ToString()).X / 2));
-            ImGui.TextUnformatted(locNumber.ToString());
+            ImGui.Text(locNumber.ToString());
             ImGui.NextColumn();
 
             ImGui.SetNextItemWidth(-1);
@@ -175,7 +175,7 @@ public class DevPluginsSettingsEntry : SettingsEntry
         }
 
         ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 8 - (ImGui.CalcTextSize(locNumber.ToString()).X / 2));
-        ImGui.TextUnformatted(locNumber.ToString());
+        ImGui.Text(locNumber.ToString());
         ImGui.NextColumn();
         ImGui.SetNextItemWidth(-1);
         ImGui.InputText("##devPluginLocationInput"u8, ref this.devPluginTempLocation, 300);

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
@@ -58,7 +58,7 @@ public class DevPluginsSettingsEntry : SettingsEntry
 
     public override void Draw()
     {
-        using var id = ImRaii.PushId("devPluginLocation");
+        using var id = ImRaii.PushId("devPluginLocation"u8);
         ImGui.TextUnformatted(this.Name);
         if (this.devPluginLocationsChanged)
         {
@@ -97,11 +97,11 @@ public class DevPluginsSettingsEntry : SettingsEntry
 
         ImGui.Separator();
 
-        ImGui.TextUnformatted("#");
+        ImGui.TextUnformatted("#"u8);
         ImGui.NextColumn();
-        ImGui.TextUnformatted("Path");
+        ImGui.TextUnformatted("Path"u8);
         ImGui.NextColumn();
-        ImGui.TextUnformatted("Enabled");
+        ImGui.TextUnformatted("Enabled"u8);
         ImGui.NextColumn();
         ImGui.TextUnformatted(string.Empty);
         ImGui.NextColumn();
@@ -150,7 +150,7 @@ public class DevPluginsSettingsEntry : SettingsEntry
             ImGui.NextColumn();
 
             ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 7 - (12 * ImGuiHelpers.GlobalScale));
-            ImGui.Checkbox("##devPluginLocationCheck", ref isEnabled);
+            ImGui.Checkbox("##devPluginLocationCheck"u8, ref isEnabled);
             ImGui.NextColumn();
 
             if (ImGuiComponents.IconButton(FontAwesomeIcon.Trash))
@@ -178,7 +178,7 @@ public class DevPluginsSettingsEntry : SettingsEntry
         ImGui.TextUnformatted(locNumber.ToString());
         ImGui.NextColumn();
         ImGui.SetNextItemWidth(-1);
-        ImGui.InputText("##devPluginLocationInput", ref this.devPluginTempLocation, 300);
+        ImGui.InputText("##devPluginLocationInput"u8, ref this.devPluginTempLocation, 300);
         ImGui.NextColumn();
         // Enabled button
         ImGui.NextColumn();

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/EnumSettingsEntry{T}.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/EnumSettingsEntry{T}.cs
@@ -135,7 +135,7 @@ internal sealed class EnumSettingsEntry<T> : SettingsEntry
             {
                 using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed))
                 {
-                    ImGui.Text(validityMsg);
+                    ImGui.TextUnformatted(validityMsg);
                 }
             }
         }
@@ -150,7 +150,7 @@ internal sealed class EnumSettingsEntry<T> : SettingsEntry
         {
             using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed))
             {
-                ImGui.Text(warningMessage);
+                ImGui.TextUnformatted(warningMessage);
             }
         }
     }

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/EnumSettingsEntry{T}.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/EnumSettingsEntry{T}.cs
@@ -87,7 +87,7 @@ internal sealed class EnumSettingsEntry<T> : SettingsEntry
         }
         else
         {
-            ImGuiHelpers.SafeTextWrapped(this.Name);
+            ImGui.TextWrapped(this.Name);
 
             var idx = this.valueBacking;
             var values = Enum.GetValues<T>();
@@ -119,11 +119,11 @@ internal sealed class EnumSettingsEntry<T> : SettingsEntry
             var desc = this.FriendlyEnumDescriptionGetter(this.valueBacking);
             if (!string.IsNullOrWhiteSpace(desc))
             {
-                ImGuiHelpers.SafeTextWrapped(desc);
+                ImGui.TextWrapped(desc);
                 ImGuiHelpers.ScaledDummy(2);
             }
 
-            ImGuiHelpers.SafeTextWrapped(this.Description);
+            ImGui.TextWrapped(this.Description);
         }
 
         if (this.CheckValidity != null)

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/EnumSettingsEntry{T}.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/EnumSettingsEntry{T}.cs
@@ -135,7 +135,7 @@ internal sealed class EnumSettingsEntry<T> : SettingsEntry
             {
                 using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed))
                 {
-                    ImGui.TextUnformatted(validityMsg);
+                    ImGui.Text(validityMsg);
                 }
             }
         }
@@ -150,7 +150,7 @@ internal sealed class EnumSettingsEntry<T> : SettingsEntry
         {
             using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed))
             {
-                ImGui.TextUnformatted(warningMessage);
+                ImGui.Text(warningMessage);
             }
         }
     }

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/HintSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/HintSettingsEntry.cs
@@ -1,8 +1,8 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
-using Dalamud.Interface.Utility;
 
 namespace Dalamud.Interface.Internal.Windows.Settings.Widgets;
 
@@ -30,6 +30,6 @@ public class HintSettingsEntry : SettingsEntry
 
     public override void Draw()
     {
-        ImGuiHelpers.SafeTextColoredWrapped(this.color, this.text);
+        ImGui.TextColoredWrapped(this.color, this.text);
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
@@ -69,7 +69,7 @@ public sealed class LanguageChooserSettingsEntry : SettingsEntry
 
     public override void Draw()
     {
-        ImGui.TextUnformatted(this.Name);
+        ImGui.Text(this.Name);
         ImGui.Combo("##XlLangCombo", ref this.langIndex, this.locLanguages);
         ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsLanguageHint", "Select the language Dalamud will be displayed in."));
     }

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
@@ -69,7 +69,7 @@ public sealed class LanguageChooserSettingsEntry : SettingsEntry
 
     public override void Draw()
     {
-        ImGui.Text(this.Name);
+        ImGui.TextUnformatted(this.Name);
         ImGui.Combo("##XlLangCombo", ref this.langIndex, this.locLanguages);
         ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsLanguageHint", "Select the language Dalamud will be displayed in."));
     }

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
@@ -71,6 +71,6 @@ public sealed class LanguageChooserSettingsEntry : SettingsEntry
     {
         ImGui.Text(this.Name);
         ImGui.Combo("##XlLangCombo", ref this.langIndex, this.locLanguages);
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsLanguageHint", "Select the language Dalamud will be displayed in."));
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingsLanguageHint", "Select the language Dalamud will be displayed in."));
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/SettingsEntry{T}.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/SettingsEntry{T}.cs
@@ -125,7 +125,7 @@ internal sealed class SettingsEntry<T> : SettingsEntry
             {
                 using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed))
                 {
-                    ImGui.Text(validityMsg);
+                    ImGui.TextUnformatted(validityMsg);
                 }
             }
         }
@@ -140,7 +140,7 @@ internal sealed class SettingsEntry<T> : SettingsEntry
         {
             using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed))
             {
-                ImGui.Text(warningMessage);
+                ImGui.TextUnformatted(warningMessage);
             }
         }
     }

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/SettingsEntry{T}.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/SettingsEntry{T}.cs
@@ -79,7 +79,7 @@ internal sealed class SettingsEntry<T> : SettingsEntry
         }
         else if (type == typeof(DirectoryInfo))
         {
-            ImGuiHelpers.SafeTextWrapped(this.Name);
+            ImGui.TextWrapped(this.Name);
 
             var value = this.Value as DirectoryInfo;
             var nativeBuffer = value?.FullName ?? string.Empty;
@@ -91,7 +91,7 @@ internal sealed class SettingsEntry<T> : SettingsEntry
         }
         else if (type == typeof(string))
         {
-            ImGuiHelpers.SafeTextWrapped(this.Name);
+            ImGui.TextWrapped(this.Name);
 
             var nativeBuffer = this.Value as string ?? string.Empty;
 
@@ -113,7 +113,7 @@ internal sealed class SettingsEntry<T> : SettingsEntry
 
         using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudGrey))
         {
-            ImGuiHelpers.SafeTextWrapped(this.Description);
+            ImGui.TextWrapped(this.Description);
         }
 
         if (this.CheckValidity != null)

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/SettingsEntry{T}.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/SettingsEntry{T}.cs
@@ -125,7 +125,7 @@ internal sealed class SettingsEntry<T> : SettingsEntry
             {
                 using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed))
                 {
-                    ImGui.TextUnformatted(validityMsg);
+                    ImGui.Text(validityMsg);
                 }
             }
         }
@@ -140,7 +140,7 @@ internal sealed class SettingsEntry<T> : SettingsEntry
         {
             using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed))
             {
-                ImGui.TextUnformatted(warningMessage);
+                ImGui.Text(warningMessage);
             }
         }
     }

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/ThirdRepoSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/ThirdRepoSettingsEntry.cs
@@ -60,7 +60,7 @@ public class ThirdRepoSettingsEntry : SettingsEntry
     {
         var config = Service<DalamudConfiguration>.Get();
 
-        using var id = ImRaii.PushId("thirdRepo");
+        using var id = ImRaii.PushId("thirdRepo"u8);
         ImGui.TextUnformatted(Loc.Localize("DalamudSettingsCustomRepo", "Custom Plugin Repositories"));
         if (this.thirdRepoListChanged)
         {
@@ -136,20 +136,20 @@ public class ThirdRepoSettingsEntry : SettingsEntry
 
         ImGui.Separator();
 
-        ImGui.TextUnformatted("#");
+        ImGui.TextUnformatted("#"u8);
         ImGui.NextColumn();
-        ImGui.TextUnformatted("URL");
+        ImGui.TextUnformatted("URL"u8);
         ImGui.NextColumn();
-        ImGui.TextUnformatted("Enabled");
+        ImGui.TextUnformatted("Enabled"u8);
         ImGui.NextColumn();
         ImGui.TextUnformatted(string.Empty);
         ImGui.NextColumn();
 
         ImGui.Separator();
 
-        ImGui.TextUnformatted("0");
+        ImGui.TextUnformatted("0"u8);
         ImGui.NextColumn();
-        ImGui.TextUnformatted("XIVLauncher");
+        ImGui.TextUnformatted("XIVLauncher"u8);
         ImGui.NextColumn();
         ImGui.NextColumn();
         ImGui.NextColumn();
@@ -197,7 +197,7 @@ public class ThirdRepoSettingsEntry : SettingsEntry
             ImGui.NextColumn();
 
             ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 7 - (12 * ImGuiHelpers.GlobalScale));
-            if (ImGui.Checkbox("##thirdRepoCheck", ref isEnabled))
+            if (ImGui.Checkbox("##thirdRepoCheck"u8, ref isEnabled))
             {
                 this.thirdRepoListChanged = true;
             }
@@ -229,7 +229,7 @@ public class ThirdRepoSettingsEntry : SettingsEntry
         ImGui.TextUnformatted(repoNumber.ToString());
         ImGui.NextColumn();
         ImGui.SetNextItemWidth(-1);
-        ImGui.InputText("##thirdRepoUrlInput", ref this.thirdRepoTempUrl, 300);
+        ImGui.InputText("##thirdRepoUrlInput"u8, ref this.thirdRepoTempUrl, 300);
         ImGui.NextColumn();
         // Enabled button
         ImGui.NextColumn();

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/ThirdRepoSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/ThirdRepoSettingsEntry.cs
@@ -61,13 +61,13 @@ public class ThirdRepoSettingsEntry : SettingsEntry
         var config = Service<DalamudConfiguration>.Get();
 
         using var id = ImRaii.PushId("thirdRepo"u8);
-        ImGui.TextUnformatted(Loc.Localize("DalamudSettingsCustomRepo", "Custom Plugin Repositories"));
+        ImGui.Text(Loc.Localize("DalamudSettingsCustomRepo", "Custom Plugin Repositories"));
         if (this.thirdRepoListChanged)
         {
             using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.HealerGreen))
             {
                 ImGui.SameLine();
-                ImGui.TextUnformatted(Loc.Localize("DalamudSettingsChanged", "(Changed)"));
+                ImGui.Text(Loc.Localize("DalamudSettingsChanged", "(Changed)"));
             }
         }
 
@@ -136,20 +136,20 @@ public class ThirdRepoSettingsEntry : SettingsEntry
 
         ImGui.Separator();
 
-        ImGui.TextUnformatted("#"u8);
+        ImGui.Text("#"u8);
         ImGui.NextColumn();
-        ImGui.TextUnformatted("URL"u8);
+        ImGui.Text("URL"u8);
         ImGui.NextColumn();
-        ImGui.TextUnformatted("Enabled"u8);
+        ImGui.Text("Enabled"u8);
         ImGui.NextColumn();
-        ImGui.TextUnformatted(string.Empty);
+        ImGui.Text(string.Empty);
         ImGui.NextColumn();
 
         ImGui.Separator();
 
-        ImGui.TextUnformatted("0"u8);
+        ImGui.Text("0"u8);
         ImGui.NextColumn();
-        ImGui.TextUnformatted("XIVLauncher"u8);
+        ImGui.Text("XIVLauncher"u8);
         ImGui.NextColumn();
         ImGui.NextColumn();
         ImGui.NextColumn();
@@ -165,7 +165,7 @@ public class ThirdRepoSettingsEntry : SettingsEntry
             id.Push(thirdRepoSetting.Url);
 
             ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 8 - (ImGui.CalcTextSize(repoNumber.ToString()).X / 2));
-            ImGui.TextUnformatted(repoNumber.ToString());
+            ImGui.Text(repoNumber.ToString());
             ImGui.NextColumn();
 
             ImGui.SetNextItemWidth(-1);
@@ -226,7 +226,7 @@ public class ThirdRepoSettingsEntry : SettingsEntry
         }
 
         ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 8 - (ImGui.CalcTextSize(repoNumber.ToString()).X / 2));
-        ImGui.TextUnformatted(repoNumber.ToString());
+        ImGui.Text(repoNumber.ToString());
         ImGui.NextColumn();
         ImGui.SetNextItemWidth(-1);
         ImGui.InputText("##thirdRepoUrlInput"u8, ref this.thirdRepoTempUrl, 300);

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/ThirdRepoSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/ThirdRepoSettingsEntry.cs
@@ -71,7 +71,7 @@ public class ThirdRepoSettingsEntry : SettingsEntry
             }
         }
 
-        ImGuiHelpers.SafeTextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingCustomRepoHint", "Add custom plugin repositories."));
+        ImGui.TextColoredWrapped(ImGuiColors.DalamudGrey, Loc.Localize("DalamudSettingCustomRepoHint", "Add custom plugin repositories."));
 
         ImGuiHelpers.ScaledDummy(2);
 
@@ -80,24 +80,24 @@ public class ThirdRepoSettingsEntry : SettingsEntry
 
         ImGui.PushFont(InterfaceManager.IconFont);
         ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudOrange);
-        ImGuiHelpers.SafeTextWrapped(FontAwesomeIcon.ExclamationTriangle.ToIconString());
+        ImGui.TextWrapped(FontAwesomeIcon.ExclamationTriangle.ToIconString());
         ImGui.PopFont();
         ImGui.SameLine();
         ImGuiHelpers.ScaledDummy(2);
         ImGui.SameLine();
-        ImGuiHelpers.SafeTextWrapped(Loc.Localize("DalamudSettingCustomRepoWarningReadThis", "READ THIS FIRST!"));
+        ImGui.TextWrapped(Loc.Localize("DalamudSettingCustomRepoWarningReadThis", "READ THIS FIRST!"));
         ImGui.SameLine();
         ImGuiHelpers.ScaledDummy(2);
         ImGui.SameLine();
         ImGui.PushFont(InterfaceManager.IconFont);
-        ImGuiHelpers.SafeTextWrapped(FontAwesomeIcon.ExclamationTriangle.ToIconString());
+        ImGui.TextWrapped(FontAwesomeIcon.ExclamationTriangle.ToIconString());
         ImGui.PopFont();
 
-        ImGuiHelpers.SafeTextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning", "We cannot take any responsibility for custom plugins and repositories."));
-        ImGuiHelpers.SafeTextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning5", "If someone told you to copy/paste something here, it's very possible that you are being scammed or taken advantage of."));
-        ImGuiHelpers.SafeTextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning2", "Plugins have full control over your PC, like any other program, and may cause harm or crashes."));
-        ImGuiHelpers.SafeTextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning4", "They can delete your character, steal your FC or Discord account, and burn down your house."));
-        ImGuiHelpers.SafeTextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning3", "Please make absolutely sure that you only install plugins from developers you trust."));
+        ImGui.TextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning", "We cannot take any responsibility for custom plugins and repositories."));
+        ImGui.TextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning5", "If someone told you to copy/paste something here, it's very possible that you are being scammed or taken advantage of."));
+        ImGui.TextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning2", "Plugins have full control over your PC, like any other program, and may cause harm or crashes."));
+        ImGui.TextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning4", "They can delete your character, steal your FC or Discord account, and burn down your house."));
+        ImGui.TextWrapped(Loc.Localize("DalamudSettingCustomRepoWarning3", "Please make absolutely sure that you only install plugins from developers you trust."));
 
         ImGui.PopStyleColor();
 
@@ -262,7 +262,7 @@ public class ThirdRepoSettingsEntry : SettingsEntry
 
         if (!string.IsNullOrEmpty(this.thirdRepoAddError))
         {
-            ImGuiHelpers.SafeTextColoredWrapped(new Vector4(1, 0, 0, 1), this.thirdRepoAddError);
+            ImGui.TextColoredWrapped(new Vector4(1, 0, 0, 1), this.thirdRepoAddError);
         }
     }
 

--- a/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
@@ -83,7 +83,7 @@ public class StyleEditorWindow : Window
         var appliedThisFrame = false;
 
         var styleAry = config.SavedStyles.Select(x => x.Name).ToArray();
-        ImGui.Text(Loc.Localize("StyleEditorChooseStyle", "Choose Style:"));
+        ImGui.TextUnformatted(Loc.Localize("StyleEditorChooseStyle", "Choose Style:"));
         if (ImGui.Combo("###styleChooserCombo", ref this.currentSel, styleAry))
         {
             var newStyle = config.SavedStyles[this.currentSel];
@@ -202,13 +202,13 @@ public class StyleEditorWindow : Window
 
         if (isBuiltinStyle)
         {
-            ImGui.TextColored(ImGuiColors.DalamudRed, Loc.Localize("StyleEditorNotAllowed", "You cannot edit built-in styles. Please add a new style first."));
+            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, Loc.Localize("StyleEditorNotAllowed", "You cannot edit built-in styles. Please add a new style first."));
         }
         else if (appliedThisFrame)
         {
-            ImGui.Text(Loc.Localize("StyleEditorApplying", "Applying style..."));
+            ImGui.TextUnformatted(Loc.Localize("StyleEditorApplying", "Applying style..."));
         }
-        else if (ImGui.BeginTabBar("StyleEditorTabs"))
+        else if (ImGui.BeginTabBar("StyleEditorTabs"u8))
         {
             var style = ImGui.GetStyle();
 
@@ -224,28 +224,28 @@ public class StyleEditorWindow : Window
                     ImGui.SliderFloat2("ItemSpacing", ref style.ItemSpacing, 0.0f, 20.0f, "%.0f");
                     ImGui.SliderFloat2("ItemInnerSpacing", ref style.ItemInnerSpacing, 0.0f, 20.0f, "%.0f");
                     ImGui.SliderFloat2("TouchExtraPadding", ref style.TouchExtraPadding, 0.0f, 10.0f, "%.0f");
-                    ImGui.SliderFloat("IndentSpacing", ref style.IndentSpacing, 0.0f, 30.0f, "%.0f");
-                    ImGui.SliderFloat("ScrollbarSize", ref style.ScrollbarSize, 1.0f, 20.0f, "%.0f");
-                    ImGui.SliderFloat("GrabMinSize", ref style.GrabMinSize, 1.0f, 20.0f, "%.0f");
-                    ImGui.Text("Borders");
-                    ImGui.SliderFloat("WindowBorderSize", ref style.WindowBorderSize, 0.0f, 1.0f, "%.0f");
-                    ImGui.SliderFloat("ChildBorderSize", ref style.ChildBorderSize, 0.0f, 1.0f, "%.0f");
-                    ImGui.SliderFloat("PopupBorderSize", ref style.PopupBorderSize, 0.0f, 1.0f, "%.0f");
-                    ImGui.SliderFloat("FrameBorderSize", ref style.FrameBorderSize, 0.0f, 1.0f, "%.0f");
-                    ImGui.SliderFloat("TabBorderSize", ref style.TabBorderSize, 0.0f, 1.0f, "%.0f");
-                    ImGui.Text("Rounding");
-                    ImGui.SliderFloat("WindowRounding", ref style.WindowRounding, 0.0f, 12.0f, "%.0f");
-                    ImGui.SliderFloat("ChildRounding", ref style.ChildRounding, 0.0f, 12.0f, "%.0f");
-                    ImGui.SliderFloat("FrameRounding", ref style.FrameRounding, 0.0f, 12.0f, "%.0f");
-                    ImGui.SliderFloat("PopupRounding", ref style.PopupRounding, 0.0f, 12.0f, "%.0f");
-                    ImGui.SliderFloat("ScrollbarRounding", ref style.ScrollbarRounding, 0.0f, 12.0f, "%.0f");
-                    ImGui.SliderFloat("GrabRounding", ref style.GrabRounding, 0.0f, 12.0f, "%.0f");
-                    ImGui.SliderFloat("LogSliderDeadzone", ref style.LogSliderDeadzone, 0.0f, 12.0f, "%.0f");
-                    ImGui.SliderFloat("TabRounding", ref style.TabRounding, 0.0f, 12.0f, "%.0f");
-                    ImGui.Text("Alignment");
+                    ImGui.SliderFloat("IndentSpacing"u8, ref style.IndentSpacing, 0.0f, 30.0f, "%.0f"u8);
+                    ImGui.SliderFloat("ScrollbarSize"u8, ref style.ScrollbarSize, 1.0f, 20.0f, "%.0f"u8);
+                    ImGui.SliderFloat("GrabMinSize"u8, ref style.GrabMinSize, 1.0f, 20.0f, "%.0f"u8);
+                    ImGui.TextUnformatted("Borders"u8);
+                    ImGui.SliderFloat("WindowBorderSize"u8, ref style.WindowBorderSize, 0.0f, 1.0f, "%.0f"u8);
+                    ImGui.SliderFloat("ChildBorderSize"u8, ref style.ChildBorderSize, 0.0f, 1.0f, "%.0f"u8);
+                    ImGui.SliderFloat("PopupBorderSize"u8, ref style.PopupBorderSize, 0.0f, 1.0f, "%.0f"u8);
+                    ImGui.SliderFloat("FrameBorderSize"u8, ref style.FrameBorderSize, 0.0f, 1.0f, "%.0f"u8);
+                    ImGui.SliderFloat("TabBorderSize"u8, ref style.TabBorderSize, 0.0f, 1.0f, "%.0f"u8);
+                    ImGui.TextUnformatted("Rounding"u8);
+                    ImGui.SliderFloat("WindowRounding"u8, ref style.WindowRounding, 0.0f, 12.0f, "%.0f"u8);
+                    ImGui.SliderFloat("ChildRounding"u8, ref style.ChildRounding, 0.0f, 12.0f, "%.0f"u8);
+                    ImGui.SliderFloat("FrameRounding"u8, ref style.FrameRounding, 0.0f, 12.0f, "%.0f"u8);
+                    ImGui.SliderFloat("PopupRounding"u8, ref style.PopupRounding, 0.0f, 12.0f, "%.0f"u8);
+                    ImGui.SliderFloat("ScrollbarRounding"u8, ref style.ScrollbarRounding, 0.0f, 12.0f, "%.0f"u8);
+                    ImGui.SliderFloat("GrabRounding"u8, ref style.GrabRounding, 0.0f, 12.0f, "%.0f"u8);
+                    ImGui.SliderFloat("LogSliderDeadzone"u8, ref style.LogSliderDeadzone, 0.0f, 12.0f, "%.0f"u8);
+                    ImGui.SliderFloat("TabRounding"u8, ref style.TabRounding, 0.0f, 12.0f, "%.0f"u8);
+                    ImGui.TextUnformatted("Alignment"u8);
                     ImGui.SliderFloat2("WindowTitleAlign", ref style.WindowTitleAlign, 0.0f, 1.0f, "%.2f");
                     var windowMenuButtonPosition = (int)style.WindowMenuButtonPosition + 1;
-                    if (ImGui.Combo("WindowMenuButtonPosition", ref windowMenuButtonPosition, ["None", "Left", "Right"]))
+                    if (ImGui.Combo("WindowMenuButtonPosition"u8, ref windowMenuButtonPosition, ["None", "Left", "Right"]))
                         style.WindowMenuButtonPosition = (ImGuiDir)(windowMenuButtonPosition - 1);
                     ImGui.SliderFloat2("ButtonTextAlign", ref style.ButtonTextAlign, 0.0f, 1.0f, "%.2f");
                     ImGui.SameLine();
@@ -266,17 +266,17 @@ public class StyleEditorWindow : Window
 
             if (ImGui.BeginTabItem(Loc.Localize("StyleEditorColors", "Colors")))
             {
-                if (ImGui.BeginChild("ScrollingColors", ImGuiHelpers.ScaledVector2(0, -30), true, ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.NoBackground))
+                if (ImGui.BeginChild("ScrollingColors"u8, ImGuiHelpers.ScaledVector2(0, -30), true, ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.NoBackground))
                 {
                     ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 5);
 
-                    if (ImGui.RadioButton("Opaque", this.alphaFlags == ImGuiColorEditFlags.None))
+                    if (ImGui.RadioButton("Opaque"u8, this.alphaFlags == ImGuiColorEditFlags.None))
                         this.alphaFlags = ImGuiColorEditFlags.None;
                     ImGui.SameLine();
-                    if (ImGui.RadioButton("Alpha", this.alphaFlags == ImGuiColorEditFlags.AlphaPreview))
+                    if (ImGui.RadioButton("Alpha"u8, this.alphaFlags == ImGuiColorEditFlags.AlphaPreview))
                         this.alphaFlags = ImGuiColorEditFlags.AlphaPreview;
                     ImGui.SameLine();
-                    if (ImGui.RadioButton("Both", this.alphaFlags == ImGuiColorEditFlags.AlphaPreviewHalf))
+                    if (ImGui.RadioButton("Both"u8, this.alphaFlags == ImGuiColorEditFlags.AlphaPreviewHalf))
                         this.alphaFlags = ImGuiColorEditFlags.AlphaPreviewHalf;
                     ImGui.SameLine();
 
@@ -361,15 +361,15 @@ public class StyleEditorWindow : Window
 
         if (ImGui.BeginPopupModal(renameModalTitle, ref this.renameModalDrawing, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar))
         {
-            ImGui.Text(Loc.Localize("StyleEditorEnterName", "Please enter the new name for this style."));
+            ImGui.TextUnformatted(Loc.Localize("StyleEditorEnterName", "Please enter the new name for this style."));
             ImGui.Spacing();
 
-            ImGui.InputText("###renameModalInput", ref this.renameText, 255);
+            ImGui.InputText("###renameModalInput"u8, ref this.renameText, 255);
 
             const float buttonWidth = 120f;
             ImGui.SetCursorPosX((ImGui.GetWindowWidth() - buttonWidth) / 2);
 
-            if (ImGui.Button("OK", new Vector2(buttonWidth, 40)))
+            if (ImGui.Button("OK"u8, new Vector2(buttonWidth, 40)))
             {
                 config.SavedStyles[this.currentSel].Name = this.renameText;
                 config.QueueSave();

--- a/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
@@ -83,7 +83,7 @@ public class StyleEditorWindow : Window
         var appliedThisFrame = false;
 
         var styleAry = config.SavedStyles.Select(x => x.Name).ToArray();
-        ImGui.TextUnformatted(Loc.Localize("StyleEditorChooseStyle", "Choose Style:"));
+        ImGui.Text(Loc.Localize("StyleEditorChooseStyle", "Choose Style:"));
         if (ImGui.Combo("###styleChooserCombo", ref this.currentSel, styleAry))
         {
             var newStyle = config.SavedStyles[this.currentSel];
@@ -206,7 +206,7 @@ public class StyleEditorWindow : Window
         }
         else if (appliedThisFrame)
         {
-            ImGui.TextUnformatted(Loc.Localize("StyleEditorApplying", "Applying style..."));
+            ImGui.Text(Loc.Localize("StyleEditorApplying", "Applying style..."));
         }
         else if (ImGui.BeginTabBar("StyleEditorTabs"u8))
         {
@@ -227,13 +227,13 @@ public class StyleEditorWindow : Window
                     ImGui.SliderFloat("IndentSpacing"u8, ref style.IndentSpacing, 0.0f, 30.0f, "%.0f"u8);
                     ImGui.SliderFloat("ScrollbarSize"u8, ref style.ScrollbarSize, 1.0f, 20.0f, "%.0f"u8);
                     ImGui.SliderFloat("GrabMinSize"u8, ref style.GrabMinSize, 1.0f, 20.0f, "%.0f"u8);
-                    ImGui.TextUnformatted("Borders"u8);
+                    ImGui.Text("Borders"u8);
                     ImGui.SliderFloat("WindowBorderSize"u8, ref style.WindowBorderSize, 0.0f, 1.0f, "%.0f"u8);
                     ImGui.SliderFloat("ChildBorderSize"u8, ref style.ChildBorderSize, 0.0f, 1.0f, "%.0f"u8);
                     ImGui.SliderFloat("PopupBorderSize"u8, ref style.PopupBorderSize, 0.0f, 1.0f, "%.0f"u8);
                     ImGui.SliderFloat("FrameBorderSize"u8, ref style.FrameBorderSize, 0.0f, 1.0f, "%.0f"u8);
                     ImGui.SliderFloat("TabBorderSize"u8, ref style.TabBorderSize, 0.0f, 1.0f, "%.0f"u8);
-                    ImGui.TextUnformatted("Rounding"u8);
+                    ImGui.Text("Rounding"u8);
                     ImGui.SliderFloat("WindowRounding"u8, ref style.WindowRounding, 0.0f, 12.0f, "%.0f"u8);
                     ImGui.SliderFloat("ChildRounding"u8, ref style.ChildRounding, 0.0f, 12.0f, "%.0f"u8);
                     ImGui.SliderFloat("FrameRounding"u8, ref style.FrameRounding, 0.0f, 12.0f, "%.0f"u8);
@@ -242,7 +242,7 @@ public class StyleEditorWindow : Window
                     ImGui.SliderFloat("GrabRounding"u8, ref style.GrabRounding, 0.0f, 12.0f, "%.0f"u8);
                     ImGui.SliderFloat("LogSliderDeadzone"u8, ref style.LogSliderDeadzone, 0.0f, 12.0f, "%.0f"u8);
                     ImGui.SliderFloat("TabRounding"u8, ref style.TabRounding, 0.0f, 12.0f, "%.0f"u8);
-                    ImGui.TextUnformatted("Alignment"u8);
+                    ImGui.Text("Alignment"u8);
                     ImGui.SliderFloat2("WindowTitleAlign", ref style.WindowTitleAlign, 0.0f, 1.0f, "%.2f");
                     var windowMenuButtonPosition = (int)style.WindowMenuButtonPosition + 1;
                     if (ImGui.Combo("WindowMenuButtonPosition"u8, ref windowMenuButtonPosition, ["None", "Left", "Right"]))
@@ -295,7 +295,7 @@ public class StyleEditorWindow : Window
                         ImGui.ColorEdit4("##color", ref style.Colors[(int)imGuiCol], ImGuiColorEditFlags.AlphaBar | this.alphaFlags);
 
                         ImGui.SameLine(0.0f, style.ItemInnerSpacing.X);
-                        ImGui.TextUnformatted(imGuiCol.ToString());
+                        ImGui.Text(imGuiCol.ToString());
 
                         ImGui.PopID();
                     }
@@ -322,7 +322,7 @@ public class StyleEditorWindow : Window
                         }
 
                         ImGui.SameLine(0.0f, style.ItemInnerSpacing.X);
-                        ImGui.TextUnformatted(property.Name);
+                        ImGui.Text(property.Name);
 
                         ImGui.PopID();
                     }
@@ -361,7 +361,7 @@ public class StyleEditorWindow : Window
 
         if (ImGui.BeginPopupModal(renameModalTitle, ref this.renameModalDrawing, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar))
         {
-            ImGui.TextUnformatted(Loc.Localize("StyleEditorEnterName", "Please enter the new name for this style."));
+            ImGui.Text(Loc.Localize("StyleEditorEnterName", "Please enter the new name for this style."));
             ImGui.Spacing();
 
             ImGui.InputText("###renameModalInput"u8, ref this.renameText, 255);

--- a/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
@@ -202,7 +202,7 @@ public class StyleEditorWindow : Window
 
         if (isBuiltinStyle)
         {
-            ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudRed, Loc.Localize("StyleEditorNotAllowed", "You cannot edit built-in styles. Please add a new style first."));
+            ImGui.TextColored(ImGuiColors.DalamudRed, Loc.Localize("StyleEditorNotAllowed", "You cannot edit built-in styles. Please add a new style first."));
         }
         else if (appliedThisFrame)
         {

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlas.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlas.cs
@@ -129,7 +129,7 @@ public interface IFontAtlas : IDisposable
     /// <b>On use</b>:
     /// <code>
     /// using (this.fontHandle.Push())
-    ///     ImGui.TextUnformatted("Example");
+    ///     ImGui.TextUnformatted("Example"u8);
     /// </code>
     /// </example>
     public IFontHandle NewDelegateFontHandle(FontAtlasBuildStepDelegate buildStepDelegate);

--- a/Dalamud/Interface/ManagedFontAtlas/IFontAtlas.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontAtlas.cs
@@ -129,7 +129,7 @@ public interface IFontAtlas : IDisposable
     /// <b>On use</b>:
     /// <code>
     /// using (this.fontHandle.Push())
-    ///     ImGui.TextUnformatted("Example"u8);
+    ///     ImGui.Text("Example"u8);
     /// </code>
     /// </example>
     public IFontHandle NewDelegateFontHandle(FontAtlasBuildStepDelegate buildStepDelegate);

--- a/Dalamud/Interface/ManagedFontAtlas/IFontHandle.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontHandle.cs
@@ -66,18 +66,18 @@ public interface IFontHandle : IDisposable
     /// <b>Push a font with `using` clause.</b>
     /// <code>
     /// using (fontHandle.Push())
-    ///     ImGui.TextUnformatted("Test"u8);
+    ///     ImGui.Text("Test"u8);
     /// </code>
     /// <b>Push a font with a matching call to <see cref="Pop"/>.</b>
     /// <code>
     /// fontHandle.Push();
-    /// ImGui.TextUnformatted("Test 2"u8);
+    /// ImGui.Text("Test 2"u8);
     /// fontHandle.Pop();
     /// </code>
     /// <b>Push a font between two choices.</b>
     /// <code>
     /// using ((someCondition ? myFontHandle : dalamudPluginInterface.UiBuilder.MonoFontHandle).Push())
-    ///     ImGui.TextUnformatted("Test 3"u8);
+    ///     ImGui.Text("Test 3"u8);
     /// </code>
     /// </example>
     IDisposable Push();

--- a/Dalamud/Interface/ManagedFontAtlas/IFontHandle.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/IFontHandle.cs
@@ -66,18 +66,18 @@ public interface IFontHandle : IDisposable
     /// <b>Push a font with `using` clause.</b>
     /// <code>
     /// using (fontHandle.Push())
-    ///     ImGui.TextUnformatted("Test");
+    ///     ImGui.TextUnformatted("Test"u8);
     /// </code>
     /// <b>Push a font with a matching call to <see cref="Pop"/>.</b>
     /// <code>
     /// fontHandle.Push();
-    /// ImGui.TextUnformatted("Test 2");
+    /// ImGui.TextUnformatted("Test 2"u8);
     /// fontHandle.Pop();
     /// </code>
     /// <b>Push a font between two choices.</b>
     /// <code>
     /// using ((someCondition ? myFontHandle : dalamudPluginInterface.UiBuilder.MonoFontHandle).Push())
-    ///     ImGui.TextUnformatted("Test 3");
+    ///     ImGui.TextUnformatted("Test 3"u8);
     /// </code>
     /// </example>
     IDisposable Push();

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -713,10 +713,10 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
         {
             if (ImGui.Begin($"{this.namespaceName} Error", ref this.hasErrorWindow, ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize))
             {
-                ImGui.Text($"The plugin {this.namespaceName} ran into an error.\nContact the plugin developer for support.\n\nPlease try restarting your game.");
+                ImGui.TextUnformatted($"The plugin {this.namespaceName} ran into an error.\nContact the plugin developer for support.\n\nPlease try restarting your game.");
                 ImGui.Spacing();
 
-                if (ImGui.Button("OK"))
+                if (ImGui.Button("OK"u8))
                 {
                     this.hasErrorWindow = false;
                 }

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -713,7 +713,7 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
         {
             if (ImGui.Begin($"{this.namespaceName} Error", ref this.hasErrorWindow, ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize))
             {
-                ImGui.TextUnformatted($"The plugin {this.namespaceName} ran into an error.\nContact the plugin developer for support.\n\nPlease try restarting your game.");
+                ImGui.Text($"The plugin {this.namespaceName} ran into an error.\nContact the plugin developer for support.\n\nPlease try restarting your game.");
                 ImGui.Spacing();
 
                 if (ImGui.Button("OK"u8))

--- a/Dalamud/Interface/Utility/ImGuiHelpers.cs
+++ b/Dalamud/Interface/Utility/ImGuiHelpers.cs
@@ -246,16 +246,7 @@ public static partial class ImGuiHelpers
     /// </summary>
     /// <param name="color">The color of the text.</param>
     /// <param name="text">The text to write.</param>
-    public static void SafeTextColored(Vector4 color, string text)
-    {
-        using (ImRaii.PushColor(ImGuiCol.Text, color))
-        {
-            ImGui.TextUnformatted(text);
-        }
-    }
-
-    /// <inheritdoc cref="SafeTextColored(Vector4, string)"/>
-    public static void SafeTextColored(Vector4 color, ReadOnlySpan<byte> text)
+    public static void SafeTextColored(Vector4 color, ImU8String text)
     {
         using (ImRaii.PushColor(ImGuiCol.Text, color))
         {

--- a/Dalamud/Interface/Utility/ImGuiHelpers.cs
+++ b/Dalamud/Interface/Utility/ImGuiHelpers.cs
@@ -242,7 +242,29 @@ public static partial class ImGuiHelpers
     public static void SafeTextWrapped(ImU8String text) => ImGui.TextWrapped(text);
 
     /// <summary>
-    /// Write unformatted text wrapped.
+    /// Write colored, unformatted text.
+    /// </summary>
+    /// <param name="color">The color of the text.</param>
+    /// <param name="text">The text to write.</param>
+    public static void SafeTextColored(Vector4 color, string text)
+    {
+        using (ImRaii.PushColor(ImGuiCol.Text, color))
+        {
+            ImGui.TextUnformatted(text);
+        }
+    }
+
+    /// <inheritdoc cref="SafeTextColored(Vector4, string)"/>
+    public static void SafeTextColored(Vector4 color, ReadOnlySpan<byte> text)
+    {
+        using (ImRaii.PushColor(ImGuiCol.Text, color))
+        {
+            ImGui.TextUnformatted(text);
+        }
+    }
+
+    /// <summary>
+    /// Write colored, unformatted text wrapped.
     /// </summary>
     /// <param name="color">The color of the text.</param>
     /// <param name="text">The text to write.</param>

--- a/Dalamud/Interface/Utility/ImGuiHelpers.cs
+++ b/Dalamud/Interface/Utility/ImGuiHelpers.cs
@@ -5,7 +5,6 @@ using System.Numerics;
 using System.Reactive.Disposables;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Text.Unicode;
 
 using Dalamud.Bindings.ImGui;
@@ -239,6 +238,7 @@ public static partial class ImGuiHelpers
     /// Write unformatted text wrapped.
     /// </summary>
     /// <param name="text">The text to write.</param>
+    [Obsolete("Use ImGui.TextWrapped. It's safe now.", true)]
     public static void SafeTextWrapped(ImU8String text) => ImGui.TextWrapped(text);
 
     /// <summary>
@@ -246,6 +246,7 @@ public static partial class ImGuiHelpers
     /// </summary>
     /// <param name="color">The color of the text.</param>
     /// <param name="text">The text to write.</param>
+    [Obsolete("Use ImGui.TextColored. It's safe now.", true)]
     public static void SafeTextColored(Vector4 color, ImU8String text)
     {
         using (ImRaii.PushColor(ImGuiCol.Text, color))
@@ -259,11 +260,12 @@ public static partial class ImGuiHelpers
     /// </summary>
     /// <param name="color">The color of the text.</param>
     /// <param name="text">The text to write.</param>
+    [Obsolete("Use ImGui.TextColoredWrapped. It's safe.", true)]
     public static void SafeTextColoredWrapped(Vector4 color, ImU8String text)
     {
         using (ImRaii.PushColor(ImGuiCol.Text, color))
         {
-            SafeTextWrapped(text);
+            ImGui.TextWrapped(text);
         }
     }
 

--- a/Dalamud/Interface/Utility/ImGuiHelpers.cs
+++ b/Dalamud/Interface/Utility/ImGuiHelpers.cs
@@ -180,7 +180,7 @@ public static partial class ImGuiHelpers
                 col.Push(ImGuiCol.Text, color.Value);
             }
 
-            ImGui.TextUnformatted(text.Span);
+            ImGui.Text(text.Span);
         }
 
         if (ImGui.IsItemHovered())
@@ -191,11 +191,11 @@ public static partial class ImGuiHelpers
             {
                 using (ImRaii.PushFont(UiBuilder.IconFont))
                 {
-                    ImGui.TextUnformatted(FontAwesomeIcon.Copy.ToIconString());
+                    ImGui.Text(FontAwesomeIcon.Copy.ToIconString());
                 }
 
                 ImGui.SameLine();
-                ImGui.TextUnformatted(textCopy.IsNull ? text.Span : textCopy.Span);
+                ImGui.Text(textCopy.IsNull ? text.Span : textCopy.Span);
             }
         }
 
@@ -250,7 +250,7 @@ public static partial class ImGuiHelpers
     {
         using (ImRaii.PushColor(ImGuiCol.Text, color))
         {
-            ImGui.TextUnformatted(text);
+            ImGui.Text(text);
         }
     }
 
@@ -462,7 +462,7 @@ public static partial class ImGuiHelpers
     public static void CenteredText(ImU8String text)
     {
         CenterCursorForText(text.Span);
-        ImGui.TextUnformatted(text);
+        ImGui.Text(text);
     }
 
     /// <summary>

--- a/Dalamud/Interface/Utility/ImGuiHelpers.cs
+++ b/Dalamud/Interface/Utility/ImGuiHelpers.cs
@@ -242,20 +242,6 @@ public static partial class ImGuiHelpers
     public static void SafeTextWrapped(ImU8String text) => ImGui.TextWrapped(text);
 
     /// <summary>
-    /// Write colored, unformatted text.
-    /// </summary>
-    /// <param name="color">The color of the text.</param>
-    /// <param name="text">The text to write.</param>
-    [Obsolete("Use ImGui.TextColored. It's safe now.", true)]
-    public static void SafeTextColored(Vector4 color, ImU8String text)
-    {
-        using (ImRaii.PushColor(ImGuiCol.Text, color))
-        {
-            ImGui.Text(text);
-        }
-    }
-
-    /// <summary>
     /// Write colored, unformatted text wrapped.
     /// </summary>
     /// <param name="color">The color of the text.</param>

--- a/Dalamud/Interface/Utility/Internal/DevTextureSaveMenu.cs
+++ b/Dalamud/Interface/Utility/Internal/DevTextureSaveMenu.cs
@@ -97,7 +97,7 @@ internal sealed class DevTextureSaveMenu : IInternalDisposableService
                         return;
                     }
 
-                    if (ImGui.Selectable("Copy"))
+                    if (ImGui.Selectable("Copy"u8))
                         tcs.TrySetResult(null);
                     foreach (var encoder2 in encoders)
                     {

--- a/Dalamud/Interface/Utility/Table/Column.cs
+++ b/Dalamud/Interface/Utility/Table/Column.cs
@@ -16,7 +16,7 @@ public class Column<TItem>
     public virtual bool DrawFilter()
     {
         ImGui.AlignTextToFramePadding();
-        ImGui.TextUnformatted(this.Label);
+        ImGui.Text(this.Label);
         return false;
     }
 

--- a/Dalamud/Interface/Utility/Table/ColumnFlags.cs
+++ b/Dalamud/Interface/Utility/Table/ColumnFlags.cs
@@ -38,7 +38,7 @@ public class ColumnFlags<T, TItem> : Column<TItem> where T : struct, Enum
         }
 
         if (!all && ImGui.IsItemHovered())
-            ImGui.SetTooltip("Right-click to clear filters.");
+            ImGui.SetTooltip("Right-click to clear filters."u8);
 
         if (!combo)
             return false;
@@ -46,7 +46,7 @@ public class ColumnFlags<T, TItem> : Column<TItem> where T : struct, Enum
         color.Pop();
 
         var ret = false;
-        if (ImGui.Checkbox("Enable All", ref all))
+        if (ImGui.Checkbox("Enable All"u8, ref all))
         {
             this.SetValue(this.AllFlags, all);
             ret = true;

--- a/Dalamud/Interface/Utility/Table/ColumnString.cs
+++ b/Dalamud/Interface/Utility/Table/ColumnString.cs
@@ -52,6 +52,6 @@ public class ColumnString<TItem> : Column<TItem>
 
     public override void DrawColumn(TItem item, int idx)
     {
-        ImGui.TextUnformatted(this.ToName(item));
+        ImGui.Text(this.ToName(item));
     }
 }

--- a/Dalamud/Interface/Utility/Table/Table.cs
+++ b/Dalamud/Interface/Utility/Table/Table.cs
@@ -143,7 +143,7 @@ public class Table<T>
 
     private void DrawTableInternal()
     {
-        using var table = ImRaii.Table("Table", this.Headers.Length, this.Flags,
+        using var table = ImRaii.Table("Table"u8, this.Headers.Length, this.Flags,
             ImGui.GetContentRegionAvail() - this.ExtraHeight * Vector2.UnitY * ImGuiHelpers.GlobalScale);
         if (!table)
             return;

--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -536,13 +536,13 @@ public abstract class Window
 
                 if (isAvailable)
                 {
-                    ImGui.TextColored(ImGuiColors.DalamudGrey,
+                    ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey,
                                       Loc.Localize("WindowSystemContextActionClickthroughDisclaimer",
                                                    "Open this menu again by clicking the three dashes to disable clickthrough."));
                 }
                 else
                 {
-                    ImGui.TextColored(ImGuiColors.DalamudGrey,
+                    ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey,
                                       Loc.Localize("WindowSystemContextActionViewportDisclaimer",
                                                    "These features are only available if this window is inside the game window."));
                 }

--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -536,13 +536,13 @@ public abstract class Window
 
                 if (isAvailable)
                 {
-                    ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey,
+                    ImGui.TextColored(ImGuiColors.DalamudGrey,
                                       Loc.Localize("WindowSystemContextActionClickthroughDisclaimer",
                                                    "Open this menu again by clicking the three dashes to disable clickthrough."));
                 }
                 else
                 {
-                    ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudGrey,
+                    ImGui.TextColored(ImGuiColors.DalamudGrey,
                                       Loc.Localize("WindowSystemContextActionViewportDisclaimer",
                                                    "These features are only available if this window is inside the game window."));
                 }

--- a/Dalamud/Plugin/Internal/PluginErrorHandler.cs
+++ b/Dalamud/Plugin/Internal/PluginErrorHandler.cs
@@ -112,7 +112,7 @@ internal class PluginErrorHandler : IServiceType
         this.activeNotification = this.notificationManager.AddNotification(notification);
         this.activeNotification.DrawActions += _ =>
         {
-            if (ImGui.Button("Show console"))
+            if (ImGui.Button("Show console"u8))
             {
                 this.di.OpenLogWindow(this.plugin.InternalName);
                 this.activeNotification.DismissNow();
@@ -120,12 +120,12 @@ internal class PluginErrorHandler : IServiceType
 
             if (ImGui.IsItemHovered())
             {
-                ImGui.SetTooltip("Show the console filtered to this plugin");
+                ImGui.SetTooltip("Show the console filtered to this plugin"u8);
             }
 
             ImGui.SameLine();
 
-            if (ImGui.Button("Disable notifications"))
+            if (ImGui.Button("Disable notifications"u8))
             {
                 devPlugin.NotifyForErrors = false;
                 this.activeNotification.DismissNow();
@@ -133,7 +133,7 @@ internal class PluginErrorHandler : IServiceType
 
             if (ImGui.IsItemHovered())
             {
-                ImGui.SetTooltip("Disable error notifications for this plugin");
+                ImGui.SetTooltip("Disable error notifications for this plugin"u8);
             }
         };
     }

--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -360,7 +360,7 @@ public static partial class Util
     {
         var type = obj.GetType();
 
-        ImGui.TextUnformatted($"Object Dump({type.Name}) for {obj}({obj.GetHashCode()})");
+        ImGui.Text($"Object Dump({type.Name}) for {obj}({obj.GetHashCode()})");
 
         ImGuiHelpers.ScaledDummy(5);
 
@@ -745,7 +745,7 @@ public static partial class Util
                 $"       HomeWorld: {(resolveGameData ? pc.HomeWorld.ValueNullable?.Name : pc.HomeWorld.RowId.ToString())} CurrentWorld: {(resolveGameData ? pc.CurrentWorld.ValueNullable?.Name : pc.CurrentWorld.RowId.ToString())} FC: {pc.CompanyTag}\n";
         }
 
-        ImGui.TextUnformatted(actorString);
+        ImGui.Text(actorString);
         ImGui.SameLine();
         if (ImGui.Button($"C##{actor.Address.ToInt64()}"))
         {
@@ -779,7 +779,7 @@ public static partial class Util
                 $"       HomeWorld: {(resolveGameData ? pc.HomeWorld.ValueNullable?.Name : pc.HomeWorld.RowId.ToString())} CurrentWorld: {(resolveGameData ? pc.CurrentWorld.ValueNullable?.Name : pc.CurrentWorld.RowId.ToString())} FC: {pc.CompanyTag}\n";
         }
 
-        ImGui.TextUnformatted(actorString);
+        ImGui.Text(actorString);
         ImGui.SameLine();
         if (ImGui.Button($"C##{actor.Address.ToInt64()}"))
         {
@@ -856,7 +856,7 @@ public static partial class Util
         var propType = p.PropertyType;
         if (p.GetGetMethod() is not { } getMethod)
         {
-            ImGui.TextUnformatted("(No getter available)"u8);
+            ImGui.Text("(No getter available)"u8);
             return;
         }
 
@@ -950,7 +950,7 @@ public static partial class Util
                 var pointerType = typeof(T*);
                 for (var i = 0; i < spanobj.Length; i++)
                 {
-                    ImGui.TextUnformatted($"[{offset + i:n0} (0x{offset + i:X})] ");
+                    ImGui.Text($"[{offset + i:n0} (0x{offset + i:X})] ");
                     ImGui.SameLine();
                     path.Add($"{offset + i}");
                     ShowValue(addr, path, pointerType, Pointer.Box(p + i, pointerType), true);
@@ -991,7 +991,7 @@ public static partial class Util
                     var ptrObj = SafeMemory.PtrToStructure(new IntPtr(unboxed), eType);
                     if (ptrObj == null)
                     {
-                        ImGui.TextUnformatted("null or invalid"u8);
+                        ImGui.Text("null or invalid"u8);
                     }
                     else
                     {
@@ -1005,7 +1005,7 @@ public static partial class Util
             }
             else
             {
-                ImGui.TextUnformatted("null"u8);
+                ImGui.Text("null"u8);
             }
         }
         else
@@ -1016,7 +1016,7 @@ public static partial class Util
             }
             else
             {
-                ImGui.TextUnformatted($"{value}");
+                ImGui.Text($"{value}");
             }
         }
     }
@@ -1076,7 +1076,7 @@ public static partial class Util
 
                     if (fixedBuffer != null)
                     {
-                        ImGui.TextUnformatted("fixed"u8);
+                        ImGui.Text("fixed"u8);
                         ImGui.SameLine();
                         ImGuiHelpers.SafeTextColored(new Vector4(0.2f, 0.9f, 0.9f, 1), $"{fixedBuffer.ElementType.Name}[0x{fixedBuffer.Length:X}]");
                     }
@@ -1100,7 +1100,7 @@ public static partial class Util
                     {
                         if (f.FieldType.IsGenericType && (f.FieldType.IsByRef || f.FieldType.IsByRefLike))
                         {
-                            ImGui.TextUnformatted("Cannot preview ref typed fields."u8); // object never contains ref struct
+                            ImGui.Text("Cannot preview ref typed fields."u8); // object never contains ref struct
                         }
                         else if (f.FieldType == typeof(bool) && offset != null)
                         {
@@ -1115,7 +1115,7 @@ public static partial class Util
                     {
                         using (ImRaii.PushColor(ImGuiCol.Text, new Vector4(1f, 0.4f, 0.4f, 1f)))
                         {
-                            ImGui.TextUnformatted($"Error: {ex.GetType().Name}: {ex.Message}");
+                            ImGui.Text($"Error: {ex.GetType().Name}: {ex.Message}");
                         }
                     }
                     finally
@@ -1140,7 +1140,7 @@ public static partial class Util
                         }
                         else if (p.PropertyType.IsGenericType && (p.PropertyType.IsByRef || p.PropertyType.IsByRefLike))
                         {
-                            ImGui.TextUnformatted("Cannot preview ref typed properties."u8);
+                            ImGui.Text("Cannot preview ref typed properties."u8);
                         }
                         else
                         {
@@ -1151,7 +1151,7 @@ public static partial class Util
                     {
                         using (ImRaii.PushColor(ImGuiCol.Text, new Vector4(1f, 0.4f, 0.4f, 1f)))
                         {
-                            ImGui.TextUnformatted($"Error: {ex.GetType().Name}: {ex.Message}");
+                            ImGui.Text($"Error: {ex.GetType().Name}: {ex.Message}");
                         }
                     }
                     finally

--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -360,11 +360,11 @@ public static partial class Util
     {
         var type = obj.GetType();
 
-        ImGui.Text($"Object Dump({type.Name}) for {obj}({obj.GetHashCode()})");
+        ImGui.TextUnformatted($"Object Dump({type.Name}) for {obj}({obj.GetHashCode()})");
 
         ImGuiHelpers.ScaledDummy(5);
 
-        ImGui.TextColored(ImGuiColors.DalamudOrange, "-> Properties:");
+        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudOrange, "-> Properties:"u8);
 
         ImGui.Indent();
 
@@ -372,16 +372,16 @@ public static partial class Util
         {
             if (p.PropertyType.IsGenericType && (p.PropertyType.IsByRef || p.PropertyType.IsByRefLike))
             {
-                ImGui.TextColored(ImGuiColors.DalamudOrange, $"    {p.Name}: (ref typed property)");
+                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudOrange, $"    {p.Name}: (ref typed property)");
             }
             else
             {
                 var value = p.GetValue(obj);
                 var valueType = value?.GetType();
                 if (valueType == typeof(IntPtr))
-                    ImGui.TextColored(ImGuiColors.DalamudOrange, $"    {p.Name}: 0x{value:X}");
+                    ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudOrange, $"    {p.Name}: 0x{value:X}");
                 else
-                    ImGui.TextColored(ImGuiColors.DalamudOrange, $"    {p.Name}: {value}");
+                    ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudOrange, $"    {p.Name}: {value}");
             }
         }
 
@@ -389,13 +389,13 @@ public static partial class Util
 
         ImGuiHelpers.ScaledDummy(5);
 
-        ImGui.TextColored(ImGuiColors.HealerGreen, "-> Fields:");
+        ImGuiHelpers.SafeTextColored(ImGuiColors.HealerGreen, "-> Fields:"u8);
 
         ImGui.Indent();
 
         foreach (var fieldInfo in type.GetFields())
         {
-            ImGui.TextColored(ImGuiColors.HealerGreen, $"    {fieldInfo.Name}: {fieldInfo.GetValue(obj)}");
+            ImGuiHelpers.SafeTextColored(ImGuiColors.HealerGreen, $"    {fieldInfo.Name}: {fieldInfo.GetValue(obj)}");
         }
 
         ImGui.Unindent();
@@ -856,7 +856,7 @@ public static partial class Util
         var propType = p.PropertyType;
         if (p.GetGetMethod() is not { } getMethod)
         {
-            ImGui.Text("(No getter available)");
+            ImGui.TextUnformatted("(No getter available)"u8);
             return;
         }
 
@@ -991,7 +991,7 @@ public static partial class Util
                     var ptrObj = SafeMemory.PtrToStructure(new IntPtr(unboxed), eType);
                     if (ptrObj == null)
                     {
-                        ImGui.Text("null or invalid");
+                        ImGui.TextUnformatted("null or invalid"u8);
                     }
                     else
                     {
@@ -1005,7 +1005,7 @@ public static partial class Util
             }
             else
             {
-                ImGui.Text("null");
+                ImGui.TextUnformatted("null"u8);
             }
         }
         else
@@ -1016,7 +1016,7 @@ public static partial class Util
             }
             else
             {
-                ImGui.Text($"{value}");
+                ImGui.TextUnformatted($"{value}");
             }
         }
     }
@@ -1076,9 +1076,9 @@ public static partial class Util
 
                     if (fixedBuffer != null)
                     {
-                        ImGui.Text("fixed");
+                        ImGui.TextUnformatted("fixed"u8);
                         ImGui.SameLine();
-                        ImGui.TextColored(new Vector4(0.2f, 0.9f, 0.9f, 1), $"{fixedBuffer.ElementType.Name}[0x{fixedBuffer.Length:X}]");
+                        ImGuiHelpers.SafeTextColored(new Vector4(0.2f, 0.9f, 0.9f, 1), $"{fixedBuffer.ElementType.Name}[0x{fixedBuffer.Length:X}]");
                     }
                     else
                     {
@@ -1088,11 +1088,11 @@ public static partial class Util
                             ImGui.SameLine();
                         }
 
-                        ImGui.TextColored(new Vector4(0.2f, 0.9f, 0.9f, 1), $"{f.FieldType.Name}");
+                        ImGuiHelpers.SafeTextColored(new Vector4(0.2f, 0.9f, 0.9f, 1), $"{f.FieldType.Name}");
                     }
 
                     ImGui.SameLine();
-                    ImGui.TextColored(new Vector4(0.2f, 0.9f, 0.4f, 1), $"{f.Name}: ");
+                    ImGuiHelpers.SafeTextColored(new Vector4(0.2f, 0.9f, 0.4f, 1), $"{f.Name}: ");
                     ImGui.SameLine();
 
                     pathList.Add(f.Name);
@@ -1100,7 +1100,7 @@ public static partial class Util
                     {
                         if (f.FieldType.IsGenericType && (f.FieldType.IsByRef || f.FieldType.IsByRefLike))
                         {
-                            ImGui.Text("Cannot preview ref typed fields."); // object never contains ref struct
+                            ImGui.TextUnformatted("Cannot preview ref typed fields."u8); // object never contains ref struct
                         }
                         else if (f.FieldType == typeof(bool) && offset != null)
                         {
@@ -1126,9 +1126,9 @@ public static partial class Util
 
                 foreach (var p in obj.GetType().GetProperties().Where(static p => p.GetGetMethod()?.GetParameters().Length == 0))
                 {
-                    ImGui.TextColored(new Vector4(0.2f, 0.9f, 0.9f, 1), $"{p.PropertyType.Name}");
+                    ImGuiHelpers.SafeTextColored(new Vector4(0.2f, 0.9f, 0.9f, 1), $"{p.PropertyType.Name}");
                     ImGui.SameLine();
-                    ImGui.TextColored(new Vector4(0.2f, 0.6f, 0.4f, 1), $"{p.Name}: ");
+                    ImGuiHelpers.SafeTextColored(new Vector4(0.2f, 0.6f, 0.4f, 1), $"{p.Name}: ");
                     ImGui.SameLine();
 
                     pathList.Add(p.Name);
@@ -1140,7 +1140,7 @@ public static partial class Util
                         }
                         else if (p.PropertyType.IsGenericType && (p.PropertyType.IsByRef || p.PropertyType.IsByRefLike))
                         {
-                            ImGui.Text("Cannot preview ref typed properties.");
+                            ImGui.TextUnformatted("Cannot preview ref typed properties."u8);
                         }
                         else
                         {

--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -364,7 +364,7 @@ public static partial class Util
 
         ImGuiHelpers.ScaledDummy(5);
 
-        ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudOrange, "-> Properties:"u8);
+        ImGui.TextColored(ImGuiColors.DalamudOrange, "-> Properties:"u8);
 
         ImGui.Indent();
 
@@ -372,16 +372,16 @@ public static partial class Util
         {
             if (p.PropertyType.IsGenericType && (p.PropertyType.IsByRef || p.PropertyType.IsByRefLike))
             {
-                ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudOrange, $"    {p.Name}: (ref typed property)");
+                ImGui.TextColored(ImGuiColors.DalamudOrange, $"    {p.Name}: (ref typed property)");
             }
             else
             {
                 var value = p.GetValue(obj);
                 var valueType = value?.GetType();
                 if (valueType == typeof(IntPtr))
-                    ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudOrange, $"    {p.Name}: 0x{value:X}");
+                    ImGui.TextColored(ImGuiColors.DalamudOrange, $"    {p.Name}: 0x{value:X}");
                 else
-                    ImGuiHelpers.SafeTextColored(ImGuiColors.DalamudOrange, $"    {p.Name}: {value}");
+                    ImGui.TextColored(ImGuiColors.DalamudOrange, $"    {p.Name}: {value}");
             }
         }
 
@@ -389,13 +389,13 @@ public static partial class Util
 
         ImGuiHelpers.ScaledDummy(5);
 
-        ImGuiHelpers.SafeTextColored(ImGuiColors.HealerGreen, "-> Fields:"u8);
+        ImGui.TextColored(ImGuiColors.HealerGreen, "-> Fields:"u8);
 
         ImGui.Indent();
 
         foreach (var fieldInfo in type.GetFields())
         {
-            ImGuiHelpers.SafeTextColored(ImGuiColors.HealerGreen, $"    {fieldInfo.Name}: {fieldInfo.GetValue(obj)}");
+            ImGui.TextColored(ImGuiColors.HealerGreen, $"    {fieldInfo.Name}: {fieldInfo.GetValue(obj)}");
         }
 
         ImGui.Unindent();
@@ -1078,7 +1078,7 @@ public static partial class Util
                     {
                         ImGui.Text("fixed"u8);
                         ImGui.SameLine();
-                        ImGuiHelpers.SafeTextColored(new Vector4(0.2f, 0.9f, 0.9f, 1), $"{fixedBuffer.ElementType.Name}[0x{fixedBuffer.Length:X}]");
+                        ImGui.TextColored(new Vector4(0.2f, 0.9f, 0.9f, 1), $"{fixedBuffer.ElementType.Name}[0x{fixedBuffer.Length:X}]");
                     }
                     else
                     {
@@ -1088,11 +1088,11 @@ public static partial class Util
                             ImGui.SameLine();
                         }
 
-                        ImGuiHelpers.SafeTextColored(new Vector4(0.2f, 0.9f, 0.9f, 1), $"{f.FieldType.Name}");
+                        ImGui.TextColored(new Vector4(0.2f, 0.9f, 0.9f, 1), $"{f.FieldType.Name}");
                     }
 
                     ImGui.SameLine();
-                    ImGuiHelpers.SafeTextColored(new Vector4(0.2f, 0.9f, 0.4f, 1), $"{f.Name}: ");
+                    ImGui.TextColored(new Vector4(0.2f, 0.9f, 0.4f, 1), $"{f.Name}: ");
                     ImGui.SameLine();
 
                     pathList.Add(f.Name);
@@ -1126,9 +1126,9 @@ public static partial class Util
 
                 foreach (var p in obj.GetType().GetProperties().Where(static p => p.GetGetMethod()?.GetParameters().Length == 0))
                 {
-                    ImGuiHelpers.SafeTextColored(new Vector4(0.2f, 0.9f, 0.9f, 1), $"{p.PropertyType.Name}");
+                    ImGui.TextColored(new Vector4(0.2f, 0.9f, 0.9f, 1), $"{p.PropertyType.Name}");
                     ImGui.SameLine();
-                    ImGuiHelpers.SafeTextColored(new Vector4(0.2f, 0.6f, 0.4f, 1), $"{p.Name}: ");
+                    ImGui.TextColored(new Vector4(0.2f, 0.6f, 0.4f, 1), $"{p.Name}: ");
                     ImGui.SameLine();
 
                     pathList.Add(p.Name);

--- a/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.Text.cs
+++ b/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.Text.cs
@@ -282,6 +282,22 @@ public static unsafe partial class ImGui
         text.Dispose();
     }
 
+    public static void TextColoredWrapped(uint col, ImU8String text)
+    {
+        PushStyleColor(ImGuiCol.Text, col);
+        TextWrapped(text.Span);
+        PopStyleColor();
+        text.Dispose();
+    }
+
+    public static void TextColoredWrapped(scoped in Vector4 col, ImU8String text)
+    {
+        PushStyleColor(ImGuiCol.Text, col);
+        TextWrapped(text.Span);
+        PopStyleColor();
+        text.Dispose();
+    }
+
     public static bool TreeNode(ImU8String label)
     {
         var window = ImGuiP.GetCurrentWindow();


### PR DESCRIPTION
- Adds custom `ImGui.TextColoredWrapped` functions.
- Use utf8 string literals where possible.
- Use `ImGui.Text` over `ImGui.TextUnformatted`, since it's the same now and safe to call.
- Obsoletes `ImGuiHelpers.SafeTextWrapped`, since `ImGui.TextWrapped` is safe now.
- Obsoletes `ImGuiHelpers.SafeTextColoredWrapped`, since we have `ImGui.TextColoredWrapped` now.