### PR TITLE
Collect additional logs for crash handler

### DIFF
--- a/DalamudCrashHandler/DalamudCrashHandler.cpp
+++ b/DalamudCrashHandler/DalamudCrashHandler.cpp
@@ -470,6 +470,7 @@ void export_tspack(HWND hWndParent, const std::filesystem::path& logDir, const s
         "dalamud.injector.log",
         "dalamud.boot.log",
         "aria.log",
+        "wine.log"
     };
     static constexpr auto MaxSizePerLog = 1 * 1024 * 1024;
     static constexpr std::array<COMDLG_FILTERSPEC, 2> OutputFileTypeFilterSpec{{

--- a/DalamudCrashHandler/DalamudCrashHandler.cpp
+++ b/DalamudCrashHandler/DalamudCrashHandler.cpp
@@ -463,7 +463,8 @@ void open_folder_and_select_items(HWND hwndOpener, const std::wstring& path) {
 
 void export_tspack(HWND hWndParent, const std::filesystem::path& logDir, const std::string& crashLog, const std::string& troubleshootingPackData) {
     static const char* SourceLogFiles[] = {
-        "output.log",
+        "output.log", // XIVLauncher for Windows
+        "launcher.log", // XIVLauncher.Core for [mostly] Linux
         "patcher.log",
         "dalamud.log",
         "dalamud.injector.log",


### PR DESCRIPTION
Adds xlcore-based logs that were missing, `launcher.log` and `wine.log`. This should help make troubleshooting for xlcore-based platforms easier when a user uploads a tspack.