### PR TITLE
Add GPU Info to Crash Handler

### DIFF
--- a/DalamudCrashHandler/DalamudCrashHandler.cpp
+++ b/DalamudCrashHandler/DalamudCrashHandler.cpp
@@ -491,7 +491,6 @@ std::vector<IDXGIAdapter1*> enum_dxgi_adapters()
         vAdapters.push_back(pAdapter);
     }
 
-
     if (pFactory)
     {
         pFactory->Release();
@@ -1055,7 +1054,7 @@ int main() {
 
         for (IDXGIAdapter1* adapter : enum_dxgi_adapters()) {
             DXGI_ADAPTER_DESC1 adapterDescription{};
-            myAdapter->GetDesc1(&adapterDescription);
+            adapter->GetDesc1(&adapterDescription);
             log << std::format(L"GPU Desc: {}", adapterDescription.Description) << std::endl;
         }
 


### PR DESCRIPTION
I'm sure there's a better way to do this, but I also shouldn't be allowed to touch any cpp code.

This loops through all dxgi adapters based on example code I ripped from Microsoft and StackOverflow and dumps that into the crash log.

I'm hoping it doesn't make the window too tall, so if there's a better way to list only the display adapters that are unique, I'm all for it.