### PR TITLE
Add leaked stack pushes to the plugin draw statistics.

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
@@ -67,18 +67,15 @@ internal class PluginStatWindow : Window
                     {
                         foreach (var plugin in pluginManager.InstalledPlugins)
                         {
-                            if (plugin.DalamudInterface != null)
-                            {
-                                plugin.DalamudInterface.LocalUiBuilder.LastDrawTime = -1;
-                                plugin.DalamudInterface.LocalUiBuilder.MaxDrawTime = -1;
-                                plugin.DalamudInterface.LocalUiBuilder.DrawTimeHistory.Clear();
-                            }
+                            plugin.DalamudInterface?.LocalUiBuilder.PluginDrawStatistics.Reset();
                         }
                     }
 
                     var loadedPlugins = pluginManager.InstalledPlugins.Where(plugin => plugin.State == PluginState.Loaded);
-                    var totalLast = loadedPlugins.Sum(plugin => plugin.DalamudInterface?.LocalUiBuilder.LastDrawTime ?? 0);
-                    var totalAverage = loadedPlugins.Sum(plugin => plugin.DalamudInterface?.LocalUiBuilder.DrawTimeHistory.DefaultIfEmpty().Average() ?? 0);
+                    var pluginStatistics = loadedPlugins.Where(p => p.DalamudInterface is not null)
+                                                        .Select(p => p.DalamudInterface!.LocalUiBuilder.PluginDrawStatistics);
+                    var totalLast = pluginStatistics.Sum(plugin => plugin.LastDrawTime);
+                    var totalAverage = pluginStatistics.Sum(plugin => plugin.AverageDrawTime);
 
                     ImGuiComponents.TextWithLabel("Total Last", $"{totalLast / 10000f:F4}ms", "All last draw times added together");
                     ImGui.SameLine();
@@ -94,7 +91,7 @@ internal class PluginStatWindow : Window
 
                     using var table = ImRaii.Table(
                         "##PluginStatsDrawTimes"u8,
-                        4,
+                        5,
                         ImGuiTableFlags.RowBg
                         | ImGuiTableFlags.SizingStretchProp
                         | ImGuiTableFlags.Sortable
@@ -110,6 +107,7 @@ internal class PluginStatWindow : Window
                         ImGui.TableSetupColumn("Last"u8, ImGuiTableColumnFlags.NoSort); // Changes too fast to sort
                         ImGui.TableSetupColumn("Longest"u8);
                         ImGui.TableSetupColumn("Average"u8);
+                        ImGui.TableSetupColumn("Leaks"u8);
                         ImGui.TableHeadersRow();
 
                         var sortSpecs = ImGui.TableGetSortSpecs();
@@ -119,11 +117,14 @@ internal class PluginStatWindow : Window
                                      ? loadedPlugins.OrderBy(plugin => plugin.Name)
                                      : loadedPlugins.OrderByDescending(plugin => plugin.Name),
                             2 => sortSpecs.Specs.SortDirection == ImGuiSortDirection.Ascending
-                                     ? loadedPlugins.OrderBy(plugin => plugin.DalamudInterface?.LocalUiBuilder.MaxDrawTime ?? 0)
-                                     : loadedPlugins.OrderByDescending(plugin => plugin.DalamudInterface?.LocalUiBuilder.MaxDrawTime ?? 0),
+                                     ? loadedPlugins.OrderBy(plugin => plugin.DalamudInterface?.LocalUiBuilder.PluginDrawStatistics.MaxDrawTime ?? 0)
+                                     : loadedPlugins.OrderByDescending(plugin => plugin.DalamudInterface?.LocalUiBuilder.PluginDrawStatistics.MaxDrawTime ?? 0),
                             3 => sortSpecs.Specs.SortDirection == ImGuiSortDirection.Ascending
-                                     ? loadedPlugins.OrderBy(plugin => plugin.DalamudInterface?.LocalUiBuilder.DrawTimeHistory.DefaultIfEmpty().Average() ?? 0)
-                                     : loadedPlugins.OrderByDescending(plugin => plugin.DalamudInterface?.LocalUiBuilder.DrawTimeHistory.DefaultIfEmpty().Average() ?? 0),
+                                     ? loadedPlugins.OrderBy(plugin => plugin.DalamudInterface?.LocalUiBuilder.PluginDrawStatistics.AverageDrawTime ?? 0)
+                                     : loadedPlugins.OrderByDescending(plugin => plugin.DalamudInterface?.LocalUiBuilder.PluginDrawStatistics.AverageDrawTime ?? 0),
+                            4 => sortSpecs.Specs.SortDirection == ImGuiSortDirection.Ascending
+                                     ? loadedPlugins.OrderBy(plugin => plugin.DalamudInterface?.LocalUiBuilder.PluginDrawStatistics.LeakedStacks ?? 0)
+                                     : loadedPlugins.OrderByDescending(plugin => plugin.DalamudInterface?.LocalUiBuilder.PluginDrawStatistics.LeakedStacks ?? 0),
                             _ => loadedPlugins,
                         };
 
