### PR TITLE
Interface ActivePluginsChangeEventArgs

### DIFF
--- a/Dalamud/Plugin/ActivePluginsChangedEventArgs.cs
+++ b/Dalamud/Plugin/ActivePluginsChangedEventArgs.cs
@@ -2,10 +2,8 @@ using System.Collections.Generic;
 
 namespace Dalamud.Plugin;
 
-/// <summary>
-/// Contains data about changes to the list of active plugins.
-/// </summary>
-public class ActivePluginsChangedEventArgs : EventArgs
+/// <inheritdoc cref="IActivePluginsChangedEventArgs" />
+public class ActivePluginsChangedEventArgs : EventArgs, IActivePluginsChangedEventArgs
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ActivePluginsChangedEventArgs"/> class
@@ -19,13 +17,9 @@ public class ActivePluginsChangedEventArgs : EventArgs
         this.AffectedInternalNames = affectedInternalNames;
     }
 
-    /// <summary>
-    /// Gets the invalidation kind that caused this event to be fired.
-    /// </summary>
+    /// <inheritdoc/>
     public PluginListInvalidationKind Kind { get; }
 
-    /// <summary>
-    /// Gets the InternalNames of affected plugins.
-    /// </summary>
+    /// <inheritdoc/>
     public IEnumerable<string> AffectedInternalNames { get; }
 }

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -489,7 +489,7 @@ internal sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposa
     /// Dispatch the active plugins changed event.
     /// </summary>
     /// <param name="args">The event arguments containing information about the change.</param>
-    internal void NotifyActivePluginsChanged(ActivePluginsChangedEventArgs args)
+    internal void NotifyActivePluginsChanged(IActivePluginsChangedEventArgs args)
     {
         foreach (var action in Delegate.EnumerateInvocationList(this.ActivePluginsChanged))
         {

--- a/Dalamud/Plugin/IActivePluginsChangedEventArgs.cs
+++ b/Dalamud/Plugin/IActivePluginsChangedEventArgs.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Dalamud.Plugin;
+
+/// <summary>
+/// Contains data about changes to the list of active plugins.
+/// </summary>
+public interface IActivePluginsChangedEventArgs
+{
+    /// <summary>
+    /// Gets the invalidation kind that caused this event to be fired.
+    /// </summary>
+    PluginListInvalidationKind Kind { get; }
+
+    /// <summary>
+    /// Gets the InternalNames of affected plugins.
+    /// </summary>
+    IEnumerable<string> AffectedInternalNames { get; }
+}

--- a/Dalamud/Plugin/IDalamudPluginInterface.cs
+++ b/Dalamud/Plugin/IDalamudPluginInterface.cs
@@ -33,7 +33,7 @@ public interface IDalamudPluginInterface
     /// Delegate for events that listen to changes to the list of active plugins.
     /// </summary>
     /// <param name="args">The event arguments containing information about the change.</param>
-    public delegate void ActivePluginsChangedDelegate(ActivePluginsChangedEventArgs args);
+    public delegate void ActivePluginsChangedDelegate(IActivePluginsChangedEventArgs args);
 
     /// <summary>
     /// Event that gets fired when loc is changed


### PR DESCRIPTION
Fairly minor, interfaces ActivePluginsChangedEventArgs so any external tools relying on their own implementation of IDalamudPluginInterface can provide their own version of this(constructor is internal)