### PR TITLE
Fix managed stack traces

### DIFF
--- a/Dalamud.Boot/dllmain.cpp
+++ b/Dalamud.Boot/dllmain.cpp
@@ -314,7 +314,7 @@ HRESULT WINAPI InitializeImpl(LPVOID lpParam, HANDLE hMainThreadContinue) {
     if (FAILED(result))
         return result;
 
-    using custom_component_entry_point_fn = void (CORECLR_DELEGATE_CALLTYPE*)(LPVOID, HANDLE);
+    using custom_component_entry_point_fn = LPVOID (CORECLR_DELEGATE_CALLTYPE*)(LPVOID, HANDLE);
     const auto entrypoint_fn = reinterpret_cast<custom_component_entry_point_fn>(entrypoint_vfn);
 
     // ============================== VEH ======================================== //
@@ -385,8 +385,9 @@ HRESULT WINAPI InitializeImpl(LPVOID lpParam, HANDLE hMainThreadContinue) {
     // utils::wait_for_game_window();
 
     logging::I("Initializing Dalamud...");
-    entrypoint_fn(lpParam, hMainThreadContinue);
-    logging::I("Done!");
+    const LPVOID managed_stacktrace_fun = entrypoint_fn(lpParam, hMainThreadContinue);
+    veh::set_managed_stacktrace_fun(managed_stacktrace_fun);
+    logging::I("Done! (managed_stacktrace_fun={})", managed_stacktrace_fun);
 
     return S_OK;
 }

--- a/Dalamud.Boot/veh.cpp
+++ b/Dalamud.Boot/veh.cpp
@@ -33,6 +33,8 @@ HANDLE g_crashhandler_pipe_write = nullptr;
 
 wchar_t g_external_event_info[16384] = L"";
 
+LPVOID g_managed_stracktrace_fun = nullptr;
+
 std::recursive_mutex g_exception_handler_mutex;
 
 std::chrono::time_point<std::chrono::system_clock> g_time_start;
@@ -201,17 +203,9 @@ LONG exception_handler(EXCEPTION_POINTERS* ex)
     {
         stackTrace = L"(no CLR stack trace available)";
     }
-    else if (void* fn; const auto err = static_cast<DWORD>(g_clr->get_function_pointer(
-        L"Dalamud.EntryPoint, Dalamud",
-        L"VehCallback",
-        L"Dalamud.EntryPoint+VehDelegate, Dalamud",
-        nullptr, nullptr, &fn)))
+    else if (g_managed_stracktrace_fun)
     {
-        stackTrace = std::format(L"Failed to read stack trace: 0x{:08x}", err);
-    }
-    else
-    {
-        stackTrace = static_cast<wchar_t*(*)()>(fn)();
+        stackTrace = static_cast<wchar_t*(*)()>(g_managed_stracktrace_fun)();
         // Don't free it, as the program's going to be quit anyway
     }
 
@@ -453,6 +447,11 @@ void veh::raise_external_event(const std::wstring& info)
     const auto info_size = std::min(info.size(), std::size(g_external_event_info) - 1);
     wcsncpy_s(g_external_event_info, info.c_str(), info_size);
     RaiseException(CUSTOM_EXCEPTION_EXTERNAL_EVENT, 0, 0, nullptr);
+}
+
+void veh::set_managed_stacktrace_fun(LPVOID fun)
+{
+    g_managed_stracktrace_fun = fun;
 }
 
 extern "C" __declspec(dllexport) void BootVehRaiseExternalEventW(LPCWSTR info)

--- a/Dalamud.Boot/veh.h
+++ b/Dalamud.Boot/veh.h
@@ -3,6 +3,7 @@
 namespace veh
 {
     bool add_handler(bool doFullDump, const std::string& workingDirectory);
+    void set_managed_stacktrace_fun(LPVOID fun);
     bool remove_handler();
     void raise_external_event(const std::wstring& info);
 }

--- a/Dalamud/EntryPoint.cs
+++ b/Dalamud/EntryPoint.cs
@@ -41,20 +41,22 @@ public sealed class EntryPoint
     /// </summary>
     /// <param name="infoPtr">Pointer to a serialized <see cref="DalamudStartInfo"/> data.</param>
     /// <param name="mainThreadContinueEvent">Event used to signal the main thread to continue.</param>
