### PR TITLE
Add easier support for live-object IPC across boundaries.

### DIFF
--- a/Dalamud/Plugin/Ipc/Exceptions/AdapterMethodMissingException.cs
+++ b/Dalamud/Plugin/Ipc/Exceptions/AdapterMethodMissingException.cs
@@ -1,0 +1,23 @@
+namespace Dalamud.Plugin.Ipc;
+
+/// <summary> Exception thrown if the method requested in a <see cref="IIdDataShareAdapter"/> or a <see cref="INameDataShareAdapter"/> does not exist. </summary>
+public sealed class AdapterMethodMissingException : Exception
+{
+    /// <summary> Initializes a new instance of the <see cref="AdapterMethodMissingException"/> class using a named method. </summary>
+    /// <param name="methodName"> The name of the method. </param>
+    /// <param name="numArguments"> The number of arguments with which the method was requested. </param>
+    /// <param name="func"> Whether the method was requested as a function or an action. </param>
+    public AdapterMethodMissingException(string methodName, int numArguments, bool func)
+        : base($"No {(func ? "function" : "action")} with the name {methodName} and {numArguments} arguments is available.")
+    {
+    }
+
+    /// <summary> Initializes a new instance of the <see cref="AdapterMethodMissingException"/> class using a custom method ID. </summary>
+    /// <param name="methodId"> The custom ID of the method. </param>
+    /// <param name="numArguments"> The number of arguments with which the method was requested. </param>
+    /// <param name="func"> Whether the method was requested as a function or an action. </param>
+    public AdapterMethodMissingException(int methodId, int numArguments, bool func)
+        : base($"No {(func ? "function" : "action")} with the ID {methodId} and {numArguments} arguments is available.")
+    {
+    }
+}

--- a/Dalamud/Plugin/Ipc/Exceptions/AdapterTypeMismatchException.cs
+++ b/Dalamud/Plugin/Ipc/Exceptions/AdapterTypeMismatchException.cs
@@ -1,0 +1,33 @@
+namespace Dalamud.Plugin.Ipc;
+
+/// <summary> Exception thrown if the method requested in a <see cref="IIdDataShareAdapter"/> or a <see cref="INameDataShareAdapter"/> can not handle a specified argument type. </summary>
+public sealed class AdapterTypeMismatchException : Exception
+{
+    /// <summary> Initializes a new instance of the <see cref="AdapterTypeMismatchException"/> class using a named method. </summary>
+    /// <param name="methodName"> The name of the method. </param>
+    /// <param name="numArguments"> The number of arguments with which the method was requested. </param>
+    /// <param name="func"> Whether the method was requested as a function or an action. </param>
+    /// <param name="argumentIndex"> The index of the failing argument, or -1 if it is the return type. </param>
+    /// <param name="passedType"> The passed type that was incompatible. </param>
+    public AdapterTypeMismatchException(string methodName, int numArguments, bool func, int argumentIndex, Type passedType)
+        : base(
+            argumentIndex is -1
+                ? $"The {(func ? "function" : "action")} with the name {methodName} and {numArguments} arguments can not return a value of type {passedType}."
+                : $"The {(func ? "function" : "action")} with the name {methodName} and {numArguments} arguments can not be invoked with an argument of type {passedType} as argument {argumentIndex}.")
+    {
+    }
+
+    /// <summary> Initializes a new instance of the <see cref="AdapterTypeMismatchException"/> class using a custom method ID. </summary>
+    /// <param name="methodId"> The custom ID of the method. </param>
+    /// <param name="numArguments"> The number of arguments with which the method was requested. </param>
+    /// <param name="func"> Whether the method was requested as a function or an action. </param>
+    /// <param name="argumentIndex"> The index of the failing argument, or -1 if it is the return type. </param>
+    /// <param name="passedType"> The passed type that was incompatible. </param>
+    public AdapterTypeMismatchException(int methodId, int numArguments, bool func, int argumentIndex, Type passedType)
+        : base(
+            argumentIndex is -1
+                ? $"The {(func ? "function" : "action")} with the ID {methodId} and {numArguments} arguments can not return a value of type {passedType}."
+                : $"The {(func ? "function" : "action")} with the ID {methodId} and {numArguments} arguments can not be invoked with an argument of type {passedType} as argument {argumentIndex}.")
+    {
+    }
+}

