### PR TITLE
fix: respect system dark mode setting

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
@@ -65,7 +65,14 @@ internal sealed class SettingsTabLook : SettingsTab
             {
                 try
                 {
-                    Service<InterfaceManager>.GetNullable()?.SetImmersiveMode(b);
+                    if (b)
+                    {
+                        Service<InterfaceManager>.GetNullable()?.SetImmersiveModeFromSystemTheme();
+                    }
+                    else
+                    {
+                        Service<InterfaceManager>.GetNullable()?.SetImmersiveMode(false);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/Dalamud/Memory/MemoryHelper.cs
+++ b/Dalamud/Memory/MemoryHelper.cs
@@ -265,6 +265,31 @@ public static unsafe class MemoryHelper
     }
 
     /// <summary>
+    /// Compares a UTF-16 character span with a null-terminated UTF-16 string at <paramref name="memoryAddress"/>.
+    /// </summary>
+    /// <param name="charSpan">UTF-16 character span (e.g., from a string literal).</param>
+    /// <param name="memoryAddress">Address of null-terminated UTF-16 (wide) string, as used by Windows APIs.</param>
+    /// <returns><see langword="true"/> if equal; otherwise, <see langword="false"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe bool EqualsZeroTerminatedWideString(
+        scoped ReadOnlySpan<char> charSpan,
+        nint memoryAddress)
+    {
+        if (memoryAddress == 0)
+            return charSpan.Length == 0;
+
+        char* p = (char*)memoryAddress;
+
+        foreach (char c in charSpan)
+        {
+            if (*p++ != c)
+                return false;
+        }
+
+        return *p == '\0';
+    }
+
+    /// <summary>
     /// Read a UTF-8 encoded string from a specified memory address.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
This PR fixes the behavior of `WindowIsImmersive `to match its hint and i18n description.
The setting currently forces a fixed dark/light title bar, but the hint says it should follow the system theme and change title bar mode.
This change makes the title bar respect the system’s current light/dark mode when enabled
The `WindowIsImmersive` property is somewhat ambiguous, and I'm unsure whether the name should be changed.