### PR TITLE
feat: Add configurable plugin load order with sync/async overrides

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -338,6 +338,16 @@ internal sealed class DalamudConfiguration : IInternalDisposableService
     public List<string>? DtrOrder { get; set; }
 
     /// <summary>
+    /// Gets or sets the plugin load order, by internal name.
+    /// </summary>
+    public List<string>? PluginLoadOrder { get; set; }
+
+    /// <summary>
+    /// Gets or sets the plugin load order override mode, by internal name.
+    /// </summary>
+    public Dictionary<string, PluginLoadOrderMode>? PluginLoadOrderOverrides { get; set; }
+
+    /// <summary>
     /// Gets or sets the list of ignored DTR elements, by title.
     /// </summary>
     public List<string>? DtrIgnore { get; set; }

--- a/Dalamud/Configuration/Internal/PluginLoadOrderMode.cs
+++ b/Dalamud/Configuration/Internal/PluginLoadOrderMode.cs
@@ -1,0 +1,22 @@
+namespace Dalamud.Configuration.Internal;
+
+/// <summary>
+/// Override for plugin load flavor in the load order list.
+/// </summary>
+internal enum PluginLoadOrderMode
+{
+    /// <summary>
+    /// Use the plugin's default load flavor.
+    /// </summary>
+    Default = 0,
+
+    /// <summary>
+    /// Force synchronous load.
+    /// </summary>
+    ForceSync = 1,
+
+    /// <summary>
+    /// Force asynchronous load.
+    /// </summary>
+    ForceAsync = 2,
+}

--- a/Dalamud/Interface/Internal/PluginCategoryManager.cs
+++ b/Dalamud/Interface/Internal/PluginCategoryManager.cs
@@ -25,6 +25,7 @@ internal class PluginCategoryManager
         new(CategoryKind.AvailableForTesting, "special.availableForTesting", () => Locs.Category_AvailableForTesting, CategoryInfo.AppearCondition.DoPluginTest),
         new(CategoryKind.Hidden, "special.hidden", () => Locs.Category_Hidden, CategoryInfo.AppearCondition.AnyHiddenPlugins),
         new(CategoryKind.DevInstalled, "special.devInstalled", () => Locs.Category_DevInstalled),
+        new(CategoryKind.PluginLoadOrder, "special.pluginLoadOrder", () => Locs.Category_PluginLoadOrder),
         new(CategoryKind.IconTester, "special.devIconTester", () => Locs.Category_IconTester),
         new(CategoryKind.DalamudChangelogs, "special.dalamud", () => Locs.Category_Dalamud),
         new(CategoryKind.PluginChangelogs, "special.plugins", () => Locs.Category_Plugins),
@@ -46,7 +47,7 @@ internal class PluginCategoryManager
 
     private GroupInfo[] groupList =
     [
-        new(GroupKind.DevTools, () => Locs.Group_DevTools, CategoryKind.DevInstalled, CategoryKind.IconTester),
+        new(GroupKind.DevTools, () => Locs.Group_DevTools, CategoryKind.DevInstalled, CategoryKind.PluginLoadOrder, CategoryKind.IconTester),
         new(GroupKind.Installed, () => Locs.Group_Installed, CategoryKind.All, CategoryKind.IsTesting, CategoryKind.UpdateablePlugins, CategoryKind.PluginProfiles),
         new(GroupKind.Available, () => Locs.Group_Available, CategoryKind.All),
         new(GroupKind.Changelog, () => Locs.Group_Changelog, CategoryKind.All, CategoryKind.DalamudChangelogs, CategoryKind.PluginChangelogs)
@@ -141,6 +142,11 @@ internal class PluginCategoryManager
         /// Updateable plugins.
         /// </summary>
         UpdateablePlugins = 15,
+
+        /// <summary>
+        /// Customize plugin load order.
+        /// </summary>
+        PluginLoadOrder = 16,
         
         /// <summary>
         /// Plugins tagged as "other".
@@ -549,6 +555,8 @@ internal class PluginCategoryManager
         public static string Category_Hidden => Loc.Localize("InstallerCategoryHidden", "Hidden");
         
         public static string Category_DevInstalled => Loc.Localize("InstallerInstalledDevPlugins", "Installed Dev Plugins");
+
+        public static string Category_PluginLoadOrder => Loc.Localize("InstallerCategoryPluginLoadOrder", "Plugin Load Order");
 
         public static string Category_IconTester => "Image/Icon Tester";
 


### PR DESCRIPTION
This adds a Dev Tools “Plugin Load Order” page where you manually build the ordered list by selecting enabled plugins from the dropdown and clicking “Add to load order,” then drag rows to reorder and use “Remove” to delete entries; each row shows the plugin’s default load flavor and lets you override it via the dropdown.

On boot, plugins in the list load in that order, keeping sync plugins in the sync path and async plugins in a sequential async path.

When a plugin is disabled it falls out of the enabled list, so it is automatically removed from the load order and any override entry is cleaned up. 

<img width="1777" height="364" alt="image" src="https://github.com/user-attachments/assets/7a1f8382-3b40-43ac-af34-124f62e4ab27" />