--- a/Dalamud/Plugin/Ipc/IDataShareAdapter.cs
+++ b/Dalamud/Plugin/Ipc/IDataShareAdapter.cs
@@ -1,231 +1,93 @@
 namespace Dalamud.Plugin.Ipc;
 
-/// <summary> An interface to provide live IPC adapters that can provide arbitrary values without the runtime overhead of IPC queries. </summary>
-/// <remarks> Implement only whichever type of methods suits you best. This can then be used to create a wrapper encapsulating the actually available properties, either by the provider library, or on the consumer side. </remarks>
-public interface IDataShareAdapter : IDisposable
+/// <summary> An interface to provide live IPC adapters that can invoke methods directly using custom IDs without the runtime overhead of IPC queries. </summary>
+/// <remarks> Implement only methods you actually need. This can then be used to create a wrapper encapsulating the actually available methods or properties, either by the provider library, or on the consumer side. </remarks>
+public interface IIdDataShareAdapter : IDisposable
 {
-    /// <summary> Get the value of a specific property by its name generically to avoid boxing of value types. </summary>
-    /// <typeparam name="T"> The type the value should have. This needs to be a type known to Dalamud again. </typeparam>
-    /// <param name="propertyName"> The name of the property. </param>
-    /// <returns> The value. </returns>
-    /// <remarks>
-    ///   Should throw an exception if the requested property does not exist, or the return type is wrong.<br/>
-    ///   The method should generally be implemented as a switch-statement.
-    /// </remarks>
-    public T? GetValue<T>(string propertyName)
-        => throw new NotImplementedException();
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke(int methodId)
+        => throw new AdapterMethodMissingException(methodId, 0, false);
 
-    /// <summary> Get the value of a specific property by a custom integral ID generically to avoid boxing of value types. </summary>
-    /// <typeparam name="T"> The type the value should have. This needs to be a type known to Dalamud again. </typeparam>
-    /// <param name="propertyId"> The custom integral ID of the property. </param>
-    /// <returns> The value. </returns>
-    /// <remarks>
-    ///   Should throw an exception if the requested property does not exist, or the return type is wrong. <br/>
-    ///   The method should generally be implemented as a switch-statement.
-    /// </remarks>
-    public T? GetValue<T>(int propertyId)
-        => throw new NotImplementedException();
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1>(int methodId, T1 argument1)
+        where T1 : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 1, false);
 
-    /// <summary> Set the value of a specific property by its name generically to avoid boxing of value types. </summary>
-    /// <typeparam name="T"> The type the value should have. This needs to be a type known to Dalamud again. </typeparam>
-    /// <param name="propertyName"> The name of the property. </param>
-    /// <param name="newValue"> The intended new value of the property. </param>
-    /// <returns> True if the property was changed, false otherwise. </returns>
-    /// <remarks>
-    ///   Should either throw an exception if the requested property does not exist, or the value type is wrong, or just return false.<br/>
-    ///   The method should generally be implemented as a switch-statement.
-    /// </remarks>
-    public bool SetValue<T>(string propertyName, T newValue)
-        => throw new NotImplementedException();
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1, T2>(int methodId, T1 argument1, T2 argument2)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 2, false);
 
