### PR TITLE
Add ImGui.EndTabItem call to end of Blur tab

### DIFF
--- a/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
@@ -367,6 +367,8 @@ public class StyleEditorWindow : Window
                         "This will allow you to set the strength of the blur effect for plugin windows.\n" +
                         "Set to 0% to disable the blur effect. This may not be supported by all of your plugins. Contact the plugin author if you want them to support this feature."));
                 ImGui.PopStyleColor();
+
+                ImGui.EndTabItem();
             }
 
             if (changes)


### PR DESCRIPTION
Adds a call to `ImGui.EndTabItem();` to the end of the new "Blur" tab. Without this the rename modal popup can't appear while the Blur tab is active.