### PR TITLE
Pass down SelfTestRegistry to SelfTestWindow

### DIFF
--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -33,6 +33,7 @@ using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
 using Dalamud.Logging.Internal;
 using Dalamud.Plugin.Internal;
+using Dalamud.Plugin.SelfTest.Internal;
 using Dalamud.Storage.Assets;
 using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
@@ -103,7 +104,8 @@ internal class DalamudInterface : IInternalDisposableService
         TitleScreenMenu titleScreenMenu,
         GameGui gameGui,
         ConsoleManager consoleManager,
-        AddonLifecycle addonLifecycle)
+        AddonLifecycle addonLifecycle,
+        SelfTestRegistry selfTestRegistry)
     {
         this.dalamud = dalamud;
         this.configuration = configuration;
@@ -119,7 +121,7 @@ internal class DalamudInterface : IInternalDisposableService
         this.pluginStatWindow = new PluginStatWindow() { IsOpen = false };
         this.pluginWindow = new PluginInstallerWindow(pluginImageCache, configuration) { IsOpen = false };
         this.settingsWindow = new SettingsWindow() { IsOpen = false };
-        this.selfTestWindow = new SelfTestWindow() { IsOpen = false };
+        this.selfTestWindow = new SelfTestWindow(selfTestRegistry) { IsOpen = false };
         this.styleEditorWindow = new StyleEditorWindow() { IsOpen = false };
         this.titleScreenMenuWindow = new TitleScreenMenuWindow(
             clientState,

--- a/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/SelfTestWindow.cs
@@ -13,7 +13,6 @@ using Dalamud.Logging.Internal;
 using Dalamud.Plugin.SelfTest;
 using Dalamud.Plugin.SelfTest.Internal;
 using Dalamud.Utility;
-using Lumina.Excel.Sheets;
 
 namespace Dalamud.Interface.Internal.Windows.SelfTest;
 
@@ -36,10 +35,11 @@ internal class SelfTestWindow : Window
     /// <summary>
     /// Initializes a new instance of the <see cref="SelfTestWindow"/> class.
     /// </summary>
-    public SelfTestWindow()
+    /// <param name="selfTestRegistry">An instance of <see cref="SelfTestRegistry"/>.</param>
+    public SelfTestWindow(SelfTestRegistry selfTestRegistry)
         : base("Dalamud Self-Test", ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse)
     {
-        this.selfTestRegistry = Service<SelfTestRegistry>.Get();
+        this.selfTestRegistry = selfTestRegistry;
         this.Size = new Vector2(800, 800);
         this.SizeCondition = ImGuiCond.FirstUseEver;
 


### PR DESCRIPTION
Fixes this exception:
```log
[ERR] Service initialization failure
System.AggregateException: One or more errors occurred. (One or more errors occurred. (One or more errors occurred. (Exception has been thrown by the target of an invocation.)))
 ---> System.AggregateException: One or more errors occurred. (One or more errors occurred. (Exception has been thrown by the target of an invocation.))
 ---> System.AggregateException: One or more errors occurred. (Exception has been thrown by the target of an invocation.)
 ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.InvalidOperationException: Calling Service<Dalamud.Plugin.SelfTest.Internal.SelfTestRegistry>.Get which is not one of the dependency services is forbidden from the service constructor of Dalamud.Interface.Internal.DalamudInterface. This has a high chance of introducing hard-to-debug hangs.
   at Dalamud.Service`1.Get() in D:\dev\cs\ffxiv\Dalamud\Dalamud\Service\Service{T}.cs:line 119
   at Dalamud.Interface.Internal.Windows.SelfTest.SelfTestWindow..ctor() in D:\dev\cs\ffxiv\Dalamud\Dalamud\Interface\Internal\Windows\SelfTest\SelfTestWindow.cs:line 42
   at Dalamud.Interface.Internal.DalamudInterface..ctor(Dalamud dalamud, DalamudConfiguration configuration, FontAtlasFactory fontAtlasFactory, InterfaceManager interfaceManager, PluginImageCache pluginImageCache, DalamudAssetManager dalamudAssetManager, Framework framework, ClientState clientState, TitleScreenMenu titleScreenMenu, GameGui gameGui, ConsoleManager consoleManager, AddonLifecycle addonLifecycle) in D:\dev\cs\ffxiv\Dalamud\Dalamud\Interface\Internal\DalamudInterface.cs:line 122
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithManyArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
```