### PR TITLE
[API15] Addon/Agent Lifecycle Toggles

### DIFF
--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -36,9 +36,13 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
     [ServiceManager.ServiceConstructor]
     private AddonLifecycle()
     {
-        this.onInitializeAddonHook = Hook<AtkUnitBase.Delegates.Initialize>.FromAddress((nint)AtkUnitBase.StaticVirtualTablePointer->Initialize, this.OnAddonInitialize);
-        this.onInitializeAddonHook.Enable();
+        this.InitializeAddonLifecycle();
     }
+
+    /// <summary>
+    /// Gets a value indicating whether AddonLifecycle is Enabled.
+    /// </summary>
+    internal bool IsEnabled { get; private set; }
 
     /// <summary>
     /// Gets a list of all AddonLifecycle Event Listeners.
@@ -49,11 +53,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
     /// <inheritdoc/>
     void IInternalDisposableService.DisposeService()
     {
-        this.onInitializeAddonHook?.Dispose();
-        this.onInitializeAddonHook = null;
-
-        AllocatedTables.ForEach(entry => entry.Dispose());
-        AllocatedTables.Clear();
+        this.UnloadAddonLifecycle();
     }
 
     /// <summary>
@@ -70,6 +70,34 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
         }
 
         return matchedTable.OriginalVirtualTable;
+    }
+
+    /// <summary>
+    /// Enables AddonLifecycle to replace addon virtual tables for relaying addon events.
+    /// </summary>
+    internal void InitializeAddonLifecycle()
+    {
+        this.IsEnabled = true;
+
+        this.onInitializeAddonHook ??= Hook<AtkUnitBase.Delegates.Initialize>.FromAddress((nint)AtkUnitBase.StaticVirtualTablePointer->Initialize, this.OnAddonInitialize);
+        this.onInitializeAddonHook.Enable();
+    }
+
+    /// <summary>
+    /// Restores all modified addon virtual tables, and disables AddonLifecycle.
+    /// </summary>
+    internal void UnloadAddonLifecycle()
+    {
+        this.IsEnabled = false;
+
+        this.onInitializeAddonHook?.Dispose();
+        this.onInitializeAddonHook = null;
+
+        this.framework.RunOnFrameworkThread(() =>
+        {
+            AllocatedTables.ForEach(entry => entry.Dispose());
+            AllocatedTables.Clear();
+        });
     }
 
     /// <summary>
