### PR TITLE
Add back DefaultFont into ImRaii

### DIFF
--- a/Dalamud/Interface/Utility/Raii/Disposables/FontDisposable.cs
+++ b/Dalamud/Interface/Utility/Raii/Disposables/FontDisposable.cs
@@ -16,7 +16,14 @@ public static partial class ImRaii
 
         /// <summary> Push the default font if any other font is currently pushed. </summary>
         /// <returns> A disposable object that can be used to push further fonts and pops those fonts after leaving scope. Use with using. </returns>
+        [Obsolete("Use `ImRaii.DefaultFont()` instead.")]
+        // ReSharper disable once MemberHidesStaticFromOuterClass
         public static FontDisposable DefaultFont()
+            => new FontDisposable().Push(DefaultPushed, FontPushCounter > 0);
+
+        /// <summary> Push the default font if any other font is currently pushed. </summary>
+        /// <returns> A disposable object that can be used to push further fonts and pops those fonts after leaving scope. Use with using. </returns>
+        public static FontDisposable PushDefaultFont()
             => new FontDisposable().Push(DefaultPushed, FontPushCounter > 0);
 
         /// <summary> Push a font to the font stack. </summary>

--- a/Dalamud/Interface/Utility/Raii/ImGui.cs
+++ b/Dalamud/Interface/Utility/Raii/ImGui.cs
@@ -50,6 +50,9 @@ public static partial class ImRaii
     public static FontDisposable PushFont(ImFontPtr font, bool condition = true)
         => new FontDisposable().Push(font, condition);
 
+    public static FontDisposable DefaultFont()
+        => FontDisposable.PushDefaultFont();
+
     public static IdDisposable PushId(ImU8String id, bool enabled = true)
         => new IdDisposable().Push(id, enabled);
 


### PR DESCRIPTION
I missed this when porting everything, and people already started using `FontDisposable.DefaultFont` leading to an outer class clash. 
Should be fine to remove come API 16