-    public delegate void InitDelegate(IntPtr infoPtr, IntPtr mainThreadContinueEvent);
+    /// <returns>Function pointer to the VEH stack trace function.</returns>
+    public delegate IntPtr InitDelegate(IntPtr infoPtr, IntPtr mainThreadContinueEvent);
 
     /// <summary>
     /// A delegate used from VEH handler on exception which CoreCLR will fast fail by default.
     /// </summary>
     /// <returns>HGLOBAL for message.</returns>
-    public delegate IntPtr VehDelegate();
+    private delegate IntPtr VehDelegate();
 
     /// <summary>
     /// Initialize Dalamud.
     /// </summary>
     /// <param name="infoPtr">Pointer to a serialized <see cref="DalamudStartInfo"/> data.</param>
     /// <param name="mainThreadContinueEvent">Event used to signal the main thread to continue.</param>
-    public static void Initialize(IntPtr infoPtr, IntPtr mainThreadContinueEvent)
+    /// <returns>Function pointer to the VEH stack trace function.</returns>
+    public static IntPtr Initialize(IntPtr infoPtr, IntPtr mainThreadContinueEvent)
     {
         var infoStr = Marshal.PtrToStringUTF8(infoPtr)!;
         var info = JsonConvert.DeserializeObject<DalamudStartInfo>(infoStr)!;
@@ -63,22 +65,8 @@ public sealed class EntryPoint
             Windows.Win32.PInvoke.MessageBox(HWND.Null, "Press OK to continue (BeforeDalamudConstruct)", "Dalamud Boot", MESSAGEBOX_STYLE.MB_OK);
 
         new Thread(() => RunThread(info, mainThreadContinueEvent)).Start();
-    }
 
-    /// <summary>
-    /// Returns stack trace.
-    /// </summary>
-    /// <returns>HGlobal to wchar_t* stack trace c-string.</returns>
-    public static IntPtr VehCallback()
-    {
-        try
-        {
-            return Marshal.StringToHGlobalUni(new StackTrace(1).ToString());
-        }
-        catch (Exception e)
-        {
-            return Marshal.StringToHGlobalUni("Fail: " + e);
-        }
+        return Marshal.GetFunctionPointerForDelegate<VehDelegate>(VehCallback);
     }
 
     /// <summary>
@@ -333,5 +321,21 @@ public sealed class EntryPoint
     {
         if (!args.Observed)
             Log.Error(args.Exception, "Unobserved exception in Task.");
+    }
+
+    /// <summary>
+    /// Returns stack trace.
+    /// </summary>
+    /// <returns>HGlobal to wchar_t* stack trace c-string.</returns>
+    private static IntPtr VehCallback()
+    {
+        try
+        {
+            return Marshal.StringToHGlobalUni(new StackTrace(1).ToString());
+        }
+        catch (Exception e)
+        {
+            return Marshal.StringToHGlobalUni("Fail: " + e);
+        }
     }
 }

--- a/DalamudCrashHandler/DalamudCrashHandler.cpp
+++ b/DalamudCrashHandler/DalamudCrashHandler.cpp
@@ -1059,7 +1059,12 @@ int main() {
             log << std::format(L"GPU Desc: {}", adapterDescription.Description) << std::endl;
         }
 
-        log << L"\n" << stackTrace << std::endl;
+        if (!stackTrace.empty())
+        {
+            log << L"\nManaged Call Stack\n{";
+            log << L"\n" << stackTrace << std::endl;
+            log << L"\n}\n";
+        }
 
         if (pProgressDialog)
             pProgressDialog->SetLine(3, L"Refreshing Module List", FALSE, NULL);


### PR DESCRIPTION
From .NET 10 onward, load_assembly_and_get_function_pointer() loads the assembly into a different load context than what get_function_pointer() uses to resolve the assembly later on, causing us to not resolve Dalamud when needing the VEH callback. Changed to just pass the VEH callback through init. Sounds like a bug in the hosting interface, maybe we should make a ticket.