### PR TITLE
Fix loading `.tex` file from filesystem

### DIFF
--- a/Dalamud/Interface/Textures/Internal/SharedImmediateTextures/GamePathSharedImmediateTexture.cs
+++ b/Dalamud/Interface/Textures/Internal/SharedImmediateTextures/GamePathSharedImmediateTexture.cs
@@ -70,7 +70,7 @@ internal sealed class GamePathSharedImmediateTexture : SharedImmediateTexture
         }
 
         cancellationToken.ThrowIfCancellationRequested();
-        var wrap = tm.NoThrottleCreateFromTexFile(file);
+        var wrap = tm.NoThrottleCreateFromTexFile(file.Header, file.TextureBuffer);
         tm.BlameSetName(wrap, this.ToString());
         return wrap;
     }


### PR DESCRIPTION
It needed `.LoadFile` to work correctly, but since the stuff we need are public anyway might as well use them directly.