### PR TITLE
Fix FollowJmp mishandling indirect jumps

### DIFF
--- a/Dalamud/Hooking/Internal/HookManager.cs
+++ b/Dalamud/Hooking/Internal/HookManager.cs
@@ -135,6 +135,10 @@ internal class HookManager : IInternalDisposableService
                         newAddress = (IntPtr)inst.IPRelativeMemoryAddress;
                         newAddress = Marshal.ReadIntPtr(newAddress);
                         break;
+                    case OpKind.Memory when inst.IsJmpNearIndirect:
+                    case OpKind.Memory when inst.IsJmpFarIndirect:
+                        Log.Verbose($"Encountered indirect assembly jump ({kind}) from {address.ToInt64():X}, returning unresolved");
+                        return address;
                     case OpKind.Memory:
                         newAddress = (IntPtr)inst.MemoryDisplacement64;
                         newAddress = Marshal.ReadIntPtr(newAddress);


### PR DESCRIPTION
Required to not crash when AsmHooking instructions such as this one in dxvk:

<img width="645" height="262" alt="image" src="https://github.com/user-attachments/assets/9382de69-1050-4f7a-9b66-f531fb588d2d" />


Right now, it misuses the relative offset as an absolute address:

<img width="636" height="144" alt="image" src="https://github.com/user-attachments/assets/7efc89fa-036c-42ff-bc3b-abf77e4178b0" />

<img width="349" height="120" alt="image" src="https://github.com/user-attachments/assets/88472b69-ed92-440a-aa43-84112f81f595" />


I wasn't sure whether to throw because of it being an error, or simply return early as that's the least destructive action here and fixes plugins affected by this (namely CustomResolution on Linux). I went with an early return for now though.