### PR TITLE
fix: Schedule removal of CS types from API

### DIFF
--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonRefreshArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonRefreshArgs.cs
@@ -1,3 +1,5 @@
+using Dalamud.Utility;
+
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
@@ -31,6 +33,8 @@ public class AddonRefreshArgs : AddonArgs, ICloneable
     /// <summary>
     /// Gets the AtkValues in the form of a span.
     /// </summary>
+    [Api14ToDo(Api14ToDoAttribute.Remove)]
+    [Obsolete($"Exposed ClientStructs type; use {nameof(AtkValues)}/{nameof(AtkValueCount)} instead.", false)]
     public unsafe Span<AtkValue> AtkValueSpan => new(this.AtkValues.ToPointer(), (int)this.AtkValueCount);
 
     /// <inheritdoc cref="ICloneable.Clone"/>

--- a/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonSetupArgs.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonArgTypes/AddonSetupArgs.cs
@@ -1,3 +1,5 @@
+using Dalamud.Utility;
+
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
@@ -31,6 +33,8 @@ public class AddonSetupArgs : AddonArgs, ICloneable
     /// <summary>
     /// Gets the AtkValues in the form of a span.
     /// </summary>
+    [Api14ToDo(Api14ToDoAttribute.Remove)]
+    [Obsolete($"Exposed ClientStructs type; use {nameof(AtkValues)}/{nameof(AtkValueCount)} instead.", false)]
     public unsafe Span<AtkValue> AtkValueSpan => new(this.AtkValues.ToPointer(), (int)this.AtkValueCount);
 
     /// <inheritdoc cref="ICloneable.Clone"/>

--- a/Dalamud/Game/Addon/Lifecycle/AddonEvent.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonEvent.cs
@@ -12,11 +12,11 @@ public enum AddonEvent
     /// <summary>
     /// An event that is fired prior to an addon being setup with its implementation of
     /// <see cref="AtkUnitBase.OnSetup"/>. This event is useful for modifying the initial data contained within
-    /// <see cref="AddonSetupArgs.AtkValueSpan"/> prior to the addon being created.
+    /// <see cref="AddonSetupArgs.AtkValues"/> prior to the addon being created.
     /// </summary>
     /// <seealso cref="AddonSetupArgs"/>
     PreSetup,
-    
+
     /// <summary>
     /// An event that is fired after an addon has finished its initial setup. This event is particularly useful for
     /// developers seeking to add custom elements to now-initialized and populated node lists, as well as reading data
@@ -64,7 +64,7 @@ public enum AddonEvent
     /// </remarks>
     /// <seealso cref="AddonFinalizeArgs"/>
     PreFinalize,
-    
+
     /// <summary>
     /// An event that is fired before a call to <see cref="AtkUnitBase.OnRequestedUpdate"/> is made in response to a
     /// change in the subscribed <see cref="AddonRequestedUpdateArgs.NumberArrayData"/> or
@@ -81,13 +81,13 @@ public enum AddonEvent
     /// to the Free Company's overview.
     /// </example>
     PreRequestedUpdate,
-    
+
     /// <summary>
     /// An event that is fired after an addon has finished processing an <c>ArrayData</c> update.
     /// See <see cref="PreRequestedUpdate"/> for more information.
     /// </summary>
     PostRequestedUpdate,
-    
+
     /// <summary>
     /// An event that is fired before an addon calls its <see cref="AtkUnitManager.RefreshAddon"/> method. Refreshes are
     /// generally triggered in response to certain user interactions such as changing tabs, and are primarily used to
@@ -96,13 +96,13 @@ public enum AddonEvent
     /// <seealso cref="AddonRefreshArgs"/>
     /// <seealso cref="PostRefresh"/>
     PreRefresh,
-    
+
     /// <summary>
     /// An event that is fired after an addon has finished its refresh.
     /// See <see cref="PreRefresh"/> for more information.
     /// </summary>
     PostRefresh,
-    
+
     /// <summary>
     /// An event that is fired before an addon begins processing a user-driven event via
     /// <see cref="AtkEventListener.ReceiveEvent"/>, such as mousing over an element or clicking a button. This event
@@ -112,7 +112,7 @@ public enum AddonEvent
     /// <seealso cref="AddonReceiveEventArgs"/>
     /// <seealso cref="PostReceiveEvent"/>
     PreReceiveEvent,
-    
+
     /// <summary>
     /// An event that is fired after an addon finishes calling its <see cref="AtkEventListener.ReceiveEvent"/> method.
     /// See <see cref="PreReceiveEvent"/> for more information.

--- a/Dalamud/Game/ClientState/JobGauge/Types/SMNGauge.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Types/SMNGauge.cs
@@ -1,4 +1,6 @@
 using Dalamud.Game.ClientState.JobGauge.Enums;
+using Dalamud.Utility;
+
 using FFXIVClientStructs.FFXIV.Client.Game.Gauge;
 
 namespace Dalamud.Game.ClientState.JobGauge.Types;
@@ -69,6 +71,7 @@ public unsafe class SMNGauge : JobGaugeBase<SummonerGauge>
     /// Gets the current aether flags.
     /// Use the summon accessors instead.
     /// </summary>
+    [Api14ToDo("Declare our own enum for this to avoid CS type.")]
     public AetherFlags AetherFlags => this.Struct->AetherFlags;
 
     /// <summary>

