### PR TITLE
fix: EventItem name for Japanese client.

### DIFF
--- a/Dalamud/Utility/ItemUtil.cs
+++ b/Dalamud/Utility/ItemUtil.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using Dalamud.Data;
 using Dalamud.Game;
 using Dalamud.Game.Text;
+
 using Lumina.Excel.Sheets;
 using Lumina.Text;
 using Lumina.Text.ReadOnly;
@@ -125,10 +126,15 @@ public static class ItemUtil
 
         if (IsEventItem(itemId))
         {
+            // Only English, German, and French have a Name field.
+            // For other languages, the Name is an empty string, and the Singular field should be used instead.
+            language ??= dataManager.Language;
+            var useSingular = language is not (ClientLanguage.English or ClientLanguage.German or ClientLanguage.French);
+
             return dataManager
                 .GetExcelSheet<EventItem>(language)
                 .TryGetRow(itemId, out var eventItem)
-                    ? eventItem.Name
+                    ? (useSingular ? eventItem.Singular : eventItem.Name)
                     : default;
         }
 


### PR DESCRIPTION
ItemPayloadSelfTest will fail in a Japanese client.
Only English, German, and French have a Name field.For other languages, the Name is an empty string, and the Singular field should be used instead.
<img width="1517" height="397" alt="image" src="https://github.com/user-attachments/assets/263a9448-9012-4fa5-a71c-b7e4cec605e5" />