### PR TITLE
ISeStringEvaluator: Add ReadOnlySpan<byte> support

### DIFF
--- a/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
@@ -122,6 +122,15 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
     }
 
     /// <inheritdoc/>
+    public ReadOnlySeString EvaluateMacroString(
+        ReadOnlySpan<byte> macroString,
+        Span<SeStringParameter> localParameters = default,
+        ClientLanguage? language = null)
+    {
+        return this.Evaluate(ReadOnlySeString.FromMacroString(macroString).AsSpan(), localParameters, language);
+    }
+
+    /// <inheritdoc/>
     public ReadOnlySeString EvaluateFromAddon(
         uint addonId,
         Span<SeStringParameter> localParameters = default,

--- a/Dalamud/Game/Text/Evaluator/SeStringParameter.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringParameter.cs
@@ -77,4 +77,6 @@ public readonly struct SeStringParameter
     public static implicit operator SeStringParameter(DSeString value) => new(new ReadOnlySeString(value.Encode()));
 
     public static implicit operator SeStringParameter(string value) => new(value);
+
+    public static implicit operator SeStringParameter(ReadOnlySpan<byte> value) => new(value);
 }

--- a/Dalamud/Plugin/Services/ISeStringEvaluator.cs
+++ b/Dalamud/Plugin/Services/ISeStringEvaluator.cs
@@ -39,6 +39,15 @@ public interface ISeStringEvaluator
     ReadOnlySeString EvaluateMacroString(string macroString, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null);
 
     /// <summary>
+    /// Evaluates macros in a macro string.
+    /// </summary>
+    /// <param name="macroString">The macro string.</param>
+    /// <param name="localParameters">An optional list of local parameters.</param>
+    /// <param name="language">An optional language override.</param>
+    /// <returns>An evaluated <see cref="ReadOnlySeString"/>.</returns>
+    ReadOnlySeString EvaluateMacroString(ReadOnlySpan<byte> macroString, Span<SeStringParameter> localParameters = default, ClientLanguage? language = null);
+
+    /// <summary>
     /// Evaluates macros in text from the Addon sheet.
     /// </summary>
     /// <param name="addonId">The row id of the Addon sheet.</param>


### PR DESCRIPTION
- Adds an overload for `ISeStringEvaluator.EvaluateMacroString` taking `ReadOnlySpan<byte>`.
  - Supported by [ReadOnlySeString.FromMacroString](https://github.com/NotAdam/Lumina/blob/master/src/Lumina/Text/ReadOnly/ReadOnlySeString.cs#L305)
- Adds an implicit cast from `ReadOnlySpan<byte>` to `SeStringParameter`.