### PR TITLE
Clear ImDrawListSplitter when disposing SeStringDrawState

### DIFF
--- a/Dalamud/Interface/ImGuiSeStringRenderer/Internal/SeStringRenderer.cs
+++ b/Dalamud/Interface/ImGuiSeStringRenderer/Internal/SeStringRenderer.cs
@@ -170,7 +170,7 @@ internal class SeStringRenderer : IServiceType
 
         // This also does argument validation for drawParams. Do it here.
         // `using var` makes a struct read-only, but we do want to modify it.
-        var stateStorage = new SeStringDrawState(
+        using var stateStorage = new SeStringDrawState(
             sss,
             drawParams,
             ThreadSafety.IsMainThread ? this.colorStackSetMainThread : new(this.colorStackSetMainThread.ColorTypes),

--- a/Dalamud/Interface/ImGuiSeStringRenderer/SeStringDrawState.cs
+++ b/Dalamud/Interface/ImGuiSeStringRenderer/SeStringDrawState.cs
@@ -10,6 +10,7 @@ using Dalamud.Interface.Utility;
 using Dalamud.Utility;
 
 using FFXIVClientStructs.FFXIV.Component.GUI;
+
 using Lumina.Text.Payloads;
 using Lumina.Text.ReadOnly;
 
@@ -17,7 +18,7 @@ namespace Dalamud.Interface.ImGuiSeStringRenderer;
 
 /// <summary>Calculated values from <see cref="SeStringDrawParams"/> using ImGui styles.</summary>
 [StructLayout(LayoutKind.Sequential)]
-public unsafe ref struct SeStringDrawState
+public unsafe ref struct SeStringDrawState : IDisposable
 {
     private static readonly int ChannelCount = Enum.GetValues<SeStringDrawChannel>().Length;
 
@@ -193,6 +194,9 @@ public unsafe ref struct SeStringDrawState
 
     /// <summary>Gets the text fragments.</summary>
     internal List<TextFragment> Fragments { get; }
+
+    /// <inheritdoc/>
+    public void Dispose() => this.splitter.ClearFreeMemory();
 
     /// <summary>Sets the current channel in the ImGui draw list splitter.</summary>
     /// <param name="channelIndex">Channel to switch to.</param>


### PR DESCRIPTION
[ClearFreeMemory](https://github.com/goatcorp/gc-imgui/blob/master/imgui_draw.cpp#L1676) is called in the [destructor of ImDrawListSplitter](https://github.com/goatcorp/gc-imgui/blob/master/imgui.h#L2434).