### PR TITLE
[API14] Fix services using wrong namespaces

### DIFF
--- a/Dalamud/Game/Addon/Events/AddonEventManagerAddressResolver.cs
+++ b/Dalamud/Game/Addon/Events/AddonEventManagerAddressResolver.cs
@@ -1,4 +1,6 @@
-﻿namespace Dalamud.Game.Addon.Events;
+using Dalamud.Plugin.Services;
+
+namespace Dalamud.Game.Addon.Events;
 
 /// <summary>
 /// AddonEventManager memory address resolver.

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycleAddressResolver.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycleAddressResolver.cs
@@ -1,4 +1,4 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
+using Dalamud.Plugin.Services;
 
 namespace Dalamud.Game.Addon.Lifecycle;
 

--- a/Dalamud/Game/BaseAddressResolver.cs
+++ b/Dalamud/Game/BaseAddressResolver.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 
+using Dalamud.Plugin.Services;
+
 namespace Dalamud.Game;
 
 /// <summary>

--- a/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
+++ b/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
@@ -1,3 +1,5 @@
+using Dalamud.Plugin.Services;
+
 namespace Dalamud.Game.ClientState;
 
 /// <summary>

--- a/Dalamud/Game/ClientState/Objects/TargetManager.cs
+++ b/Dalamud/Game/ClientState/Objects/TargetManager.cs
@@ -1,6 +1,7 @@
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
+using Dalamud.Plugin.Services;
 
 using FFXIVClientStructs.FFXIV.Client.Game.Control;
 

--- a/Dalamud/Game/Config/GameConfigAddressResolver.cs
+++ b/Dalamud/Game/Config/GameConfigAddressResolver.cs
@@ -1,4 +1,6 @@
-﻿namespace Dalamud.Game.Config;
+using Dalamud.Plugin.Services;
+
+namespace Dalamud.Game.Config;
 
 /// <summary>
 /// Game config system address resolver.

--- a/Dalamud/Game/DutyState/DutyStateAddressResolver.cs
+++ b/Dalamud/Game/DutyState/DutyStateAddressResolver.cs
@@ -1,3 +1,5 @@
+using Dalamud.Plugin.Services;
+
 namespace Dalamud.Game.DutyState;
 
 /// <summary>

--- a/Dalamud/Game/Gui/GameGuiAddressResolver.cs
+++ b/Dalamud/Game/Gui/GameGuiAddressResolver.cs
@@ -1,3 +1,5 @@
+using Dalamud.Plugin.Services;
+
 namespace Dalamud.Game.Gui;
 
 /// <summary>

--- a/Dalamud/Game/Gui/NamePlate/NamePlateGuiAddressResolver.cs
+++ b/Dalamud/Game/Gui/NamePlate/NamePlateGuiAddressResolver.cs
@@ -1,3 +1,5 @@
+using Dalamud.Plugin.Services;
+
 namespace Dalamud.Game.Gui.NamePlate;
 
 /// <summary>

--- a/Dalamud/Game/Network/GameNetworkAddressResolver.cs
+++ b/Dalamud/Game/Network/GameNetworkAddressResolver.cs
@@ -1,3 +1,5 @@
+using Dalamud.Plugin.Services;
+
 namespace Dalamud.Game.Network;
 
 /// <summary>

--- a/Dalamud/Game/Network/Internal/NetworkHandlersAddressResolver.cs
+++ b/Dalamud/Game/Network/Internal/NetworkHandlersAddressResolver.cs
@@ -1,4 +1,6 @@
-﻿namespace Dalamud.Game.Network.Internal;
+using Dalamud.Plugin.Services;
+
+namespace Dalamud.Game.Network.Internal;
 
 /// <summary>
 /// Internal address resolver for the network handlers.

--- a/Dalamud/Game/SigScanner.cs
+++ b/Dalamud/Game/SigScanner.cs
@@ -8,6 +8,8 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 
+using Dalamud.Plugin.Services;
+
 using Iced.Intel;
 using Newtonsoft.Json;
 using Serilog;

--- a/Dalamud/Game/TargetSigScanner.cs
+++ b/Dalamud/Game/TargetSigScanner.cs
@@ -1,8 +1,9 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.IO;
 
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
+using Dalamud.Plugin.Services;
 
 namespace Dalamud.Game;
 

--- a/Dalamud/Plugin/Services/ISelfTestRegistry.cs
+++ b/Dalamud/Plugin/Services/ISelfTestRegistry.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 
-using Dalamud.Plugin.Services;
+using Dalamud.Plugin.SelfTest;
 
-namespace Dalamud.Plugin.SelfTest;
+namespace Dalamud.Plugin.Services;
 
 /// <summary>
 /// Interface for registering and unregistering self-test steps from plugins.

--- a/Dalamud/Plugin/Services/ISigScanner.cs
+++ b/Dalamud/Plugin/Services/ISigScanner.cs
@@ -2,9 +2,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 
-using Dalamud.Plugin.Services;
-
-namespace Dalamud.Game;
+namespace Dalamud.Plugin.Services;
 
 /// <summary>
 /// A SigScanner facilitates searching for memory signatures in a given ProcessModule.

--- a/Dalamud/Plugin/Services/ITargetManager.cs
+++ b/Dalamud/Plugin/Services/ITargetManager.cs
@@ -1,7 +1,7 @@
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Plugin.Services;
 
-namespace Dalamud.Game.ClientState.Objects;
+namespace Dalamud.Plugin.Services;
 
 /// <summary>
 /// Get and set various kinds of targets for the player.
@@ -37,13 +37,13 @@ public interface ITargetManager : IDalamudService
     /// Set to null to clear the target.
     /// </summary>
     public IGameObject? SoftTarget { get; set; }
-    
+
     /// <summary>
     /// Gets or sets the gpose target.
     /// Set to null to clear the target.
     /// </summary>
     public IGameObject? GPoseTarget { get; set; }
-    
+
     /// <summary>
     /// Gets or sets the mouseover nameplate target.
     /// Set to null to clear the target.


### PR DESCRIPTION
Interfaces for services are in the `Dalamud.Plugin.Services` namespace, yet
- `ISigScanner` was in `Dalamud.Game`,
- `ITargetManager` was in `Dalamud.Game.ClientState.Objects`, and
- `ISelfTestRegistry` was in `Dalamud.Plugin.SelfTest`.