@@ -140,18 +141,39 @@ internal class PluginStatWindow : Window
                             ImGui.TableNextColumn();
                             ImGui.Text(plugin.Manifest.Name);
 
-                            if (plugin.DalamudInterface != null)
+                            if (plugin.DalamudInterface?.LocalUiBuilder.PluginDrawStatistics is {} stats)
                             {
                                 ImGui.TableNextColumn();
-                                ImGui.Text($"{plugin.DalamudInterface.LocalUiBuilder.LastDrawTime / 10000f:F4}ms");
+                                ImGui.Text($"{stats.LastDrawTime / 10000f:F4}ms");
 
                                 ImGui.TableNextColumn();
-                                ImGui.Text($"{plugin.DalamudInterface.LocalUiBuilder.MaxDrawTime / 10000f:F4}ms");
+                                ImGui.Text($"{stats.MaxDrawTime / 10000f:F4}ms");
 
                                 ImGui.TableNextColumn();
-                                ImGui.Text(plugin.DalamudInterface.LocalUiBuilder.DrawTimeHistory.Count > 0
-                                               ? $"{plugin.DalamudInterface.LocalUiBuilder.DrawTimeHistory.Average() / 10000f:F4}ms"
-                                               : "-");
+                                ImGui.Text($"{stats.AverageDrawTime / 10000f:F4}ms");
+
+                                ImGui.TableNextColumn();
+                                ImGui.Text($"{stats.LeakedStacks}");
+                                if (ImGui.IsItemHovered())
+                                {
+                                    using var tt = ImRaii.Tooltip();
+                                    using (ImRaii.Group())
+                                    {
+                                        ImGui.Text("Leaked Styles"u8);
+                                        ImGui.Text("Leaked Colors"u8);
+                                        ImGui.Text("Leaked Fonts"u8);
+                                        ImGui.Text("Leaked Disableds"u8);
+                                    }
+
+                                    ImGui.SameLine();
+                                    using (ImRaii.Group())
+                                    {
+                                        ImGui.Text($"{stats.LeakedStyles}");
+                                        ImGui.Text($"{stats.LeakedColors}");
+                                        ImGui.Text($"{stats.LeakedFonts}");
+                                        ImGui.Text($"{stats.LeakedDisableds}");
+                                    }
+                                }
                             }
                         }
                     }

--- a/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginStatWindow.cs
@@ -141,7 +141,7 @@ internal class PluginStatWindow : Window
                             ImGui.TableNextColumn();
                             ImGui.Text(plugin.Manifest.Name);
 
