### PR TITLE
Allow banned plugins to not specify version

### DIFF
--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1240,7 +1240,7 @@ internal class PluginManager : IInternalDisposableService
         }
 
         return this.bannedPlugins.Any(ban => (ban.Name == manifest.InternalName || ban.Name == Hash.GetStringSha256Hash(manifest.InternalName))
-                                                                        && ban.AssemblyVersion >= versionToCheck);
+                                                                        && (ban.AssemblyVersion == null || ban.AssemblyVersion >= versionToCheck));
     }
 
     /// <summary>

--- a/Dalamud/Plugin/Internal/Types/BannedPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/BannedPlugin.cs
@@ -17,7 +17,7 @@ internal struct BannedPlugin
     /// Gets plugin assembly version.
     /// </summary>
     [JsonProperty]
-    public Version AssemblyVersion { get; private set; }
+    public Version? AssemblyVersion { get; private set; }
 
     /// <summary>
     /// Gets reason for the ban.


### PR DESCRIPTION
- Allows for plugins to be banned without specifying a version in bannedplugin.json