### PR TITLE
Restore old SizeContrains logic to prevent 0x0 windows

### DIFF
--- a/Dalamud/Interface/Windowing/WindowHost.cs
+++ b/Dalamud/Interface/Windowing/WindowHost.cs
@@ -543,10 +543,7 @@ public class WindowHost
 
         if (this.Window.SizeConstraints.HasValue)
         {
-            var (min, max) = this.GetValidatedConstraints(this.Window.SizeConstraints.Value);
-            ImGui.SetNextWindowSizeConstraints(
-                min * ImGuiHelpers.GlobalScale,
-                max * ImGuiHelpers.GlobalScale);
+            ImGui.SetNextWindowSizeConstraints(this.Window.SizeConstraints.Value.MinimumSize * ImGuiHelpers.GlobalScale, this.Window.SizeConstraints.Value.MaximumSize * ImGuiHelpers.GlobalScale);
         }
 
         var maxBgAlpha = this.internalAlpha ?? this.Window.BgAlpha;
@@ -564,18 +561,6 @@ public class WindowHost
         {
             ImGui.SetNextWindowBgAlpha(maxBgAlpha.Value);
         }
-    }
-
-    private (Vector2 Min, Vector2 Max) GetValidatedConstraints(WindowSizeConstraints constraints)
-    {
-        var min = constraints.MinimumSize;
-        var max = constraints.MaximumSize;
-
-        // If max < min, treat as "no constraint" (float.MaxValue)
-        if (max.X < min.X || max.Y < min.Y)
-            max = new Vector2(float.MaxValue);
-
-        return (min, max);
     }
 
     private void PreHandlePreset(WindowSystemPersistence? persistence)

--- a/Dalamud/Interface/Windowing/WindowSizeConstraints.cs
+++ b/Dalamud/Interface/Windowing/WindowSizeConstraints.cs
@@ -7,6 +7,8 @@ namespace Dalamud.Interface.Windowing;
 /// </summary>
 public struct WindowSizeConstraints
 {
+    private Vector2 internalMaxSize = new(float.MaxValue);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="WindowSizeConstraints"/> struct.
     /// </summary>
@@ -17,10 +19,27 @@ public struct WindowSizeConstraints
     /// <summary>
     /// Gets or sets the minimum size of the window.
     /// </summary>
-    public Vector2 MinimumSize { get; set; }
+    public Vector2 MinimumSize { get; set; } = new(0);
 
     /// <summary>
     /// Gets or sets the maximum size of the window.
     /// </summary>
-    public Vector2 MaximumSize { get; set; }
+    public Vector2 MaximumSize
+    {
+        get => this.GetSafeMaxSize();
+        set => this.internalMaxSize = value;
+    }
+
+    private Vector2 GetSafeMaxSize()
+    {
+        // TODO Rework for interface
+        // Important: There needs to be a valid MaximumSize or 0x0 windows can occur.
+
+        var currentMin = this.MinimumSize;
+
+        if (this.internalMaxSize.X < currentMin.X || this.internalMaxSize.Y < currentMin.Y)
+            return new Vector2(float.MaxValue);
+
+        return this.internalMaxSize;
+    }
 }


### PR DESCRIPTION
Prevents 0x0 size contrains from occuring.

If a plugin window ctor uses `ScaledVector2` it triggers undefined behaviour based on load order, with the potential result being that `ImGuiHelper.GlobalScale` being still 0 and the follow up calculation `Vector2 * 0` returning a `Vector2(0, 0)`

This PR prevents the 0 from spiraling into the `SetNextWindowSizeConstraints()`

Current behaviour:
```cs
Minimum = 0,
Maximum = Not set (default 0)

if (maximum < minimum) <--- false
    return maxValue
    
    
return (min, max) <--- both 0

<--- Window is forced to resize to 0x0 because Range = 0 <---> 0
```

Restored behaviour:
```cs
Minimum = 0,
Maximum = Not set (default maxValue)

if (maximum < minimum) <--- false
    return maxValue
    
    
return (min, max) <--- 0, maxValue

<--- Window keeps whatever Size it has because Range = 0 <---> maxValue
```