### PR TITLE
Add favorite and pinned plugin functionality to the plugin manager

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -126,6 +126,16 @@ internal sealed class DalamudConfiguration : IInternalDisposableService
     public List<string> HiddenPluginInternalName { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets a list of favorite plugins.
+    /// </summary>
+    public List<string> FavoritePluginInternalName { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets a list of pinned plugins.
+    /// </summary>
+    public List<string> PinnedPluginInternalName { get; set; } = [];
+
+    /// <summary>
     /// Gets or sets a list of seen plugins.
     /// </summary>
     public List<string> SeenPluginInternalName { get; set; } = [];

--- a/Dalamud/Interface/Internal/PluginCategoryManager.cs
+++ b/Dalamud/Interface/Internal/PluginCategoryManager.cs
@@ -34,6 +34,7 @@ internal class PluginCategoryManager
         new(CategoryKind.EnabledPlugins, "special.enabled", () => Locs.Category_EnabledPlugins),
         new(CategoryKind.DisabledPlugins, "special.disabled", () => Locs.Category_DisabledPlugins),
         new(CategoryKind.IncompatiblePlugins, "special.incompatible", () => Locs.Category_IncompatiblePlugins),
+        new(CategoryKind.FavoritePlugins, "special.favorite", () => Locs.Category_FavoritePlugins),
 
         // Tag-driven categories
         new(CategoryKind.Other, "other", () => Locs.Category_Other),
@@ -51,7 +52,7 @@ internal class PluginCategoryManager
     private GroupInfo[] groupList =
     [
         new(GroupKind.DevTools, () => Locs.Group_DevTools, CategoryKind.DevInstalled, CategoryKind.IconTester),
-        new(GroupKind.Installed, () => Locs.Group_Installed, CategoryKind.All, CategoryKind.IsTesting, CategoryKind.UpdateablePlugins, CategoryKind.EnabledPlugins, CategoryKind.DisabledPlugins, CategoryKind.IncompatiblePlugins, CategoryKind.PluginProfiles),
+        new(GroupKind.Installed, () => Locs.Group_Installed, CategoryKind.All, CategoryKind.IsTesting, CategoryKind.UpdateablePlugins, CategoryKind.EnabledPlugins, CategoryKind.DisabledPlugins, CategoryKind.IncompatiblePlugins, CategoryKind.FavoritePlugins, CategoryKind.PluginProfiles),
         new(GroupKind.Available, () => Locs.Group_Available, CategoryKind.All),
         new(GroupKind.Changelog, () => Locs.Group_Changelog, CategoryKind.All, CategoryKind.DalamudChangelogs, CategoryKind.PluginChangelogs)
 
@@ -160,6 +161,11 @@ internal class PluginCategoryManager
         /// Incompatible plugins.
         /// </summary>
         IncompatiblePlugins = 18,
+
+        /// <summary>
+        /// Favorite plugins.
+        /// </summary>
+        FavoritePlugins = 19,
 
         /// <summary>
         /// Plugins tagged as "other".
@@ -579,6 +585,8 @@ internal class PluginCategoryManager
         public static string Category_DisabledPlugins => Loc.Localize("InstallerCategoryDisabledPlugins", "Disabled");
 
         public static string Category_IncompatiblePlugins => Loc.Localize("InstallerCategoryIncompatiblePlugins", "Incompatible");
+
+        public static string Category_FavoritePlugins => Loc.Localize("InstallerCategoryFavoritePlugins", "Favorites");
 
         public static string Category_Other => Loc.Localize("InstallerCategoryOther", "Other");
 

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -141,7 +141,8 @@ internal class PluginInstallerWindow : Window, IDisposable
 
     private LoadingIndicatorKind loadingIndicatorKind = LoadingIndicatorKind.Unknown;
 
-    private string verifiedCheckmarkHoveredPlugin = string.Empty;
+    private string currentlyHoveredPlugin = string.Empty;
+    private string currentlyHoveredObject = string.Empty;
 
     private string? staleDalamudNewVersion = null;
 
@@ -244,6 +245,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         Enabled,
         Disabled,
         Incompatible,
+        Favorite,
     }
 
     private bool AnyOperationInProgress => this.installStatus == OperationStatus.InProgress ||
@@ -1547,10 +1549,17 @@ internal class PluginInstallerWindow : Window, IDisposable
         }
 
         var applyPluginFilters = filter != InstalledPluginListFilter.Dev;
+        var configuration = Service<DalamudConfiguration>.Get();
+        var favoriteList = configuration.FavoritePluginInternalName;
+        var pinnedList = configuration.PinnedPluginInternalName;
         var filteredList = pluginList
-                   .Where(plugin => !this.IsManifestFiltered(plugin.Manifest))
-                   .Where(plugin => !applyPluginFilters || !this.IsInstalledPluginFiltered(plugin, false))
-                           .ToList();
+                           // Filter out plugins that don't match the search if any
+                          .Where(plugin => !this.IsManifestFiltered(plugin.Manifest))
+                          .Where(plugin => !applyPluginFilters || !this.IsInstalledPluginFiltered(plugin, false))
+                           // Order plugins by pinned status, then by name
+                          .OrderBy(plugin => !pinnedList.Contains(plugin.Manifest.InternalName))
+                          .ThenBy(plugin => plugin.Manifest.Name)
+                          .ToList();
 
         if (filteredList.Count == 0)
         {
@@ -1572,6 +1581,9 @@ internal class PluginInstallerWindow : Window, IDisposable
                 continue;
 
             if (filter == InstalledPluginListFilter.Incompatible && !(plugin.IsOutdated || plugin.IsBanned || plugin.IsOrphaned || plugin.IsDecommissioned))
+                continue;
+
+            if (filter == InstalledPluginListFilter.Favorite && !favoriteList.Contains(plugin.Manifest.InternalName))
                 continue;
 
             // Find applicable update and manifest, if we have them
@@ -1609,6 +1621,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                 InstalledPluginListFilter.Enabled => Locs.TabBody_NoPluginsEnabled,
                 InstalledPluginListFilter.Disabled => Locs.TabBody_NoPluginsDisabled,
                 InstalledPluginListFilter.Incompatible => Locs.TabBody_NoPluginsIncompatible,
+                InstalledPluginListFilter.Favorite => Locs.TabBody_NoPluginsFavorite,
                 _ => throw new ArgumentException(null, nameof(filter)),
             };
 
@@ -1856,6 +1869,10 @@ internal class PluginInstallerWindow : Window, IDisposable
 
                     case PluginCategoryManager.CategoryKind.IncompatiblePlugins:
                         this.DrawInstalledPluginList(InstalledPluginListFilter.Incompatible);
+                        break;
+
+                    case PluginCategoryManager.CategoryKind.FavoritePlugins:
+                        this.DrawInstalledPluginList(InstalledPluginListFilter.Favorite);
                         break;
 
                     case PluginCategoryManager.CategoryKind.PluginProfiles:
@@ -2373,21 +2390,55 @@ internal class PluginInstallerWindow : Window, IDisposable
             var devIconOutlineColor = KnownColor.White.Vector();
             var devIconColor = KnownColor.MediumOrchid.Vector();
 
+            const string tooltipIdentifier = "VerifiedCheckmarkIcon";
+
             if (plugin is LocalDevPlugin)
             {
                 this.DrawFontawesomeIconOutlined(FontAwesomeIcon.Wrench, devIconOutlineColor, devIconColor);
-                this.VerifiedCheckmarkFadeTooltip(label, "This is a dev plugin. You added it.");
+                this.IconFadeTooltip(label, tooltipIdentifier, "This is a dev plugin. You added it.");
             }
             else if (!flags.HasFlag(PluginHeaderFlags.IsThirdParty))
             {
                 this.DrawFontawesomeIconOutlined(FontAwesomeIcon.CheckCircle, verifiedOutlineColor, verifiedIconColor);
-                this.VerifiedCheckmarkFadeTooltip(label, Locs.VerifiedCheckmark_VerifiedTooltip);
+                this.IconFadeTooltip(label, tooltipIdentifier, Locs.VerifiedCheckmark_VerifiedTooltip);
             }
             else
             {
                 this.DrawFontawesomeIconOutlined(FontAwesomeIcon.ExclamationCircle, unverifiedOutlineColor, unverifiedIconColor);
-                this.VerifiedCheckmarkFadeTooltip(label, Locs.VerifiedCheckmark_UnverifiedTooltip);
+                this.IconFadeTooltip(label, tooltipIdentifier, Locs.VerifiedCheckmark_UnverifiedTooltip);
             }
+        }
+
+        // Pinned indicator
+        if (plugin != null && Service<DalamudConfiguration>.Get().PinnedPluginInternalName.Contains(plugin.Manifest.InternalName))
+        {
+            ImGui.SameLine();
+            ImGui.Text(" "u8);
+            ImGui.SameLine();
+
+            var pinIconOutlineColor = KnownColor.Crimson.Vector();
+            var pinIconColor = KnownColor.White.Vector() with { W = 0.75f };
+
+            const string tooltipIdentifier = "PinnedIcon";
+
+            this.DrawFontawesomeIconOutlined(FontAwesomeIcon.Thumbtack, pinIconOutlineColor, pinIconColor);
+            this.IconFadeTooltip(label, tooltipIdentifier, Locs.PluginIconToolTip_PinnedIconTooltip);
+        }
+
+        // Favorite star indicator
+        if (plugin != null && Service<DalamudConfiguration>.Get().FavoritePluginInternalName.Contains(plugin.Manifest.InternalName))
+        {
+            ImGui.SameLine();
+            ImGui.Text(" "u8);
+            ImGui.SameLine();
+
+            var starIconOutlineColor = KnownColor.Black.Vector();
+            var starIconColor = KnownColor.Gold.Vector();
+
+            const string tooltipIdentifier = "FavoriteIcon";
+
+            this.DrawFontawesomeIconOutlined(FontAwesomeIcon.Star, starIconOutlineColor, starIconColor);
+            this.IconFadeTooltip(label, tooltipIdentifier, Locs.PluginIconToolTip_FavoriteIconTooltip);
         }
 
         // Download count
