### PR TITLE
Use built dlls instead of csproj for docfx

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -4,18 +4,17 @@
       "src": [
         {
           "files": [
-            "Dalamud.Interface/Dalamud.Interface.csproj",
-            "Dalamud/Dalamud.csproj",
-            "lib/ImGuiScene/ImGuiScene/ImGuiScene.csproj",
-            "lib/ImGuiScene/deps/ImGui.NET/src/ImGui.NET-472/ImGui.NET-472.csproj",
-            "lib/ImGuiScene/deps/SDL2-CS/SDL2-CS.csproj"
+            "bin/Release/Dalamud.dll"
           ]
         }
       ],
       "dest": "api",
       "disableGitFeatures": false,
       "disableDefaultFilter": false,
-      "filter": "filterConfig.yml"
+      "filter": "filterConfig.yml",
+      "properties": {
+            "TargetFramework": "net10.0-windows"
+      }
     }
   ],
   "build": {


### PR DESCRIPTION
Does lock us to Release but given we're only building Release in ci-build.mjs over in dalamud-docs I don't see an issue.