### PR TITLE
Properly initialize GameInventoryItems

### DIFF
--- a/Dalamud/Game/Inventory/GameInventory.cs
+++ b/Dalamud/Game/Inventory/GameInventory.cs
@@ -305,7 +305,8 @@ internal class GameInventory : IInternalDisposableService
     private GameInventoryItem[] CreateItemsArray(int length)
     {
         var items = new GameInventoryItem[length];
-        items.Initialize();
+        foreach (ref var item in items.AsSpan())
+            item = new();
         return items;
     }
 


### PR DESCRIPTION
I noticed NullPointerExceptions on login that happened when the InventoryItem.IsEmpty function was called in the GameInventoryItem.IsEmpty property.
That happens because the Ctor isn't called that sets the VirtualTable pointer.
[`Array.Initialize`](https://learn.microsoft.com/en-us/dotnet/api/system.array.initialize) is specifically only for value-type arrays, so we have to change the way we initialize these arrays, since GameInventoryItem just a `record`.