@@ -95,7 +123,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
     internal void UnregisterListener(AddonLifecycleEventListener listener)
     {
         listener.IsRequestedToClear = true;
-        
+
         if (this.isInvokingListeners)
         {
             this.framework.RunOnTick(() => this.UnregisterListenerMethod(listener));
@@ -125,7 +153,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
             foreach (var listener in globalListeners)
             {
                 if (listener.IsRequestedToClear) continue;
-                
+
                 try
                 {
                     listener.FunctionDelegate.Invoke(eventType, args);
@@ -143,7 +171,7 @@ internal unsafe class AddonLifecycle : IInternalDisposableService
             foreach (var listener in addonListener)
             {
                 if (listener.IsRequestedToClear) continue;
-                
+
                 try
                 {
                     listener.FunctionDelegate.Invoke(eventType, args);

--- a/Dalamud/Game/Agent/AgentLifecycle.cs
+++ b/Dalamud/Game/Agent/AgentLifecycle.cs
@@ -34,24 +34,18 @@ internal unsafe class AgentLifecycle : IInternalDisposableService
     private Hook<AgentModule.Delegates.Ctor>? onInitializeAgentsHook;
     private bool isInvokingListeners;
 
+    private bool areVirtualTablesReplaced;
+
     [ServiceManager.ServiceConstructor]
     private AgentLifecycle()
     {
-        var agentModuleInstance = AgentModule.Instance();
-
-        // Hook is only used to determine appropriate timing for replacing Agent Virtual Tables
-        // If the agent module is already initialized, then we can replace the tables safely.
-        if (agentModuleInstance is null)
-        {
-            this.onInitializeAgentsHook = Hook<AgentModule.Delegates.Ctor>.FromAddress((nint)AgentModule.MemberFunctionPointers.Ctor, this.OnAgentModuleInitialize);
-            this.onInitializeAgentsHook.Enable();
-        }
-        else
-        {
-            // For safety because this might be injected async, we will make sure we are on the main thread first.
-            this.framework.RunOnFrameworkThread(() => this.ReplaceVirtualTables(agentModuleInstance));
-        }
+        this.InitializeAgentLifecycle();
     }
+
+    /// <summary>
+    /// Gets a value indicating whether AgentLifecycle is Enabled.
+    /// </summary>
+    internal bool IsEnabled { get; private set; }
 
     /// <summary>
     /// Gets a list of all AgentLifecycle Event Listeners.
@@ -62,11 +56,7 @@ internal unsafe class AgentLifecycle : IInternalDisposableService
     /// <inheritdoc/>
     void IInternalDisposableService.DisposeService()
     {
-        this.onInitializeAgentsHook?.Dispose();
-        this.onInitializeAgentsHook = null;
-
-        AllocatedTables.ForEach(entry => entry.Dispose());
-        AllocatedTables.Clear();
+        this.UnloadAgentLifecycle();
     }
 
     /// <summary>
@@ -83,6 +73,57 @@ internal unsafe class AgentLifecycle : IInternalDisposableService
         }
 
         return matchedTable.OriginalVirtualTable;
+    }
+
+    /// <summary>
+    /// Replaces all native Agent Virtual Tables with Modified Virtual Tables to intercept agent events.
+    /// </summary>
+    /// <remarks>
+    /// This function will only queue the actual table initialization to be handled appropriately with current game state.
+    /// </remarks>
+    internal void InitializeAgentLifecycle()
+    {
+        this.IsEnabled = true;
+
+        // Don't allow loading virtual tables if they are already loaded.
+        if (this.areVirtualTablesReplaced)
+        {
+            return;
+        }
+
+        var agentModuleInstance = AgentModule.Instance();
+
+        // Hook is only used to determine appropriate timing for replacing Agent Virtual Tables
+        // If the agent module is already initialized, then we can replace the tables safely, else wait for AgentModule ctor.
+        if (agentModuleInstance is not null)
+        {
+            // For safety because this might be injected async, we will make sure we are on the main thread first.
+            this.framework.RunOnFrameworkThread(() => this.ReplaceVirtualTables(agentModuleInstance));
+        }
+        else
+        {
+            this.onInitializeAgentsHook ??= Hook<AgentModule.Delegates.Ctor>.FromAddress((nint)AgentModule.MemberFunctionPointers.Ctor, this.OnAgentModuleInitialize);
+            this.onInitializeAgentsHook.Enable();
+        }
+    }
+
+    /// <summary>
+    /// Restores all agents original Virtual Tables.
+    /// </summary>
+    internal void UnloadAgentLifecycle()
+    {
+        this.IsEnabled = false;
+
+        this.onInitializeAgentsHook?.Dispose();
+        this.onInitializeAgentsHook = null;
+
+        if (this.areVirtualTablesReplaced)
+        {
+            AllocatedTables.ForEach(entry => entry.Dispose());
+            AllocatedTables.Clear();
+        }
+
+        this.areVirtualTablesReplaced = false;
     }
 
     /// <summary>
@@ -108,7 +149,7 @@ internal unsafe class AgentLifecycle : IInternalDisposableService
     internal void UnregisterListener(AgentLifecycleEventListener listener)
     {
         listener.IsRequestedToClear = true;
-        
+
         if (this.isInvokingListeners)
         {
             this.framework.RunOnTick(() => this.UnregisterListenerMethod(listener));
@@ -138,7 +179,7 @@ internal unsafe class AgentLifecycle : IInternalDisposableService
             foreach (var listener in globalListeners)
             {
                 if (listener.IsRequestedToClear) continue;
-                
+
                 try
                 {
                     listener.FunctionDelegate.Invoke(eventType, args);
@@ -156,7 +197,7 @@ internal unsafe class AgentLifecycle : IInternalDisposableService
             foreach (var listener in agentListener)
             {
                 if (listener.IsRequestedToClear) continue;
-                
+
                 try
                 {
                     listener.FunctionDelegate.Invoke(eventType, args);
@@ -224,6 +265,12 @@ internal unsafe class AgentLifecycle : IInternalDisposableService
 
     private void ReplaceVirtualTables(AgentModule* agentModule)
     {
+        // Prevent Double Replacement.
+        if (this.areVirtualTablesReplaced)
+        {
+            return;
+        }
+
         foreach (uint index in Enumerable.Range(0, agentModule->Agents.Length))
         {
             try
@@ -244,6 +291,8 @@ internal unsafe class AgentLifecycle : IInternalDisposableService
                 Log.Error(e, "Exception in AgentLifecycle during ReplaceVirtualTables.");
             }
         }
+
+        this.areVirtualTablesReplaced = true;
     }
 }
 

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -13,6 +13,7 @@ using Dalamud.Bindings.ImPlot;
 using Dalamud.Configuration.Internal;
 using Dalamud.Console;
 using Dalamud.Game.Addon.Lifecycle;
+using Dalamud.Game.Agent;
 using Dalamud.Game.ClientState;
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.Keys;
@@ -873,6 +874,35 @@ internal class DalamudInterface : IInternalDisposableService
 
                     ImGui.Separator();
 
+                    var addonLifecycle = Service<AddonLifecycle>.Get();
+                    var agentLifecycle = Service<AgentLifecycle>.Get();
+
+                    if (ImGui.MenuItem("Addon Lifecycle Enabled", (byte*)null, addonLifecycle.IsEnabled))
+                    {
+                        if (addonLifecycle.IsEnabled)
+                        {
+                            addonLifecycle.UnloadAddonLifecycle();
+                        }
+                        else
+                        {
+                            addonLifecycle.InitializeAddonLifecycle();
+                        }
+                    }
+
+                    if (ImGui.MenuItem("Agent Lifecycle Enabled", (byte*)null, agentLifecycle.IsEnabled))
+                    {
+                        if (agentLifecycle.IsEnabled)
+                        {
+                            agentLifecycle.UnloadAgentLifecycle();
+                        }
+                        else
+                        {
+                            agentLifecycle.InitializeAgentLifecycle();
+                        }
+                    }
+
+                    ImGui.Separator();
+
                     if (ImGui.BeginMenu("Crash game"u8))
                     {
                         if (ImGui.MenuItem("Access Violation"u8))
@@ -882,40 +912,31 @@ internal class DalamudInterface : IInternalDisposableService
 
                         if (ImGui.MenuItem("Set UiModule to NULL"u8))
                         {
-                            unsafe
-                            {
-                                var framework = Framework.Instance();
-                                framework->UIModule = (UIModule*)0;
-                            }
+                            var framework = Framework.Instance();
+                            framework->UIModule = (UIModule*)0;
                         }
 
                         if (ImGui.MenuItem("Set UiModule to invalid ptr"u8))
                         {
-                            unsafe
-                            {
-                                var framework = Framework.Instance();
-                                framework->UIModule = (UIModule*)0x12345678;
-                            }
+                            var framework = Framework.Instance();
+                            framework->UIModule = (UIModule*)0x12345678;
                         }
 
                         if (ImGui.MenuItem("Deref nullptr in Hook"u8))
                         {
-                            unsafe
-                            {
-                                var hook = Hook<CrashDebugDelegate>.FromAddress(
-                                    (nint)UIModule.StaticVirtualTablePointer->GetUIInputData,
-                                    self =>
-                                    {
-                                        _ = *(byte*)0;
-                                        return (nint)UIModule.Instance()->GetUIInputData();
-                                    });
-                                hook.Enable();
-                            }
+                            var hook = Hook<CrashDebugDelegate>.FromAddress(
+                                (nint)UIModule.StaticVirtualTablePointer->GetUIInputData,
+                                self =>
+                                {
+                                    _ = *(byte*)0;
+                                    return (nint)UIModule.Instance()->GetUIInputData();
+                                });
+                            hook.Enable();
                         }
 
                         if (ImGui.MenuItem("Cause CLR fastfail"u8))
                         {
-                            static unsafe void CauseFastFail()
+                            static void CauseFastFail()
                             {
                                 // ReSharper disable once NotAccessedVariable
                                 var texture = Unsafe.AsRef<AtkTexture>((void*)0x12345678);


### PR DESCRIPTION
Allows devs to toggle on and off the Addon/Agent Lifecycle Services.

This will restore the original virtual tables for all Addons/Agents so devs that need to trace the origin of calls are able to do so.

Original virtual tables are restored on the next frame after toggled off. This setting does not persist on restart.

Agent Lifecycle can be freely disabled and re-enabled without any change in behavior except an obvious pause on events being triggered.

Addon Lifecycle will unload, but not re-load the virtual tables for active addons, instead it will simply resume listening for addon initialization events. So any addons that had their virtual tables stripped will no longer call AddonLifecycle events until the service is re-enabled, and the addon finalized and re-constructed.