### PR TITLE
fix input scalar not working the same way as normal imgui code

### DIFF
--- a/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.InputScalar.cs
+++ b/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.InputScalar.cs
@@ -270,8 +270,8 @@ public static unsafe partial class ImGui
                           labelPtr,
                           dataType,
                           dataPtr,
-                          stepPtr,
-                          stepFastPtr,
+                          step > T.Zero ? stepPtr : null,
+                          stepFast > T.Zero ? stepFastPtr : null,
                           formatPtr,
                           flags) != 0;
             label.Dispose();
@@ -298,8 +298,8 @@ public static unsafe partial class ImGui
                           dataType,
                           dataPtr,
                           data.Length,
-                          stepPtr,
-                          stepFastPtr,
+                          step > T.Zero ? stepPtr : null,
+                          stepFast > T.Zero ? stepFastPtr : null,
                           formatPtr,
                           flags) != 0;
             label.Dispose();
@@ -325,8 +325,8 @@ public static unsafe partial class ImGui
                           labelPtr,
                           GetImGuiDataType<T>(),
                           dataPtr,
-                          stepPtr,
-                          stepFastPtr,
+                          step > T.Zero ? stepPtr : null,
+                          stepFast > T.Zero ? stepFastPtr : null,
                           formatPtr,
                           flags) != 0;
             label.Dispose();
@@ -353,8 +353,8 @@ public static unsafe partial class ImGui
                           GetImGuiDataType<T>(),
                           dataPtr,
                           data.Length,
-                          stepPtr,
-                          stepFastPtr,
+                          step > T.Zero ? stepPtr : null,
+                          stepFast > T.Zero ? stepFastPtr : null,
                           formatPtr,
                           flags) != 0;
             label.Dispose();


### PR DESCRIPTION
Example of how it is used in cpp
```cpp
bool ImGui::InputInt(const char* label, int* v, int step, int step_fast, ImGuiInputTextFlags flags)
{
    // Hexadecimal input provided as a convenience but the flag name is awkward. Typically you'd use InputText() to parse your own data, if you want to handle prefixes.
    const char* format = (flags & ImGuiInputTextFlags_CharsHexadecimal) ? "%08X" : "%d";
    return InputScalar(label, ImGuiDataType_S32, (void*)v, (void*)(step > 0 ? &step : NULL), (void*)(step_fast > 0 ? &step_fast : NULL), format, flags);
}
```

fixes issue of: [Discovery](https://discord.com/channels/581875019861328007/653504487352303619/1402602718291431485)
[Issue Raised](https://discord.com/channels/581875019861328007/860813266468732938/1402606718273323108)