### PR TITLE
Add Ornament and GlassesStyle unlock hook

### DIFF
--- a/Dalamud/Game/UnlockState/UnlockState.cs
+++ b/Dalamud/Game/UnlockState/UnlockState.cs
@@ -759,7 +759,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
 
     private void SetGlassesStyleUnlockedDetour(CSPlayerState* thisPtr, ushort glassesStyleId, byte isUnlocked)
     {
-        this.setOrnamentUnlockedHook.Original(thisPtr, glassesStyleId, isUnlocked);
+        this.setGlassesStyleUnlockedHook.Original(thisPtr, glassesStyleId, isUnlocked);
 
         if (isUnlocked == 0 || !this.IsLoaded)
             return;

--- a/Dalamud/Game/UnlockState/UnlockState.cs
+++ b/Dalamud/Game/UnlockState/UnlockState.cs
@@ -53,6 +53,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
     private readonly Hook<CSAchievement.Delegates.SetAchievementCompleted> setAchievementCompletedHook;
     private readonly Hook<TitleList.Delegates.SetTitleUnlocked> setTitleUnlockedHook;
     private readonly Hook<SetOrnamentUnlockedDelegate> setOrnamentUnlockedHook;
+    private readonly Hook<SetGlassesStyleUnlockedDelegate> setGlassesStyleUnlockedHook;
 
     [ServiceManager.ServiceConstructor]
     private UnlockState()
@@ -74,12 +75,20 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
             this.sigScanner.ScanText("48 89 5C 24 ?? 57 48 83 EC ?? 8B DA 41 0F B6 F8 C1 EA"),
             this.SetOrnamentUnlockedDetour);
 
+        // TODO: replace with PlayerState.SetGlassesStyleUnlocked
+        this.setGlassesStyleUnlockedHook = Hook<SetGlassesStyleUnlockedDelegate>.FromAddress(
+            this.sigScanner.ScanText("48 89 5C 24 ?? 57 48 83 EC ?? 0F BF DA 41 0F B6 F8"),
+            this.SetGlassesStyleUnlockedDetour);
+
         this.setAchievementCompletedHook.Enable();
         this.setTitleUnlockedHook.Enable();
         this.setOrnamentUnlockedHook.Enable();
+        this.setGlassesStyleUnlockedHook.Enable();
     }
 
     private delegate void SetOrnamentUnlockedDelegate(CSPlayerState* thisPtr, uint ornamentId, byte isUnlocked);
+
+    private delegate void SetGlassesStyleUnlockedDelegate(CSPlayerState* thisPtr, ushort glassesStyleId, byte isUnlocked);
 
     /// <inheritdoc/>
     public event IUnlockState.UnlockDelegate Unlock;
@@ -102,6 +111,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         this.setAchievementCompletedHook.Dispose();
         this.setTitleUnlockedHook.Dispose();
         this.setOrnamentUnlockedHook.Dispose();
+        this.setGlassesStyleUnlockedHook.Dispose();
     }
 
     /// <inheritdoc/>
@@ -732,6 +742,16 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
             return;
 
         this.RaiseUnlockSafely((RowRef)LuminaUtils.CreateRef<Ornament>(ornamentId));
+    }
+
+    private void SetGlassesStyleUnlockedDetour(CSPlayerState* thisPtr, ushort glassesStyleId, byte isUnlocked)
+    {
+        this.setOrnamentUnlockedHook.Original(thisPtr, glassesStyleId, isUnlocked);
+
+        if (isUnlocked == 0 || !this.IsLoaded)
+            return;
+
+        this.RaiseUnlockSafely((RowRef)LuminaUtils.CreateRef<GlassesStyle>(glassesStyleId));
     }
 
     private void Update()

--- a/Dalamud/Game/UnlockState/UnlockState.cs
+++ b/Dalamud/Game/UnlockState/UnlockState.cs
@@ -20,6 +20,7 @@ using Lumina.Excel.Sheets;
 using AchievementSheet = Lumina.Excel.Sheets.Achievement;
 using ActionSheet = Lumina.Excel.Sheets.Action;
 using CSAchievement = FFXIVClientStructs.FFXIV.Client.Game.UI.Achievement;
+using CSPlayerState = FFXIVClientStructs.FFXIV.Client.Game.UI.PlayerState;
 using InstanceContentSheet = Lumina.Excel.Sheets.InstanceContent;
 using PublicContentSheet = Lumina.Excel.Sheets.PublicContent;
 