@@ -3169,6 +3220,30 @@ internal class PluginInstallerWindow : Window, IDisposable
                     _ = pluginManager.ReloadAllReposAsync();
                 }
             }
+
+            // Favorite
+            var isFavorite = configuration.FavoritePluginInternalName.Contains(plugin.Manifest.InternalName);
+            if (ImGui.MenuItem(isFavorite ? Locs.PluginContext_RemoveFavorite : Locs.PluginContext_AddFavorite))
+            {
+                if (isFavorite)
+                    configuration.FavoritePluginInternalName.Remove(plugin.Manifest.InternalName);
+                else
+                    configuration.FavoritePluginInternalName.Add(plugin.Manifest.InternalName);
+                configuration.QueueSave();
+            }
+
+            // Pinned
+            var isPinned = configuration.PinnedPluginInternalName.Contains(plugin.Manifest.InternalName);
+            if (ImGui.MenuItem(isPinned ? Locs.PluginContext_UnpinPlugin : Locs.PluginContext_PinPlugin))
+            {
+                if (isPinned)
+                    configuration.PinnedPluginInternalName.Remove(plugin.Manifest.InternalName);
+                else
+                    configuration.PinnedPluginInternalName.Add(plugin.Manifest.InternalName);
+                configuration.QueueSave();
+            }
+
+            ImGui.Separator();
 
             if (ImGui.MenuItem(Locs.PluginContext_DeletePluginConfigReload))
             {
@@ -4210,23 +4285,26 @@ internal class PluginInstallerWindow : Window, IDisposable
     }
 
     // Animates a tooltip when hovering over the ImGui Item before this call.
