### PR TITLE
Don't prevent closing native windows if pinned or clickthrough plugin windows are focused

### DIFF
--- a/Dalamud/Game/Internal/DalamudAtkTweaks.cs
+++ b/Dalamud/Game/Internal/DalamudAtkTweaks.cs
@@ -113,7 +113,7 @@ internal sealed unsafe class DalamudAtkTweaks : IInternalDisposableService
     private void AtkUnitBaseReceiveGlobalEventDetour(AtkUnitBase* thisPtr, AtkEventType eventType, int eventParam, AtkEvent* atkEvent, AtkEventData* atkEventData)
     {
         // 3 == Close
-        if (eventType == AtkEventType.InputReceived && WindowSystem.HasAnyWindowSystemFocus && atkEventData != null && *(int*)atkEventData == 3 && this.configuration.IsFocusManagementEnabled)
+        if (eventType == AtkEventType.InputReceived && WindowSystem.ShouldInhibitAtkCloseEvents && atkEventData != null && *(int*)atkEventData == 3 && this.configuration.IsFocusManagementEnabled)
         {
             Log.Verbose($"Cancelling global event SendHotkey command due to WindowSystem {WindowSystem.FocusedWindowSystemNamespace}");
             return;
@@ -124,7 +124,7 @@ internal sealed unsafe class DalamudAtkTweaks : IInternalDisposableService
 
     private void AgentHudOpenSystemMenuDetour(AgentHUD* thisPtr, AtkValue* atkValueArgs, uint menuSize)
     {
-        if (WindowSystem.HasAnyWindowSystemFocus && this.configuration.IsFocusManagementEnabled)
+        if (WindowSystem.ShouldInhibitAtkCloseEvents && this.configuration.IsFocusManagementEnabled)
         {
             Log.Verbose($"Cancelling OpenSystemMenu due to WindowSystem {WindowSystem.FocusedWindowSystemNamespace}");
             return;

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -1175,6 +1175,7 @@ internal partial class InterfaceManager : IInternalDisposableService
 
         WindowSystem.HasAnyWindowSystemFocus = false;
         WindowSystem.FocusedWindowSystemNamespace = string.Empty;
+        WindowSystem.ShouldInhibitAtkCloseEvents = false;
 
         if (this.IsDispatchingEvents)
         {

--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -227,6 +227,16 @@ public abstract class Window
     public bool AllowClickthrough { get; set; } = true;
 
     /// <summary>
+    /// Gets a value indicating whether this window is pinned.
+    /// </summary>
+    public bool IsPinned => this.internalIsPinned;
+
+    /// <summary>
+    /// Gets a value indicating whether this window is click-through.
+    /// </summary>
+    public bool IsClickthrough => this.internalIsClickthrough;
+
+    /// <summary>
     /// Gets or sets a list of available title bar buttons.
     ///
     /// If <see cref="AllowPinning"/> or <see cref="AllowClickthrough"/> are set to true, and this features is not

--- a/Dalamud/Interface/Windowing/WindowSystem.cs
+++ b/Dalamud/Interface/Windowing/WindowSystem.cs
@@ -61,6 +61,12 @@ public class WindowSystem
     public string? Namespace { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether ATK close events should be inhibited while any window has focus.
+    /// Does not respect windows that are pinned or clickthrough.
+    /// </summary>
+    internal static bool ShouldInhibitAtkCloseEvents { get; set; }
+
+    /// <summary>
     /// Add a window to this <see cref="WindowSystem"/>.
     /// The window system doesn't own your window, it just renders it
     /// You need to store a reference to it to use it later.
@@ -130,7 +136,7 @@ public class WindowSystem
             window.DrawInternal(flags, persistence);
         }
 
-        var focusedWindow = this.windows.FirstOrDefault(window => window.IsFocused && window.RespectCloseHotkey);
+        var focusedWindow = this.windows.FirstOrDefault(window => window.IsFocused);
         this.HasAnyFocus = focusedWindow != default;
 
         if (this.HasAnyFocus)
@@ -154,6 +160,11 @@ public class WindowSystem
                 this.lastFocusedWindowName = string.Empty;
             }
         }
+
+        ShouldInhibitAtkCloseEvents |= this.windows.Any(w => w.IsFocused &&
+                                                            w.RespectCloseHotkey &&
+                                                            !w.IsPinned &&
+                                                            !w.IsClickthrough);
 
         if (hasNamespace)
             ImGui.PopID();


### PR DESCRIPTION
The UX of this was confusing - the window won't close, but it still steals close events.
We should consider removing the global focus APIs in api14 with the interface redo.