### PR TITLE
SeStringEvaluator: Add support for SwitchPlatform

### DIFF
--- a/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
@@ -247,6 +247,9 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
             case MacroCode.Switch:
                 return this.TryResolveSwitch(in context, payload);
 
+            case MacroCode.SwitchPlatform:
+                return this.TryResolveSwitchPlatform(in context, payload);
+
             case MacroCode.PcName:
                 return this.TryResolvePcName(in context, payload);
 
@@ -448,6 +451,29 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
         }
 
         return false;
+    }
+
+    private bool TryResolveSwitchPlatform(in SeStringContext context, in ReadOnlySePayloadSpan payload)
+    {
+        if (!payload.TryGetExpression(out var expr1))
+            return false;
+
+        if (!expr1.TryGetInt(out var intVal))
+            return false;
+
+        // Our version of the game uses IsMacClient() here and the
+        // Xbox version seems to always return 7 for the platform.
+        var platform = Util.IsWine() ? 5 : 3;
+
+        // The sheet is seeminly split into first 20 rows for wired controllers
+        // and the last 20 rows for wireless controllers.
+        var rowId = (uint)((20 * ((intVal - 1) / 20)) + (platform - 4 < 2 ? 2 : 1));
+
+        if (!this.dataManager.GetExcelSheet<Platform>().TryGetRow(rowId, out var platformRow))
+            return false;
+
+        context.Builder.Append(platformRow.Name);
+        return true;
     }
 
     private unsafe bool TryResolvePcName(in SeStringContext context, in ReadOnlySePayloadSpan payload)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
 
     <!-- Dependency versions -->
     <PropertyGroup Label="Dependency Versions">
-        <LuminaVersion>6.3.0</LuminaVersion>
+        <LuminaVersion>6.4.0</LuminaVersion>
         <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
Adds support for the new `switchplatform` macro code.
Seems to be fairly easy and hardcoded right now. Most likely different code for different platforms.
See `vtbl_Client::UI::Misc::RaptureTextModule___Component::Text::MacroDecoder` vf5.

From my testing, it always prints Gamepad, no matter the value you pass to it.

Also updates Lumina to 6.4.0 ([compare](https://github.com/NotAdam/Lumina/compare/6.3.0...6.4.0)) for the MacroCode enum value.

<img width="755" height="232" alt="Screenshot" src="https://github.com/user-attachments/assets/d90ea990-4511-4580-bcd2-247d08d5bc68" />

