### PR TITLE
fix DNCGauge.NextStep OOB read when all dance steps are completed

### DIFF
--- a/Dalamud/Game/ClientState/JobGauge/Types/DNCGauge.cs
+++ b/Dalamud/Game/ClientState/JobGauge/Types/DNCGauge.cs
@@ -47,7 +47,7 @@ public unsafe class DNCGauge : JobGaugeBase<FFXIVClientStructs.FFXIV.Client.Game
     /// Gets the next step in the current dance.
     /// </summary>
     /// <returns>The next dance step action ID.</returns>
-    public uint NextStep => 15999u + this.Struct->DanceSteps[this.Struct->StepIndex] - 1;
+    public uint NextStep => this.Struct->StepIndex >= 4 ? 0 : 15999u + this.Struct->DanceSteps[this.Struct->StepIndex] - 1;
 
     /// <summary>
     /// Gets a value indicating whether the player is dancing or not.


### PR DESCRIPTION
NextStep indexes into DanceSteps[StepIndex] raw - but DanceSteps is only 4 elements and StepIndex reaches 4 after completing all steps during Technical Step (before hitting finish). reads garbage past the array.

same guard ClientStructs already has in DancerGauge.CurrentStep.

fixes #2295