### PR TITLE
Erroring Window Style Fix

### DIFF
--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -57,7 +57,6 @@ public abstract class Window
 
     private bool hasError = false;
     private Exception? lastError;
-    private bool isErrorStylePushed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Window"/> class.
@@ -426,6 +425,7 @@ public abstract class Window
                 UIGlobals.PlaySoundEffect(this.OnOpenSfxId);
         }
 
+        var isErrorStylePushed = false;
         if (!this.hasError)
         {
             this.PreDraw();
@@ -434,7 +434,7 @@ public abstract class Window
         else
         {
             Style.StyleModelV1.DalamudStandard.Push();
-            this.isErrorStylePushed = true;
+            isErrorStylePushed = true;
         }
 
         if (this.ForceMainWindow)
@@ -697,7 +697,7 @@ public abstract class Window
         }
         else
         {
-            if (this.isErrorStylePushed)
+            if (isErrorStylePushed)
             {
                 Style.StyleModelV1.DalamudStandard.Pop();
             }


### PR DESCRIPTION
Forces dalamuds standard style onto any window that is erroring so that the error can actually be read and interacted with.

For example, with the following test code:

```cs
    private class DemoWindow() : Window("Exception Test Window", ImGuiWindowFlags.AlwaysAutoResize) {
        public override void Draw() {
            ImGui.Text("butts");
            ImGui.PushStyleColor(ImGuiCol.WindowBg, Vector4.Zero);
            throw new Exception("Boom");
            ImGui.Text("Butts2");
        }
    }
```

What is shown is:
<img width="1179" height="506" alt="ffxiv_dx11_aadzrrhlOL" src="https://github.com/user-attachments/assets/0b01938c-3eec-4b88-a5b2-77d5f0da2671" />

after this PR is merged you will see:
<img width="1160" height="557" alt="ffxiv_dx11_7O7X9mebiO" src="https://github.com/user-attachments/assets/803b0d1e-1251-4099-a7a5-53f4e7bc7361" />

