### PR TITLE
Update ClientStructs to ce5287dce8 and adapt to 7.5 API changes

### DIFF
--- a/Dalamud/Data/RsvResolver.cs
+++ b/Dalamud/Data/RsvResolver.cs
@@ -6,6 +6,8 @@ using Dalamud.Logging.Internal;
 
 using FFXIVClientStructs.FFXIV.Client.LayoutEngine;
 
+using InteropGenerator.Runtime;
+
 using Lumina.Text.ReadOnly;
 
 namespace Dalamud.Data;
@@ -42,9 +44,9 @@ internal sealed unsafe class RsvResolver : IDisposable
         this.addRsvStringHook.Dispose();
     }
 
-    private bool AddRsvStringDetour(LayoutWorld* @this, byte* rsvString, byte* resolvedString, nuint resolvedStringSize)
+    private bool AddRsvStringDetour(LayoutWorld* @this, CStringPointer rsvString, byte* resolvedString, nuint resolvedStringSize)
     {
-        var rsv = new ReadOnlySeString(MemoryMarshal.CreateReadOnlySpanFromNullTerminated(rsvString));
+        var rsv = new ReadOnlySeString(rsvString.AsSpan());
         var resolved = new ReadOnlySeString(new ReadOnlySpan<byte>(resolvedString, (int)resolvedStringSize));
         Log.Debug($"Resolving RSV \"{rsv}\" to \"{resolved}\".");
         this.Lookup[rsv] = resolved;

--- a/Dalamud/Game/Addon/Events/AddonEventManager.cs
+++ b/Dalamud/Game/Addon/Events/AddonEventManager.cs
@@ -173,7 +173,7 @@ internal unsafe class AddonEventManager : IInternalDisposableService
 
                 if (atkCursor.Type != this.cursorOverride)
                 {
-                    atkCursor.SetCursorType((AtkCursor.CursorType)this.cursorOverride, 1);
+                    atkCursor.SetCursorType((AtkCursor.CursorType)this.cursorOverride, true);
                 }
 
                 return;

--- a/Dalamud/Game/Addon/Events/EventDataTypes/AddonMouseEventData.cs
+++ b/Dalamud/Game/Addon/Events/EventDataTypes/AddonMouseEventData.cs
@@ -3,7 +3,7 @@
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 using AtkMouseData = FFXIVClientStructs.FFXIV.Component.GUI.AtkEventData.AtkMouseData;
-using ModifierFlag = FFXIVClientStructs.FFXIV.Component.GUI.AtkEventData.AtkMouseData.ModifierFlag;
+using ModifierFlag = FFXIVClientStructs.FFXIV.Component.GUI.ModifierFlag;
 
 namespace Dalamud.Game.Addon.Events.EventDataTypes;
 

--- a/Dalamud/Game/Agent/AgentLifecycle.cs
+++ b/Dalamud/Game/Agent/AgentLifecycle.cs
@@ -171,9 +171,9 @@ internal unsafe class AgentLifecycle : IInternalDisposableService
         this.isInvokingListeners = false;
     }
 
