### PR TITLE
enforce limits on alpha slider

### DIFF
--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -523,7 +523,7 @@ public abstract class Window
                 if (ImGui.SliderFloat(Loc.Localize("WindowSystemContextActionAlpha", "Opacity"), ref alpha, 20f,
                                       100f))
                 {
-                    this.internalAlpha = alpha / 100f;
+                    this.internalAlpha = Math.Clamp(alpha / 100f, 0.2f, 1f);
                     this.presetDirty = true;
                 }
 


### PR DESCRIPTION
enforce limits on the alpha slider
If someone control-clicks to set alpha to 0 it is impossible for them to fix it without manually editing the dalamud config file.