@@ -77,7 +78,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
     /// <inheritdoc/>
     public bool IsTitleListLoaded => UIState.Instance()->TitleList.DataReceived;
 
-    private bool IsLoaded => PlayerState.Instance()->IsLoaded;
+    private bool IsLoaded => CSPlayerState.Instance()->IsLoaded;
 
     /// <inheritdoc/>
     void IInternalDisposableService.DisposeService()
@@ -114,7 +115,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         if (!this.IsLoaded)
             return false;
 
-        return PlayerState.Instance()->IsAdventureComplete(row.RowId - 0x210000);
+        return CSPlayerState.Instance()->IsAdventureComplete(row.RowId - 0x210000);
     }
 
     /// <inheritdoc/>
@@ -123,7 +124,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         if (!this.IsLoaded)
             return false;
 
-        return PlayerState.Instance()->IsAetherCurrentUnlocked(row.RowId);
+        return CSPlayerState.Instance()->IsAetherCurrentUnlocked(row.RowId);
     }
 
     /// <inheritdoc/>
@@ -132,7 +133,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         if (!this.IsLoaded)
             return false;
 
-        return PlayerState.Instance()->IsAetherCurrentZoneComplete(row.RowId);
+        return CSPlayerState.Instance()->IsAetherCurrentZoneComplete(row.RowId);
     }
 
     /// <inheritdoc/>
@@ -276,7 +277,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         if (!this.IsLoaded)
             return false;
 
-        return PlayerState.Instance()->IsGlassesUnlocked((ushort)row.RowId);
+        return CSPlayerState.Instance()->IsGlassesUnlocked((ushort)row.RowId);
     }
 
     /// <inheritdoc/>
@@ -317,10 +318,10 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
                 return UIState.Instance()->Buddy.CompanionInfo.IsBuddyEquipUnlocked(row.ItemAction.Value.Data[0]);
 
             case ItemActionAction.Mount:
-                return PlayerState.Instance()->IsMountUnlocked(row.ItemAction.Value.Data[0]);
+                return CSPlayerState.Instance()->IsMountUnlocked(row.ItemAction.Value.Data[0]);
 
             case ItemActionAction.SecretRecipeBook:
-                return PlayerState.Instance()->IsSecretRecipeBookUnlocked(row.ItemAction.Value.Data[0]);
+                return CSPlayerState.Instance()->IsSecretRecipeBookUnlocked(row.ItemAction.Value.Data[0]);
 
             case ItemActionAction.UnlockLink:
             case ItemActionAction.OccultRecords:
@@ -330,19 +331,19 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
                 return UIState.Instance()->IsTripleTriadCardUnlocked((ushort)row.AdditionalData.RowId);
 
             case ItemActionAction.FolkloreTome:
-                return PlayerState.Instance()->IsFolkloreBookUnlocked(row.ItemAction.Value.Data[0]);
+                return CSPlayerState.Instance()->IsFolkloreBookUnlocked(row.ItemAction.Value.Data[0]);
 
             case ItemActionAction.OrchestrionRoll when row.AdditionalData.Is<Orchestrion>():
-                return PlayerState.Instance()->IsOrchestrionRollUnlocked(row.AdditionalData.RowId);
+                return CSPlayerState.Instance()->IsOrchestrionRollUnlocked(row.AdditionalData.RowId);
 
             case ItemActionAction.FramersKit:
-                return PlayerState.Instance()->IsFramersKitUnlocked(row.AdditionalData.RowId);
+                return CSPlayerState.Instance()->IsFramersKitUnlocked(row.AdditionalData.RowId);
 
             case ItemActionAction.Ornament:
-                return PlayerState.Instance()->IsOrnamentUnlocked(row.ItemAction.Value.Data[0]);
+                return CSPlayerState.Instance()->IsOrnamentUnlocked(row.ItemAction.Value.Data[0]);
 
             case ItemActionAction.Glasses:
-                return PlayerState.Instance()->IsGlassesUnlocked((ushort)row.AdditionalData.RowId);
+                return CSPlayerState.Instance()->IsGlassesUnlocked((ushort)row.AdditionalData.RowId);
 
             case ItemActionAction.SoulShards when PublicContentOccultCrescent.GetState() is var occultCrescentState && occultCrescentState != null:
                 var supportJobId = (byte)row.ItemAction.Value.Data[0];
