### PR TITLE
Don't overwrite Window.IsOpen unless it was actually closed

### DIFF
--- a/Dalamud/Interface/Windowing/WindowHost.cs
+++ b/Dalamud/Interface/Windowing/WindowHost.cs
@@ -301,9 +301,9 @@ public class WindowHost
             }
         }
 
-        if (this.Window.IsOpen != isWindowOpen)
+        if (this.Window.IsOpen && !isWindowOpen)
         {
-            this.Window.IsOpen = isWindowOpen;
+            this.Window.IsOpen = false;
         }
 
         const string additionsPopupName = "WindowSystemContextActions";


### PR DESCRIPTION
Currently, this condition always overwrites the value of a changed `Window.IsOpen` after draw with the state of the titlebar close ref, which can prevent windows from closing themselves via `IsOpen`. After this change, we just close it if and only if it was closed via the titlebar.