### PR TITLE
Lock plugin list in NotifyPluginsForStateChange

### DIFF
--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1299,13 +1299,16 @@ internal class PluginManager : IInternalDisposableService
     /// <param name="affectedInternalNames">The affected plugins.</param>
     public void NotifyPluginsForStateChange(PluginListInvalidationKind kind, IEnumerable<string> affectedInternalNames)
     {
-        foreach (var installedPlugin in this.installedPluginsList)
+        lock (this.pluginListLock)
         {
-            if (!installedPlugin.IsLoaded || installedPlugin.DalamudInterface == null)
-                continue;
+            foreach (var installedPlugin in this.installedPluginsList)
+            {
+                if (!installedPlugin.IsLoaded || installedPlugin.DalamudInterface == null)
+                    continue;
 
-            installedPlugin.DalamudInterface.NotifyActivePluginsChanged(
-                new ActivePluginsChangedEventArgs(kind, affectedInternalNames));
+                installedPlugin.DalamudInterface.NotifyActivePluginsChanged(
+                    new ActivePluginsChangedEventArgs(kind, affectedInternalNames));
+            }
         }
     }
 


### PR DESCRIPTION
To prevent this exception from being thrown, which was posted in [Discord](https://discord.com/channels/581875019861328007/860813266468732938/1430521765754568766):
```log
2025-10-22 07:25:31.271 -04:00 [ERR] [LOCALPLUGIN] Error while loading Weatherman, failed to bind and call the plugin constructor
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at System.Collections.Generic.List`1.Enumerator.MoveNext()
   at Dalamud.Plugin.Internal.PluginManager.NotifyPluginsForStateChange(PluginListInvalidationKind kind, IEnumerable`1 affectedInternalNames) in /_/Dalamud/Plugin/Internal/PluginManager.cs:line 1302
   at Dalamud.Plugin.Internal.Types.LocalPlugin.LoadAsync(PluginLoadReason reason, Boolean reloading) in /_/Dalamud/Plugin/Internal/Types/LocalPlugin.cs:line 400
```