### PR TITLE
Fix for testing plugins with older stable releases

### DIFF
--- a/Dalamud/Interface/Internal/PluginCategoryManager.cs
+++ b/Dalamud/Interface/Internal/PluginCategoryManager.cs
@@ -294,7 +294,7 @@ internal class PluginCategoryManager
                 }
             }
 
-            if (PluginManager.HasTestingVersion(manifest) || manifest.IsTestingExclusive)
+            if (manifest.IsTestingExclusive || manifest.IsAvailableForTesting)
                 categoryList.Add(CategoryKind.AvailableForTesting);
 
             // always add, even if empty

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -2454,10 +2454,11 @@ internal class PluginInstallerWindow : Window, IDisposable
         var configuration = Service<DalamudConfiguration>.Get();
         var pluginManager = Service<PluginManager>.Get();
 
+        var canUseTesting = pluginManager.CanUseTesting(manifest);
         var useTesting = pluginManager.UseTesting(manifest);
         var wasSeen = this.WasPluginSeen(manifest.InternalName);
 
-        var effectiveApiLevel = useTesting && manifest.TestingDalamudApiLevel != null ? manifest.TestingDalamudApiLevel.Value : manifest.DalamudApiLevel;
+        var effectiveApiLevel = useTesting ? manifest.TestingDalamudApiLevel.Value : manifest.DalamudApiLevel;
         var isOutdated = effectiveApiLevel < PluginManager.DalamudApiLevel;
 
         var isIncompatible = manifest.MinimumDalamudVersion != null &&
@@ -2487,7 +2488,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         {
             label += Locs.PluginTitleMod_TestingExclusive;
         }
