### PR TITLE
Fix IsAutoUpdateComplete throwing when unloaded

### DIFF
--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -103,7 +103,7 @@ internal sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposa
     /// <summary>
     /// Gets a value indicating whether auto-updates have already completed this session.
     /// </summary>
-    public bool IsAutoUpdateComplete => Service<AutoUpdateManager>.Get().IsAutoUpdateComplete;
+    public bool IsAutoUpdateComplete => Service<AutoUpdateManager>.GetNullable()?.IsAutoUpdateComplete ?? false;
 
     /// <summary>
     /// Gets the repository from which this plugin was installed.


### PR DESCRIPTION
Fixes `IsAutoUpdateComplete` throwing an `UnloadedException` when it is accessed after AutoUpdateManager is unloaded on shutdown (see https://discord.com/channels/581875019861328007/860813266468732938/1437927930607964294).