--- a/Dalamud/Game/Gui/Dtr/DtrBarEntry.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBarEntry.cs
@@ -143,7 +143,7 @@ internal sealed unsafe class DtrBarEntry : IDisposable, IDtrBarEntry
     }
 
     /// <inheritdoc/>
-    [Api13ToDo("Maybe make this config scoped to internal name?")]
+    [Api14ToDo("Maybe make this config scoped to internal name?")]
     public bool UserHidden => this.configuration.DtrIgnore?.Contains(this.Title) ?? false;
 
     /// <summary>

--- a/Dalamud/Interface/Animation/Easing.cs
+++ b/Dalamud/Interface/Animation/Easing.cs
@@ -48,7 +48,7 @@ public abstract class Easing
     /// Gets the current value of the animation, following unclamped logic.
     /// </summary>
     [Obsolete($"This field has been deprecated. Use either {nameof(ValueClamped)} or {nameof(ValueUnclamped)} instead.", true)]
-    [Api13ToDo("Map this field to ValueClamped, probably.")]
+    [Api14ToDo("Map this field to ValueClamped, probably.")]
     public double Value => this.ValueUnclamped;
 
     /// <summary>

--- a/Dalamud/Interface/Components/ImGuiComponents.HelpMarker.cs
+++ b/Dalamud/Interface/Components/ImGuiComponents.HelpMarker.cs
@@ -1,5 +1,7 @@
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility.Raii;
+using Dalamud.Utility;
+
 using FFXIVClientStructs.FFXIV.Common.Math;
 
 namespace Dalamud.Interface.Components;
@@ -21,6 +23,7 @@ public static partial class ImGuiComponents
     /// <param name="helpText">The text to display on hover.</param>
     /// <param name="icon">The icon to use.</param>
     /// <param name="color">The color of the icon.</param>
+    [Api14ToDo("Replace CS Vector4 with System.Numerics.Vector4")]
     public static void HelpMarker(string helpText, FontAwesomeIcon icon, Vector4? color = null)
     {
         using var col = new ImRaii.Color();

--- a/Dalamud/Utility/Api14ToDoAttribute.cs
+++ b/Dalamud/Utility/Api14ToDoAttribute.cs
@@ -4,7 +4,7 @@ namespace Dalamud.Utility;
 /// Utility class for marking something to be changed for API 13, for ease of lookup.
 /// </summary>
 [AttributeUsage(AttributeTargets.All, Inherited = false)]
-internal sealed class Api13ToDoAttribute : Attribute
+internal sealed class Api14ToDoAttribute : Attribute
 {
     /// <summary>
     /// Marks that this should be made internal.
@@ -12,11 +12,16 @@ internal sealed class Api13ToDoAttribute : Attribute
     public const string MakeInternal = "Make internal.";
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="Api13ToDoAttribute"/> class.
+    /// Marks that this should be removed entirely.
+    /// </summary>
+    public const string Remove = "Remove.";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Api14ToDoAttribute"/> class.
     /// </summary>
     /// <param name="what">The explanation.</param>
     /// <param name="what2">The explanation 2.</param>
-    public Api13ToDoAttribute(string what, string what2 = "")
+    public Api14ToDoAttribute(string what, string what2 = "")
     {
         _ = what;
         _ = what2;

--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -75,7 +75,7 @@ public static partial class Util
     /// <summary>
     /// Gets the Dalamud version.
     /// </summary>
-    [Api13ToDo("Remove. Make both versions here internal. Add an API somewhere.")]
+    [Api14ToDo("Remove. Make both versions here internal. Add an API somewhere.")]
     public static string AssemblyVersion { get; } =
         Assembly.GetAssembly(typeof(ChatHandlers))!.GetName().Version!.ToString();
 


### PR DESCRIPTION
Deprecates/tags a few ClientStructs types in Dalamud's public API.

List of detected cases:

```
Dalamud.Game.Addon.Lifecycle.AddonArgTypes.AddonRefreshArgs.AtkValueSpan.get -> System.Span<FFXIVClientStructs.FFXIV.Component.GUI.AtkValue>
Dalamud.Game.Addon.Lifecycle.AddonArgTypes.AddonSetupArgs.AtkValueSpan.get -> System.Span<FFXIVClientStructs.FFXIV.Component.GUI.AtkValue>
Dalamud.Game.ClientState.JobGauge.Types.SMNGauge.AetherFlags.get -> FFXIVClientStructs.FFXIV.Client.Game.Gauge.AetherFlags
static Dalamud.Interface.Components.ImGuiComponents.HelpMarker(string! helpText, Dalamud.Interface.FontAwesomeIcon icon, FFXIVClientStructs.FFXIV.Common.Math.Vector4? color = null) -> void
static Dalamud.Memory.MemoryHelper.ReadSeString(FFXIVClientStructs.FFXIV.Client.System.String.Utf8String* utf8String) -> Dalamud.Game.Text.SeStringHandling.SeString!
static Dalamud.Memory.MemoryHelper.ReadSeString(FFXIVClientStructs.FFXIV.Client.System.String.Utf8String* utf8String, out Dalamud.Game.Text.SeStringHandling.SeString! value) -> void
static Dalamud.Utility.Numerics.VectorExtensions.ToByteColor(this System.Numerics.Vector4 v) -> FFXIVClientStructs.FFXIV.Client.Graphics.ByteColor
```

The `MemoryHelper` and `VectorExtensions` variants are a non-issue IMO, as they have well-documented alternatives and can be handled in other ways. I wouldn't be opposed to stripping out `ToByteColor` though, just to avoid confusion with custom CS.