-        else if (configuration.DoPluginTest && PluginManager.HasTestingVersion(manifest))
+        else if (canUseTesting)
         {
             label += Locs.PluginTitleMod_TestingAvailable;
         }

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -3782,16 +3782,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
     private bool IsManifestFiltered(IPluginManifest manifest)
     {
-        var hasSearchString = !string.IsNullOrWhiteSpace(this.searchText);
-        var oldApi = (manifest.TestingDalamudApiLevel == null
-                            || manifest.TestingDalamudApiLevel < PluginManager.DalamudApiLevel)
-                          && manifest.DalamudApiLevel < PluginManager.DalamudApiLevel;
-        var installed = this.IsManifestInstalled(manifest).IsInstalled;
-
-        if (oldApi && !hasSearchString && !installed)
-            return true;
-
-        if (!hasSearchString)
+        if (string.IsNullOrWhiteSpace(this.searchText))
             return false;
 
         return this.GetManifestSearchScore(manifest) < 1;

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -2593,8 +2593,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         var configuration = Service<DalamudConfiguration>.Get();
         var pluginManager = Service<PluginManager>.Get();
 
-        var hasTestingVersionAvailable = configuration.DoPluginTest &&
-                                         PluginManager.HasTestingVersion(manifest);
+        var hasTestingVersionAvailable = configuration.DoPluginTest && manifest.IsAvailableForTesting;
 
         if (ImGui.BeginPopupContextItem("ItemContextMenu"u8))
         {
@@ -2689,8 +2688,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             label += Locs.PluginTitleMod_TestingVersion;
         }
 
-        var hasTestingAvailable = this.pluginListAvailable.Any(x => x.InternalName == plugin.InternalName &&
-                                                                               x.IsAvailableForTesting);
+        var hasTestingAvailable = this.pluginListAvailable.Any(x => x.InternalName == plugin.InternalName && x.IsAvailableForTesting);
         if (hasTestingAvailable && configuration.DoPluginTest && testingOptIn == null)
         {
             label += Locs.PluginTitleMod_TestingAvailable;

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1193,9 +1193,18 @@ internal class PluginManager : IInternalDisposableService
             return false;
 
         // API level - we keep the API before this in the installer to show as "outdated"
-        var effectiveApiLevel = this.UseTesting(manifest) && manifest.TestingDalamudApiLevel != null ? manifest.TestingDalamudApiLevel.Value : manifest.DalamudApiLevel;
-        if (effectiveApiLevel < DalamudApiLevel - 1 && !this.LoadAllApiLevels)
-            return false;
+        if (!this.LoadAllApiLevels)
+        {
+            var effectiveDalamudApiLevel =
+                this.CanUseTesting(manifest) &&
+                manifest.TestingDalamudApiLevel.HasValue &&
+                manifest.TestingDalamudApiLevel.Value > manifest.DalamudApiLevel
+                    ? manifest.TestingDalamudApiLevel.Value
+                    : manifest.DalamudApiLevel;
+
+            if (effectiveDalamudApiLevel < PluginManager.DalamudApiLevel - 1)
+                return false;
+        }
 
         // Banned
         if (this.IsManifestBanned(manifest))

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -301,7 +301,7 @@ internal class LocalPlugin : IAsyncDisposable
                 throw new PluginPreconditionFailedException($"Unable to load {this.Name}, game is newer than applicable version {this.manifest.ApplicableVersion}");
 
             // We want to allow loading dev plugins with a lower API level than the current Dalamud API level, for ease of development
-            if (this.manifest.EffectiveApiLevel < PluginManager.DalamudApiLevel && !pluginManager.LoadAllApiLevels && !this.IsDev)
+            if (!pluginManager.LoadAllApiLevels && !this.IsDev && this.manifest.EffectiveApiLevel < PluginManager.DalamudApiLevel)
                 throw new PluginPreconditionFailedException($"Unable to load {this.Name}, incompatible API level {this.manifest.EffectiveApiLevel}");
 
             // We might want to throw here?

--- a/Dalamud/Plugin/Internal/Types/Manifest/IPluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/Manifest/IPluginManifest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Dalamud.Plugin.Internal.Types.Manifest;
 
@@ -118,4 +118,9 @@ public interface IPluginManifest
     /// Gets an URL for the plugin's icon.
     /// </summary>
     public string? IconUrl { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this plugin is eligible for testing.
+    /// </summary>
+    public bool IsAvailableForTesting { get; }
 }

--- a/Dalamud/Plugin/Internal/Types/Manifest/RemotePluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/Manifest/RemotePluginManifest.cs
@@ -21,9 +21,4 @@ internal record RemotePluginManifest : PluginManifest
     /// Gets or sets the changelog to be shown when obtaining the testing version of the plugin.
     /// </summary>
     public string? TestingChangelog { get; set; }
-
-    /// <summary>
-    /// Gets a value indicating whether this plugin is eligible for testing.
-    /// </summary>
-    public bool IsAvailableForTesting => this.TestingAssemblyVersion != null && this.TestingAssemblyVersion > this.AssemblyVersion;
 }

--- a/Dalamud/Plugin/Internal/Types/PluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginManifest.cs
@@ -160,4 +160,10 @@ internal record PluginManifest : IPluginManifest
     /// <inheritdoc/>
     [JsonProperty("_Dip17Channel")]
     public string? Dip17Channel { get; init; }
+
+    /// <inheritdoc/>
+    public bool IsAvailableForTesting
+        => this.TestingAssemblyVersion != null &&
+           this.TestingAssemblyVersion > this.AssemblyVersion &&
+           this.TestingDalamudApiLevel == PluginManager.DalamudApiLevel;
 }


### PR DESCRIPTION
When a plugins last stable release is older than the last Dalamud API version, it wouldn't be shown in the Plugin installer.
This is currently happening for Quest Tracker ([manifest](https://kamori.goats.dev/Plugin/Plugin/QuestTracker)), which has a DalamudApiLevel of 11.

There are two issues that come into play:
1) When searching for a plugin in the Plugin Installer, the function `PluginInstallerWindow.IsManifestFiltered` would filter out plugins that didn't match the current API level. This is redundant in my opinion, since the API version is checked in `PluginManager.IsManifestEligible` when the plugin repository loads.
2) The `PluginManager.IsManifestEligible` function on the other hand only checked the `TestingDalamudApiLevel` if the user *already* has opted in to testing of this plugin. I changed it so that the specific plugin testing opt-in state is not taken into consideration.

---

For convenience, I moved `RemotePluginManifest.IsAvailableForTesting` up to `IPluginManifest`, implemented by the base class `PluginManifest`. With that, the function `PluginManager.HasTestingVersion` has been removed.