### PR TITLE
Add CPU info to crash log

### DIFF
--- a/DalamudCrashHandler/DalamudCrashHandler.cpp
+++ b/DalamudCrashHandler/DalamudCrashHandler.cpp
@@ -698,8 +698,6 @@ void get_cpu_info(wchar_t *vendor, wchar_t *brand)
     std::array<int, 4> cpui;
     int nIds_;
     int nExIds_;
-    std::string vendor_;
-    std::string brand_;
     std::vector<std::array<int, 4>> data_;
     std::vector<std::array<int, 4>> extdata_;
     size_t convertedChars = 0;


### PR DESCRIPTION
Added a function to retrieve CPU vendor and brand information.

From my system it would add:
```
CPU Vendor: AuthenticAMD
CPU Brand: AMD Ryzen 7 5800X 8-Core Processor
```
to the log
<img width="1297" height="688" alt="image" src="https://github.com/user-attachments/assets/cfa2341c-2e9f-4805-ae62-162c42961f56" />
