### PR TITLE
Fix double entries in plugin installer

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -1320,8 +1320,8 @@ internal class PluginInstallerWindow : Window, IDisposable
         {
             var plugin = this.pluginListInstalled
                              .FirstOrDefault(plugin => plugin.Manifest.InternalName == availableManifest.InternalName &&
-                                                       plugin.Manifest.RepoUrl == availableManifest.RepoUrl &&
-                                                       !plugin.IsDev);
+                                        (!availableManifest.SourceRepo.IsThirdParty || plugin.Manifest.InstalledFromUrl == availableManifest.SourceRepo.PluginMasterUrl) &&
+                                        !plugin.IsDev);
 
             // We "consumed" this plugin from the pile and remove it.
             if (plugin != null)

--- a/Dalamud/Plugin/Internal/Types/Manifest/ILocalPluginManifest.cs
+++ b/Dalamud/Plugin/Internal/Types/Manifest/ILocalPluginManifest.cs
@@ -7,8 +7,7 @@ public interface ILocalPluginManifest : IPluginManifest
 {
     /// <summary>
     /// Gets the 3rd party repo URL that this plugin was installed from. Used to display where the plugin was
-    /// sourced from on the installed plugin view. This should not be included in the plugin master. This value is null
-    /// when installed from the main repo.
+    /// sourced from on the installed plugin view. This should not be included in the plugin master.
     /// </summary>
     public string InstalledFromUrl { get; }
 
@@ -16,7 +15,7 @@ public interface ILocalPluginManifest : IPluginManifest
     /// Gets a value indicating whether the plugin should be deleted during the next cleanup.
     /// </summary>
     public bool ScheduledForDeletion { get; }
-    
+
     /// <summary>
     /// Gets an ID uniquely identifying this specific installation of a plugin.
     /// </summary>


### PR DESCRIPTION
The old check `repoUrl == repoUrl` broke in 7.5 because of manifest changes, and was wrong to begin with.
Now the check is done against `InstalledFromUrl` and `SourceRepo.PluginMasterUrlSourceRepo.PluginMasterUrl` if it is a custom repo plugin.