-    private void VerifiedCheckmarkFadeTooltip(string source, string tooltip)
+    private void IconFadeTooltip(string plugin, string identifier, string tooltip)
     {
         const float fadeInStartDelay = 250.0f;
 
-        var isHoveringSameItem = this.verifiedCheckmarkHoveredPlugin == source;
+        var isHoveringSameItem = this.currentlyHoveredPlugin == plugin
+                                 && this.currentlyHoveredObject == identifier;
 
         // If we just started a hover, start the timer
         if (ImGui.IsItemHovered() && !this.tooltipFadeInStopwatch.IsRunning)
         {
-            this.verifiedCheckmarkHoveredPlugin = source;
+            this.currentlyHoveredPlugin = plugin;
+            this.currentlyHoveredObject = identifier;
             this.tooltipFadeInStopwatch.Restart();
         }
 
         // If we were last hovering this plugins item and are no longer hovered over that item, reset the timer
         if (!ImGui.IsItemHovered() && isHoveringSameItem)
         {
-            this.verifiedCheckmarkHoveredPlugin = string.Empty;
+            this.currentlyHoveredPlugin = string.Empty;
+            this.currentlyHoveredObject = string.Empty;
             this.tooltipFadeInStopwatch.Stop();
             this.tooltipFadeEasing.Reset();
         }
@@ -4323,6 +4401,8 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         public static string TabBody_NoPluginsIncompatible => Loc.Localize("InstallerNoPluginsIncompatible", "You don't have any incompatible plugins.");
 
+        public static string TabBody_NoPluginsFavorite => Loc.Localize("InstallerNoPluginsFavorite", "You don't have any favorite plugins.\nYou can mark plugins as favorite in the plugin context menu.");
+
         #endregion
 
         #region Search text
@@ -4398,6 +4478,14 @@ internal class PluginInstallerWindow : Window, IDisposable
         public static string PluginContext_DeletePluginConfig => Loc.Localize("InstallerDeletePluginConfig", "Reset plugin data");
 
         public static string PluginContext_DeletePluginConfigReload => Loc.Localize("InstallerDeletePluginConfigReload", "Reset plugin data and reload");
+
+        public static string PluginContext_AddFavorite => Loc.Localize("InstallerAddFavorite", "Add to favorites");
+
+        public static string PluginContext_RemoveFavorite => Loc.Localize("InstallerRemoveFavorite", "Remove from favorites");
+
+        public static string PluginContext_PinPlugin => Loc.Localize("InstallerPinPlugin", "Pin to top");
+
+        public static string PluginContext_UnpinPlugin => Loc.Localize("InstallerUnpinPlugin", "Unpin from top");
 
         #endregion
 
@@ -4505,6 +4593,14 @@ internal class PluginInstallerWindow : Window, IDisposable
         public static string PluginButtonToolTip_SingleProfileDisabled(string name) => Loc.Localize("InstallerSingleProfileDisabled", "The collection '{0}' which contains this plugin is disabled.\nPlease enable it in the collections manager to toggle the plugin individually.").Format(name);
 
         public static string PluginButtonToolTip_SingleProfileDoesNotWantActive(string name) => Loc.Localize("InstallerSingleProfileDoesNotWantActive", "The collection '{0}' which contains this plugin is active, but is not set to activate on this character.\nPlease change the collection's settings or remove the plugin from that collection to toggle the plugin individually.").Format(name);
+
+        #endregion
+
+        #region Plugin icon tooltips
+
+        public static string PluginIconToolTip_FavoriteIconTooltip => Loc.Localize("InstallerFavoriteTooltip", "This plugin is in your favorites.");
+
+        public static string PluginIconToolTip_PinnedIconTooltip => Loc.Localize("InstallerPinnedTooltip", "This plugin is pinned to the top.");
 
         #endregion
 

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -1551,14 +1551,10 @@ internal class PluginInstallerWindow : Window, IDisposable
         var applyPluginFilters = filter != InstalledPluginListFilter.Dev;
         var configuration = Service<DalamudConfiguration>.Get();
         var favoriteList = configuration.FavoritePluginInternalName;
-        var pinnedList = configuration.PinnedPluginInternalName;
         var filteredList = pluginList
                            // Filter out plugins that don't match the search if any
                           .Where(plugin => !this.IsManifestFiltered(plugin.Manifest))
                           .Where(plugin => !applyPluginFilters || !this.IsInstalledPluginFiltered(plugin, false))
-                           // Order plugins by pinned status, then by name
-                          .OrderBy(plugin => !pinnedList.Contains(plugin.Manifest.InternalName))
-                          .ThenBy(plugin => plugin.Manifest.Name)
                           .ToList();
 
         if (filteredList.Count == 0)
@@ -3241,6 +3237,8 @@ internal class PluginInstallerWindow : Window, IDisposable
                 else
                     configuration.PinnedPluginInternalName.Add(plugin.Manifest.InternalName);
                 configuration.QueueSave();
+                // Resort plugins to update pinned order
+                this.ResortPlugins();
             }
 
             ImGui.Separator();
