### PR TITLE
Fix IndexOutOfRangeException in xldata Task Scheduler when Local Path is blank

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TaskSchedulerWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TaskSchedulerWidget.cs
@@ -266,7 +266,7 @@ internal class TaskSchedulerWidget : IDataWindowWidget
 
             ImGui.Text($"{this.downloadState.Downloaded:##,###}/{this.downloadState.Total:##,###} ({this.downloadState.Percentage:0.00}%)");
 
-            using var disabled = ImRaii.Disabled(this.downloadTask?.IsCompleted is false || this.localPath[0] == 0);
+            using var disabled = ImRaii.Disabled(this.downloadTask?.IsCompleted is false || string.IsNullOrEmpty(this.localPath));
             ImGui.AlignTextToFramePadding();
             ImGui.Text("Download"u8);
             ImGui.SameLine();


### PR DESCRIPTION
Fixes #2449

## Description
Fixes an `IndexOutOfRangeException` in the xldata Task Scheduler pane that occurs when the Local Path field is cleared or left blank. 

Updated the `ImRaii.Disabled` state check to use `string.IsNullOrEmpty(this.localPath)` instead of unsafely checking the string's index. The UI now gracefully disables the relevant controls when the path is missing.