@@ -383,7 +384,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         if (!this.IsLoaded)
             return false;
 
-        return PlayerState.Instance()->IsMcGuffinUnlocked(row.RowId);
+        return CSPlayerState.Instance()->IsMcGuffinUnlocked(row.RowId);
     }
 
     /// <inheritdoc/>
@@ -392,7 +393,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         if (!this.IsLoaded)
             return false;
 
-        return PlayerState.Instance()->IsMountUnlocked(row.RowId);
+        return CSPlayerState.Instance()->IsMountUnlocked(row.RowId);
     }
 
     /// <inheritdoc/>
@@ -407,7 +408,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         if (!this.IsLoaded)
             return false;
 
-        return PlayerState.Instance()->IsOrchestrionRollUnlocked(row.RowId);
+        return CSPlayerState.Instance()->IsOrchestrionRollUnlocked(row.RowId);
     }
 
     /// <inheritdoc/>
@@ -416,7 +417,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         if (!this.IsLoaded)
             return false;
 
-        return PlayerState.Instance()->IsOrnamentUnlocked(row.RowId);
+        return CSPlayerState.Instance()->IsOrnamentUnlocked(row.RowId);
     }
 
     /// <inheritdoc/>
@@ -458,7 +459,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         if (!this.IsLoaded)
             return false;
 
-        return PlayerState.Instance()->IsSecretRecipeBookUnlocked(row.RowId);
+        return CSPlayerState.Instance()->IsSecretRecipeBookUnlocked(row.RowId);
     }
 
     /// <inheritdoc/>

--- a/Dalamud/Game/UnlockState/UnlockState.cs
+++ b/Dalamud/Game/UnlockState/UnlockState.cs
@@ -44,11 +44,15 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
     private readonly GameGui gameGui = Service<GameGui>.Get();
 
     [ServiceManager.ServiceDependency]
+    private readonly TargetSigScanner sigScanner = Service<TargetSigScanner>.Get();
+
+    [ServiceManager.ServiceDependency]
     private readonly RecipeData recipeData = Service<RecipeData>.Get();
 
     private readonly ConcurrentDictionary<Type, HashSet<uint>> cachedUnlockedRowIds = [];
     private readonly Hook<CSAchievement.Delegates.SetAchievementCompleted> setAchievementCompletedHook;
     private readonly Hook<TitleList.Delegates.SetTitleUnlocked> setTitleUnlockedHook;
+    private readonly Hook<SetOrnamentUnlockedDelegate> setOrnamentUnlockedHook;
 
     [ServiceManager.ServiceConstructor]
     private UnlockState()
@@ -65,9 +69,17 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
             (nint)TitleList.MemberFunctionPointers.SetTitleUnlocked,
             this.SetTitleUnlockedDetour);
 
+        // TODO: replace with PlayerState.SetOrnamentUnlocked
+        this.setOrnamentUnlockedHook = Hook<SetOrnamentUnlockedDelegate>.FromAddress(
+            this.sigScanner.ScanText("48 89 5C 24 ?? 57 48 83 EC ?? 8B DA 41 0F B6 F8 C1 EA"),
+            this.SetOrnamentUnlockedDetour);
+
         this.setAchievementCompletedHook.Enable();
         this.setTitleUnlockedHook.Enable();
+        this.setOrnamentUnlockedHook.Enable();
     }
+
+    private delegate void SetOrnamentUnlockedDelegate(CSPlayerState* thisPtr, uint ornamentId, byte isUnlocked);
 
     /// <inheritdoc/>
     public event IUnlockState.UnlockDelegate Unlock;
@@ -89,6 +101,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
 
         this.setAchievementCompletedHook.Dispose();
         this.setTitleUnlockedHook.Dispose();
+        this.setOrnamentUnlockedHook.Dispose();
     }
 
     /// <inheritdoc/>
@@ -709,6 +722,16 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
             return;
 
         this.RaiseUnlockSafely((RowRef)LuminaUtils.CreateRef<Title>(id));
+    }
+
+    private void SetOrnamentUnlockedDetour(CSPlayerState* thisPtr, uint ornamentId, byte isUnlocked)
+    {
+        this.setOrnamentUnlockedHook.Original(thisPtr, ornamentId, isUnlocked);
+
+        if (isUnlocked == 0 || !this.IsLoaded)
+            return;
+
+        this.RaiseUnlockSafely((RowRef)LuminaUtils.CreateRef<Ornament>(ornamentId));
     }
 
     private void Update()

