### PR TITLE
Use AgentLobbys OnLogout vfunc

### DIFF
--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -38,7 +38,7 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
     private readonly ClientStateAddressResolver address;
     private readonly Hook<EventFramework.Delegates.SetTerritoryTypeId> setupTerritoryTypeHook;
     private readonly Hook<UIModule.Delegates.HandlePacket> uiModuleHandlePacketHook;
-    private readonly Hook<LogoutCallbackInterface.Delegates.OnLogout> onLogoutHook;
+    private Hook<LogoutCallbackInterface.Delegates.OnLogout> onLogoutHook;
 
     [ServiceManager.ServiceDependency]
     private readonly Framework framework = Service<Framework>.Get();
@@ -64,14 +64,12 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
 
         this.setupTerritoryTypeHook = Hook<EventFramework.Delegates.SetTerritoryTypeId>.FromAddress(setTerritoryTypeAddr, this.SetupTerritoryTypeDetour);
         this.uiModuleHandlePacketHook = Hook<UIModule.Delegates.HandlePacket>.FromAddress((nint)UIModule.StaticVirtualTablePointer->HandlePacket, this.UIModuleHandlePacketDetour);
-        this.onLogoutHook = Hook<LogoutCallbackInterface.Delegates.OnLogout>.FromAddress((nint)LogoutCallbackInterface.StaticVirtualTablePointer->OnLogout, this.OnLogoutDetour);
 
         this.framework.Update += this.FrameworkOnOnUpdateEvent;
         this.networkHandlers.CfPop += this.NetworkHandlersOnCfPop;
 
         this.setupTerritoryTypeHook.Enable();
         this.uiModuleHandlePacketHook.Enable();
-        this.onLogoutHook.Enable();
 
         this.framework.RunOnTick(this.Setup);
     }
@@ -184,6 +182,9 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
 
     private unsafe void Setup()
     {
+        this.onLogoutHook = Hook<LogoutCallbackInterface.Delegates.OnLogout>.FromAddress((nint)AgentLobby.Instance()->LogoutCallbackInterface.VirtualTable->OnLogout, this.OnLogoutDetour);
+        this.onLogoutHook.Enable();
+
         this.TerritoryType = (ushort)GameMain.Instance()->CurrentTerritoryTypeId;
     }
 


### PR DESCRIPTION
The signature was changed from the AgentLobby's LogoutCallbackInterface VTable, to the original LogoutCallbackInterface VTable, which is correct, but broke our OnLogout hook.

This changes it so it grabs the address to OnLogout from AgentLobby instead.

**This PR is required for the following commit**
- https://github.com/aers/FFXIVClientStructs/commit/834d3cc94082fd812cf6cda8da217b22e4f9f15d

which is about to be pulled in with
- https://github.com/goatcorp/Dalamud/pull/2390

Then the last self-test also works again:

<img width="522" height="70" alt="proof" src="https://github.com/user-attachments/assets/07039689-2d8e-4fd0-863b-f1e051c09894" />
