### PR TITLE
Fix font corruption caused by Font Awesome icon button in Data window

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/FontAwesomeTestWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/FontAwesomeTestWidget.cs
@@ -114,7 +114,7 @@ internal class FontAwesomeTestWidget : IDataWindowWidget
                     Task.FromResult(
                         Service<TextureManager>.Get().CreateTextureFromSeString(
                             ReadOnlySeString.FromText(this.icons[i].ToIconString()),
-                            new() { Font = ImGui.GetFont(), FontSize = ImGui.GetFontSize() })));
+                            new() { Font = ImGui.GetFont(), FontSize = ImGui.GetFontSize(), ScreenOffset = Vector2.Zero })));
             }
 
             ImGui.PopFont();


### PR DESCRIPTION
In the Dalamud Data window, clicking one of the Font Awesome Test buttons (which should open the texture export menu) causes the following exception:

```
00:36:03.489 | ERR | Could not draw data
	System.ArgumentException: ScreenOffset must be set when specifying a target draw list, as it cannot be fetched from the ImGui state. (GetCursorScreenPos?)
	   at Dalamud.Interface.ImGuiSeStringRenderer.Internal.SeStringRenderer.Draw(ReadOnlySeStringSpan sss, SeStringDrawParams& drawParams, ImGuiId imGuiId, ImGuiButtonFlags buttonFlags) in /_/Dalamud/Interface/ImGuiSeStringRenderer/Internal/SeStringRenderer.cs:line 153
	   at Dalamud.Interface.ImGuiSeStringRenderer.Internal.SeStringRenderer.CreateDrawData(ReadOnlySeStringSpan sss, SeStringDrawParams& drawParams) in /_/Dalamud/Interface/ImGuiSeStringRenderer/Internal/SeStringRenderer.cs:line 94
	   at Dalamud.Interface.Textures.Internal.TextureManager.CreateTextureFromSeString(ReadOnlySpan`1 text, SeStringDrawParams& drawParams, String debugName) in /_/Dalamud/Interface/Textures/Internal/TextureManager.FromSeString.cs:line 21
	   at Dalamud.Interface.Internal.Windows.Data.Widgets.FontAwesomeTestWidget.Draw() in /_/Dalamud/Interface/Internal/Windows/Data/Widgets/FontAwesomeTestWidget.cs:line 111
	   at Dalamud.Interface.Internal.Windows.Data.DataWindow.DrawContents() in /_/Dalamud/Interface/Internal/Windows/Data/DataWindow.cs:line 188
```

The above exception causes the icon font to leak into the stack and corrupt the global ImGui font.

This patch fixes the issue by giving a `Vector2.Zero` for `ScreenOffset`.