### PR TITLE
Adding access to the windows Thumbnail cache

### DIFF
--- a/Dalamud/Interface/Textures/Internal/TextureManager.BlameTracker.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManager.BlameTracker.cs
@@ -59,7 +59,7 @@ internal sealed partial class TextureManager
     /// <param name="textureWrap">The texture.</param>
     /// <param name="ownerPlugin">The plugin.</param>
     /// <returns>Same <paramref name="textureWrap"/>.</returns>
-    public unsafe IDalamudTextureWrap Blame(IDalamudTextureWrap textureWrap, LocalPlugin? ownerPlugin)
+    public unsafe IDalamudTextureWrap Blame(IDalamudTextureWrap? textureWrap, LocalPlugin? ownerPlugin)
     {
         if (!this.dalamudConfiguration.UseTexturePluginTracking)
             return textureWrap;

--- a/Dalamud/Interface/Textures/Internal/TextureManagerPluginScoped.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManagerPluginScoped.cs
@@ -454,6 +454,15 @@ internal sealed class TextureManagerPluginScoped
         await manager.CopyToClipboardAsync(wrap, preferredFileNameWithoutExtension, leaveWrapOpen, cancellationToken);
     }
 
+    /// <inheritdoc/>
+    public IDalamudTextureWrap? TryGetFileThumbnail(string path)
+    {
+        var manager = this.ManagerOrThrow;
+        var textureWrap = manager.TryGetFileThumbnail(path);
+        manager.Blame(textureWrap, this.plugin);
+        return textureWrap;
+    }
+
     private void ResultOnInterceptTexDataLoad(string path, ref string? replacementPath) =>
         this.InterceptTexDataLoad?.Invoke(path, ref replacementPath);
 }

--- a/Dalamud/Plugin/Services/ITextureProvider.cs
+++ b/Dalamud/Plugin/Services/ITextureProvider.cs
@@ -330,4 +330,9 @@ public interface ITextureProvider : IDalamudService
     /// <c>((delegate* unmanaged&lt;nint, void&gt;)(*(nint**)ptr)[3](ptr)</c>.</para>
     /// </remarks>
     nint ConvertToKernelTexture(IDalamudTextureWrap wrap, bool leaveWrapOpen = false);
+
+    /// <summary>Tries to get a files thumbnail from the Win32 API</summary>
+    /// <param name="filePath">Path to file you want to preview.</param>
+    /// <returns>A <see cref="IDalamudTextureWrap"/> TextureWrap or null.</returns>
+    IDalamudTextureWrap? TryGetFileThumbnail(string filePath);
 }


### PR DESCRIPTION
This adds support for accessing the windows thumbnail cache for a specified file. This should enable reliable thumbnail generation for the Dalamud file browser in the future.