### PR TITLE
Remove obsolete enum values from FlyTextKind

### DIFF
--- a/Dalamud/Game/Gui/FlyText/FlyTextKind.cs
+++ b/Dalamud/Game/Gui/FlyText/FlyTextKind.cs
@@ -95,30 +95,12 @@ public enum FlyTextKind : int
     /// <summary>
     /// Val1 in serif font next to all caps condensed font Text1 with Text2 in sans-serif as subtitle.
     /// </summary>
-    [Obsolete("Use Dataset instead", true)]
-    Unknown16 = 16,
-
-    /// <summary>
-    /// Val1 in serif font next to all caps condensed font Text1 with Text2 in sans-serif as subtitle.
-    /// </summary>
     Dataset = 16,
 
     /// <summary>
     /// Val1 in serif font, Text2 in sans-serif as subtitle.
     /// </summary>
-    [Obsolete("Use Knowledge instead", true)]
-    Unknown17 = 17,
-
-    /// <summary>
-    /// Val1 in serif font, Text2 in sans-serif as subtitle.
-    /// </summary>
     Knowledge = 17,
-
-    /// <summary>
-    /// Val1 in serif font, Text2 in sans-serif as subtitle.
-    /// </summary>
-    [Obsolete("Use PhantomExp instead", true)]
-    Unknown18 = 18,
 
     /// <summary>
     /// Val1 in serif font, Text2 in sans-serif as subtitle.


### PR DESCRIPTION
They have been obsolete for nearly 7 months (before 7.3).