### PR TITLE
Fix testing-exclusive plugins always detecting available updates

### DIFF
--- a/Dalamud/Game/Text/XivChatTypeExtensions.cs
+++ b/Dalamud/Game/Text/XivChatTypeExtensions.cs
@@ -39,7 +39,7 @@ public static class XivChatTypeExtensions
         XivChatType.GmLinkshell7 => true,
         XivChatType.GmLinkshell8 => true,
         XivChatType.GmNoviceNetwork => true,
-        _ => false
+        _ => false,
     };
 
     /// <summary>
@@ -71,6 +71,6 @@ public static class XivChatTypeExtensions
         XivChatType.Gathering => true,
         XivChatType.FreeCompanyLoginLogout => true,
         XivChatType.PvpTeamLoginLogout => true,
-        _ => false
+        _ => false,
     };
 }

--- a/Dalamud/Interface/Internal/PluginCategoryManager.cs
+++ b/Dalamud/Interface/Internal/PluginCategoryManager.cs
@@ -4,8 +4,8 @@ using System.Linq;
 
 using CheapLoc;
 
-using Dalamud.Plugin.Internal;
 using Dalamud.Plugin.Internal.Types;
+using Dalamud.Plugin.Internal.Types.Manifest;
 
 namespace Dalamud.Interface.Internal;
 
@@ -100,52 +100,52 @@ internal class PluginCategoryManager
         /// All plugins.
         /// </summary>
         All = 0,
-        
+
         /// <summary>
         /// Plugins currently being tested.
         /// </summary>
         IsTesting = 1,
-        
+
         /// <summary>
         /// Plugins available for testing.
         /// </summary>
         AvailableForTesting = 2,
-        
+
         /// <summary>
         /// Plugins that were hidden.
         /// </summary>
         Hidden = 3,
-        
+
         /// <summary>
         /// Installed dev plugins.
         /// </summary>
         DevInstalled = 10,
-        
+
         /// <summary>
         /// Icon tester.
         /// </summary>
         IconTester = 11,
-        
+
         /// <summary>
         /// Changelogs for Dalamud.
         /// </summary>
         DalamudChangelogs = 12,
-        
+
         /// <summary>
         /// Changelogs for plugins.
         /// </summary>
         PluginChangelogs = 13,
-        
+
         /// <summary>
         /// Change plugin profiles.
         /// </summary>
         PluginProfiles = 14,
-        
+
         /// <summary>
         /// Updateable plugins.
         /// </summary>
         UpdateablePlugins = 15,
-        
+
         /// <summary>
         /// Enabled plugins.
         /// </summary>
@@ -165,37 +165,37 @@ internal class PluginCategoryManager
         /// Plugins tagged as "other".
         /// </summary>
         Other = FirstTagBasedCategoryId + 0,
-        
+
         /// <summary>
         /// Plugins tagged as "jobs".
         /// </summary>
         Jobs = FirstTagBasedCategoryId + 1,
-        
+
         /// <summary>
         /// Plugins tagged as "ui".
         /// </summary>
         Ui = FirstTagBasedCategoryId + 2,
-        
+
         /// <summary>
         /// Plugins tagged as "minigames".
         /// </summary>
         MiniGames = FirstTagBasedCategoryId + 3,
-        
+
         /// <summary>
         /// Plugins tagged as "inventory".
         /// </summary>
         Inventory = FirstTagBasedCategoryId + 4,
-        
+
         /// <summary>
         /// Plugins tagged as "sound".
         /// </summary>
         Sound = FirstTagBasedCategoryId + 5,
-        
+
         /// <summary>
         /// Plugins tagged as "social".
         /// </summary>
         Social = FirstTagBasedCategoryId + 6,
-        
+
         /// <summary>
         /// Plugins tagged as "utility".
         /// </summary>
@@ -211,7 +211,7 @@ internal class PluginCategoryManager
     /// Gets the list of all known UI groups.
     /// </summary>
     public GroupInfo[] GroupList => this.groupList;
-    
+
     /// <summary>
     /// Gets or sets the current group kind.
     /// </summary>
