### PR TITLE
Exclude Cosmopouch from IGameInventory

### DIFF
--- a/Dalamud/Game/Inventory/GameInventory.cs
+++ b/Dalamud/Game/Inventory/GameInventory.cs
@@ -18,6 +18,14 @@ namespace Dalamud.Game.Inventory;
 [ServiceManager.EarlyLoadedService]
 internal class GameInventory : IInternalDisposableService
 {
+    /// <summary>
+    /// Lists excluded InventoryTypes that are not supported by this service.
+    /// </summary>
+    internal static readonly GameInventoryType[] ExcludedInventoryTypes = [
+        GameInventoryType.Cosmopouch1,
+        GameInventoryType.Cosmopouch2
+    ];
+
     private readonly List<GameInventoryPluginScoped> subscribersPendingChange = [];
     private readonly List<GameInventoryPluginScoped> subscribers = [];
 
@@ -43,7 +51,7 @@ internal class GameInventory : IInternalDisposableService
     [ServiceManager.ServiceConstructor]
     private GameInventory()
     {
-        this.inventoryTypes = Enum.GetValues<GameInventoryType>();
+        this.inventoryTypes = [.. Enum.GetValues<GameInventoryType>().Where(static type => !ExcludedInventoryTypes.Contains(type))];
         this.inventoryItems = new GameInventoryItem[this.inventoryTypes.Length][];
 
         this.gameGui.AgentUpdate += this.OnAgentUpdate;

--- a/Dalamud/Game/Inventory/GameInventoryItem.cs
+++ b/Dalamud/Game/Inventory/GameInventoryItem.cs
@@ -313,6 +313,9 @@ public unsafe struct GameInventoryItem : IEquatable<GameInventoryItem>
     /// <returns>The span.</returns>
     internal static ReadOnlySpan<GameInventoryItem> GetReadOnlySpanOfInventory(GameInventoryType type)
     {
+        if (GameInventory.ExcludedInventoryTypes.Contains(type))
+            return default;
+
         var inventoryManager = InventoryManager.Instance();
         if (inventoryManager is null) return default;
 

--- a/Dalamud/Game/Inventory/GameInventoryItem.cs
+++ b/Dalamud/Game/Inventory/GameInventoryItem.cs
@@ -318,7 +318,8 @@ public unsafe struct GameInventoryItem : IEquatable<GameInventoryItem>
 
         var inventory = inventoryManager->GetInventoryContainer((InventoryType)type);
         if (inventory is null) return default;
+        if (inventory->Items is null) return default;
 
-        return new ReadOnlySpan<GameInventoryItem>(inventory->Items, (int)inventory->Size);
+        return new ReadOnlySpan<GameInventoryItem>(inventory->Items, inventory->Size);
     }
 }


### PR DESCRIPTION
The enum values Cosmopouch1 and Cosmopouch2 were previously not part of the GameInventoryType enum, because they are not part of the normal InventoryManager. They inherit from InventoryItem, and GameInventoryItem only copies that part, which causes them to be useless. Supporting Cosmopouches would require a rewrite of the service.

I've excluded them internally for now, but they will still be present in the GameInventoryType enum.

Also, when I started the game, I once crashed at https://github.com/goatcorp/Dalamud/blob/d8228a5073fcb8b09ff8f41991fbe93616c8cc20/Dalamud/Game/Inventory/GameInventory.cs#L113

I'm not exactly sure what's wrong, but the Items pointer is not null-checked here and could be a potential issue. Maybe it has something to do with Cosmopouches, so let's hope this is fixed with this PR.
