### PR TITLE
Restore commandId parameter

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/Payloads/DalamudLinkPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/DalamudLinkPayload.cs
@@ -16,7 +16,7 @@ public class DalamudLinkPayload : Payload
     public override PayloadType Type => PayloadType.DalamudLink;
 
     /// <summary>Gets the plugin command ID to be linked.</summary>
-    public Guid CommandId { get; internal set; }
+    public uint CommandId { get; internal set; }
 
     /// <summary>Gets an optional extra integer value 1.</summary>
     public int Extra1 { get; internal set; }
@@ -40,7 +40,7 @@ public class DalamudLinkPayload : Payload
         var ssb = Lumina.Text.SeStringBuilder.SharedPool.Get();
         var res = ssb.BeginMacro(MacroCode.Link)
                      .AppendIntExpression((int)EmbeddedInfoType.DalamudLink - 1)
-                     .AppendStringExpression(this.CommandId.ToString())
+                     .AppendUIntExpression(this.CommandId)
                      .AppendIntExpression(this.Extra1)
                      .AppendIntExpression(this.Extra2)
                      .BeginStringExpression()
@@ -72,15 +72,15 @@ public class DalamudLinkPayload : Payload
             if (!pluginExpression.TryGetString(out var pluginString))
                 return;
 
-            if (!commandIdExpression.TryGetString(out var commandId))
+            if (!commandIdExpression.TryGetUInt(out var commandId))
                 return;
 
             this.Plugin = pluginString.ExtractText();
-            this.CommandId = Guid.Parse(commandId.ExtractText());
+            this.CommandId = commandId;
         }
         else
         {
-            if (!commandIdExpression.TryGetString(out var commandId))
+            if (!commandIdExpression.TryGetUInt(out var commandId))
                 return;
 
             if (!extra1Expression.TryGetInt(out var extra1))
@@ -102,7 +102,7 @@ public class DalamudLinkPayload : Payload
                 return;
             }
 
-            this.CommandId = Guid.Parse(commandId.ExtractText());
+            this.CommandId = commandId;
             this.Extra1 = extra1;
             this.Extra2 = extra2;
             this.Plugin = extraData[0];

--- a/Dalamud/Plugin/Services/IChatGui.cs
+++ b/Dalamud/Plugin/Services/IChatGui.cs
@@ -83,20 +83,21 @@ public interface IChatGui
     /// <summary>
     /// Gets the dictionary of Dalamud Link Handlers.
     /// </summary>
-    public IReadOnlyDictionary<(string PluginName, Guid CommandId), Action<Guid, SeString>> RegisteredLinkHandlers { get; }
+    public IReadOnlyDictionary<(string PluginName, uint CommandId), Action<uint, SeString>> RegisteredLinkHandlers { get; }
 
     /// <summary>
     /// Register a chat link handler.
     /// </summary>
+    /// <param name="commandId">The ID of the command.</param>
     /// <param name="commandAction">The action to be executed.</param>
     /// <returns>Returns an SeString payload for the link.</returns>
-    public DalamudLinkPayload AddChatLinkHandler(Action<Guid, SeString> commandAction);
+    public DalamudLinkPayload AddChatLinkHandler(uint commandId, Action<uint, SeString> commandAction);
 
     /// <summary>
     /// Remove a chat link handler.
     /// </summary>
     /// <param name="commandId">The ID of the command.</param>
-    public void RemoveChatLinkHandler(Guid commandId);
+    public void RemoveChatLinkHandler(uint commandId);
 
     /// <summary>
     /// Removes all chat link handlers registered by the plugin.


### PR DESCRIPTION
When plugins reload, they'll re-register command handlers and get a new guid. Links in chat will no longer work since the guid changed.

This restores the plugin devs ability to pass their own `commandId`.

Please also remove this from the docs. The functions just changed services.
https://github.com/goatcorp/dalamud-docs/blob/main/docs/versions/v13.md#major-changes