### PR TITLE
Properly lowercase for tags for plugin installer search

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -3804,7 +3804,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         if (!manifest.Punchline.IsNullOrEmpty())
             scores.Add(matcher.Matches(manifest.Punchline.ToLowerInvariant()) * 100);
         if (manifest.Tags != null)
-            scores.Add(matcher.MatchesAny(manifest.Tags.ToArray()) * 100);
+            scores.Add(matcher.MatchesAny(manifest.Tags.Select(tag => tag.ToLowerInvariant()).ToArray()) * 100);
 
         return scores.Max();
     }


### PR DESCRIPTION
Make plugin installer tag search work properly by setting them to lowercase like all other fields are.