### PR TITLE
Prevent ImGui text box methods from cloning unchanged input every frame

### DIFF
--- a/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.Manual.cs
+++ b/imgui/Dalamud.Bindings.ImGui/Custom/ImGui.Manual.cs
@@ -127,8 +127,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputText(label, t.Buffer[..(maxLength + 1)], flags, callback);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -140,8 +145,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputText(label, t.Buffer[..(maxLength + 1)], flags, callback);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -153,8 +163,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputText(label, t.Buffer[..(maxLength + 1)], flags, callback, ref context);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -166,8 +181,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputText(label, t.Buffer[..(maxLength + 1)], flags, callback, in context);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -287,8 +307,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputTextEx(label, hint, t.Buffer[..(maxLength + 1)], sizeArg, flags, callback);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -300,8 +325,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputTextEx(label, hint, t.Buffer[..(maxLength + 1)], sizeArg, flags, callback);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -314,8 +344,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputTextEx(label, hint, t.Buffer[..(maxLength + 1)], sizeArg, flags, callback, ref context);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -328,8 +363,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputTextEx(label, hint, t.Buffer[..(maxLength + 1)], sizeArg, flags, callback, in context);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -388,8 +428,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputTextMultiline(label, t.Buffer[..(maxLength + 1)], size, flags, callback);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -401,8 +446,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputTextMultiline(label, t.Buffer[..(maxLength + 1)], size, flags, callback);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -414,8 +464,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputTextMultiline(label, t.Buffer[..(maxLength + 1)], size, flags, callback, ref context);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -427,8 +482,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputTextMultiline(label, t.Buffer[..(maxLength + 1)], size, flags, callback, in context);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -477,8 +537,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputTextWithHint(label, hint, t.Buffer[..(maxLength + 1)], flags, callback);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -490,8 +555,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputTextWithHint(label, hint, t.Buffer[..(maxLength + 1)], flags, callback);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -503,8 +573,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputTextWithHint(label, hint, t.Buffer[..(maxLength + 1)], flags, callback, ref context);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -516,8 +591,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = InputTextWithHint(label, hint, t.Buffer[..(maxLength + 1)], flags, callback, in context);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }
@@ -541,8 +621,13 @@ public unsafe partial class ImGui
         var t = new ImU8String(buf);
         t.Reserve(maxLength + 1);
         var r = TempInputText(bb, id, label, t.Buffer[..(maxLength + 1)], flags);
-        var i = t.Buffer.IndexOf((byte)0);
-        buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+
+        if (r)
+        {
+            var i = t.Buffer.IndexOf((byte)0);
+            buf = Encoding.UTF8.GetString(i == -1 ? t.Buffer : t.Buffer[..i]);
+        }
+
         t.Recycle();
         return r;
     }


### PR DESCRIPTION
The overloads taking a `ref string` for the input text of the various
ways to display a text box would all take the input string, copy it into
a buffer for imgui and then unconditionally produce a new string once
the imgui call returned. Now we only create a new string when the return
value of the native function actually indicates that the text changed.

This makes the GC happy, and also users like me who like to make the GC
happy.

Other side effects: The assumption that the reference doesn't change if
the method returns false, which is very reasonable IMO, is now correct.