--- a/Dalamud/Game/UnlockState/UnlockState.cs
+++ b/Dalamud/Game/UnlockState/UnlockState.cs
@@ -88,6 +88,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         this.gameGui.AgentUpdate -= this.OnAgentUpdate;
 
         this.setAchievementCompletedHook.Dispose();
+        this.setTitleUnlockedHook.Dispose();
     }
 
     /// <inheritdoc/>

--- a/Dalamud/Game/UnlockState/UnlockState.cs
+++ b/Dalamud/Game/UnlockState/UnlockState.cs
@@ -301,7 +301,17 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         if (!this.IsLoaded)
             return false;
 
-        return CSPlayerState.Instance()->IsGlassesUnlocked((ushort)row.RowId);
+        return row.Style.IsValid && this.IsGlassesStyleUnlocked(row.Style.Value);
+    }
+
+    /// <inheritdoc/>
+    public bool IsGlassesStyleUnlocked(GlassesStyle row)
+    {
+        if (!this.IsLoaded)
+            return false;
+
+        return CSPlayerState.Instance()->UnlockedGlassesStylesBitArray.TryGet((int)row.RowId, out var isUnlocked)
+            && isUnlocked;
     }
 
     /// <inheritdoc/>
@@ -614,6 +624,9 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         if (rowRef.TryGetValue<Glasses>(out var glassesRow))
             return this.IsGlassesUnlocked(glassesRow);
 
+        if (rowRef.TryGetValue<GlassesStyle>(out var glassesStyleRow))
+            return this.IsGlassesStyleUnlocked(glassesStyleRow);
+
         if (rowRef.TryGetValue<HowTo>(out var howToRow))
             return this.IsHowToUnlocked(howToRow);
 
@@ -785,6 +798,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         this.UpdateUnlocksForSheet<Emote>();
         this.UpdateUnlocksForSheet<GeneralAction>();
         this.UpdateUnlocksForSheet<Glasses>();
+        this.UpdateUnlocksForSheet<GlassesStyle>();
         this.UpdateUnlocksForSheet<HowTo>();
         this.UpdateUnlocksForSheet<InstanceContentSheet>();
         this.UpdateUnlocksForSheet<Item>();
@@ -966,6 +980,9 @@ internal class UnlockStatePluginScoped : IInternalDisposableService, IUnlockStat
 
     /// <inheritdoc/>
     public bool IsGlassesUnlocked(Glasses row) => this.unlockStateService.IsGlassesUnlocked(row);
+
+    /// <inheritdoc/>
+    public bool IsGlassesStyleUnlocked(GlassesStyle row) => this.unlockStateService.IsGlassesStyleUnlocked(row);
 
     /// <inheritdoc/>
     public bool IsHowToUnlocked(HowTo row) => this.unlockStateService.IsHowToUnlocked(row);

--- a/Dalamud/Plugin/Services/IUnlockState.cs
+++ b/Dalamud/Plugin/Services/IUnlockState.cs
@@ -201,6 +201,13 @@ public interface IUnlockState : IDalamudService
     bool IsGlassesUnlocked(Glasses row);
 
     /// <summary>
+    /// Determines whether the specified GlassesStyle is unlocked.
+    /// </summary>
+    /// <param name="row">The GlassesStyle row to check.</param>
+    /// <returns><see langword="true"/> if unlocked; otherwise, <see langword="false"/>.</returns>
+    bool IsGlassesStyleUnlocked(GlassesStyle row);
+
+    /// <summary>
     /// Determines whether the specified HowTo is unlocked.
     /// </summary>
     /// <param name="row">The HowTo row to check.</param>


### PR DESCRIPTION
- Adds hooks to `PlayerState.SetOrnamentUnlocked` and `PlayerState.SetGlassesStyleUnlocked` to fire the `Unlock` event. These functions don't set `AgentUpdateFlag.UnlocksUpdate`.
- Adds `IUnlockState.IsGlassesStyleUnlocked` and makes use of it internally for `IsGlassesUnlocked` in order to avoid an excel lookup in the native function.
- Adds a missing Dispose call for the `SetTitleUnlocked` hook.