-    /// <summary> Set the value of a specific property by a custom integral ID generically to avoid boxing of value types. </summary>
-    /// <typeparam name="T"> The type the value should have. This needs to be a type known to Dalamud again. </typeparam>
-    /// <param name="propertyId"> The custom integral ID of the property. </param>
-    /// <param name="newValue"> The intended new value of the property. </param>
-    /// <returns> True if the property was changed, false otherwise. </returns>
-    /// <remarks>
-    ///   Should either throw an exception if the requested property does not exist, or the value type is wrong, or just return false.<br/>
-    ///   The method should generally be implemented as a switch-statement.
-    /// </remarks>
-    public bool SetValue<T>(int propertyId, T newValue)
-        => throw new NotImplementedException();
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1, T2, T3>(int methodId, T1 argument1, T2 argument2, T3 argument3)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 3, false);
 
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke(string methodName)
-        => throw new NotImplementedException();
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1, T2, T3, T4>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 4, false);
 
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1>(string methodName, T1 argument1)
-        => throw new NotImplementedException();
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1, T2, T3, T4, T5>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 5, false);
 
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1, T2>(string methodName, T1 argument1, T2 argument2)
-        => throw new NotImplementedException();
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1, T2, T3, T4, T5, T6>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 6, false);
 
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1, T2, T3>(string methodName, T1 argument1, T2 argument2, T3 argument3)
-        => throw new NotImplementedException();
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1, T2, T3, T4, T5, T6, T7>(
+        int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        where T7 : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 7, false);
 
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1, T2, T3, T4>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6, T7>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, T8>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8)
-        => throw new NotImplementedException();
-
-    /// <summary> Try to invoke an action by its name using generic arguments. </summary>
-    /// <typeparam name="T1"> The first parameter type. </typeparam>
-    /// <typeparam name="T2"> The second parameter type. </typeparam>
-    /// <typeparam name="T3"> The third parameter type. </typeparam>
-    /// <typeparam name="T4"> The fourth parameter type. </typeparam>
-    /// <typeparam name="T5"> The fifth parameter type. </typeparam>
-    /// <typeparam name="T6"> The sixth parameter type. </typeparam>
-    /// <typeparam name="T7"> The seventh parameter type. </typeparam>
-    /// <typeparam name="T8"> The eight parameter type. </typeparam>
-    /// <typeparam name="T9"> The ninth parameter type. </typeparam>
-    /// <param name="methodName"> The name of the method to invoke. </param>
-    /// <param name="argument1"> The first argument. </param>
-    /// <param name="argument2"> The second argument. </param>
-    /// <param name="argument3"> The third argument. </param>
-    /// <param name="argument4"> The fourth argument. </param>
-    /// <param name="argument5"> The fifth argument. </param>
-    /// <param name="argument6"> The sixth argument. </param>
-    /// <param name="argument7"> The seventh argument. </param>
-    /// <param name="argument8"> The eighth argument. </param>
-    /// <param name="argument9"> The ninth argument. </param>
-    /// <returns> True if the invocation was successful, false otherwise. </returns>
-    /// <remarks>
-    ///   Should either throw an exception if the requested method does not exist, or any of the parameter types is wrong, or just return false.<br/>
-    ///   The method should generally be implemented as a switch-statement.
-    /// </remarks>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, T8, T9>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8, T9 argument9)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<TRet>(string methodName, out TRet? ret)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, TRet>(string methodName, T1 argument1, out TRet? ret)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, T2, TRet>(string methodName, T1 argument1, T2 argument2, out TRet? ret)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, T2, T3, TRet>(string methodName, T1 argument1, T2 argument2, T3 argument3, out TRet? ret)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, T2, T3, T4, TRet>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, out TRet? ret)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5, TRet>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, out TRet? ret)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6, TRet>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, out TRet? ret)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, TRet>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, out TRet? ret)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, T8, TRet>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8, out TRet? ret)
-        => throw new NotImplementedException();
-
-    /// <summary> Try to invoke a function by its name using generic arguments. </summary>
-    /// <typeparam name="T1"> The first parameter type. </typeparam>
-    /// <typeparam name="T2"> The second parameter type. </typeparam>
-    /// <typeparam name="T3"> The third parameter type. </typeparam>
-    /// <typeparam name="T4"> The fourth parameter type. </typeparam>
-    /// <typeparam name="T5"> The fifth parameter type. </typeparam>
-    /// <typeparam name="T6"> The sixth parameter type. </typeparam>
-    /// <typeparam name="T7"> The seventh parameter type. </typeparam>
-    /// <typeparam name="T8"> The eight parameter type. </typeparam>
-    /// <typeparam name="T9"> The ninth parameter type. </typeparam>
-    /// <typeparam name="TRet"> The type of the returned value. </typeparam>
-    /// <param name="methodName"> The name of the method to invoke. </param>
-    /// <param name="argument1"> The first argument. </param>
-    /// <param name="argument2"> The second argument. </param>
-    /// <param name="argument3"> The third argument. </param>
-    /// <param name="argument4"> The fourth argument. </param>
-    /// <param name="argument5"> The fifth argument. </param>
-    /// <param name="argument6"> The sixth argument. </param>
-    /// <param name="argument7"> The seventh argument. </param>
-    /// <param name="argument8"> The eighth argument. </param>
-    /// <param name="argument9"> The ninth argument. </param>
-    /// <param name="ret"> The returned value on success, undefined on failure. </param>
-    /// <returns> True if the invocation was successful, false otherwise. </returns>
-    /// <remarks>
-    ///   Should either throw an exception if the requested method does not exist, or any of the parameter types or the return type is wrong, or just return false.<br/>
-    ///   The method should generally be implemented as a switch-statement.
-    /// </remarks>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, T8, T9, TRet>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8, T9 argument9, out TRet? ret)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke(int methodId)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1>(int methodId, T1 argument1)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1, T2>(int methodId, T1 argument1, T2 argument2)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1, T2, T3>(int methodId, T1 argument1, T2 argument2, T3 argument3)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1, T2, T3, T4>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6, T7>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7)
-        => throw new NotImplementedException();
-
-    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, T8>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8)
-        => throw new NotImplementedException();
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1, T2, T3, T4, T5, T6, T7, T8>(
+        int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        where T7 : allows ref struct
+        where T8 : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 8, false);
 
     /// <summary> Try to invoke an action by a custom integral ID using generic arguments. </summary>