-    private void OnAgentModuleInitialize(AgentModule* thisPtr, UIModule* uiModule)
+    private AgentModule* OnAgentModuleInitialize(AgentModule* thisPtr, UIModule* uiModule)
     {
-        this.onInitializeAgentsHook!.Original(thisPtr, uiModule);
+        var result = this.onInitializeAgentsHook!.Original(thisPtr, uiModule);
 
         try
         {
@@ -187,6 +187,8 @@ internal unsafe class AgentLifecycle : IInternalDisposableService
         {
             Log.Error(e, "Exception in AgentLifecycle during AgentModule Ctor.");
         }
+
+        return result;
     }
 
     private void RegisterListenerMethod(AgentLifecycleEventListener listener)

--- a/Dalamud/Game/Agent/AgentVirtualTable.cs
+++ b/Dalamud/Game/Agent/AgentVirtualTable.cs
@@ -10,7 +10,7 @@ using FFXIVClientStructs.FFXIV.Client.System.Memory;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
-using AtkValueType = FFXIVClientStructs.FFXIV.Component.GUI.ValueType;
+using AtkValueType = FFXIVClientStructs.FFXIV.Component.GUI.AtkValueType;
 
 namespace Dalamud.Game.Agent;
 
@@ -94,7 +94,7 @@ internal unsafe class AgentVirtualTable : IDisposable
         this.ModifiedVirtualTable->Show = (delegate* unmanaged<AgentInterface*, void>)Marshal.GetFunctionPointerForDelegate(this.showFunction);
         this.ModifiedVirtualTable->Hide = (delegate* unmanaged<AgentInterface*, void>)Marshal.GetFunctionPointerForDelegate(this.hideFunction);
         this.ModifiedVirtualTable->Update = (delegate* unmanaged<AgentInterface*, uint, void>)Marshal.GetFunctionPointerForDelegate(this.updateFunction);
-        this.ModifiedVirtualTable->OnGameEvent = (delegate* unmanaged<AgentInterface*, AgentInterface.GameEvent, void>)Marshal.GetFunctionPointerForDelegate(this.gameEventFunction);
+        this.ModifiedVirtualTable->OnGameEvent = (delegate* unmanaged<AgentInterface*, AgentGameEvent, void>)Marshal.GetFunctionPointerForDelegate(this.gameEventFunction);
         this.ModifiedVirtualTable->OnLevelChange = (delegate* unmanaged<AgentInterface*, byte, ushort, void>)Marshal.GetFunctionPointerForDelegate(this.levelChangeFunction);
         this.ModifiedVirtualTable->OnClassJobChange = (delegate* unmanaged<AgentInterface*, byte, void>)Marshal.GetFunctionPointerForDelegate(this.classJobChangeFunction);
     }
@@ -313,7 +313,7 @@ internal unsafe class AgentVirtualTable : IDisposable
         }
     }
 
