### PR TITLE
Prevent freeing stackallocated AtkValue

### DIFF
--- a/Dalamud/Game/Agent/AgentVirtualTable.cs
+++ b/Dalamud/Game/Agent/AgentVirtualTable.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -9,6 +9,8 @@ using Dalamud.Logging.Internal;
 using FFXIVClientStructs.FFXIV.Client.System.Memory;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Component.GUI;
+
+using AtkValueType = FFXIVClientStructs.FFXIV.Component.GUI.ValueType;
 
 namespace Dalamud.Game.Agent;
 
@@ -146,7 +148,8 @@ internal unsafe class AgentVirtualTable : IDisposable
                 }
                 else
                 {
-                    result->SetBool(false);
+                    result->Type = AtkValueType.Bool;
+                    result->Bool = false;
                 }
             }
             catch (Exception e)
@@ -195,7 +198,8 @@ internal unsafe class AgentVirtualTable : IDisposable
                 }
                 else
                 {
-                    result->SetBool(false);
+                    result->Type = AtkValueType.Bool;
+                    result->Bool = false;
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
The `returnValue` that is passed to an agents ReceiveEvent is always stackallocated and its memory is not cleared (see `Component::GUI::AtkUnitBase.FireCallback`).
Calling the CS helper [AtkValue.SetBool](https://github.com/aers/FFXIVClientStructs/blob/89ccac3/FFXIVClientStructs/FFXIV/Component/GUI/AtkValue.cs#L127) when the `ValueType.Managed` flag is randomy set by garbage on the stack, will cause it to try and access/free a garbage pointer, ending up in a crash.
All the agents just set the Type and Bool directly, so we should do the same.