### PR TITLE
Set ClientState.TerritoryType on load

### DIFF
--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -184,7 +184,7 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
 
     private unsafe void Setup()
     {
-        this.SetTerritoryType((ushort)GameMain.Instance()->CurrentTerritoryTypeId);
+        this.TerritoryType = (ushort)GameMain.Instance()->CurrentTerritoryTypeId;
     }
 
     private unsafe void SetupTerritoryTypeDetour(EventFramework* eventFramework, ushort territoryType)

--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -72,6 +72,8 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
         this.setupTerritoryTypeHook.Enable();
         this.uiModuleHandlePacketHook.Enable();
         this.onLogoutHook.Enable();
+
+        this.framework.RunOnTick(this.Setup);
     }
 
     private unsafe delegate void ProcessPacketPlayerSetupDelegate(nint a1, nint packet);
@@ -180,8 +182,22 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
         this.networkHandlers.CfPop -= this.NetworkHandlersOnCfPop;
     }
 
+    private unsafe void Setup()
+    {
+        this.SetTerritoryType((ushort)GameMain.Instance()->CurrentTerritoryTypeId);
+    }
+
     private unsafe void SetupTerritoryTypeDetour(EventFramework* eventFramework, ushort territoryType)
     {
+        this.SetTerritoryType(territoryType);
+        this.setupTerritoryTypeHook.Original(eventFramework, territoryType);
+    }
+
+    private unsafe void SetTerritoryType(ushort territoryType)
+    {
+        if (this.TerritoryType == territoryType)
+            return;
+
         Log.Debug("TerritoryType changed: {0}", territoryType);
 
         this.TerritoryType = territoryType;
@@ -207,8 +223,6 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
                 }
             }
         }
-
-        this.setupTerritoryTypeHook.Original(eventFramework, territoryType);
     }
 
     private unsafe void UIModuleHandlePacketDetour(


### PR DESCRIPTION
This fixes an issue where TerritoryType reports 0 after Dalamud is injected while the player is already logged in.
TerritoryType was only updated when a InitZone packet was received.

Setting it in the ctor isn't possible, because DataManager isn't initialized at that point and we need it for the IsPvP lookup. So I moved it off to the first Framework tick.