### PR TITLE
Use custom GetPinnableReference instead of deferring it to Span

### DIFF
--- a/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.ComboAndList.cs
+++ b/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.ComboAndList.cs
@@ -99,7 +99,7 @@ public static unsafe partial class ImGui
 
         fixed (byte* labelPtr = &label.GetPinnableNullTerminatedReference())
         fixed (int* currentItemPtr = &currentItem)
-        fixed (byte* itemsSeparatedByZerosPtr = itemsSeparatedByZeros.Span)
+        fixed (byte* itemsSeparatedByZerosPtr = itemsSeparatedByZeros)
         {
             var r = ImGuiNative.Combo(labelPtr, currentItemPtr, itemsSeparatedByZerosPtr, popupMaxHeightInItems) != 0;
             label.Dispose();

--- a/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.InputScalar.cs
+++ b/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.InputScalar.cs
@@ -362,5 +362,4 @@ public static unsafe partial class ImGui
             return res;
         }
     }
-
 }

--- a/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.Misc.cs
+++ b/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.Misc.cs
@@ -91,6 +91,7 @@ public static unsafe partial class ImGui
 
     public static void AddInputCharacter(ImGuiIOPtr self, char c) => ImGuiNative.AddInputCharacter(self, c);
     public static void AddInputCharacter(ImGuiIOPtr self, Rune c) => ImGuiNative.AddInputCharacter(self, (uint)c.Value);
