### PR TITLE
Fix Addon/AgentLifyCycle listener execution after unreg request

### DIFF
--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -94,6 +94,8 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
     /// <param name="listener">The listener to unregister.</param>
     internal void UnregisterListener(AddonLifecycleEventListener listener)
     {
+        listener.IsRequestedToClear = true;
+        
         if (this.isInvokingListeners)
         {
             this.framework.RunOnTick(() => this.UnregisterListenerMethod(listener));
@@ -122,6 +124,8 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
         {
             foreach (var listener in globalListeners)
             {
+                if (listener.IsRequestedToClear) continue;
+                
                 try
                 {
                     listener.FunctionDelegate.Invoke(eventType, args);
@@ -138,6 +142,8 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
         {
             foreach (var listener in addonListener)
             {
+                if (listener.IsRequestedToClear) continue;
+                
                 try
                 {
                     listener.FunctionDelegate.Invoke(eventType, args);

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycleEventListener.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycleEventListener.cs
@@ -35,4 +35,9 @@ internal class AddonLifecycleEventListener
     /// Gets the delegate this listener invokes.
     /// </summary>
     public IAddonLifecycle.AddonEventDelegate FunctionDelegate { get; init; }
+
+    /// <summary>
+    /// Gets or sets if the listener is requested to be cleared.
+    /// </summary>
+    internal bool IsRequestedToClear { get; set; }
 }

--- a/Dalamud/Game/Agent/AgentLifecycle.cs
+++ b/Dalamud/Game/Agent/AgentLifecycle.cs
@@ -107,6 +107,8 @@ internal unsafe class AgentLifecycle : IInternalDisposableService
     /// <param name="listener">The listener to unregister.</param>
     internal void UnregisterListener(AgentLifecycleEventListener listener)
     {
+        listener.IsRequestedToClear = true;
+        
         if (this.isInvokingListeners)
         {
             this.framework.RunOnTick(() => this.UnregisterListenerMethod(listener));
@@ -135,6 +137,8 @@ internal unsafe class AgentLifecycle : IInternalDisposableService
         {
             foreach (var listener in globalListeners)
             {
+                if (listener.IsRequestedToClear) continue;
+                
                 try
                 {
                     listener.FunctionDelegate.Invoke(eventType, args);
@@ -151,6 +155,8 @@ internal unsafe class AgentLifecycle : IInternalDisposableService
         {
             foreach (var listener in agentListener)
             {
+                if (listener.IsRequestedToClear) continue;
+                
                 try
                 {
                     listener.FunctionDelegate.Invoke(eventType, args);

--- a/Dalamud/Game/Agent/AgentLifecycleEventListener.cs
+++ b/Dalamud/Game/Agent/AgentLifecycleEventListener.cs
@@ -35,4 +35,9 @@ public class AgentLifecycleEventListener
     /// Gets the delegate this listener invokes.
     /// </summary>
     public IAgentLifecycle.AgentEventDelegate FunctionDelegate { get; init; }
+    
+    /// <summary>
+    /// Gets or sets if the listener is requested to be cleared.
+    /// </summary>
+    internal bool IsRequestedToClear { get; set; }
 }


### PR DESCRIPTION
Added an `internal bool IsRequestedToClear` to both `AddonLifecycleListener` and `AgentLifecycleListener`.

This prevents the deferred to next frame behavior from executing logic that should have already been cleared, avoiding potential leaks or errors.