### PR TITLE
Always pop DalamudStandard style if pushed earlier in Draw

### DIFF
--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -672,16 +672,13 @@ public abstract class Window
                 Task.FromResult<IDalamudTextureWrap>(tex));
         }
 
-        if (!this.hasError)
+        if (isErrorStylePushed)
         {
-            this.PostDraw();
+            Style.StyleModelV1.DalamudStandard.Pop();
         }
         else
         {
-            if (isErrorStylePushed)
-            {
-                Style.StyleModelV1.DalamudStandard.Pop();
-            }
+            this.PostDraw();
         }
 
         this.PostHandlePreset(persistence);


### PR DESCRIPTION
Errors are cleared during `DrawErrorMessage`, so when clearing an error, `this.hasError` is `true` at the top of `DrawInternal` but false at the end of `DrawInternal`. This means the check to pop the previously pushed style won't happen and the forced style will leak for the rest of the session.

This changes it so that we always pop the forced Dalamud style if it was pushed earlier in `DrawInternal`.