### PR TITLE
Fix PlayerState.Level being synced

### DIFF
--- a/Dalamud/Game/Player/PlayerState.cs
+++ b/Dalamud/Game/Player/PlayerState.cs
@@ -77,7 +77,7 @@ internal unsafe class PlayerState : IServiceType, IPlayerState
     public RowRef<ClassJob> ClassJob => this.IsLoaded ? LuminaUtils.CreateRef<ClassJob>(CSPlayerState.Instance()->CurrentClassJobId) : default;
 
     /// <inheritdoc/>
-    public short Level => this.IsLoaded ? CSPlayerState.Instance()->CurrentLevel : default;
+    public short Level => this.IsLoaded && this.ClassJob.IsValid ? this.GetClassJobLevel(this.ClassJob.Value) : this.EffectiveLevel;
 
     /// <inheritdoc/>
     public bool IsLevelSynced => this.IsLoaded && CSPlayerState.Instance()->IsLevelSynced;

--- a/Dalamud/Plugin/Services/IPlayerState.cs
+++ b/Dalamud/Plugin/Services/IPlayerState.cs
@@ -79,7 +79,7 @@ public interface IPlayerState : IDalamudService
     bool IsLevelSynced { get; }
 
     /// <summary>
-    /// Gets the effective level of the local character.
+    /// Gets the effective level of the local character, taking level sync into account.
     /// </summary>
     short EffectiveLevel { get; }
 


### PR DESCRIPTION
CurrentLevel is already synced for some reason, so we have to grab the current classes/jobs level from the level array instead.