### PR TITLE
Require TestingDalamudApiLevel to be set for testing

### DIFF
--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -362,6 +362,9 @@ internal class PluginManager : IInternalDisposableService
         if (!this.configuration.DoPluginTest)
             return false;
 
+        if (!manifest.TestingDalamudApiLevel.HasValue)
+            return false;
+
         return manifest.IsTestingExclusive || manifest.IsAvailableForTesting;
     }
 


### PR DESCRIPTION
This should fix a possible `Nullable object must have a value.` on TestingDalamudApiLevel at
https://github.com/goatcorp/Dalamud/blob/ea07f41ab14dffb93b9ef9cac00f4d8a9f8d8e03/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs#L2461 for third party plugin manifests that don't specify it.