### PR TITLE
Update SeStringEvaluator, Payload, AutoTranslatePayload

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/Payload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payload.cs
@@ -208,7 +208,7 @@ public abstract partial class Payload
         }
 
         payload ??= new RawPayload((byte)chunkType);
-        payload.DecodeImpl(reader, reader.BaseStream.Position + chunkLen - 1);
+        payload.DecodeImpl(reader, reader.BaseStream.Position + chunkLen);
 
         // read through the rest of the packet
         var readBytes = (uint)(reader.BaseStream.Position - packetStart);

--- a/Dalamud/Game/Text/SeStringHandling/Payloads/RawPayload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payloads/RawPayload.cs
@@ -95,14 +95,12 @@ public class RawPayload : Payload
     /// <inheritdoc/>
     protected override byte[] EncodeImpl()
     {
-        var chunkLen = this.data.Length + 1;
-
         var bytes = new List<byte>()
         {
             START_BYTE,
             this.chunkType,
-            (byte)chunkLen,
         };
+        bytes.AddRange(MakeInteger((uint)this.data.Length)); // chunkLen
         bytes.AddRange(this.data);
 
         bytes.Add(END_BYTE);
@@ -113,6 +111,6 @@ public class RawPayload : Payload
     /// <inheritdoc/>
     protected override void DecodeImpl(BinaryReader reader, long endOfStream)
     {
-        this.data = reader.ReadBytes((int)(endOfStream - reader.BaseStream.Position + 1));
+        this.data = reader.ReadBytes((int)(endOfStream - reader.BaseStream.Position));
     }
 }


### PR DESCRIPTION
- [`bf4fc786`](bf4fc786) The auto translate code of the fixed macro parser didn't consider multiple `col-` entries in the LookupTable of the Completion sheet, as seen on RowId 2213 (TextCommand) for example. If the first column is empty (in the case of TextCommand, that is the column Alias), it takes the second one (in the case of TextCommand, that is the column Command).
- [`327ebf3b`](327ebf3b) We noticed in the updated `AutoTranslatePayload` (later down this list) that the `endOfStream` parameter of `DecodeImpl` is 1 byte too short. Further proof in `RawPayload` where it gets corrected.
- [`93a44842`](93a44842) Optimized `Payload.DecodeChunk` by skipping to the end of the payload instead of reading the remaining bytes (prevents allocation).
- [`3f037e5d`](3f037e5d) Updated `AutoTranslatePayload` to pass-through the original packet when decoded and encoded again, and to use SeStringEvaluator to get the properly evaluated text.