-    private void OnAgentGameEvent(AgentInterface* thisPtr, AgentInterface.GameEvent gameEvent)
+    private void OnAgentGameEvent(AgentInterface* thisPtr, AgentGameEvent gameEvent)
     {
         try
         {
@@ -326,7 +326,7 @@ internal unsafe class AgentVirtualTable : IDisposable
 
             this.lifecycleService.InvokeListenersSafely(AgentEvent.PreGameEvent, this.gameEventArgs);
 
-            gameEvent = (AgentInterface.GameEvent)this.gameEventArgs.GameEvent;
+            gameEvent = (AgentGameEvent)this.gameEventArgs.GameEvent;
 
             try
             {

--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -332,7 +332,7 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
                 break;
             }
 
-            case UIModulePacketType.InitZone:
+            case UIModulePacketType.ZoneInit:
             {
                 var eventArgs = ZoneInitEventArgs.Read((nint)packet);
                 Log.Debug($"ZoneInit: {eventArgs}");

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -303,7 +303,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
 
             this.HandlePrintMessageDetour(
                 RaptureLogModule.Instance(),
-                (ushort)targetChannel,
+                new LogInfo { Value = (ushort)targetChannel },
                 &sender,
                 &message,
                 chat.Timestamp,
@@ -377,13 +377,13 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
         }
     }
 
-    private uint HandlePrintMessageDetour(RaptureLogModule* thisPtr, ushort logInfo, Utf8String* senderName, Utf8String* message, int timestamp, bool silent)
+    private uint HandlePrintMessageDetour(RaptureLogModule* thisPtr, LogInfo logInfo, Utf8String* senderName, Utf8String* message, int timestamp, bool silent)
     {
         var messageId = 0u;
 
         try
         {
-            var chatType = (XivChatType)logInfo;
+            var chatType = (XivChatType)logInfo.Value;
 
             var parsedSender = SeString.Parse(senderName->AsSpan());
             var parsedMessage = SeString.Parse(message->AsSpan());

--- a/Dalamud/Game/Gui/ContextMenu/ContextMenu.cs
+++ b/Dalamud/Game/Gui/ContextMenu/ContextMenu.cs
@@ -21,7 +21,7 @@ using FFXIVClientStructs.FFXIV.Component.GUI;
 
 using InteropGenerator.Runtime;
 
-using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.ValueType;
+using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.AtkValueType;
 
 namespace Dalamud.Game.Gui.ContextMenu;
 

--- a/Dalamud/Game/Gui/FlyText/FlyTextGui.cs
+++ b/Dalamud/Game/Gui/FlyText/FlyTextGui.cs
@@ -12,6 +12,8 @@ using Dalamud.Plugin.Services;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
+using InteropGenerator.Runtime;
+
 using Serilog;
 
 namespace Dalamud.Game.Gui.FlyText;
@@ -84,11 +86,11 @@ internal sealed class FlyTextGui : IInternalDisposableService, IFlyTextGui
         int kind,
         int val1,
         int val2,
-        byte* text2,
+        CStringPointer text2,
         uint color,
         uint icon,
         uint damageTypeIcon,
-        byte* text1,
+        CStringPointer text1,
         float yOffset)
     {
         var retVal = nint.Zero;
@@ -101,8 +103,8 @@ internal sealed class FlyTextGui : IInternalDisposableService, IFlyTextGui
             var tmpKind = (FlyTextKind)kind;
             var tmpVal1 = val1;
             var tmpVal2 = val2;
-            var tmpText1 = text1 == null ? string.Empty : MemoryHelper.ReadSeStringNullTerminated((nint)text1);
-            var tmpText2 = text2 == null ? string.Empty : MemoryHelper.ReadSeStringNullTerminated((nint)text2);
+            var tmpText1 = !text1.HasValue ? string.Empty : MemoryHelper.ReadSeStringNullTerminated((nint)text1.Value);
+            var tmpText2 = !text2.HasValue ? string.Empty : MemoryHelper.ReadSeStringNullTerminated((nint)text2.Value);
             var tmpColor = color;
             var tmpIcon = icon;
             var tmpDamageTypeIcon = damageTypeIcon;
@@ -113,7 +115,7 @@ internal sealed class FlyTextGui : IInternalDisposableService, IFlyTextGui
 
             Log.Verbose($"[FlyText] Called with addonFlyText({(nint)thisPtr:X}) " +
                         $"kind({kind}) val1({val1}) val2({val2}) damageTypeIcon({damageTypeIcon}) " +
-                        $"text1({(nint)text1:X}, \"{tmpText1}\") text2({(nint)text2:X}, \"{tmpText2}\") " +
+                        $"text1({(nint)text1.Value:X}, \"{tmpText1}\") text2({(nint)text2.Value:X}, \"{tmpText2}\") " +
                         $"color({color:X}) icon({icon}) yOffset({yOffset})");
             Log.Verbose("[FlyText] Calling flytext events!");
             foreach (var d in Delegate.EnumerateInvocationList(this.FlyTextCreated))

--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -309,7 +309,7 @@ internal sealed unsafe class GameGui : IInternalDisposableService, IGameGui
         return ret;
     }
 
-    private void HandleActionHoverDetour(AgentActionDetail* hoverState, FFXIVClientStructs.FFXIV.Client.UI.Agent.ActionKind actionKind, uint actionId, int a4, bool a5, int a6, int a7)
+    private void HandleActionHoverDetour(AgentActionDetail* hoverState, FFXIVClientStructs.FFXIV.Client.Enums.DetailKind actionKind, uint actionId, int a4, bool a5, int a6, int a7)
     {
         this.handleActionHoverHook.Original(hoverState, actionKind, actionId, a4, a5, a6, a7);
         this.HoveredAction.ActionKind = (HoverActionKind)actionKind;

--- a/Dalamud/Game/Gui/PartyFinder/PartyFinderGui.cs
+++ b/Dalamud/Game/Gui/PartyFinder/PartyFinderGui.cs
@@ -7,6 +7,7 @@ using Dalamud.IoC;
 using Dalamud.IoC.Internal;
 using Dalamud.Plugin.Services;
 
+using FFXIVClientStructs.FFXIV.Client.Game.Network;
 using FFXIVClientStructs.FFXIV.Client.UI.Info;
 
 using Serilog;
@@ -56,11 +57,11 @@ internal sealed unsafe class PartyFinderGui : IInternalDisposableService, IParty
         }
     }
 
-    private void HandleReceiveListingDetour(InfoProxyCrossRealm* infoProxy, nint packet)
+    private void HandleReceiveListingDetour(InfoProxyCrossRealm* infoProxy, ServerIpcSegment<CrossRealmListingSegmentPacket>* packet)
     {
         try
         {
-            this.HandleListingEvents(packet);
+            this.HandleListingEvents((nint)packet);
         }
         catch (Exception ex)
         {

--- a/Dalamud/Game/Internal/DalamudAtkTweaks.cs
+++ b/Dalamud/Game/Internal/DalamudAtkTweaks.cs
@@ -21,7 +21,7 @@ using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
-using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.ValueType;
+using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.AtkValueType;
 
 namespace Dalamud.Game.Internal;
 
@@ -186,7 +186,7 @@ internal sealed unsafe class DalamudAtkTweaks : IInternalDisposableService
 
             addonSelectYesno->YesButton->SetEnabledState(false);
             addonSelectYesno->NoButton->SetEnabledState(false);
-            addonSelectYesno->DisableUserClose = true;
+            addonSelectYesno->ShouldFireCallbackAndHideOrClose = true;
 
             var cts = new CancellationTokenSource();
             cts.CancelAfter(60000);
@@ -197,7 +197,7 @@ internal sealed unsafe class DalamudAtkTweaks : IInternalDisposableService
             {
                 Service<Framework>.Get().Run(() =>
                 {
-                    addonSelectYesno->DisableUserClose = false;
+                    addonSelectYesno->ShouldFireCallbackAndHideOrClose = false;
                     addonSelectYesno->YesButton->SetEnabledState(true);
                     addonSelectYesno->NoButton->SetEnabledState(true);
                     addonSelectYesno->Close(false);

--- a/Dalamud/Game/Network/Internal/NetworkHandlers.cs
+++ b/Dalamud/Game/Network/Internal/NetworkHandlers.cs
@@ -17,7 +17,7 @@ using Dalamud.Hooking;
 using Dalamud.Networking.Http;
 using Dalamud.Utility;
 
-using FFXIVClientStructs.FFXIV.Client.Game.InstanceContent;
+using FFXIVClientStructs.FFXIV.Client.Game.Network;
 using FFXIVClientStructs.FFXIV.Client.Network;
 using FFXIVClientStructs.FFXIV.Client.UI.Info;
 
@@ -41,7 +41,7 @@ internal unsafe class NetworkHandlers : IInternalDisposableService
 
     private readonly NetworkHandlersAddressResolver addressResolver;
 
-    private readonly Hook<PublicContentDirector.Delegates.HandleEnterContentInfoPacket> cfPopHook;
+    private readonly Hook<PacketDispatcher.Delegates.HandleContentsFinderNotificationPacket> cfPopHook;
     private readonly Hook<PacketDispatcher.Delegates.HandleMarketBoardPurchasePacket> mbPurchaseHook;
     private readonly Hook<InfoProxyItemSearch.Delegates.ProcessItemHistory> mbHistoryHook;
     private readonly Hook<CustomTalkReceiveResponse> customTalkHook; // used for marketboard taxes
@@ -169,7 +169,7 @@ internal unsafe class NetworkHandlers : IInternalDisposableService
             this.MarketBoardSendPurchaseRequestDetour);
         this.mbSendPurchaseRequestHook.Enable();
 
-        this.cfPopHook = Hook<PublicContentDirector.Delegates.HandleEnterContentInfoPacket>.FromAddress(PublicContentDirector.Addresses.HandleEnterContentInfoPacket.Value, this.CfPopDetour);
+        this.cfPopHook = Hook<PacketDispatcher.Delegates.HandleContentsFinderNotificationPacket>.FromAddress(PacketDispatcher.Addresses.HandleContentsFinderNotificationPacket.Value, this.CfPopDetour);
         this.cfPopHook.Enable();
     }
 
@@ -260,9 +260,9 @@ internal unsafe class NetworkHandlers : IInternalDisposableService
         return (playerState.ContentId, playerState.CurrentWorld.RowId);
     }
 
-    private unsafe nint CfPopDetour(PublicContentDirector.EnterContentInfoPacket* packetData)
+    private unsafe void CfPopDetour(ContentsFinderNotificationPacket* packetData)
     {
-        var result = this.cfPopHook.OriginalDisposeSafe(packetData);
+        this.cfPopHook.OriginalDisposeSafe(packetData);
 
         try
         {
@@ -274,7 +274,7 @@ internal unsafe class NetworkHandlers : IInternalDisposableService
             var conditionId = reader.ReadUInt16();
 
             if (notifyType != 3)
-                return result;
+                return;
 
             if (this.configuration.DutyFinderTaskbarFlash)
                 Util.FlashWindow();
@@ -284,7 +284,7 @@ internal unsafe class NetworkHandlers : IInternalDisposableService
             if (!cfCondition.IsValid)
             {
                 Log.Error("CFC key {ConditionId} not in Lumina data", conditionId);
-                return result;
+                return;
             }
 
             var cfcName = cfCondition.Value.Name.ToDalamudString();
@@ -310,8 +310,6 @@ internal unsafe class NetworkHandlers : IInternalDisposableService
         {
             Log.Error(ex, "CfPopDetour threw an exception");
         }
-
-        return result;
     }
 
     private IObservable<List<MarketBoardCurrentOfferings.MarketBoardItemListing>> OnMarketBoardListingsBatch(

--- a/Dalamud/Game/Player/PlayerState.cs
+++ b/Dalamud/Game/Player/PlayerState.cs
@@ -187,9 +187,9 @@ internal unsafe class PlayerState : IServiceType, IPlayerState
 
         return grandCompany.RowId switch
         {
-            1 => CSPlayerState.Instance()->GCRankMaelstrom,
-            2 => CSPlayerState.Instance()->GCRankTwinAdders,
-            3 => CSPlayerState.Instance()->GCRankImmortalFlames,
+            1 => CSPlayerState.Instance()->GCRanks[0],
+            2 => CSPlayerState.Instance()->GCRanks[1],
+            3 => CSPlayerState.Instance()->GCRanks[2],
             _ => default,
         };
     }

--- a/Dalamud/Interface/Internal/UiDebug/Browsing/AddonTree.AtkValues.cs
+++ b/Dalamud/Interface/Internal/UiDebug/Browsing/AddonTree.AtkValues.cs
@@ -7,7 +7,7 @@ using Dalamud.Utility;
 
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
-using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.ValueType;
+using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.AtkValueType;
 
 namespace Dalamud.Interface.Internal.UiDebug.Browsing;
 

--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -425,7 +425,12 @@ public abstract class Window
                 this.IsFocused = false;
 
                 if (internalDrawParams.Flags.HasFlag(WindowDrawFlags.UseSoundEffects) && !this.DisableWindowSounds)
-                    UIGlobals.PlaySoundEffect(this.OnCloseSfxId);
+                {
+                    unsafe
+                    {
+                        UIGlobals.PlaySoundEffect(this.OnCloseSfxId);
+                    }
+                }
             }
 
             if (this.fadeOutTexture != null)
@@ -468,7 +473,12 @@ public abstract class Window
             this.OnOpen();
 
             if (internalDrawParams.Flags.HasFlag(WindowDrawFlags.UseSoundEffects) && !this.DisableWindowSounds)
-                UIGlobals.PlaySoundEffect(this.OnOpenSfxId);
+            {
+                unsafe
+                {
+                    UIGlobals.PlaySoundEffect(this.OnOpenSfxId);
+                }
+            }
         }
 
         var isErrorStylePushed = false;


### PR DESCRIPTION
Bumps `lib/FFXIVClientStructs` from `73eac9124` to `ce5287dce8` (matches the current pointer on `csupdate-master`) and adapts Dalamud for the 7.5 breaking changes that have PR #2705 stuck on a failing CI build.

Posted as an alternative path forward for #2705 — feel free to merge as-is, cherry-pick onto `csupdate-master`, or just use as a reference. `dotnet build Dalamud/Dalamud.csproj -c Release` is clean (0/0).

### Changes

**Type renames / un-nestings**
- `Component.GUI.ValueType` → `AtkValueType` (AgentVirtualTable, ContextMenu, DalamudAtkTweaks, AddonTree.AtkValues)
- `AtkEventData.AtkMouseData.ModifierFlag` → `Component.GUI.ModifierFlag` (un-nested; AddonMouseEventData)
- `AgentInterface.GameEvent` → `AgentGameEvent` (un-nested; AgentVirtualTable)
- `PublicContentDirector.EnterContentInfoPacket` → `Client.Game.Network.ContentsFinderNotificationPacket`, `PublicContentDirector.Delegates.HandleEnterContentInfoPacket` → `PacketDispatcher.Delegates.HandleContentsFinderNotificationPacket` (NetworkHandlers; detour now returns void)
- `Agent.ActionKind` → `Enums.DetailKind` (GameGui)

**Obsolete-attribute fixes**
- `UIModulePacketType.InitZone` → `ZoneInit` (ClientState)
- `AddonSelectYesno.DisableUserClose` → `ShouldFireCallbackAndHideOrClose` (DalamudAtkTweaks ×2)
- `PlayerState.GCRank{Maelstrom,TwinAdders,ImmortalFlames}` → `GCRanks[0/1/2]` (PlayerState)

**Signature changes**
- `UIGlobals.PlaySoundEffect` exposes pointer default args; wrapped two Window call sites in `unsafe` blocks
- `AtkCursor.SetCursorType` second arg is now `bool` (AddonEventManager)
- `AgentModule.Delegates.Ctor` now returns `AgentModule*`; `OnAgentModuleInitialize` forwards the original return (AgentLifecycle)
- `LayoutWorld.Delegates.AddRsvString` first arg is `CStringPointer` (RsvResolver; imported `InteropGenerator.Runtime`)
- `RaptureLogModule.Delegates.PrintMessage` second arg is `LogInfo` (ChatGui; detour parameter and one in-process call site that constructs `LogInfo` from the existing ushort)
- `AddonFlyText.Delegates.CreateFlyText` text1/text2 are `CStringPointer` (FlyTextGui; null checks via `HasValue`, nint casts via `.Value`)
- `InfoProxyCrossRealm.Delegates.ReceiveListing` packet param is `ServerIpcSegment<CrossRealmListingSegmentPacket>*` (PartyFinderGui)

### Caveats

- Only built `Dalamud/Dalamud.csproj` locally; relying on CI for the C++ Boot DLL and full solution.
- `LogInfo` is constructed via `new LogInfo { Value = (ushort)targetChannel }` in the in-process detour invocation. Open to a different idiom if there's a preferred construction pattern.