+
     public static void AddInputCharacters(ImGuiIOPtr self, ImU8String str)
     {
         fixed (byte* strPtr = &str.GetPinnableNullTerminatedReference())
@@ -121,7 +122,7 @@ public static unsafe partial class ImGui
 
     public static uint GetID(ImU8String strId)
     {
-        fixed (byte* strIdPtr = strId.Span)
+        fixed (byte* strIdPtr = strId)
         {
             var r = ImGuiNative.GetID(strIdPtr, strIdPtr + strId.Length);
             strId.Dispose();
@@ -135,7 +136,7 @@ public static unsafe partial class ImGui
 
     public static void PushID(ImU8String strId)
     {
-        fixed (byte* strIdPtr = strId.Span)
+        fixed (byte* strIdPtr = strId)
         {
             ImGuiNative.PushID(strIdPtr, strIdPtr + strId.Length);
             strId.Dispose();

--- a/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.Text.cs
+++ b/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.Text.cs
@@ -8,13 +8,15 @@ public static unsafe partial class ImGui
 {
     public static void AddText(ImFontGlyphRangesBuilderPtr self, ImU8String text)
     {
-        fixed (byte* textPtr = text.Span) ImGuiNative.AddText(self.Handle, textPtr, textPtr + text.Length);
+        fixed (byte* textPtr = text)
+            ImGuiNative.AddText(self.Handle, textPtr, textPtr + text.Length);
         text.Dispose();
     }
 
     public static void AddText(ImDrawListPtr self, Vector2 pos, uint col, ImU8String text)
     {
-        fixed (byte* textPtr = text.Span) ImGuiNative.AddText(self.Handle, pos, col, textPtr, textPtr + text.Length);
+        fixed (byte* textPtr = text)
+            ImGuiNative.AddText(self.Handle, pos, col, textPtr, textPtr + text.Length);
         text.Dispose();
     }
 
@@ -22,7 +24,7 @@ public static unsafe partial class ImGui
         ImDrawListPtr self, ImFontPtr font, float fontSize, Vector2 pos, uint col, ImU8String text, float wrapWidth,
         scoped in Vector4 cpuFineClipRect)
     {
-        fixed (byte* textPtr = text.Span)
+        fixed (byte* textPtr = text)
         fixed (Vector4* cpuFineClipRectPtr = &cpuFineClipRect)
             ImGuiNative.AddText(
                 self.Handle,
@@ -41,14 +43,15 @@ public static unsafe partial class ImGui
         ImDrawListPtr self, ImFontPtr font, float fontSize, Vector2 pos, uint col, ImU8String text,
         float wrapWidth = 0f)
     {
-        fixed (byte* textPtr = text.Span)
+        fixed (byte* textPtr = text)
             ImGuiNative.AddText(self.Handle, font, fontSize, pos, col, textPtr, textPtr + text.Length, wrapWidth, null);
         text.Dispose();
     }
 
     public static void append(this ImGuiTextBufferPtr self, ImU8String str)
     {
-        fixed (byte* strPtr = str.Span) ImGuiNative.append(self.Handle, strPtr, strPtr + str.Length);
+        fixed (byte* strPtr = str)
+            ImGuiNative.append(self.Handle, strPtr, strPtr + str.Length);
         str.Dispose();
     }
 
@@ -60,8 +63,8 @@ public static unsafe partial class ImGui
         scoped ref readonly var style = ref g.Style;
         var labelSize = CalcTextSize(text.Span);
         var totalSize = new Vector2(
-                g.FontSize + (labelSize.X > 0.0f ? (labelSize.X + style.FramePadding.X * 2) : 0.0f),
-                labelSize.Y); // Empty text doesn't add padding
+            g.FontSize + (labelSize.X > 0.0f ? (labelSize.X + style.FramePadding.X * 2) : 0.0f),
+            labelSize.Y); // Empty text doesn't add padding
         var pos = window->DC.CursorPos;
         pos.Y += window->DC.CurrLineTextBaseOffset;
         ImGuiP.ItemSize(totalSize, 0.0f);
@@ -82,7 +85,7 @@ public static unsafe partial class ImGui
         ImU8String text, bool hideTextAfterDoubleHash = false, float wrapWidth = -1.0f)
     {
         var @out = Vector2.Zero;
-        fixed (byte* textPtr = text.Span)
+        fixed (byte* textPtr = text)
             ImGuiNative.CalcTextSize(
                 &@out,
                 textPtr,
@@ -97,7 +100,7 @@ public static unsafe partial class ImGui
         ImFontPtr self, float size, float maxWidth, float wrapWidth, ImU8String text, out int remaining)
     {
         var @out = Vector2.Zero;
-        fixed (byte* textPtr = text.Span)
+        fixed (byte* textPtr = text)
         {
             byte* remainingPtr = null;
             ImGuiNative.CalcTextSizeA(
@@ -119,7 +122,7 @@ public static unsafe partial class ImGui
     public static int CalcWordWrapPositionA(
         ImFontPtr font, float scale, ImU8String text, float wrapWidth)
     {
-        fixed (byte* ptr = text.Span)
+        fixed (byte* ptr = text)
         {
             var r =
                 (int)(ImGuiNative.CalcWordWrapPositionA(font.Handle, scale, ptr, ptr + text.Length, wrapWidth) - ptr);
@@ -131,7 +134,7 @@ public static unsafe partial class ImGui
     public static void InsertChars(
         ImGuiInputTextCallbackDataPtr self, int pos, ImU8String text)
     {
-        fixed (byte* ptr = text.Span)
+        fixed (byte* ptr = text)
             ImGuiNative.InsertChars(self.Handle, pos, ptr, ptr + text.Length);
         text.Dispose();
     }
@@ -190,7 +193,7 @@ public static unsafe partial class ImGui
         {
             g.LogBuffer.Buf.Resize(0);
             append(&g.Handle->LogBuffer, text.Span);
-            fixed (byte* textPtr = text.Span)
+            fixed (byte* textPtr = text)
                 ImGuiPNative.ImFileWrite(textPtr, 1, (ulong)text.Length, g.LogFile);
         }
         else
@@ -203,7 +206,7 @@ public static unsafe partial class ImGui
 
     public static void PassFilter(ImGuiTextFilterPtr self, ImU8String text)
     {
-        fixed (byte* textPtr = text.Span)
+        fixed (byte* textPtr = text)
             ImGuiNative.PassFilter(self.Handle, textPtr, textPtr + text.Length);
         text.Dispose();
     }
@@ -212,7 +215,7 @@ public static unsafe partial class ImGui
         ImFontPtr self, ImDrawListPtr drawList, float size, Vector2 pos, uint col, Vector4 clipRect,
         ImU8String text, float wrapWidth = 0.0f, bool cpuFineClip = false)
     {
-        fixed (byte* textPtr = text.Span)
+        fixed (byte* textPtr = text)
             ImGuiNative.RenderText(
                 self,
                 drawList,
@@ -237,7 +240,7 @@ public static unsafe partial class ImGui
 
     public static void Text(ImU8String text)
     {
-        fixed (byte* ptr = text.Span)
+        fixed (byte* ptr = text)
             ImGuiNative.TextUnformatted(ptr, ptr + text.Length);
         text.Dispose();
     }

--- a/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.Widgets.cs
+++ b/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.Widgets.cs
@@ -27,7 +27,8 @@ public static unsafe partial class ImGui
         }
     }
 
-    public static bool BeginChild(ImU8String strId, Vector2 size = default, bool border = false, ImGuiWindowFlags flags = ImGuiWindowFlags.None)
+    public static bool BeginChild(
+        ImU8String strId, Vector2 size = default, bool border = false, ImGuiWindowFlags flags = ImGuiWindowFlags.None)
     {
         fixed (byte* strIdPtr = &strId.GetPinnableNullTerminatedReference())
         {
@@ -37,10 +38,12 @@ public static unsafe partial class ImGui
         }
     }
 
-    public static bool BeginChild(uint id, Vector2 size = default, bool border = false, ImGuiWindowFlags flags = ImGuiWindowFlags.None) =>
+    public static bool BeginChild(
+        uint id, Vector2 size = default, bool border = false, ImGuiWindowFlags flags = ImGuiWindowFlags.None) =>
         ImGuiNative.BeginChild(id, size, border ? (byte)1 : (byte)0, flags) != 0;
 
-    public static bool BeginCombo(ImU8String label, ImU8String previewValue, ImGuiComboFlags flags = ImGuiComboFlags.None)
+    public static bool BeginCombo(
+        ImU8String label, ImU8String previewValue, ImGuiComboFlags flags = ImGuiComboFlags.None)
     {
         fixed (byte* labelPtr = &label.GetPinnableNullTerminatedReference())
         fixed (byte* previewValuePtr = &previewValue.GetPinnableNullTerminatedReference())
@@ -82,7 +85,8 @@ public static unsafe partial class ImGui
         }
     }
 
-    public static bool BeginPopupContextItem(ImU8String strId, ImGuiPopupFlags popupFlags = ImGuiPopupFlags.MouseButtonDefault)
+    public static bool BeginPopupContextItem(
+        ImU8String strId, ImGuiPopupFlags popupFlags = ImGuiPopupFlags.MouseButtonDefault)
     {
         fixed (byte* strIdPtr = &strId.GetPinnableNullTerminatedReference())
         {
@@ -92,7 +96,8 @@ public static unsafe partial class ImGui
         }
     }
 
-    public static bool BeginPopupContextWindow(ImU8String strId, ImGuiPopupFlags popupFlags = ImGuiPopupFlags.MouseButtonDefault)
+    public static bool BeginPopupContextWindow(
+        ImU8String strId, ImGuiPopupFlags popupFlags = ImGuiPopupFlags.MouseButtonDefault)
     {
         fixed (byte* strIdPtr = &strId.GetPinnableNullTerminatedReference())
         {
@@ -102,7 +107,8 @@ public static unsafe partial class ImGui
         }
     }
 
-    public static bool BeginPopupContextVoid(ImU8String strId, ImGuiPopupFlags popupFlags = ImGuiPopupFlags.MouseButtonDefault)
+    public static bool BeginPopupContextVoid(
+        ImU8String strId, ImGuiPopupFlags popupFlags = ImGuiPopupFlags.MouseButtonDefault)
     {
         fixed (byte* strIdPtr = &strId.GetPinnableNullTerminatedReference())
         {
@@ -280,7 +286,14 @@ public static unsafe partial class ImGui
     {
         fixed (byte* versionPtr = &versionStr.GetPinnableNullTerminatedReference())
         {
-            var r = ImGuiNative.DebugCheckVersionAndDataLayout(versionPtr, szIo, szStyle, szVec2, szVec4, szDrawVert, szDrawIdx) != 0;
+            var r = ImGuiNative.DebugCheckVersionAndDataLayout(
+                        versionPtr,
+                        szIo,
+                        szStyle,
+                        szVec2,
+                        szVec4,
+                        szDrawVert,
+                        szDrawIdx) != 0;
             versionStr.Dispose();
             return r;
         }
@@ -363,7 +376,7 @@ public static unsafe partial class ImGui
 
     public static void LoadIniSettingsFromMemory(ImU8String iniData)
     {
-        fixed (byte* iniDataPtr = iniData.Span)
+        fixed (byte* iniDataPtr = iniData)
             ImGuiNative.LoadIniSettingsFromMemory(iniDataPtr, (nuint)iniData.Length);
         iniData.Dispose();
     }
@@ -381,7 +394,11 @@ public static unsafe partial class ImGui
         fixed (byte* labelPtr = &label.GetPinnableNullTerminatedReference())
         fixed (byte* shortcutPtr = &shortcut.GetPinnableNullTerminatedReference())
         {
-            var r = ImGuiNative.MenuItem(labelPtr, shortcutPtr, selected ? (byte)1 : (byte)0, enabled ? (byte)1 : (byte)0) != 0;
+            var r = ImGuiNative.MenuItem(
+                        labelPtr,
+                        shortcutPtr,
+                        selected ? (byte)1 : (byte)0,
+                        enabled ? (byte)1 : (byte)0) != 0;
             label.Dispose();
             shortcut.Dispose();
             return r;
@@ -416,7 +433,11 @@ public static unsafe partial class ImGui
     {
         fixed (byte* labelPtr = &label.GetPinnableNullTerminatedReference())
         {
-            var r = ImGuiNative.MenuItem(labelPtr, null, selected ? (byte)1 : (byte)0, enabled ? (byte)1 : (byte)0) != 0;
+            var r = ImGuiNative.MenuItem(
+                        labelPtr,
+                        null,
+                        selected ? (byte)1 : (byte)0,
+                        enabled ? (byte)1 : (byte)0) != 0;
             label.Dispose();
             return r;
         }
@@ -429,7 +450,8 @@ public static unsafe partial class ImGui
         strId.Dispose();
     }
 
-    public static void OpenPopup(uint id, ImGuiPopupFlags popupFlags = ImGuiPopupFlags.None) => ImGuiNative.OpenPopup(id, popupFlags);
+    public static void OpenPopup(uint id, ImGuiPopupFlags popupFlags = ImGuiPopupFlags.None) =>
+        ImGuiNative.OpenPopup(id, popupFlags);
 
     public static void OpenPopupOnItemClick(
         ImU8String strId, ImGuiPopupFlags popupFlags = ImGuiPopupFlags.MouseButtonDefault)
@@ -457,7 +479,7 @@ public static unsafe partial class ImGui
     {
         fixed (byte* labelPtr = &label.GetPinnableNullTerminatedReference())
         {
-            var r = ImGuiNative.RadioButton(labelPtr, active ? (byte)1:(byte)0) != 0;
+            var r = ImGuiNative.RadioButton(labelPtr, active ? (byte)1 : (byte)0) != 0;
             label.Dispose();
             return r;
         }
@@ -468,8 +490,8 @@ public static unsafe partial class ImGui
         fixed (byte* labelPtr = &label.GetPinnableNullTerminatedReference())
         {
             var pressed = ImGuiNative.RadioButton(
-                labelPtr,
-                EqualityComparer<T>.Default.Equals(v, vButton) ? (byte)1 : (byte)0) != 0;
+                              labelPtr,
+                              EqualityComparer<T>.Default.Equals(v, vButton) ? (byte)1 : (byte)0) != 0;
             if (pressed)
                 v = vButton;
             return pressed;
@@ -483,22 +505,25 @@ public static unsafe partial class ImGui
     }
 
     public static bool Selectable(
-        ImU8String label, bool selected = false, ImGuiSelectableFlags flags = ImGuiSelectableFlags.None, Vector2 size = default)
+        ImU8String label, bool selected = false, ImGuiSelectableFlags flags = ImGuiSelectableFlags.None,
+        Vector2 size = default)
     {
         fixed (byte* labelPtr = &label.GetPinnableNullTerminatedReference())
         {
-            var r = ImGuiNative.Selectable(labelPtr, selected ?(byte)1:(byte)0, flags, size)!=0;
+            var r = ImGuiNative.Selectable(labelPtr, selected ? (byte)1 : (byte)0, flags, size) != 0;
             label.Dispose();
             return r;
         }
     }
 
-    public static bool Selectable(ImU8String label, ref bool selected, ImGuiSelectableFlags flags = ImGuiSelectableFlags.None, Vector2 size = default)
+    public static bool Selectable(
+        ImU8String label, ref bool selected, ImGuiSelectableFlags flags = ImGuiSelectableFlags.None,
+        Vector2 size = default)
     {
         fixed (byte* labelPtr = &label.GetPinnableNullTerminatedReference())
-            fixed (bool* selectedPtr = &selected)
+        fixed (bool* selectedPtr = &selected)
         {
-            var r = ImGuiNative.Selectable(labelPtr, selectedPtr, flags, size)!=0;
+            var r = ImGuiNative.Selectable(labelPtr, selectedPtr, flags, size) != 0;
             label.Dispose();
             return r;
         }
@@ -516,7 +541,7 @@ public static unsafe partial class ImGui
         fixed (byte* typePtr = &type.GetPinnableNullTerminatedReference())
         fixed (byte* dataPtr = data)
         {
-            var r = ImGuiNative.SetDragDropPayload(typePtr, dataPtr, (nuint)data.Length, cond)!=0;
+            var r = ImGuiNative.SetDragDropPayload(typePtr, dataPtr, (nuint)data.Length, cond) != 0;
             type.Dispose();
             return r;
         }
@@ -529,7 +554,8 @@ public static unsafe partial class ImGui
         tabOrDockedWindowLabel.Dispose();
     }
 
-    public static void SetWindowCollapsed(bool collapsed, ImGuiCond cond = ImGuiCond.None) => ImGuiNative.SetWindowCollapsed(collapsed ? (byte)1 : (byte)0, cond);
+    public static void SetWindowCollapsed(bool collapsed, ImGuiCond cond = ImGuiCond.None) =>
+        ImGuiNative.SetWindowCollapsed(collapsed ? (byte)1 : (byte)0, cond);
 
     public static void SetWindowCollapsed(ImU8String name, bool collapsed, ImGuiCond cond = ImGuiCond.None)
     {
@@ -547,7 +573,8 @@ public static unsafe partial class ImGui
         name.Dispose();
     }
 
-    public static void SetWindowPos(Vector2 pos, ImGuiCond cond = ImGuiCond.None) => ImGuiNative.SetWindowPos(pos, cond);
+    public static void SetWindowPos(Vector2 pos, ImGuiCond cond = ImGuiCond.None) =>
+        ImGuiNative.SetWindowPos(pos, cond);
 
     public static void SetWindowPos(ImU8String name, Vector2 pos, ImGuiCond cond = ImGuiCond.None)
     {
@@ -556,7 +583,8 @@ public static unsafe partial class ImGui
         name.Dispose();
     }
 
-    public static void SetWindowSize(Vector2 size, ImGuiCond cond = ImGuiCond.None) => ImGuiNative.SetWindowSize(size, cond);
+    public static void SetWindowSize(Vector2 size, ImGuiCond cond = ImGuiCond.None) =>
+        ImGuiNative.SetWindowSize(size, cond);
 
     public static void SetWindowSize(ImU8String name, Vector2 size, ImGuiCond cond = ImGuiCond.None)
     {
@@ -632,7 +660,7 @@ public static unsafe partial class ImGui
     {
         prefix.AppendLiteral(": ");
         prefix.AppendFormatted(value);
-        fixed (byte* prefixPtr = prefix.Span)
+        fixed (byte* prefixPtr = prefix)
         {
             ImGuiNative.TextUnformatted(prefixPtr, prefixPtr + prefix.Length);
             prefix.Dispose();

--- a/imgui/Dalamud.Bindings.ImGui/Custom/ImGuiInputTextCallbackData.Custom.cs
+++ b/imgui/Dalamud.Bindings.ImGui/Custom/ImGuiInputTextCallbackData.Custom.cs
@@ -3,6 +3,7 @@ namespace Dalamud.Bindings.ImGui;
 public unsafe partial struct ImGuiInputTextCallbackData
 {
     public readonly Span<byte> BufSpan => new(this.Buf, this.BufSize);
+
     public readonly Span<byte> BufTextSpan => new(this.Buf, this.BufTextLen);
 
     public void InsertChars(int pos, ImU8String text)
@@ -15,6 +16,7 @@ public unsafe partial struct ImGuiInputTextCallbackData
 public unsafe partial struct ImGuiInputTextCallbackDataPtr
 {
     public readonly Span<byte> BufSpan => this.Handle->BufSpan;
+
     public readonly Span<byte> BufTextSpan => this.Handle->BufTextSpan;
 
     public void InsertChars(int pos, ImU8String text) => ImGui.InsertChars(this, pos, text);

--- a/imgui/Dalamud.Bindings.ImGui/Custom/ImGuiP.Plot.cs
+++ b/imgui/Dalamud.Bindings.ImGui/Custom/ImGuiP.Plot.cs
@@ -69,7 +69,7 @@ public static unsafe partial class ImGuiP
         ImGuiPlotType plotType, ImU8String label, ImGui.GetFloatRefContextDelegate<TContext> valuesGetter,
         scoped in TContext context,
         int valuesCount, int valuesOffset, ImU8String overlayText, float scaleMin, float scaleMax, Vector2 frameSize)
-        where TContext: allows ref struct
+        where TContext : allows ref struct
     {
         fixed (byte* labelPtr = &label.GetPinnableNullTerminatedReference())
         fixed (byte* overlayTextPtr = &overlayText.GetPinnableNullTerminatedReference())

--- a/imgui/Dalamud.Bindings.ImGui/Custom/ImGuiP.Text.cs
+++ b/imgui/Dalamud.Bindings.ImGui/Custom/ImGuiP.Text.cs
@@ -41,7 +41,7 @@ public static unsafe partial class ImGuiP
 
     public static uint GetID(ImGuiWindowPtr self, ImU8String str)
     {
-        fixed (byte* strPtr = str.Span)
+        fixed (byte* strPtr = str)
         {
             var seed = *self.IDStack.Back;
             var id = ImGuiPNative.ImHashStr(strPtr, (nuint)str.Length, seed);
@@ -63,7 +63,7 @@ public static unsafe partial class ImGuiP
 
     public static uint ImHashStr(ImU8String data, uint seed = 0)
     {
-        fixed (byte* ptr = data.Span)
+        fixed (byte* ptr = data)
         {
             var res = ImGuiPNative.ImHashStr(ptr, (nuint)data.Length, seed);
             data.Dispose();
@@ -133,14 +133,14 @@ public static unsafe partial class ImGuiP
     public static void LogRenderedText(scoped in Vector2 refPos, ImU8String text)
     {
         fixed (Vector2* refPosPtr = &refPos)
-        fixed (byte* textPtr = text.Span)
+        fixed (byte* textPtr = text)
             ImGuiPNative.LogRenderedText(refPosPtr, textPtr, textPtr + text.Length);
         text.Dispose();
     }
 
     public static void RenderText(Vector2 pos, ImU8String text, bool hideTextAfterHash = true)
     {
-        fixed (byte* textPtr = text.Span)
+        fixed (byte* textPtr = text)
             ImGuiPNative.RenderText(pos, textPtr, textPtr + text.Length, hideTextAfterHash ? (byte)1 : (byte)0);
         text.Dispose();
     }
@@ -148,7 +148,7 @@ public static unsafe partial class ImGuiP
     public static void RenderTextWrapped(
         Vector2 pos, ImU8String text, float wrapWidth)
     {
-        fixed (byte* textPtr = text.Span)
+        fixed (byte* textPtr = text)
             ImGuiPNative.RenderTextWrapped(pos, textPtr, textPtr + text.Length, wrapWidth);
         text.Dispose();
     }
@@ -160,7 +160,7 @@ public static unsafe partial class ImGuiP
     {
         var textSizeIfKnownOrDefault = textSizeIfKnown ?? default;
         var clipRectOrDefault = clipRect ?? default;
-        fixed (byte* textPtr = text.Span)
+        fixed (byte* textPtr = text)
             ImGuiPNative.RenderTextClipped(
                 posMin,
                 posMax,
@@ -179,7 +179,7 @@ public static unsafe partial class ImGuiP
     {
         var textSizeIfKnownOrDefault = textSizeIfKnown ?? default;
         var clipRectOrDefault = clipRect ?? default;
-        fixed (byte* textPtr = text.Span)
+        fixed (byte* textPtr = text)
             ImGuiPNative.RenderTextClippedEx(
                 drawList.Handle,
                 posMin,
@@ -197,7 +197,7 @@ public static unsafe partial class ImGuiP
         ImU8String text, scoped in Vector2? textSizeIfKnown = null)
     {
         var textSizeIfKnownOrDefault = textSizeIfKnown ?? default;
-        fixed (byte* textPtr = text.Span)
+        fixed (byte* textPtr = text)
             ImGuiPNative.RenderTextEllipsis(
                 drawList.Handle,
                 posMin,

--- a/imgui/Dalamud.Bindings.ImGui/ImU8String.cs
+++ b/imgui/Dalamud.Bindings.ImGui/ImU8String.cs
@@ -169,6 +169,28 @@ public ref struct ImU8String : IDisposable
     public static unsafe implicit operator ImU8String(byte* text) => new(text);
     public static unsafe implicit operator ImU8String(char* text) => new(text);
 
+    public ref readonly byte GetPinnableReference()
+    {
+        if (this.IsNull)
+            return ref Unsafe.NullRef<byte>();
+
+        if (this.IsEmpty)
+            return ref this.FixedBufferSpan[0];
+
+        return ref this.Span.GetPinnableReference();
+    }
+
+    public ref readonly byte GetPinnableReference(ReadOnlySpan<byte> defaultValue)
+    {
+        if (this.IsNull)
+            return ref defaultValue.GetPinnableReference();
+
+        if (this.IsEmpty)
+            return ref this.FixedBufferSpan[0];
+
+        return ref this.Span.GetPinnableReference();
+    }
+
     public ref readonly byte GetPinnableNullTerminatedReference(ReadOnlySpan<byte> defaultValue = default)
     {
         if (this.IsNull)


### PR DESCRIPTION
https://github.com/dotnet/corert/blob/c6af4cfc8b625851b91823d9be746c4f7abdc667/src/System.Private.CoreLib/shared/System/ReadOnlySpan.cs#L252-L264

`""u8.GetPinnableReference()` will return `nullptr`, and ImGui incorrectly assumes `text=null, textEnd=null` as a zero-terminated string pointer which is a null, rather than as a `[null, null)`. This PR implements `ImU8String.GetPinnableReference()` which will still return a valid pointer even when the contents are empty, except when it is explicitly null(default).