### PR TITLE
Fix null characters in BitmapCodecInfo strings

### DIFF
--- a/Dalamud/Interface/Textures/Internal/BitmapCodecInfo.cs
+++ b/Dalamud/Interface/Textures/Internal/BitmapCodecInfo.cs
@@ -50,6 +50,6 @@ internal sealed class BitmapCodecInfo : IBitmapCodecInfo
         _ = readFuncPtr(codecInfo, 0, null, &cch);
         var buf = stackalloc char[(int)cch + 1];
         Marshal.ThrowExceptionForHR(readFuncPtr(codecInfo, cch + 1, buf, &cch));
-        return new(buf, 0, (int)cch);
+        return new string(buf, 0, (int)cch).Trim('\0');
     }
 }


### PR DESCRIPTION
this also fixes an error when saving images in certain formats in the icon browser due to the file extensions containing a null character (png, gif and dds)

not sure if this is a new error or if it was just not reported/seen before
using `cch - 1` is likely the more appropriate way but i thought trimming might be safer