### PR TITLE
Add missing IDalamudService markers

### DIFF
--- a/Dalamud/Interface/DragDrop/IDragDropManager.cs
+++ b/Dalamud/Interface/DragDrop/IDragDropManager.cs
@@ -1,11 +1,13 @@
 using System.Collections.Generic;
 
+using Dalamud.Plugin.Services;
+
 namespace Dalamud.Interface.DragDrop;
 
 /// <summary>
 /// A service to handle external drag and drop from WinAPI.
 /// </summary>
-public interface IDragDropManager
+public interface IDragDropManager : IDalamudService
 {
     /// <summary> Gets a value indicating whether Drag and Drop functionality is available at all. </summary>
     public bool ServiceAvailable { get; }

--- a/Dalamud/IoC/Internal/ServiceContainer.cs
+++ b/Dalamud/IoC/Internal/ServiceContainer.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Dalamud.Logging.Internal;
+using Dalamud.Plugin.Services;
 
 namespace Dalamud.IoC.Internal;
 
@@ -76,6 +77,7 @@ internal class ServiceContainer : IServiceType
 
             Debug.Assert(!this.interfaceToTypeMap.ContainsKey(resolvableType), "A service already implements this interface, this is not allowed");
             Debug.Assert(type.IsAssignableTo(resolvableType), "Service does not inherit from indicated ResolveVia type");
+            Debug.Assert(resolvableType.IsAssignableTo(typeof(IDalamudService)), "Indicated ResolveVia type does not inherit from IDalamudService");
 
             this.interfaceToTypeMap[resolvableType] = type;
         }

--- a/Dalamud/Storage/Assets/IDalamudAssetManager.cs
+++ b/Dalamud/Storage/Assets/IDalamudAssetManager.cs
@@ -1,9 +1,10 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Threading.Tasks;
 
 using Dalamud.Interface.Textures.TextureWraps;
+using Dalamud.Plugin.Services;
 
 namespace Dalamud.Storage.Assets;
 
@@ -16,7 +17,7 @@ namespace Dalamud.Storage.Assets;
 /// Think of C++ [[nodiscard]]. Also, like the intended meaning of the attribute, such methods will not have
 /// externally visible state changes.
 /// </summary>
-public interface IDalamudAssetManager
+public interface IDalamudAssetManager : IDalamudService
 {
     /// <summary>
     /// Gets the shared texture wrap for <see cref="DalamudAsset.Empty4X4"/>.


### PR DESCRIPTION
This adds the missing `IDalamudService` markers to two service interfaces that were missing it, and adds an assert to detect future similar oversights.

For API 15, they should also be moved to the usual namespace.

cc @Haselnussbomber 