### PR TITLE
Fix Sender/Message not being marked as modified

### DIFF
--- a/Dalamud/Game/Chat/ChatMessage.cs
+++ b/Dalamud/Game/Chat/ChatMessage.cs
@@ -124,10 +124,24 @@ internal class ChatMessage : IHandleableChatMessage
     public SeString Message { get; set; }
 
     /// <inheritdoc />
-    public bool SenderModified => new ReadOnlySeString(this.Sender.Encode()) != this.OriginalSender;
+    public bool SenderModified
+    {
+        get
+        {
+            var encoded = this.Sender.Encode();
+            return new ReadOnlySeStringSpan(encoded) != this.OriginalSender;
+        }
+    }
 
     /// <inheritdoc />
-    public bool MessageModified => new ReadOnlySeString(this.Message.Encode()) != this.OriginalMessage;
+    public bool MessageModified
+    {
+        get
+        {
+            var encoded = this.Message.Encode();
+            return new ReadOnlySeStringSpan(encoded) != this.OriginalMessage;
+        }
+    }
 
     /// <inheritdoc />
     public int Timestamp { get; private set; }

--- a/Dalamud/Game/Chat/ChatMessage.cs
+++ b/Dalamud/Game/Chat/ChatMessage.cs
@@ -1,5 +1,8 @@
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Utility;
+
+using Lumina.Text.ReadOnly;
 
 namespace Dalamud.Game.Chat;
 
@@ -25,6 +28,16 @@ public interface IChatMessage
     /// Gets the relationship of the entity receiving the message or being targeted by the action.
     /// </summary>
     XivChatRelationKind TargetKind { get; }
+
+    /// <summary>
+    /// Gets the original sender name, before any plugin might have changed it.
+    /// </summary>
+    ReadOnlySeString OriginalSender { get; }
+
+    /// <summary>
+    /// Gets the original message, before any plugin might have changed it.
+    /// </summary>
+    ReadOnlySeString OriginalMessage { get; }
 
     /// <summary>
     /// Gets the sender name.
@@ -99,40 +112,22 @@ internal class ChatMessage : IHandleableChatMessage
     public XivChatRelationKind TargetKind { get; private set; }
 
     /// <inheritdoc />
-    public SeString Sender
-    {
-        get;
-        set
-        {
-            var newValue = value ?? new SeString();
-
-            if (field == null || !field.Encode().SequenceEqual(newValue.Encode()))
-                this.SenderModified = true;
-
-            field = newValue;
-        }
-    }
+    public ReadOnlySeString OriginalSender { get; private set; }
 
     /// <inheritdoc />
-    public SeString Message
-    {
-        get;
-        set
-        {
-            var newValue = value ?? new SeString();
-
-            if (field == null || !field.Encode().SequenceEqual(newValue.Encode()))
-                this.MessageModified = true;
-
-            field = newValue;
-        }
-    }
+    public ReadOnlySeString OriginalMessage { get; private set; }
 
     /// <inheritdoc />
-    public bool SenderModified { get; private set; }
+    public SeString Sender { get; set; }
 
     /// <inheritdoc />
-    public bool MessageModified { get; private set; }
+    public SeString Message { get; set; }
+
+    /// <inheritdoc />
+    public bool SenderModified => new ReadOnlySeString(this.Sender.Encode()) != this.OriginalSender;
+
+    /// <inheritdoc />
+    public bool MessageModified => new ReadOnlySeString(this.Message.Encode()) != this.OriginalMessage;
 
     /// <inheritdoc />
     public int Timestamp { get; private set; }
@@ -149,18 +144,18 @@ internal class ChatMessage : IHandleableChatMessage
     /// <param name="logKind">The type of chat.</param>
     /// <param name="sourceKind">The relationship of the entity sending the message or performing the action.</param>
     /// <param name="targetKind">The relationship of the entity receiving the message or being targeted by the action.</param>
-    /// <param name="lSender">The sender name.</param>
-    /// <param name="lMessage">The message sent.</param>
+    /// <param name="sender">The sender name.</param>
+    /// <param name="message">The message sent.</param>
     /// <param name="timestamp">The timestamp of when the message was sent.</param>
-    internal void SetData(XivChatType logKind, XivChatRelationKind sourceKind, XivChatRelationKind targetKind, SeString lSender, SeString lMessage, int timestamp)
+    internal void SetData(XivChatType logKind, XivChatRelationKind sourceKind, XivChatRelationKind targetKind, ReadOnlySeString sender, ReadOnlySeString message, int timestamp)
     {
         this.LogKind = logKind;
         this.SourceKind = sourceKind;
         this.TargetKind = targetKind;
-        this.Sender = lSender;
-        this.Message = lMessage;
-        this.SenderModified = false;
-        this.MessageModified = false;
+        this.OriginalSender = sender;
+        this.OriginalMessage = message;
+        this.Sender = sender.ToDalamudString();
+        this.Message = message.ToDalamudString();
         this.Timestamp = timestamp;
         this.IsHandled = false;
     }
@@ -175,8 +170,6 @@ internal class ChatMessage : IHandleableChatMessage
         this.TargetKind = 0;
         this.Sender = null;
         this.Message = null;
-        this.SenderModified = false;
-        this.MessageModified = false;
         this.Timestamp = 0;
         this.IsHandled = false;
     }

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -389,10 +389,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
             var sourceKind = (XivChatRelationKind)logInfo.SourceKind;
             var targetKind = (XivChatRelationKind)logInfo.TargetKind;
 
-            var lSender = sender->AsDalamudSeString();
-            var lMessage = message->AsDalamudSeString();
-
-            this.currentChatMessage.SetData(logKind, sourceKind, targetKind, lSender, lMessage, timestamp);
+            this.currentChatMessage.SetData(logKind, sourceKind, targetKind, sender->AsReadOnlySeString(), message->AsReadOnlySeString(), timestamp);
 
             // First pass
             foreach (var action in Delegate.EnumerateInvocationList(this.ChatMessage))


### PR DESCRIPTION
Plugin devs are able to modify the Payloads of the Sender and Message SeStrings.
I didn't think of that, when I made the new API, because I was thinking in ReadOnly mode, so those had to be set with new SeStrings.
I've changed it, so that it now saves the original sender and message as ReadOnlySeString and compares agains them.
This sadly causes allocations when accessing the Modified properties, but that was basically how it worked pre-API15.