### PR TITLE
Add CPU and GPU info to Dalamud.Boot log

### DIFF
--- a/Dalamud.Boot/dllmain.cpp
+++ b/Dalamud.Boot/dllmain.cpp
@@ -1,7 +1,10 @@
+#include <format>
 #include "pch.h"
 
 #include <d3d11.h>
+#include <dxgi.h>
 #include <dxgi1_3.h>
+#pragma comment(lib, "dxgi.lib")
 
 #include "DalamudStartInfo.h"
 #include "hooks.h"
@@ -128,6 +131,108 @@ static void CheckMsvcrtVersion() {
     }
 }
 
+//TODO: write shit
+
+void get_cpu_info(wchar_t* vendor, wchar_t* brand)
+{
+    // Gotten and reformatted to not include all data as listed at https://learn.microsoft.com/en-us/cpp/intrinsics/cpuid-cpuidex?view=msvc-170#example
+
+    // int cpuInfo[4] = {-1};
+    std::array<int, 4> cpui;
+    int nIds_;
+    int nExIds_;
+    std::vector<std::array<int, 4>> data_;
+    std::vector<std::array<int, 4>> extdata_;
+    size_t convertedChars = 0;
+
+    // Calling __cpuid with 0x0 as the function_id argument
+    // gets the number of the highest valid function ID.
+    __cpuid(cpui.data(), 0);
+    nIds_ = cpui[0];
+
+    for (int i = 0; i <= nIds_; ++i)
+    {
+        __cpuidex(cpui.data(), i, 0);
+        data_.push_back(cpui);
+    }
+
+    // Capture vendor string
+    char vendorA[0x20];
+    memset(vendorA, 0, sizeof(vendorA));
+    *reinterpret_cast<int*>(vendorA) = data_[0][1];
+    *reinterpret_cast<int*>(vendorA + 4) = data_[0][3];
+    *reinterpret_cast<int*>(vendorA + 8) = data_[0][2];
+    mbstowcs_s(&convertedChars, vendor, 0x20, vendorA, _TRUNCATE);
+
+    // Calling __cpuid with 0x80000000 as the function_id argument
+    // gets the number of the highest valid extended ID.
+    __cpuid(cpui.data(), 0x80000000);
+    nExIds_ = cpui[0];
+
+    for (int i = 0x80000000; i <= nExIds_; ++i)
+    {
+        __cpuidex(cpui.data(), i, 0);
+        extdata_.push_back(cpui);
+    }
+
+    // Interpret CPU brand string if reported
+    if (nExIds_ >= 0x80000004)
+    {
+        char brandA[0x40];
+        memset(brandA, 0, sizeof(brandA));
+        memcpy(brandA, extdata_[2].data(), sizeof(cpui));
+        memcpy(brandA + 16, extdata_[3].data(), sizeof(cpui));
+        memcpy(brandA + 32, extdata_[4].data(), sizeof(cpui));
+        mbstowcs_s(&convertedChars, brand, 0x40, brandA, _TRUNCATE);
+    }
+}
+
+std::vector<IDXGIAdapter1*> enum_dxgi_adapters()
+{
+    std::vector<IDXGIAdapter1*> vAdapters;
+
+    IDXGIFactory1* pFactory = NULL;
+    if (FAILED(CreateDXGIFactory1(__uuidof(IDXGIFactory1), (void**)&pFactory)))
+    {
+        return vAdapters;
+    }
+
+    IDXGIAdapter1* pAdapter;
+    for (UINT i = 0;
+        pFactory->EnumAdapters1(i, &pAdapter) != DXGI_ERROR_NOT_FOUND;
+        ++i)
+    {
+        vAdapters.push_back(pAdapter);
+    }
+
+    if (pFactory)
+    {
+        pFactory->Release();
+    }
+
+    return vAdapters;
+}
+
+
+static void PrintCpuGpuInfo() {
+    
+    wchar_t vendor[0x20];
+    wchar_t brand[0x40];
+    get_cpu_info(vendor, brand);
+
+
+    logging::I(std::format(L"CPU Vendor: {}", vendor));
+    logging::I(std::format(L"CPU Brand: {}", brand));
+
+    for (IDXGIAdapter1* adapter : enum_dxgi_adapters()) {
+        DXGI_ADAPTER_DESC1 adapterDescription{};
+        adapter->GetDesc1(&adapterDescription);
+
+        logging::I(std::format(L"GPU Desc: {}", adapterDescription.Description));
+    }
+
+}
+
 HRESULT WINAPI InitializeImpl(LPVOID lpParam, HANDLE hMainThreadContinue) {
     g_startInfo.from_envvars();
 
@@ -209,6 +314,7 @@ HRESULT WINAPI InitializeImpl(LPVOID lpParam, HANDLE hMainThreadContinue) {
     if ((g_startInfo.BootWaitMessageBox & DalamudStartInfo::WaitMessageboxFlags::BeforeInitialize) != DalamudStartInfo::WaitMessageboxFlags::None)
         MessageBoxW(nullptr, L"Press OK to continue (BeforeInitialize)", L"Dalamud Boot", MB_OK);
 
+    PrintCpuGpuInfo();
     CheckMsvcrtVersion();
 
     if (g_startInfo.BootDebugDirectX) {


### PR DESCRIPTION
This is basically a direct copy from what's in the crash handler, which is great when people crash, but less useful when they don't get the crash handler and we want to fetch this info from a manually generated tspack or log directly.
