### PR TITLE
feat: Identify the plugin causing an assertion failure

### DIFF
--- a/Dalamud/Interface/Internal/Asserts/AssertHandler.cs
+++ b/Dalamud/Interface/Internal/Asserts/AssertHandler.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Windows.Forms;
 
+using Dalamud.Plugin.Internal;
 using Dalamud.Utility;
 
 using Serilog;
@@ -55,7 +56,8 @@ internal class AssertHandler : IDisposable
     /// </summary>
     public unsafe void Setup()
     {
-        CustomNativeFunctions.igCustom_SetAssertCallback(Marshal.GetFunctionPointerForDelegate(this.callback).ToPointer());
+        CustomNativeFunctions.igCustom_SetAssertCallback(
+            Marshal.GetFunctionPointerForDelegate(this.callback).ToPointer());
     }
 
     /// <summary>
@@ -78,10 +80,11 @@ internal class AssertHandler : IDisposable
         var file = Marshal.PtrToStringAnsi(new IntPtr(pFile));
         if (expr == null || file == null)
         {
-            Log.Warning("ImGui assertion failed: {Expr} at {File}:{Line} (failed to parse)",
-                        expr,
-                        file,
-                        line);
+            Log.Warning(
+                "ImGui assertion failed: {Expr} at {File}:{Line} (failed to parse)",
+                expr,
+                file,
+                line);
             return;
         }
 
@@ -93,7 +96,7 @@ internal class AssertHandler : IDisposable
         if (!this.ShowAsserts && !this.everShownAssertThisSession)
             return;
 
-        Lazy<string> stackTrace = new(() => DiagnosticUtil.GetUsefulTrace(new StackTrace()).ToString());
+        Lazy<StackTrace> stackTrace = new(() => DiagnosticUtil.GetUsefulTrace(new StackTrace()));
 
         if (!this.EnableVerboseLogging)
         {
@@ -103,11 +106,12 @@ internal class AssertHandler : IDisposable
 
                 if (count <= HideThreshold || count % HidePrintEvery == 0)
                 {
-                    Log.Warning("ImGui assertion failed: {Expr} at {File}:{Line} (repeated {Count} times)",
-                                expr,
-                                file,
-                                line,
-                                count);
+                    Log.Warning(
+                        "ImGui assertion failed: {Expr} at {File}:{Line} (repeated {Count} times)",
+                        expr,
+                        file,
+                        line,
+                        count);
                 }
             }
             else
@@ -117,11 +121,12 @@ internal class AssertHandler : IDisposable
         }
         else
         {
-            Log.Warning("ImGui assertion failed: {Expr} at {File}:{Line}\n{StackTrace:l}",
-                        expr,
-                        file,
-                        line,
-                        stackTrace.Value);
+            Log.Warning(
+                "ImGui assertion failed: {Expr} at {File}:{Line}\n{StackTrace:l}",
+                expr,
+                file,
+                line,
+                stackTrace.Value.ToString());
         }
 
         if (!this.ShowAsserts)
@@ -145,7 +150,7 @@ internal class AssertHandler : IDisposable
         }
 
         // grab the stack trace now that we've decided to show UI.
-        _ = stackTrace.Value;
+        var responsiblePlugin = Service<PluginManager>.GetNullable()?.FindCallingPlugin(stackTrace.Value);
 
         var gitHubUrl = GetRepoUrl();
         var showOnGitHubButton = new TaskDialogButton
@@ -175,11 +180,28 @@ internal class AssertHandler : IDisposable
         var ignoreButton = TaskDialogButton.Ignore;
 
         TaskDialogButton? result = null;
+
         void DialogThreadStart()
         {
             // TODO(goat): This is probably not gonna work if we showed the loading dialog
             // this session since it already loaded visual styles...
             Application.EnableVisualStyles();
+
+            string text;
+            if (responsiblePlugin != null)
+            {
+                text = $"The plugin \"{responsiblePlugin.Name}\" appears to have caused an ImGui assertion failure. " +
+                       $"Please report this problem to the plugin's developer.\n\n";
+            }
+            else
+            {
+                text = "Some code in a plugin or Dalamud itself has caused an ImGui assertion failure. " +
+                       "Please report this problem in the Dalamud discord.\n\n";
+            }
+
+            text += $"You may attempt to continue running the game, but Dalamud UI elements may not work " +
+                    $"correctly, or the game may crash after resuming.\n\n" +
+                    $"{expr}\nAt: {file}:{line}";
 
             var page = new TaskDialogPage
             {
@@ -189,9 +211,9 @@ internal class AssertHandler : IDisposable
                 {
                     CollapsedButtonText = "Show stack trace",
                     ExpandedButtonText = "Hide stack trace",
-                    Text = stackTrace.Value,
+                    Text = stackTrace.Value.ToString(),
                 },
-                Text = $"Some code in a plugin or Dalamud itself has caused an internal assertion in ImGui to fail. The game will most likely crash now.\n\n{expr}\nAt: {file}:{line}",
+                Text = text,
                 Icon = TaskDialogIcon.Warning,
                 Buttons =
                 [


### PR DESCRIPTION
Modifies the assertion error to blame a specific plugin that did something wrong, when available:

<img width="1062" height="360" alt="image" src="https://github.com/user-attachments/assets/9cc37063-0eab-4cd6-b319-19e1849be7c7" />