-                            if (plugin.DalamudInterface?.LocalUiBuilder.PluginDrawStatistics is {} stats)
+                            if (plugin.DalamudInterface?.LocalUiBuilder.PluginDrawStatistics is { } stats)
                             {
                                 ImGui.TableNextColumn();
                                 ImGui.Text($"{stats.LastDrawTime / 10000f:F4}ms");

--- a/Dalamud/Interface/PluginDrawStatistics.cs
+++ b/Dalamud/Interface/PluginDrawStatistics.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+using Dalamud.Bindings.ImGui;
+
+namespace Dalamud.Interface;
+
+/// <summary> 
+/// Tracks draw timing statistics and resource stack leaks for a plugin's rendering operations.
+/// </summary>
+internal sealed class PluginDrawStatistics
+{
+    private readonly Stopwatch stopwatch = new();
+    private readonly Queue<long> drawTimeHistory = [];
+
+    private int styleStack;
+    private int colorStack;
+    private int fontStack;
+    private short disabledStack;
+
+    /// <summary>
+    /// Gets the time this plugin took to draw on the last frame.
+    /// </summary>
+    public long LastDrawTime { get; private set; } = -1;
+
+    /// <summary>
+    /// Gets the longest amount of time this plugin ever took to draw.
+    /// </summary>
+    public long MaxDrawTime { get; private set; } = -1;
+
+    /// <summary> 
+    /// Gets the average draw time.
+    /// </summary>
+    public long AverageDrawTime { get; private set; } = -1;
+
+    /// <summary> Gets the total amount of leaked style variables from this plugin. </summary>
+    public int LeakedStyles { get; private set; }
+
+    /// <summary> Gets the total amount of leaked colors from this plugin. </summary>
+    public int LeakedColors { get; private set; }
+
+    /// <summary> Gets the total amount of leaked fonts from this plugin. </summary>
+    public int LeakedFonts { get; private set; }
+
+    /// <summary> Gets the total amount of leaked disabled states from this plugin. </summary>
+    public int LeakedDisableds { get; private set; }
+
+    /// <summary> Gets the total amount of leaked stack values from this plugin. </summary>
+    public int LeakedStacks { get; private set; }
+
+    /// <summary> Initialize the data tracking before the actual draw operation. </summary>
+    public void StartUpdate()
+    {
+        this.stopwatch.Restart();
+        var context = ImGui.GetCurrentContext();
+        this.styleStack = context.StyleVarStack.Size;
+        this.colorStack = context.ColorStack.Size;
+        this.fontStack = context.FontStack.Size;
+        this.disabledStack = context.DisabledStackSize;
+        this.drawTimeHistory.EnsureCapacity(100);
+    }
+
+    /// <summary> Finalize and update the tracked data after the actual draw operation. </summary>
+    public void EndUpdate()
+    {
+        this.stopwatch.Stop();
+        this.LastDrawTime = this.stopwatch.ElapsedTicks;
+        this.MaxDrawTime = Math.Max(this.LastDrawTime, this.MaxDrawTime);
+        while (this.drawTimeHistory.Count >= 100) this.drawTimeHistory.Dequeue();
+        this.drawTimeHistory.Enqueue(this.LastDrawTime);
+        this.AverageDrawTime = this.drawTimeHistory.Sum() / this.drawTimeHistory.Count;
+
+        var context = ImGui.GetCurrentContext();
+        if (this.styleStack < context.StyleVarStack.Size)
+            this.LeakedStyles += context.StyleVarStack.Size - this.styleStack;
+        if (this.colorStack < context.ColorStack.Size)
+            this.LeakedColors += context.ColorStack.Size - this.colorStack;
+        if (this.fontStack < context.FontStack.Size)
+            this.LeakedFonts += context.FontStack.Size - this.fontStack;
+        if (this.disabledStack < context.DisabledStackSize)
+            this.LeakedDisableds += context.DisabledStackSize - this.disabledStack;
+        this.LeakedStacks = this.LeakedStyles + this.LeakedColors + this.LeakedFonts + this.LeakedDisableds;
+    }
+
+    /// <summary> Clear all tracking data. </summary>
+    public void Reset()
+    {
+        this.AverageDrawTime = -1;
+        this.LastDrawTime = -1;
+        this.MaxDrawTime = -1;
+        this.drawTimeHistory.Clear();
+        this.LeakedStyles = 0;
+        this.LeakedColors = 0;
+        this.LeakedFonts = 0;
+        this.LeakedDisableds = 0;
+        this.LeakedStacks = 0;
+    }
+}

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -288,8 +286,8 @@ public interface IUiBuilder
 /// </summary>
 public sealed class UiBuilder : IDisposable, IUiBuilder
 {
+
     private readonly LocalPlugin plugin;
-    private readonly Stopwatch stopwatch;
     private readonly HitchDetector hitchDetector;
     private readonly string namespaceName;
     private readonly InterfaceManager interfaceManager = Service<InterfaceManager>.Get();
@@ -318,7 +316,6 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
     {
         try
         {
-            this.stopwatch = new Stopwatch();
             this.hitchDetector = new HitchDetector($"UiBuilder({namespaceName})", this.configuration.UiBuilderHitch);
             this.namespaceName = namespaceName;
             this.plugin = plugin;
@@ -594,6 +591,9 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
     internal static bool DoStats { get; set; } = false;
 #endif
 
+    /// <summary> Gets draw statistics for this plugin. </summary>
+    internal PluginDrawStatistics PluginDrawStatistics { get; } = new();
+
     /// <summary>
     /// Gets a value indicating whether this UiBuilder has a configuration UI registered.
     /// </summary>
@@ -603,21 +603,6 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
     /// Gets a value indicating whether this UiBuilder has a configuration UI registered.
     /// </summary>
     internal bool HasMainUi => this.OpenMainUi != null;
-
-    /// <summary>
-    /// Gets or sets the time this plugin took to draw on the last frame.
-    /// </summary>
-    internal long LastDrawTime { get; set; } = -1;
-
-    /// <summary>
-    /// Gets or sets the longest amount of time this plugin ever took to draw.
-    /// </summary>
-    internal long MaxDrawTime { get; set; } = -1;
-
-    /// <summary>
-    /// Gets or sets a history of the last draw times, used to calculate an average.
-    /// </summary>
-    internal List<long> DrawTimeHistory { get; set; } = [];
 
     private InterfaceManager? InterfaceManagerWithScene =>
         Service<InterfaceManager.InterfaceManagerWithScene>.GetNullable()?.Manager;
@@ -786,10 +771,7 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
         }
 
         ImGui.PushID(this.namespaceName);
-        if (DoStats)
-        {
-            this.stopwatch.Restart();
-        }
+        if (DoStats) this.PluginDrawStatistics.StartUpdate();
 
         if (this.hasErrorWindow)
         {
@@ -822,14 +804,7 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
 
         this.FrameCount++;
 
-        if (DoStats)
-        {
-            this.stopwatch.Stop();
-            this.LastDrawTime = this.stopwatch.ElapsedTicks;
-            this.MaxDrawTime = Math.Max(this.LastDrawTime, this.MaxDrawTime);
-            this.DrawTimeHistory.Add(this.LastDrawTime);
-            while (this.DrawTimeHistory.Count > 100) this.DrawTimeHistory.RemoveAt(0);
-        }
+        if (DoStats) this.PluginDrawStatistics.EndUpdate();
 
         ImGui.PopID();
 

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -286,7 +286,6 @@ public interface IUiBuilder
 /// </summary>
 public sealed class UiBuilder : IDisposable, IUiBuilder
 {
-
     private readonly LocalPlugin plugin;
     private readonly HitchDetector hitchDetector;
     private readonly string namespaceName;


### PR DESCRIPTION
Adds tracking of the four major style stacks in Dalamud to the start and end of plugin-local draw events, when statistics are tracked.

Also refactors the draw statistics a bit.