@@ -229,12 +229,12 @@ internal class PluginCategoryManager
             }
         }
     }
-    
+
     /// <summary>
     /// Gets information about currently selected group.
     /// </summary>
     public GroupInfo CurrentGroup => this.groupList[this.currentGroupIdx];
-    
+
     /// <summary>
     /// Gets or sets the current category kind.
     /// </summary>
@@ -250,7 +250,7 @@ internal class PluginCategoryManager
             }
         }
     }
-    
+
     /// <summary>
     /// Gets information about currently selected category.
     /// </summary>
@@ -274,7 +274,7 @@ internal class PluginCategoryManager
     /// Rebuild available categories based on currently available plugins.
     /// </summary>
     /// <param name="availablePlugins">list of all available plugin manifests to install.</param>
-    public void BuildCategories(IEnumerable<PluginManifest> availablePlugins)
+    public void BuildCategories(IEnumerable<RemotePluginManifest> availablePlugins)
     {
         // rebuild map plugin name -> categoryIds
         this.mapPluginCategories.Clear();
@@ -334,7 +334,7 @@ internal class PluginCategoryManager
         {
             groupAvail.Categories.Add(this.CategoryList[categoryIdx].CategoryKind);
         }
-        
+
         // Hidden at the end
         groupAvail.Categories.Add(CategoryKind.Hidden);
 
@@ -405,7 +405,7 @@ internal class PluginCategoryManager
     public void SetCategoryHighlightsForPlugins(IEnumerable<PluginManifest> plugins)
     {
         ArgumentNullException.ThrowIfNull(plugins);
-        
+
         this.highlightedCategoryKinds.Clear();
 
         foreach (var entry in plugins)
@@ -486,7 +486,7 @@ internal class PluginCategoryManager
             /// Check if plugin testing is enabled.
             /// </summary>
             DoPluginTest,
-            
+
             /// <summary>
             /// Check if there are any hidden plugins.
             /// </summary>
@@ -565,7 +565,7 @@ internal class PluginCategoryManager
         public static string Category_AvailableForTesting => Loc.Localize("InstallerCategoryAvailableForTesting", "Testing Available");
 
         public static string Category_Hidden => Loc.Localize("InstallerCategoryHidden", "Hidden");
-        
+
         public static string Category_DevInstalled => Loc.Localize("InstallerInstalledDevPlugins", "Installed Dev Plugins");
 
         public static string Category_IconTester => "Image/Icon Tester";
@@ -579,7 +579,7 @@ internal class PluginCategoryManager
         public static string Category_DisabledPlugins => Loc.Localize("InstallerCategoryDisabledPlugins", "Disabled");
 
         public static string Category_IncompatiblePlugins => Loc.Localize("InstallerCategoryIncompatiblePlugins", "Incompatible");
-        
+
         public static string Category_Other => Loc.Localize("InstallerCategoryOther", "Other");
 
         public static string Category_Jobs => Loc.Localize("InstallerCategoryJobs", "Jobs");

--- a/Dalamud/Interface/Internal/Windows/PluginImageCache.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginImageCache.cs
@@ -58,7 +58,7 @@ internal class PluginImageCache : IInternalDisposableService
     private readonly CancellationTokenSource cancelToken = new();
     private readonly Task downloadTask;
     private readonly Task loadTask;
-    
+
     private readonly ConcurrentDictionary<string, LoadedIcon?> pluginIconMap = new();
     private readonly ConcurrentDictionary<string, IDalamudTextureWrap?[]?> pluginImagesMap = new();
 
@@ -100,7 +100,7 @@ internal class PluginImageCache : IInternalDisposableService
     /// </summary>
     public IDalamudTextureWrap TroubleIcon =>
         this.dalamudAssetManager.GetDalamudTextureWrap(DalamudAsset.TroubleIcon, this.EmptyTexture);
-    
+
     /// <summary>
     /// Gets the devPlugin icon overlay.
     /// </summary>
@@ -191,14 +191,10 @@ internal class PluginImageCache : IInternalDisposableService
     /// <returns>True if an entry exists, may be null if currently downloading.</returns>
     public bool TryGetIcon(LocalPlugin? plugin, IPluginManifest manifest, bool isThirdParty, out IDalamudTextureWrap? iconTexture, out DateTime? loadedSince)
     {
+        ArgumentNullException.ThrowIfNull(manifest);
+
         iconTexture = null;
         loadedSince = null;
-
-        if (manifest == null || manifest.InternalName == null)
-        {
-            Log.Error("THIS SHOULD NEVER HAPPEN! manifest == null || manifest.InternalName == null");
-            return false;
-        }
 
         var key = plugin?.EffectiveWorkingPluginId.ToString() ?? manifest.InternalName;
 
@@ -243,6 +239,8 @@ internal class PluginImageCache : IInternalDisposableService
     /// <returns>True if the image array exists, may be empty if currently downloading.</returns>
     public bool TryGetImages(LocalPlugin? plugin, IPluginManifest manifest, bool isThirdParty, out IDalamudTextureWrap?[] imageTextures)
     {
+        ArgumentNullException.ThrowIfNull(manifest);
+
         if (!this.pluginImagesMap.TryAdd(manifest.InternalName, null))
         {
             var found = this.pluginImagesMap[manifest.InternalName];
@@ -477,8 +475,7 @@ internal class PluginImageCache : IInternalDisposableService
             isThirdParty = true;
         }
 
-        var useTesting = Service<PluginManager>.Get().UseTesting(manifest);
-        var url = this.GetPluginIconUrl(manifest, isThirdParty, useTesting);
+        var url = this.GetPluginIconUrl(manifest, isThirdParty);
 
         if (url.IsNullOrEmpty())
         {
@@ -563,8 +560,7 @@ internal class PluginImageCache : IInternalDisposableService
             isThirdParty = true;
         }
 
-        var useTesting = Service<PluginManager>.Get().UseTesting(manifest);
-        var urls = this.GetPluginImageUrls(manifest, isThirdParty, useTesting);
+        var urls = this.GetPluginImageUrls(manifest, isThirdParty);
         urls = urls?.Where(x => !string.IsNullOrEmpty(x)).ToList();
         if (urls?.Any() != true)
         {
@@ -623,15 +619,18 @@ internal class PluginImageCache : IInternalDisposableService
         }
     }
 
-    private string? GetPluginIconUrl(IPluginManifest manifest, bool isThirdParty, bool isTesting)
+    private string? GetPluginIconUrl(IPluginManifest manifest, bool isThirdParty)
     {
         if (isThirdParty)
             return manifest.IconUrl;
 
+        if (manifest.Dip17Channel.IsNullOrEmpty())
+            return null;
+
         return MainRepoDip17ImageUrl.Format(manifest.Dip17Channel!, manifest.InternalName, "icon.png");
     }
 
-    private List<string?>? GetPluginImageUrls(IPluginManifest manifest, bool isThirdParty, bool isTesting)
+    private List<string?>? GetPluginImageUrls(IPluginManifest manifest, bool isThirdParty)
     {
         if (isThirdParty)
         {
@@ -688,7 +687,7 @@ internal class PluginImageCache : IInternalDisposableService
 
         return output;
     }
-    
+
     /// <summary>
     /// Record for a loaded icon.
     /// </summary>

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -3033,10 +3033,9 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         if (ImGui.BeginPopupContextItem("InstalledItemContextMenu"u8))
         {
-            if (configuration.DoPluginTest && remoteManifest != null)
+            if (configuration.DoPluginTest)
             {
-                var repoManifest = this.pluginListAvailable.FirstOrDefault(x => x.InternalName == plugin.Manifest.InternalName);
-                if (repoManifest?.IsTestingExclusive == true)
+                if (remoteManifest == null || remoteManifest?.IsTestingExclusive == true)
                     ImGui.BeginDisabled();
 
                 if (ImGui.MenuItem(Locs.PluginContext_TestingOptIn, optIn != null))
@@ -3045,7 +3044,8 @@ internal class PluginInstallerWindow : Window, IDisposable
                     {
                         configuration.PluginTestingOptIns!.Remove(optIn);
 
-                        if (remoteManifest.TestingAssemblyVersion > repoManifest?.AssemblyVersion)
+                        // Warn about downgrade
+                        if (remoteManifest?.TestingAssemblyVersion > remoteManifest?.AssemblyVersion)
                         {
                             this.testingWarningModalOnNextFrame = true;
                         }
@@ -3059,7 +3059,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                     _ = pluginManager.ReloadAllReposAsync();
                 }
 
-                if (repoManifest?.IsTestingExclusive == true)
+                if (remoteManifest?.IsTestingExclusive == true)
                     ImGui.EndDisabled();
             }
 

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -108,7 +108,7 @@ internal class PluginInstallerWindow : Window, IDisposable
     private string feedbackModalBody = string.Empty;
     private string feedbackModalContact = string.Empty;
     private bool feedbackModalIncludeException = false;
-    private IPluginManifest? feedbackPlugin = null;
+    private RemotePluginManifest? feedbackPlugin = null;
     private bool feedbackIsTesting = false;
 
     private int updatePluginCount = 0;
@@ -2851,7 +2851,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         if (plugin.IsTesting)
             flags |= PluginHeaderFlags.IsTesting;
 
-        if (this.DrawPluginCollapsingHeader(label, plugin, plugin.Manifest, flags, () => this.DrawInstalledPluginContextMenu(plugin, testingOptIn), index))
+        if (this.DrawPluginCollapsingHeader(label, plugin, plugin.Manifest, flags, () => this.DrawInstalledPluginContextMenu(plugin, remoteManifest, testingOptIn), index))
         {
             if (!this.WasPluginSeen(plugin.Manifest.InternalName))
                 configuration.SeenPluginInternalName.Add(plugin.Manifest.InternalName);
@@ -2880,10 +2880,11 @@ internal class PluginInstallerWindow : Window, IDisposable
             var canFeedback = !isThirdParty &&
                               !plugin.IsDev &&
                               !plugin.IsOrphaned &&
-                              (plugin.Manifest.DalamudApiLevel == PluginManager.DalamudApiLevel ||
-                               (plugin.Manifest.TestingDalamudApiLevel == PluginManager.DalamudApiLevel && hasTestingAvailable)) &&
+                              remoteManifest != null &&
+                              (remoteManifest.DalamudApiLevel == PluginManager.DalamudApiLevel ||
+                               (remoteManifest.TestingDalamudApiLevel == PluginManager.DalamudApiLevel && hasTestingAvailable)) &&
                               acceptsFeedback &&
-                              availablePluginUpdate == default;
+                              availablePluginUpdate == null;
 
             // Installed from
             if (plugin.IsDev)
@@ -2949,7 +2950,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             if (canFeedback)
             {
                 ImGui.SameLine();
-                this.DrawSendFeedbackButton(plugin.Manifest, plugin.IsTesting, false);
+                this.DrawSendFeedbackButton(remoteManifest, plugin.IsTesting, false);
             }
 
             if (availablePluginUpdate != default && !plugin.IsDev)
@@ -3025,14 +3026,14 @@ internal class PluginInstallerWindow : Window, IDisposable
         ImGui.PopStyleColor(2);
     }
 
-    private unsafe void DrawInstalledPluginContextMenu(LocalPlugin plugin, PluginTestingOptIn? optIn)
+    private unsafe void DrawInstalledPluginContextMenu(LocalPlugin plugin, RemotePluginManifest? remoteManifest, PluginTestingOptIn? optIn)
     {
         var pluginManager = Service<PluginManager>.Get();
         var configuration = Service<DalamudConfiguration>.Get();
 
         if (ImGui.BeginPopupContextItem("InstalledItemContextMenu"u8))
         {
-            if (configuration.DoPluginTest)
+            if (configuration.DoPluginTest && remoteManifest != null)
             {
                 var repoManifest = this.pluginListAvailable.FirstOrDefault(x => x.InternalName == plugin.Manifest.InternalName);
                 if (repoManifest?.IsTestingExclusive == true)
@@ -3044,7 +3045,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                     {
                         configuration.PluginTestingOptIns!.Remove(optIn);
 
-                        if (plugin.Manifest.TestingAssemblyVersion > repoManifest?.AssemblyVersion)
+                        if (remoteManifest.TestingAssemblyVersion > repoManifest?.AssemblyVersion)
                         {
                             this.testingWarningModalOnNextFrame = true;
                         }
@@ -3437,7 +3438,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         }
     }
 
-    private void DrawSendFeedbackButton(IPluginManifest manifest, bool isTesting, bool big)
+    private void DrawSendFeedbackButton(RemotePluginManifest manifest, bool isTesting, bool big)
     {
         var clicked = big ?
                           ImGuiComponents.IconButtonWithText(FontAwesomeIcon.Comment, Locs.FeedbackModal_Title) :

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabExperimental.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabExperimental.cs
@@ -30,7 +30,11 @@ internal sealed class SettingsTabExperimental : SettingsTab
             LazyLoc.Localize("DalamudSettingsPluginTest", "Get plugin testing builds"),
             LazyLoc.Localize("DalamudSettingsPluginTestHint", "Receive testing prereleases for selected plugins.\nTo opt-in to testing builds for a plugin, you have to right click it in the \"Installed Plugins\" tab of the plugin installer and select \"Receive plugin testing versions\"."),
             c => c.DoPluginTest,
-            (v, c) => c.DoPluginTest = v),
+            (v, c) =>
+            {
+                c.DoPluginTest = v;
+                _ = Service<PluginManager>.Get().ReloadAllReposAsync();
+            }),
         new HintSettingsEntry(
             LazyLoc.Localize("DalamudSettingsPluginTestWarning", "Testing plugins may contain bugs or crash your game. Please only enable this if you are aware of the risks."),
             ImGuiColors.AttentionForeground),

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -361,7 +361,7 @@ internal class PluginManager : IInternalDisposableService
     /// </summary>
     /// <param name="manifest">Manifest to check.</param>
     /// <returns>A value indicating whether testing can be used.</returns>
-    public bool CanUseTesting(IPluginManifest manifest)
+    public bool CanUseTesting(RemotePluginManifest manifest)
     {
         if (!this.configuration.DoPluginTest)
             return false;
@@ -378,7 +378,7 @@ internal class PluginManager : IInternalDisposableService
     /// </summary>
     /// <param name="manifest">Manifest to check.</param>
     /// <returns>A value indicating whether testing should be used.</returns>
-    public bool UseTesting(IPluginManifest manifest)
+    public bool UseTesting(RemotePluginManifest manifest)
     {
         return this.CanUseTesting(manifest) && this.HasTestingOptIn(manifest);
     }
@@ -506,8 +506,9 @@ internal class PluginManager : IInternalDisposableService
                         continue;
                     }
 
-                    if (manifest.IsTestingExclusive && this.configuration.PluginTestingOptIns!.All(x => x.InternalName != manifest.InternalName))
-                        this.configuration.PluginTestingOptIns.Add(new PluginTestingOptIn(manifest.InternalName));
+                    // NOTE(goat): We don't know this anymore after the manifest migration, but it shouldn't matter anymore, everyone should be migrated
+                    // if (manifest.IsTestingExclusive && this.configuration.PluginTestingOptIns!.All(x => x.InternalName != manifest.InternalName))
+                    //    this.configuration.PluginTestingOptIns.Add(new PluginTestingOptIn(manifest.InternalName));
 
                     versionsDefs.Add(new PluginDef(dllFile, manifest, false));
                 }
@@ -527,7 +528,7 @@ internal class PluginManager : IInternalDisposableService
 
             try
             {
-                pluginDefs.Add(versionsDefs.MaxBy(x => x.Manifest!.EffectiveVersion));
+                pluginDefs.Add(versionsDefs.MaxBy(x => x.Manifest!.AssemblyVersion));
             }
             catch (Exception ex)
             {
@@ -1157,7 +1158,7 @@ internal class PluginManager : IInternalDisposableService
     /// </summary>
     /// <param name="manifest">Plugin manifest.</param>
     /// <returns>If the manifest is eligible.</returns>
-    public bool IsManifestEligible(PluginManifest manifest)
+    public bool IsManifestEligible(RemotePluginManifest manifest)
     {
         // Testing exclusive
         if (manifest.IsTestingExclusive && !this.configuration.DoPluginTest)
@@ -1177,7 +1178,7 @@ internal class PluginManager : IInternalDisposableService
                     ? manifest.TestingDalamudApiLevel.Value
                     : manifest.DalamudApiLevel;
 
-            if (effectiveDalamudApiLevel < PluginManager.DalamudApiLevel - 1)
+            if (effectiveDalamudApiLevel < DalamudApiLevel - 1)
                 return false;
         }
 
@@ -1193,19 +1194,18 @@ internal class PluginManager : IInternalDisposableService
     /// </summary>
     /// <param name="manifest">Manifest to inspect.</param>
     /// <returns>A value indicating whether the plugin/manifest has been banned.</returns>
-    public bool IsManifestBanned(PluginManifest manifest)
+    public bool IsManifestBanned(IPluginManifest manifest)
     {
-        Debug.Assert(this.bannedPlugins != null, "this.bannedPlugins != null");
+        if (this.bannedPlugins == null)
+            throw new Exception("Banned plugins not loaded");
 
         if (this.LoadBannedPlugins)
             return false;
 
-        var config = Service<DalamudConfiguration>.Get();
-
         var versionToCheck = manifest.AssemblyVersion;
-        if (config.DoPluginTest && manifest.TestingAssemblyVersion > manifest.AssemblyVersion)
+        if (manifest is RemotePluginManifest remoteManifest && this.UseTesting(remoteManifest) && remoteManifest.TestingAssemblyVersion > manifest.AssemblyVersion)
         {
-            versionToCheck = manifest.TestingAssemblyVersion;
+            versionToCheck = remoteManifest.TestingAssemblyVersion;
         }
 
         return this.bannedPlugins.Any(ban => (ban.Name == manifest.InternalName || ban.Name == Hash.GetStringSha256Hash(manifest.InternalName))
@@ -1501,6 +1501,10 @@ internal class PluginManager : IInternalDisposableService
                                                 ? repoManifest.SourceRepo.PluginMasterUrl
                                                 : SpecialPluginSource.MainRepo;
 
+            // HACK: We need to do this at the moment so that D17 plugins can load their assets.
+            // Goat should get off his ass and fix the pipeline in Plogon to specify correct URLs
+            tempManifest.Dip17Channel = repoManifest.Dip17Channel;
+
             tempManifest.Save(tempManifestFile, "installation");
 
             // Copy the directory to the final location
@@ -1744,9 +1748,7 @@ internal class PluginManager : IInternalDisposableService
 
             foreach (var plugin in this.installedPluginsList)
             {
-                var installedVersion = plugin.IsTesting
-                                           ? plugin.Manifest.TestingAssemblyVersion
-                                           : plugin.Manifest.AssemblyVersion;
+                var installedVersion = plugin.Manifest.AssemblyVersion;
 
                 var updates = this.AvailablePlugins
                                   .Where(remoteManifest => plugin.Manifest.InternalName == remoteManifest.InternalName)

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -176,12 +176,12 @@ internal class LocalPlugin : IAsyncDisposable
     /// <summary>
     /// Gets a value indicating whether this plugin's API level is out of date.
     /// </summary>
-    public bool IsOutdated => this.manifest.EffectiveApiLevel < PluginManager.DalamudApiLevel;
+    public bool IsOutdated => this.manifest.DalamudApiLevel < PluginManager.DalamudApiLevel;
 
     /// <summary>
     /// Gets a value indicating whether the plugin is for testing use only.
     /// </summary>
-    public bool IsTesting => this.manifest.IsTestingExclusive || this.manifest.Testing;
+    public bool IsTesting => this.manifest.Testing;
 
     /// <summary>
     /// Gets a value indicating whether this plugin is orphaned(belongs to a repo) or not.
@@ -221,7 +221,7 @@ internal class LocalPlugin : IAsyncDisposable
     /// <summary>
     /// Gets the effective version of this plugin.
     /// </summary>
-    public Version EffectiveVersion => this.manifest.EffectiveVersion;
+    public Version EffectiveVersion => this.manifest.AssemblyVersion;
 
     /// <summary>
     /// Gets the effective working plugin ID for this plugin.
@@ -315,8 +315,8 @@ internal class LocalPlugin : IAsyncDisposable
                 throw new PluginPreconditionFailedException($"Unable to load {this.Name}, game is newer than applicable version {this.manifest.ApplicableVersion}");
 
             // We want to allow loading dev plugins with a lower API level than the current Dalamud API level, for ease of development
-            if (!pluginManager.LoadAllApiLevels && !this.IsDev && this.manifest.EffectiveApiLevel < PluginManager.DalamudApiLevel)
-                throw new PluginPreconditionFailedException($"Unable to load {this.Name}, incompatible API level {this.manifest.EffectiveApiLevel}");
+            if (!pluginManager.LoadAllApiLevels && !this.IsDev && this.manifest.DalamudApiLevel < PluginManager.DalamudApiLevel)
+                throw new PluginPreconditionFailedException($"Unable to load {this.Name}, incompatible API level {this.manifest.DalamudApiLevel}");
 
             // We might want to throw here?
             if (!this.IsWantedByAnyProfile)

--- a/Dalamud/Plugin/Internal/Types/Manifest/IPluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/Manifest/IPluginManifest.cs
@@ -38,11 +38,6 @@ public interface IPluginManifest
     public Version AssemblyVersion { get; }
 
     /// <summary>
-    /// Gets the assembly version of the plugin's testing variant.
-    /// </summary>
-    public Version? TestingAssemblyVersion { get; }
-
-    /// <summary>
     /// Gets the minimum Dalamud assembly version this plugin requires.
     /// </summary>
     public Version? MinimumDalamudVersion { get; }
@@ -74,12 +69,6 @@ public interface IPluginManifest
     public int DalamudApiLevel { get; }
 
     /// <summary>
-    /// Gets the API level of the plugin's testing variant.
-    /// For the current API level, please see <see cref="PluginManager.DalamudApiLevel"/> for the currently used API level.
-    /// </summary>
-    public int? TestingDalamudApiLevel { get; }
-
-    /// <summary>
     /// Gets the number of downloads this plugin has.
     /// </summary>
     public long DownloadCount { get; }
@@ -105,11 +94,6 @@ public interface IPluginManifest
     public string? FeedbackMessage { get; }
 
     /// <summary>
-    /// Gets a value indicating whether the plugin is only available for testing.
-    /// </summary>
-    public bool IsTestingExclusive { get; }
-
-    /// <summary>
     /// Gets a list of screenshot image URLs to show in the plugin installer.
     /// </summary>
     public List<string>? ImageUrls { get; }
@@ -118,9 +102,4 @@ public interface IPluginManifest
     /// Gets an URL for the plugin's icon.
     /// </summary>
     public string? IconUrl { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether this plugin is eligible for testing.
-    /// </summary>
-    public bool IsAvailableForTesting { get; }
 }

--- a/Dalamud/Plugin/Internal/Types/Manifest/LocalPluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/Manifest/LocalPluginManifest.cs
@@ -43,16 +43,6 @@ internal record LocalPluginManifest : PluginManifest, ILocalPluginManifest
     public bool IsThirdParty => !this.InstalledFromUrl.IsNullOrEmpty() && this.InstalledFromUrl != SpecialPluginSource.MainRepo;
 
     /// <summary>
-    /// Gets the effective version of this plugin.
-    /// </summary>
-    public Version EffectiveVersion => this.Testing && this.TestingAssemblyVersion != null ? this.TestingAssemblyVersion : this.AssemblyVersion;
-
-    /// <summary>
-    /// Gets the effective API level of this plugin.
-    /// </summary>
-    public int EffectiveApiLevel => this.Testing && this.TestingDalamudApiLevel != null ? this.TestingDalamudApiLevel.Value : this.DalamudApiLevel;
-
-    /// <summary>
     /// Save a plugin manifest to file.
     /// </summary>
     /// <param name="manifestFile">Path to save at.</param>

--- a/Dalamud/Plugin/Internal/Types/Manifest/RemotePluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/Manifest/RemotePluginManifest.cs
@@ -17,9 +17,34 @@ internal record RemotePluginManifest : PluginManifest
     /// </summary>
     [JsonIgnore]
     public PluginRepository SourceRepo { get; set; } = null!;
-    
+
     /// <summary>
     /// Gets or sets the changelog to be shown when obtaining the testing version of the plugin.
     /// </summary>
     public string? TestingChangelog { get; set; }
+
+    /// <summary>
+    /// Gets or sets the assembly version of the plugin's testing variant.
+    /// </summary>
+    public Version? TestingAssemblyVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the API level of the plugin's testing variant.
+    /// For the current API level, please see <see cref="PluginManager.DalamudApiLevel"/> for the currently used API level.
+    /// </summary>
+    public int? TestingDalamudApiLevel { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the plugin is only available for testing.
+    /// </summary>
+    public bool IsTestingExclusive { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this plugin is eligible for testing.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsAvailableForTesting
+        => this.TestingAssemblyVersion != null &&
+           this.TestingAssemblyVersion > this.AssemblyVersion &&
+           this.TestingDalamudApiLevel == PluginManager.DalamudApiLevel;
 }

--- a/Dalamud/Plugin/Internal/Types/PluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginManifest.cs
@@ -59,14 +59,6 @@ internal record PluginManifest : IPluginManifest
 
     /// <inheritdoc/>
     [JsonProperty]
-    public Version? TestingAssemblyVersion { get; init; }
-
-    /// <inheritdoc/>
-    [JsonProperty]
-    public bool IsTestingExclusive { get; init; }
-
-    /// <inheritdoc/>
-    [JsonProperty]
     public string? RepoUrl { get; init; }
 
     /// <summary>
@@ -83,10 +75,6 @@ internal record PluginManifest : IPluginManifest
     /// <inheritdoc/>
     [JsonProperty]
     public int DalamudApiLevel { get; init; } = PluginManager.DalamudApiLevel;
-
-    /// <inheritdoc/>
-    [JsonProperty]
-    public int? TestingDalamudApiLevel { get; init; }
 
     /// <inheritdoc/>
     [JsonProperty]
@@ -160,12 +148,5 @@ internal record PluginManifest : IPluginManifest
 
     /// <inheritdoc/>
     [JsonProperty("_Dip17Channel")]
-    public string? Dip17Channel { get; init; }
-
-    /// <inheritdoc/>
-    [JsonIgnore]
-    public bool IsAvailableForTesting
-        => this.TestingAssemblyVersion != null &&
-           this.TestingAssemblyVersion > this.AssemblyVersion &&
-           this.TestingDalamudApiLevel == PluginManager.DalamudApiLevel;
+    public string? Dip17Channel { get; set; }
 }

--- a/Dalamud/Support/BugBait.cs
+++ b/Dalamud/Support/BugBait.cs
@@ -26,7 +26,7 @@ internal static class BugBait
     /// <param name="reporter">The reporter name.</param>
     /// <param name="includeException">Whether the most recent exception to occur should be included in the report.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public static async Task SendFeedback(IPluginManifest plugin, bool isTesting, string content, string reporter, bool includeException)
+    public static async Task SendFeedback(RemotePluginManifest plugin, bool isTesting, string content, string reporter, bool includeException)
     {
         if (content.IsNullOrWhitespace())
             return;


### PR DESCRIPTION
We should split the remote/local manifest up further and create an abstraction for the former. I'm not sure if this is bulletproof, but we'll see.