### PR TITLE
Add Platform/OS to plugin feedback

### DIFF
--- a/Dalamud/Support/BugBait.cs
+++ b/Dalamud/Support/BugBait.cs
@@ -36,6 +36,7 @@ internal static class BugBait
             Reporter = reporter,
             Name = plugin.InternalName,
             Version = isTesting ? plugin.TestingAssemblyVersion?.ToString() : plugin.AssemblyVersion.ToString(),
+            Platform = Util.GetHostPlatform().ToString(),
             DalamudHash = Util.GetScmVersion(),
         };
 
@@ -65,6 +66,9 @@ internal static class BugBait
 
         [JsonProperty("version")]
         public string? Version { get; set; }
+
+        [JsonProperty("platform")]
+        public string? Platform { get; set; }
 
         [JsonProperty("reporter")]
         public string? Reporter { get; set; }


### PR DESCRIPTION
Adds whether the user is on Windows/Mac/Linux to all feedback reports. Eventually I want to expand this to include the specific Wine build information for Mac/Linux to make troubleshooting certain things nicer.

Bugbait PR: pending