@@ -4199,6 +4197,18 @@ internal class PluginInstallerWindow : Window, IDisposable
             default:
                 throw new InvalidEnumArgumentException("Unknown plugin sort type.");
         }
+
+        this.SortPluginsByPinnedStatus();
+    }
+
+    private void SortPluginsByPinnedStatus()
+    {
+        var configuration = Service<DalamudConfiguration>.Get();
+        var pinnedList = new HashSet<string>(configuration.PinnedPluginInternalName);
+
+        this.pluginListInstalled = this.pluginListInstalled
+                                       .OrderByDescending(p => pinnedList.Contains(p.Manifest.InternalName))
+                                       .ToList();
     }
 
     private bool WasPluginSeen(string internalName) =>


### PR DESCRIPTION
This PR introduces two quality‑of‑life improvements to the Plugin Manager window:

### **1. Favorite plugins**
A new *Favorites* category is added.  
Users can mark any installed plugin as a favorite, and those plugins will appear in this dedicated category.

This solves a limitation of plugin collections: collections are tied to their toggle state, so they cannot serve as a simple “quick access” list. Favorites provide this list.

### **2. Pinned plugins**
Users can now pin plugins.  
Pinned plugins always appear at the top of the list in any **Installed Plugins** category.

I initially considered placing favorites at the top of the list, but this approach lacked flexibility. With both features available, users can independently choose which plugins should be pinned and which should simply be favorites.


