### PR TITLE
Fix crash on getting the FileName of ImageNodes

### DIFF
--- a/Dalamud/Interface/Internal/UiDebug/Browsing/NodeTree.Image.cs
+++ b/Dalamud/Interface/Internal/UiDebug/Browsing/NodeTree.Image.cs
@@ -297,17 +297,11 @@ internal unsafe partial class ImageNodeTree : ResNodeTree
             }
 
             this.TexType = asset->AtkTexture.TextureType;
+            this.Texture = asset->AtkTexture.IsTextureReady() ? asset->AtkTexture.GetKernelTexture() : null;
 
-            if (this.TexType == Resource)
+            if (this.TexType == Resource && asset->AtkTexture.Resource != null && asset->AtkTexture.Resource->TexFileResourceHandle != null)
             {
-                var resource = asset->AtkTexture.Resource;
-                this.Texture = resource->KernelTextureObject;
-                this.Path = Marshal.PtrToStringAnsi(new(resource->TexFileResourceHandle->ResourceHandle.FileName.BufferPtr));
-            }
-            else
-            {
-                this.Texture = this.TexType == KernelTexture ? asset->AtkTexture.KernelTexture : null;
-                this.Path = null;
+                this.Path = asset->AtkTexture.Resource->TexFileResourceHandle->ResourceHandle.FileName.ToString();
             }
 
             this.HiRes = this.Path?.Contains("_hr1") ?? false;


### PR DESCRIPTION
Reported in #game-crashes: https://discord.com/channels/581875019861328007/1084906540592549958/1473361454232113376

Well, at least I think this could help. I couldn't reproduce the crash to begin with.