### PR TITLE
Fix bad style index when chosen style is deleted without save

### DIFF
--- a/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
@@ -122,6 +122,8 @@ public class StyleEditorWindow : Window
 
         if (ImGuiComponents.IconButton(FontAwesomeIcon.Trash) && this.currentSel != 0)
         {
+            var deletingChosenStyle = config.ChosenStyle == config.SavedStyles[this.currentSel].Name;
+
             this.currentSel--;
             var newStyle = config.SavedStyles[this.currentSel];
             newStyle.Apply();
@@ -129,6 +131,9 @@ public class StyleEditorWindow : Window
             appliedThisFrame = true;
 
             config.SavedStyles.RemoveAt(this.currentSel + 1);
+
+            if (deletingChosenStyle)
+                config.ChosenStyle = newStyle.Name;
 
             config.QueueSave();
         }


### PR DESCRIPTION
Currently, when the current "chosen" style is deleted, if the style editor is closed with "Close" rather than "Save and Close", we do not update `config.ChosenStyle` (since this is done by the save code) and can end up with a deleted style name in that field. This breaks the style editor window until the game is restarted (at which point it will reset to the default Dalamud Standard style).

With this change, we detect if we're deleting the currently chosen style and update `config.ChosenStyle` with the previous style in the list to prevent an invalid style name being left in the config.