### PR TITLE
Replaced List<nint> with HashSet<nint> for seenLogMessageObjects in ChatGui

### DIFF
--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -42,7 +42,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
 
     private readonly Queue<XivChatEntry> chatQueue = new();
     private readonly Dictionary<(string PluginName, uint CommandId), Action<uint, SeString>> dalamudLinkHandlers = [];
-    private readonly List<nint> seenLogMessageObjects = [];
+    private readonly HashSet<nint> seenLogMessageObjects = [];
 
     private readonly Hook<PrintMessageDelegate> printMessageHook;
     private readonly Hook<InventoryItem.Delegates.Copy> inventoryItemCopyHook;


### PR DESCRIPTION
Using a HashSet<T> avoids unnecessary iteration during lookup checks, offering better performance when processing many log messages (e.g. combat)