### PR TITLE
Add 2 extension methods for the newly added XivChatType

### DIFF
--- a/Dalamud/Game/Text/XivChatTypeExtensions.cs
+++ b/Dalamud/Game/Text/XivChatTypeExtensions.cs
@@ -16,4 +16,61 @@ public static class XivChatTypeExtensions
     {
         return chatType.GetAttribute<XivChatTypeInfoAttribute>();
     }
+
+    /// <summary>
+    /// Gets whether the chat type is used by a GM to talk.
+    /// </summary>
+    /// <param name="type">The chat type.</param>
+    /// <returns>True if used by GM.</returns>
+    public static bool IsUsedByGm(this XivChatType type) => type switch
+    {
+        XivChatType.GmTell => true,
+        XivChatType.GmSay => true,
+        XivChatType.GmShout => true,
+        XivChatType.GmYell => true,
+        XivChatType.GmParty => true,
+        XivChatType.GmFreeCompany => true,
+        XivChatType.GmLinkshell1 => true,
+        XivChatType.GmLinkshell2 => true,
+        XivChatType.GmLinkshell3 => true,
+        XivChatType.GmLinkshell4 => true,
+        XivChatType.GmLinkshell5 => true,
+        XivChatType.GmLinkshell6 => true,
+        XivChatType.GmLinkshell7 => true,
+        XivChatType.GmLinkshell8 => true,
+        XivChatType.GmNoviceNetwork => true,
+        _ => false
+    };
+
+    /// <summary>
+    /// Gets whether the chat type utilizes <see cref="XivChatRelationKind"/>.
+    /// </summary>
+    /// <param name="type">The chat type.</param>
+    /// <returns>True if <see cref="XivChatRelationKind"/> are used.</returns>
+    public static bool AppliesRelationKind(this XivChatType type) => type switch
+    {
+        // Battle
+        XivChatType.Damage => true,
+        XivChatType.Miss => true,
+        XivChatType.Action => true,
+        XivChatType.Item => true,
+        XivChatType.Healing => true,
+        XivChatType.GainBuff => true,
+        XivChatType.LoseBuff => true,
+        XivChatType.GainDebuff => true,
+        XivChatType.LoseDebuff => true,
+
+        // Announcements
+        XivChatType.SystemMessage => true,
+        XivChatType.SystemError => true,
+        XivChatType.ErrorMessage => true,
+        XivChatType.LootNotice => true,
+        XivChatType.Progress => true,
+        XivChatType.LootRoll => true,
+        XivChatType.Crafting => true,
+        XivChatType.Gathering => true,
+        XivChatType.FreeCompanyLoginLogout => true,
+        XivChatType.PvpTeamLoginLogout => true,
+        _ => false
+    };
 }


### PR DESCRIPTION
Taken from https://github.com/Infiziert90/ChatTwo/blob/main/ChatTwo/Code/ChatTypeExt.cs#L339

All entries didn't exist in Dalamud, and now that ChatMessage returns the actual Source and Target some devs may be interested in what XivChatType support them. 
Gm one has been added for easier filtering in plugins that may have accidentally block them before.