-    /// <typeparam name="T1"> The first parameter type. </typeparam>
-    /// <typeparam name="T2"> The second parameter type. </typeparam>
-    /// <typeparam name="T3"> The third parameter type. </typeparam>
-    /// <typeparam name="T4"> The fourth parameter type. </typeparam>
-    /// <typeparam name="T5"> The fifth parameter type. </typeparam>
-    /// <typeparam name="T6"> The sixth parameter type. </typeparam>
-    /// <typeparam name="T7"> The seventh parameter type. </typeparam>
-    /// <typeparam name="T8"> The eight parameter type. </typeparam>
-    /// <typeparam name="T9"> The ninth parameter type. </typeparam>
+    /// <typeparam name="T1"> The first parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T2"> The second parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T3"> The third parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T4"> The fourth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T5"> The fifth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T6"> The sixth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T7"> The seventh parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T8"> The eight parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T9"> The ninth parameter type. This needs to be a type known to Dalamud again. </typeparam>
     /// <param name="methodId"> The custom integral ID of the method. </param>
     /// <param name="argument1"> The first argument. </param>
     /// <param name="argument2"> The second argument. </param>
@@ -236,61 +98,121 @@ public interface IDataShareAdapter : IDisposable
     /// <param name="argument7"> The seventh argument. </param>
     /// <param name="argument8"> The eighth argument. </param>
     /// <param name="argument9"> The ninth argument. </param>
-    /// <returns> True if the invocation was successful, false otherwise. </returns>
     /// <remarks>
