### PR TITLE
Update Lumina to 7.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="CheapLoc" Version="1.1.8" />
     <PackageVersion Include="MinSharp" Version="1.0.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="Lumina" Version="7.1.0" />
+    <PackageVersion Include="Lumina" Version="7.2.0" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.0" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="10.0.0" />


### PR DESCRIPTION
Small update to expose the RowType in RowRef types, by @Critical-Impact.

Release: https://github.com/NotAdam/Lumina/releases/tag/7.2.0
Changes: https://github.com/NotAdam/Lumina/compare/7.1.0...7.2.0