### PR TITLE
Add more null checks to NamePlateUpdateHander.GameObject

### DIFF
--- a/Dalamud/Game/Gui/NamePlate/NamePlateUpdateHandler.cs
+++ b/Dalamud/Game/Gui/NamePlate/NamePlateUpdateHandler.cs
@@ -340,9 +340,13 @@ internal unsafe class NamePlateUpdateHandler : INamePlateUpdateHandler
                 return null;
             }
 
-            return this.gameObject ??= this.context.ObjectTable[
-                       this.context.Ui3DModule->NamePlateObjectInfoPointers[this.ArrayIndex]
-                           .Value->GameObject->ObjectIndex];
+            var objectInfoPtr = this.context.Ui3DModule->NamePlateObjectInfoPointers[this.ArrayIndex];
+            if (objectInfoPtr.Value == null) return null;
+
+            var gameObjectPtr = objectInfoPtr.Value->GameObject;
+            if (gameObjectPtr == null) return null;
+
+            return this.gameObject ??= this.context.ObjectTable[gameObjectPtr->ObjectIndex];
         }
     }
 


### PR DESCRIPTION
Based on reports from Pet Nicknames users, it seems there is a rare crash happening somewhere in this code. While I can't reproduce it, I've added some extra null checks to see if this helps.