-    ///   Should either throw an exception if the requested method does not exist, or any of the parameter types is wrong, or just return false.<br/>
+    ///   Should throw <see cref="AdapterMethodMissingException"/> if the requested method does not exist. <br/>
+    ///   Should throw <see cref="AdapterTypeMismatchException"/> if the requested method can not handle a provided argument. <br/>
     ///   The method should generally be implemented as a switch-statement.
     /// </remarks>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, T8, T9>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8, T9 argument9)
-        => throw new NotImplementedException();
+    void Invoke<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+        int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8,
+        T9 argument9)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        where T7 : allows ref struct
+        where T8 : allows ref struct
+        where T9 : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 9, false);
 
     /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<TRet>(int methodId, out TRet? ret)
-        => throw new NotImplementedException();
+    bool TryInvoke<TRet>(int methodId, out TRet? ret)
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 0, true);
 
     /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, TRet>(int methodId, T1 argument1, out TRet? ret)
-        => throw new NotImplementedException();
+    bool TryInvoke<T1, TRet>(int methodId, T1 argument1, out TRet? ret)
+        where T1 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 1, true);
 
     /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, T2, TRet>(int methodId, T1 argument1, T2 argument2, out TRet? ret)
-        => throw new NotImplementedException();
+    bool TryInvoke<T1, T2, TRet>(int methodId, T1 argument1, T2 argument2, out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 2, true);
 
     /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, T2, T3, TRet>(int methodId, T1 argument1, T2 argument2, T3 argument3, out TRet? ret)
-        => throw new NotImplementedException();
+    bool TryInvoke<T1, T2, T3, TRet>(int methodId, T1 argument1, T2 argument2, T3 argument3, out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 3, true);
 
     /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, T2, T3, T4, TRet>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, out TRet? ret)
-        => throw new NotImplementedException();
+    bool TryInvoke<T1, T2, T3, T4, TRet>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 4, true);
 
     /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5, TRet>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, out TRet? ret)
-        => throw new NotImplementedException();
+    bool TryInvoke<T1, T2, T3, T4, T5, TRet>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 5, true);
 
     /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6, TRet>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, out TRet? ret)
-        => throw new NotImplementedException();
+    bool TryInvoke<T1, T2, T3, T4, T5, T6, TRet>(
+        int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 6, true);
 
     /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, TRet>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, out TRet? ret)
-        => throw new NotImplementedException();
+    bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, TRet>(
+        int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        where T7 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 7, true);
 
     /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(int,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, T8, TRet>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8, out TRet? ret)
-        => throw new NotImplementedException();
+    bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, T8, TRet>(
+        int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8,
+        out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        where T7 : allows ref struct
+        where T8 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 8, true);
 
     /// <summary> Try to invoke a function by a custom integral ID using generic arguments. </summary>
-    /// <typeparam name="T1"> The first parameter type. </typeparam>
-    /// <typeparam name="T2"> The second parameter type. </typeparam>
-    /// <typeparam name="T3"> The third parameter type. </typeparam>
-    /// <typeparam name="T4"> The fourth parameter type. </typeparam>
-    /// <typeparam name="T5"> The fifth parameter type. </typeparam>
-    /// <typeparam name="T6"> The sixth parameter type. </typeparam>
-    /// <typeparam name="T7"> The seventh parameter type. </typeparam>
-    /// <typeparam name="T8"> The eight parameter type. </typeparam>
-    /// <typeparam name="T9"> The ninth parameter type. </typeparam>
-    /// <typeparam name="TRet"> The type of the returned value. </typeparam>
+    /// <typeparam name="T1"> The first parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T2"> The second parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T3"> The third parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T4"> The fourth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T5"> The fifth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T6"> The sixth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T7"> The seventh parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T8"> The eight parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T9"> The ninth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="TRet"> The type of the returned value. This needs to be a type known to Dalamud again. </typeparam>
     /// <param name="methodId"> The name of the method to invoke. </param>
     /// <param name="argument1"> The first argument. </param>
     /// <param name="argument2"> The second argument. </param>
