### PR TITLE
Update ClientState

### DIFF
--- a/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
+++ b/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
@@ -20,6 +20,11 @@ internal sealed class ClientStateAddressResolver : BaseAddressResolver
     // Functions
 
     /// <summary>
+    /// Gets the address of the method that handles the ZoneInit packet.
+    /// </summary>
+    public nint HandleZoneInitPacket { get; private set; }
+
+    /// <summary>
     /// Gets the address of the method that sets the current public instance.
     /// </summary>
     public nint SetCurrentInstance { get; private set; }
@@ -30,6 +35,7 @@ internal sealed class ClientStateAddressResolver : BaseAddressResolver
     /// <param name="sig">The signature scanner to facilitate setup.</param>
     protected override void Setup64Bit(ISigScanner sig)
     {
+        this.HandleZoneInitPacket = sig.ScanText("E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 44 0F B6 45");
         this.SetCurrentInstance = sig.ScanText("E8 ?? ?? ?? ?? 0F B6 55 ?? 48 8D 0D ?? ?? ?? ?? C0 EA"); // NetworkModuleProxy.SetCurrentInstance
 
         // These resolve to fixed offsets only, without the base address added in, so GetStaticAddressFromSig() can't be used.

--- a/Dalamud/Game/ClientState/ZoneInit.cs
+++ b/Dalamud/Game/ClientState/ZoneInit.cs
@@ -1,0 +1,90 @@
+using System.Linq;
+using System.Text;
+
+using Dalamud.Data;
+
+using Lumina.Excel.Sheets;
+
+namespace Dalamud.Game.ClientState;
+
+/// <summary>
+/// Provides event data for when the game should initialize a zone.
+/// </summary>
+public class ZoneInitEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the territory type of the zone being entered.
+    /// </summary>
+    public TerritoryType TerritoryType { get; private set; }
+
+    /// <summary>
+    /// Gets the instance number of the zone, used when multiple copies of an area are active.
+    /// </summary>
+    public ushort Instance { get; private set; }
+
+    /// <summary>
+    /// Gets the associated content finder condition for the zone, if any.
+    /// </summary>
+    public ContentFinderCondition ContentFinderCondition { get; private set; }
+
+    /// <summary>
+    /// Gets the current weather in the zone upon entry.
+    /// </summary>
+    public Weather Weather { get; private set; }
+
+    /// <summary>
+    /// Gets the set of active festivals in the zone.
+    /// </summary>
+    public Festival[] ActiveFestivals { get; private set; } = [];
+
+    /// <summary>
+    /// Gets the phases corresponding to the active festivals.
+    /// </summary>
+    public ushort[] ActiveFestivalPhases { get; private set; } = [];
+
+    /// <summary>
+    /// Reads raw zone initialization data from a network packet and constructs the event arguments.
+    /// </summary>
+    /// <param name="packet">A pointer to the raw packet data.</param>
+    /// <returns>A <see cref="ZoneInitEventArgs"/> populated from the packet.</returns>
+    public static unsafe ZoneInitEventArgs Read(nint packet)
+    {
+        var dataManager = Service<DataManager>.Get();
+        var eventArgs = new ZoneInitEventArgs();
+
+        var flags = *(byte*)(packet + 0x12);
+
+        eventArgs.TerritoryType = dataManager.GetExcelSheet<TerritoryType>().GetRow(*(ushort*)(packet + 0x02));
+        eventArgs.Instance = flags >= 0 ? (ushort)0 : *(ushort*)(packet + 0x04);
+        eventArgs.ContentFinderCondition = dataManager.GetExcelSheet<ContentFinderCondition>().GetRow(*(ushort*)(packet + 0x06));
+        eventArgs.Weather = dataManager.GetExcelSheet<Weather>().GetRow(*(byte*)(packet + 0x10));
+
+        const int NumFestivals = 4;
+        eventArgs.ActiveFestivals = new Festival[NumFestivals];
+        eventArgs.ActiveFestivalPhases = new ushort[NumFestivals];
+
+        // There are also 4 festival ids and phases for PlayerState at +0x3E and +0x46 respectively,
+        // but it's unclear why they exist as separate entries and why they would be different.
+        for (var i = 0; i < NumFestivals; i++)
+        {
+            eventArgs.ActiveFestivals[i] = dataManager.GetExcelSheet<Festival>().GetRow(*(ushort*)(packet + 0x2E + (i * 2)));
+            eventArgs.ActiveFestivalPhases[i] = *(ushort*)(packet + 0x36 + (i * 2));
+        }
+
+        return eventArgs;
+    }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        var sb = new StringBuilder("ZoneInitEventArgs { ");
+        sb.Append($"TerritoryTypeId = {this.TerritoryType.RowId}, ");
+        sb.Append($"Instance = {this.Instance}, ");
+        sb.Append($"ContentFinderCondition = {this.ContentFinderCondition.RowId}, ");
+        sb.Append($"Weather = {this.Weather.RowId}, ");
+        sb.Append($"ActiveFestivals = [{string.Join(", ", this.ActiveFestivals.Select(f => f.RowId))}], ");
+        sb.Append($"ActiveFestivalPhases = [{string.Join(", ", this.ActiveFestivalPhases)}]");
+        sb.Append(" }");
+        return sb.ToString();
+    }
+}

--- a/Dalamud/Plugin/Services/IClientState.cs
+++ b/Dalamud/Plugin/Services/IClientState.cs
@@ -1,4 +1,5 @@
 using Dalamud.Game;
+using Dalamud.Game.ClientState;
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 
@@ -30,6 +31,11 @@ public interface IClientState
     public delegate void LogoutDelegate(int type, int code);
 
     /// <summary>
+    /// Event that gets fired when the game initializes a zone.
+    /// </summary>
+    public event Action<ZoneInitEventArgs> ZoneInit;
+
+    /// <summary>
     /// Event that gets fired when the current Territory changes.
     /// </summary>
     public event Action<ushort> TerritoryChanged;
@@ -37,12 +43,12 @@ public interface IClientState
     /// <summary>
     /// Event that gets fired when the current Map changes.
     /// </summary>
-    public event Action<uint> MapChanged;
+    public event Action<uint> MapIdChanged;
 
     /// <summary>
     /// Event that gets fired when the current zone Instance changes.
     /// </summary>
-    public event Action<uint> PublicInstanceChanged;
+    public event Action<uint> InstanceChanged;
 
     /// <summary>
     /// Event that fires when a characters ClassJob changed.
@@ -98,7 +104,7 @@ public interface IClientState
     /// <summary>
     /// Gets the instance number of the current zone, used when multiple copies of an area are active.
     /// </summary>
-    public uint PublicInstanceId { get; }
+    public uint Instance { get; }
 
     /// <summary>
     /// Gets the local player character, if one is present.


### PR DESCRIPTION
To address issue #2409, this PR adds the following to ClientState:

- A new `ZoneInit` event, fired when the game handles the ZoneInit packet. This essentially restores the previous `TerritoryChanged` behavior, but with additional info.
- A new `MapIdChanged` event, fired whenever `MapId` changes.
- A new `Instance` property, returning the current zone instance used to reduce congestion.
- A new `InstanceChanged` event, fired whenever `Instance` changes.