### **How it looks**

<img width="557" height="125" alt="Capture d&#39;écran 2026-04-30 163753" src="https://github.com/user-attachments/assets/2a91de69-1a99-40a8-85f5-e329b854cba1" />
<br>
<img width="944" height="313" alt="Capture d&#39;écran 2026-04-30 172858" src="https://github.com/user-attachments/assets/e199aa8c-af17-4398-9f4b-95c20f64368e" />
<br>
<img width="767" height="290" alt="Capture d&#39;écran 2026-04-30 171902" src="https://github.com/user-attachments/assets/849ece5e-5cc4-4b54-bab4-5dfdd3edc260" />
<br>
<img width="821" height="422" alt="Capture d&#39;écran 2026-04-30 171919" src="https://github.com/user-attachments/assets/404589d2-f2a6-4dbf-9c29-e37980710210" />
<br>
<img width="809" height="420" alt="Capture d&#39;écran 2026-04-30 171932" src="https://github.com/user-attachments/assets/808a0fcc-4e56-41ca-8e59-dd9ffc13bb59" />
<br>
<img width="889" height="425" alt="Capture d&#39;écran 2026-04-30 171952" src="https://github.com/user-attachments/assets/3e6190cc-d0a5-4adb-8ddb-cf3daeefcfb4" />