@@ -304,9 +226,270 @@ public interface IDataShareAdapter : IDisposable
     /// <param name="ret"> The returned value on success, undefined on failure. </param>
     /// <returns> True if the invocation was successful, false otherwise. </returns>
     /// <remarks>
-    ///   Should either throw an exception if the requested method does not exist, or any of the parameter types or the return type is wrong, or just return false.<br/>
+    ///   Should throw <see cref="AdapterMethodMissingException"/> if the requested method does not exist. <br/>
+    ///   Should throw <see cref="AdapterTypeMismatchException"/> if the requested method can not handle a provided argument or the return value. <br/>
     ///   The method should generally be implemented as a switch-statement.
     /// </remarks>
-    public bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, T8, T9, TRet>(int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8, T9 argument9, out TRet? ret)
-        => throw new NotImplementedException();
+    bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, T8, T9, TRet>(
+        int methodId, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8,
+        T9 argument9, out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        where T7 : allows ref struct
+        where T8 : allows ref struct
+        where T9 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodId, 9, true);
+}
+
+/// <summary> An interface to provide live IPC adapters that can invoke methods directly using names without the runtime overhead of IPC queries. </summary>
+/// <remarks> Implement only whichever type of methods suits you best. This can then be used to create a wrapper encapsulating the actually available methods or properties, either by the provider library, or on the consumer side. </remarks>
+public interface INameDataShareAdapter : IDisposable
+{
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke(string methodName)
+        => throw new AdapterMethodMissingException(methodName, 0, false);
+
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1>(string methodName, T1 argument1)
+        where T1 : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 1, false);
+
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1, T2>(string methodName, T1 argument1, T2 argument2)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 2, false);
+
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1, T2, T3>(string methodName, T1 argument1, T2 argument2, T3 argument3)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 3, false);
+
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1, T2, T3, T4>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 4, false);
+
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1, T2, T3, T4, T5>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 5, false);
+
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1, T2, T3, T4, T5, T6>(
+        string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 6, false);
+
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1, T2, T3, T4, T5, T6, T7>(
+        string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        where T7 : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 7, false);
+
+    /// <inheritdoc cref="Invoke{T1,T2,T3,T4,T5,T6,T7,T8,T9}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9)"/>
+    void Invoke<T1, T2, T3, T4, T5, T6, T7, T8>(
+        string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        where T7 : allows ref struct
+        where T8 : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 8, false);
+
+    /// <summary> Try to invoke an action by its name using generic arguments. </summary>
+    /// <typeparam name="T1"> The first parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T2"> The second parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T3"> The third parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T4"> The fourth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T5"> The fifth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T6"> The sixth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T7"> The seventh parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T8"> The eight parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T9"> The ninth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <param name="methodName"> The name of the method to invoke. </param>
+    /// <param name="argument1"> The first argument. </param>
+    /// <param name="argument2"> The second argument. </param>
+    /// <param name="argument3"> The third argument. </param>
+    /// <param name="argument4"> The fourth argument. </param>
+    /// <param name="argument5"> The fifth argument. </param>
+    /// <param name="argument6"> The sixth argument. </param>
+    /// <param name="argument7"> The seventh argument. </param>
+    /// <param name="argument8"> The eighth argument. </param>
+    /// <param name="argument9"> The ninth argument. </param>
+    /// <remarks>
+    ///   Should throw <see cref="AdapterMethodMissingException"/> if the requested method does not exist. <br/>
+    ///   Should throw <see cref="AdapterTypeMismatchException"/> if the requested method can not handle a provided argument. <br/>
+    ///   The method should generally be implemented as a switch-statement.
+    /// </remarks>
+    void Invoke<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+        string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8,
+        T9 argument9)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        where T7 : allows ref struct
+        where T8 : allows ref struct
+        where T9 : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 9, false);
+
+    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
+    bool TryInvoke<TRet>(string methodName, out TRet? ret)
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 0, true);
+
+    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
+    bool TryInvoke<T1, TRet>(string methodName, T1 argument1, out TRet? ret)
+        where T1 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 1, true);
+
+    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
+    bool TryInvoke<T1, T2, TRet>(string methodName, T1 argument1, T2 argument2, out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 2, true);
+
+    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
+    bool TryInvoke<T1, T2, T3, TRet>(string methodName, T1 argument1, T2 argument2, T3 argument3, out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 3, true);
+
+    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
+    bool TryInvoke<T1, T2, T3, T4, TRet>(string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 4, true);
+
+    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
+    bool TryInvoke<T1, T2, T3, T4, T5, TRet>(
+        string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 5, true);
+
+    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
+    bool TryInvoke<T1, T2, T3, T4, T5, T6, TRet>(
+        string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 6, true);
+
+    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
+    bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, TRet>(
+        string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        where T7 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 7, true);
+
+    /// <inheritdoc cref="TryInvoke{T1,T2,T3,T4,T5,T6,T7,T8,T9,TRet}(string,T1,T2,T3,T4,T5,T6,T7,T8,T9,out TRet)"/>
+    bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, T8, TRet>(
+        string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8,
+        out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        where T7 : allows ref struct
+        where T8 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 8, true);
+
+    /// <summary> Try to invoke a function by its name using generic arguments. </summary>
+    /// <typeparam name="T1"> The first parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T2"> The second parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T3"> The third parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T4"> The fourth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T5"> The fifth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T6"> The sixth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T7"> The seventh parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T8"> The eight parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="T9"> The ninth parameter type. This needs to be a type known to Dalamud again. </typeparam>
+    /// <typeparam name="TRet"> The type of the returned value. This needs to be a type known to Dalamud again. </typeparam>
+    /// <param name="methodName"> The name of the method to invoke. </param>
+    /// <param name="argument1"> The first argument. </param>
+    /// <param name="argument2"> The second argument. </param>
+    /// <param name="argument3"> The third argument. </param>
+    /// <param name="argument4"> The fourth argument. </param>
+    /// <param name="argument5"> The fifth argument. </param>
+    /// <param name="argument6"> The sixth argument. </param>
+    /// <param name="argument7"> The seventh argument. </param>
+    /// <param name="argument8"> The eighth argument. </param>
+    /// <param name="argument9"> The ninth argument. </param>
+    /// <param name="ret"> The returned value on success, undefined on failure. </param>
+    /// <returns> True if the invocation was successful, false otherwise. </returns>
+    /// <remarks>
+    ///   Should throw <see cref="AdapterMethodMissingException"/> if the requested method does not exist. <br/>
+    ///   Should throw <see cref="AdapterTypeMismatchException"/> if the requested method can not handle a provided argument or the return value. <br/>
+    ///   The method should generally be implemented as a switch-statement.
+    /// </remarks>
+    bool TryInvoke<T1, T2, T3, T4, T5, T6, T7, T8, T9, TRet>(
+        string methodName, T1 argument1, T2 argument2, T3 argument3, T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8,
+        T9 argument9, out TRet? ret)
+        where T1 : allows ref struct
+        where T2 : allows ref struct
+        where T3 : allows ref struct
+        where T4 : allows ref struct
+        where T5 : allows ref struct
+        where T6 : allows ref struct
+        where T7 : allows ref struct
+        where T8 : allows ref struct
+        where T9 : allows ref struct
+        where TRet : allows ref struct
+        => throw new AdapterMethodMissingException(methodName, 9, true);
 }


### PR DESCRIPTION
Add a wrapper interface to Dalamuds known types that is a disposable and can be used to wrap live-objects with property-accessors for basic types across app context boundaries.