### PR TITLE
Disable main thread check when framework is shutting down

### DIFF
--- a/Dalamud/Utility/ThreadSafety.cs
+++ b/Dalamud/Utility/ThreadSafety.cs
@@ -1,5 +1,7 @@
 using System.Runtime.CompilerServices;
 
+using Dalamud.Game;
+
 namespace Dalamud.Utility;
 
 /// <summary>
@@ -23,7 +25,9 @@ public static class ThreadSafety
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void AssertMainThread(string? message = null)
     {
-        if (!threadStaticIsMainThread)
+        var isFrameworkUnloading = Service<Framework>.GetNullable()?.IsFrameworkUnloading ?? true;
+
+        if (!threadStaticIsMainThread && !isFrameworkUnloading)
         {
             throw new InvalidOperationException(message ?? "Not on main thread!");
         }
@@ -36,7 +40,9 @@ public static class ThreadSafety
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void AssertNotMainThread()
     {
-        if (threadStaticIsMainThread)
+        var isFrameworkUnloading = Service<Framework>.GetNullable()?.IsFrameworkUnloading ?? true;
+
+        if (threadStaticIsMainThread && !isFrameworkUnloading)
         {
             throw new InvalidOperationException("On main thread!");
         }


### PR DESCRIPTION
There isn't really a need to check for it anyways and it just blows up when plugins try to access something that is guarded by this during disposal when the game is shutting down.