### PR TITLE
Add Developer Mode to settings

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -131,6 +131,11 @@ internal sealed class DalamudConfiguration : IInternalDisposableService
     public List<string> SeenPluginInternalName { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets a value indicating whether developer mode is enabled.
+    /// </summary>
+    public bool? DevMode { get; set; }
+
+    /// <summary>
     /// Gets or sets a list of additional settings for devPlugins. The key is the absolute path
     /// to the plugin DLL. This is automatically generated for any plugins in the devPlugins folder.
     /// However by specifiying this value manually, you can add arbitrary files outside the normal
@@ -636,6 +641,8 @@ internal sealed class DalamudConfiguration : IInternalDisposableService
         this.AutoUpdateBehavior ??= this.AutoUpdatePlugins
                                         ? Plugin.Internal.AutoUpdate.AutoUpdateBehavior.UpdateAll
                                         : Plugin.Internal.AutoUpdate.AutoUpdateBehavior.OnlyNotify;
+
+        this.DevMode ??= this.DevPluginLoadLocations.Count != 0;
 #pragma warning restore CS0618
     }
 

--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -642,7 +642,7 @@ internal sealed class DalamudConfiguration : IInternalDisposableService
                                         ? Plugin.Internal.AutoUpdate.AutoUpdateBehavior.UpdateAll
                                         : Plugin.Internal.AutoUpdate.AutoUpdateBehavior.OnlyNotify;
 
-        this.DevMode ??= this.DevPluginLoadLocations.Count != 0;
+        this.DevMode ??= this.DevPluginLoadLocations.Count != 0 || this.DevBarOpenAtStartup;
 #pragma warning restore CS0618
     }
 

--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -79,7 +79,7 @@ internal sealed unsafe class Dalamud : IServiceType
         // Set up FFXIVClientStructs
         this.SetupClientStructsResolver(cacheDir);
 
-        // Set up hook verification if we have any dev plugins. It takes a little while at the moment
+        // Set up hook verification if Developer Mode is enabled. It takes a little while at the moment
         if (configuration.DevMode == true)
         {
             using var t = Timings.Start("HookVerifier Init");

--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -80,7 +80,7 @@ internal sealed unsafe class Dalamud : IServiceType
         this.SetupClientStructsResolver(cacheDir);
 
         // Set up hook verification if we have any dev plugins. It takes a little while at the moment
-        if (configuration.DevPluginLoadLocations.Count > 0)
+        if (configuration.DevMode == true)
         {
             using var t = Timings.Start("HookVerifier Init");
             HookVerifier.Initialize();

--- a/Dalamud/Hooking/Internal/Verification/HookVerifier.cs
+++ b/Dalamud/Hooking/Internal/Verification/HookVerifier.cs
@@ -165,11 +165,6 @@ internal static partial class HookVerifier
     {
         exceptions = [];
 
-        // Is Developer Mode enabled?
-        var configuration = Service<DalamudConfiguration>.GetNullable();
-        if (configuration?.DevMode != true)
-            return true;
-
         // Nothing to verify for this hook?
         if (!allToVerify.TryGetValue(address, out var entries))
             return true;

--- a/Dalamud/Hooking/Internal/Verification/HookVerifier.cs
+++ b/Dalamud/Hooking/Internal/Verification/HookVerifier.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
+using Dalamud.Configuration.Internal;
 using Dalamud.Logging.Internal;
 
 using FFXIVClientStructs.FFXIV.Application.Network;
@@ -164,11 +165,14 @@ internal static partial class HookVerifier
     {
         exceptions = [];
 
+        // Is Developer Mode enabled?
+        var configuration = Service<DalamudConfiguration>.GetNullable();
+        if (configuration?.DevMode != true)
+            return true;
+
         // Nothing to verify for this hook?
         if (!allToVerify.TryGetValue(address, out var entries))
-        {
             return true;
-        }
 
         var passedType = typeof(T);
         var isAssemblyMarshaled = !Attribute.IsDefined(passedType.Assembly, typeof(DisableRuntimeMarshallingAttribute));

--- a/Dalamud/Interface/Internal/DalamudCommands.cs
+++ b/Dalamud/Interface/Internal/DalamudCommands.cs
@@ -1,3 +1,4 @@
+using System.Configuration;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -271,6 +272,7 @@ internal class DalamudCommands : IServiceType
     private void OnDebugDrawDevMenu(string command, string arguments)
     {
         Service<DalamudInterface>.Get().ToggleDevMenu();
+        Service<DalamudConfiguration>.Get().DevMode = true;
     }
 
     private void OnTogglePluginStats(string command, string arguments)

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -189,7 +189,9 @@ internal class DalamudInterface : IInternalDisposableService
                     () => Service<DalamudInterface>.GetNullable()?.ToggleDevMenu(),
                     VirtualKey.SHIFT);
 
-                if (Versioning.GetActiveTrack() != "release")
+                var pluginManager = Service<PluginManager>.Get();
+                using var pmLock = pluginManager.GetSyncScope();
+                if (Versioning.GetActiveTrack() != "release" || pluginManager.InstalledPlugins.Any(plugin => plugin.IsDev))
                 {
                     titleScreenMenu.AddEntryCore(
                         Loc.Localize("TSMDalamudDevMenu", "Developer Menu"),

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -189,8 +189,7 @@ internal class DalamudInterface : IInternalDisposableService
                     () => Service<DalamudInterface>.GetNullable()?.ToggleDevMenu(),
                     VirtualKey.SHIFT);
 
-                var hasDevPluginLocations = configuration.DevPluginLoadLocations.Count > 0;
-                if (Versioning.GetActiveTrack() != "release" || hasDevPluginLocations)
+                if (Versioning.GetActiveTrack() != "release" || configuration.DevMode == true)
                 {
                     titleScreenMenu.AddEntryCore(
                         Loc.Localize("TSMDalamudDevMenu", "Developer Menu"),

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -189,9 +189,8 @@ internal class DalamudInterface : IInternalDisposableService
                     () => Service<DalamudInterface>.GetNullable()?.ToggleDevMenu(),
                     VirtualKey.SHIFT);
 
-                var pluginManager = Service<PluginManager>.Get();
-                using var pmLock = pluginManager.GetSyncScope();
-                if (Versioning.GetActiveTrack() != "release" || pluginManager.InstalledPlugins.Any(plugin => plugin.IsDev))
+                var hasDevPluginLocations = configuration.DevPluginLoadLocations.Count > 0;
+                if (Versioning.GetActiveTrack() != "release" || hasDevPluginLocations)
                 {
                     titleScreenMenu.AddEntryCore(
                         Loc.Localize("TSMDalamudDevMenu", "Developer Menu"),

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -196,7 +196,7 @@ internal class DalamudInterface : IInternalDisposableService
                     titleScreenMenu.AddEntryCore(
                         Loc.Localize("TSMDalamudDevMenu", "Developer Menu"),
                         new ForwardingSharedImmediateTexture(dalamudAssetManager.GetDalamudTextureWrap(DalamudAsset.LogoSmall)),
-                        () => this.isImGuiDrawDevMenu = true);
+                        () => this.isImGuiDrawDevMenu = !this.isImGuiDrawDevMenu);
                 }
             });
 

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -814,8 +814,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         }
 
         // If any dev plugin locations exist, allow a shortcut for the /xldev menu item
-        var hasDevPluginLocations = configuration.DevPluginLoadLocations.Count > 0;
-        if (hasDevPluginLocations)
+        if (configuration.DevMode == true)
         {
             ImGui.SameLine();
             if (ImGui.Button(Locs.FooterButton_ScanDevPlugins))

--- a/Dalamud/Interface/Internal/Windows/Settings/SettingsTab.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/SettingsTab.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 
+using Dalamud.Interface.Internal.Windows.Settings.Widgets;
 using Dalamud.Interface.Utility;
 
 namespace Dalamud.Interface.Internal.Windows.Settings;
@@ -33,12 +34,28 @@ internal abstract class SettingsTab : IDisposable
 
     public virtual void Draw()
     {
-        foreach (var settingsEntry in this.Entries)
+        for (var i = 0; i < this.Entries.Length; i++)
         {
-            if (settingsEntry.IsVisible)
-                settingsEntry.Draw();
+            var settingsEntry = this.Entries[i];
+            if (!settingsEntry.IsVisible)
+                continue;
 
-            ImGuiHelpers.ScaledDummy(5);
+            settingsEntry.Draw();
+
+            var needsSpacing = settingsEntry is not GapSettingsEntry;
+
+            for (var j = i + 1; j < this.Entries.Length; j++)
+            {
+                var nextEntry = this.Entries[j];
+                if (!nextEntry.IsVisible)
+                    continue;
+
+                needsSpacing &= nextEntry is not GapSettingsEntry;
+                break;
+            }
+
+            if (needsSpacing)
+                ImGuiHelpers.ScaledDummy(5);
         }
 
         ImGuiHelpers.ScaledDummy(15);

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabExperimental.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabExperimental.cs
@@ -59,6 +59,12 @@ internal sealed class SettingsTabExperimental : SettingsTab
 
         new GapSettingsEntry(5, true),
 
+        new SettingsEntry<bool>(
+            LazyLoc.Localize("DalamudSettingEnableDeveloperMode", "Enable Developer Mode"),
+            LazyLoc.Localize("DalamudSettingEnableDeveloperModeHint", "Unlocks developer-specific settings."),
+            c => c.DevMode ?? false,
+            (v, c) => c.DevMode = v),
+
         new DevPluginsSettingsEntry(),
 
         new SettingsEntry<bool>(

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabExperimental.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabExperimental.cs
@@ -73,13 +73,15 @@ internal sealed class SettingsTabExperimental : SettingsTab
                 "If this setting is enabled, a window containing further details will be shown when an internal assertion in ImGui fails.\nWe recommend enabling this when developing plugins. " +
                 "This setting does not persist and will reset when the game restarts.\nUse the setting below to enable it at startup."),
             c => Service<InterfaceManager>.Get().ShowAsserts,
-            (v, _) => Service<InterfaceManager>.Get().ShowAsserts = v),
+            (v, _) => Service<InterfaceManager>.Get().ShowAsserts = v,
+            visibility: () => Service<DalamudConfiguration>.Get().DevMode == true),
 
         new SettingsEntry<bool>(
             LazyLoc.Localize("DalamudSettingEnableImGuiAssertsAtStartup", "Always enable ImGui asserts at startup"),
             LazyLoc.Localize("DalamudSettingEnableImGuiAssertsAtStartupHint", "This will enable ImGui asserts every time the game starts."),
             c => c.ImGuiAssertsEnabledAtStartup ?? false,
-            (v, c) => c.ImGuiAssertsEnabledAtStartup = v),
+            (v, c) => c.ImGuiAssertsEnabledAtStartup = v,
+            visibility: () => Service<DalamudConfiguration>.Get().DevMode == true),
 
         new GapSettingsEntry(5, true),
 

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
@@ -34,6 +34,8 @@ internal sealed class DevPluginsSettingsEntry : SettingsEntry
         this.Name = LazyLoc.Localize("DalamudSettingsDevPluginLocation", "Dev Plugin Locations");
     }
 
+    public override bool IsVisible => Service<DalamudConfiguration>.Get().DevMode == true;
+
     public override void OnClose()
     {
         this.devPluginLocations =

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/GapSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/GapSettingsEntry.cs
@@ -10,13 +10,17 @@ internal sealed class GapSettingsEntry : SettingsEntry
 {
     private readonly float size;
     private readonly bool hr;
+    private readonly Func<bool>? visibility;
 
-    public GapSettingsEntry(float size, bool hr = false)
+    public GapSettingsEntry(float size, bool hr = false, Func<bool>? visibility = null)
     {
         this.size = size;
         this.hr = hr;
+        this.visibility = visibility;
         this.IsValid = true;
     }
+
+    public override bool IsVisible => this.visibility == null || this.visibility();
 
     public override void Load()
     {

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -536,63 +536,68 @@ internal class PluginManager : IInternalDisposableService
             }
         }
 
-        // devPlugins are more freeform. Look for any dll and hope to get lucky.
-        var devDllFiles = new List<FileInfo>();
-
-        foreach (var setting in this.configuration.DevPluginLoadLocations)
-        {
-            if (!setting.IsEnabled)
-                continue;
-
-            if (Directory.Exists(setting.Path))
-            {
-                devDllFiles.AddRange(new DirectoryInfo(setting.Path).GetFiles("*.dll", SearchOption.AllDirectories));
-            }
-            else if (File.Exists(setting.Path))
-            {
-                devDllFiles.Add(new FileInfo(setting.Path));
-            }
-        }
-
-        foreach (var dllFile in devDllFiles)
-        {
-            try
-            {
-                // Manifests are now required for devPlugins
-                var manifestFile = LocalPluginManifest.GetManifestFile(dllFile);
-                if (!manifestFile.Exists)
-                {
-                    Log.Error("DLL at {DllPath} has no manifest, this is no longer valid", dllFile.FullName);
-                    continue;
-                }
-
-                var manifest = LocalPluginManifest.Load(manifestFile);
-                if (manifest == null)
-                {
-                    Log.Error("Could not deserialize manifest for DLL at {DllPath}", dllFile.FullName);
-                    continue;
-                }
-
-                if (manifest != null && manifest.InternalName.IsNullOrEmpty())
-                {
-                    Log.Error("InternalName for dll at {Path} was null", manifestFile.FullName);
-                    continue;
-                }
-
-                devPluginDefs.Add(new PluginDef(dllFile, manifest, true));
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Could not load manifest for dev at {Directory}", dllFile.FullName);
-            }
-        }
-
         // Sort for load order - unloaded definitions have default priority of 0
         pluginDefs.Sort(PluginDef.Sorter);
-        devPluginDefs.Sort(PluginDef.Sorter);
 
-        // Dev plugins should load first.
-        pluginDefs.InsertRange(0, devPluginDefs);
+        // devPlugins are more freeform. Look for any dll and hope to get lucky.
+        var isDevModeEnabled = this.configuration.DevMode == true;
+        if (isDevModeEnabled)
+        {
+            var devDllFiles = new List<FileInfo>();
+
+            foreach (var setting in this.configuration.DevPluginLoadLocations)
+            {
+                if (!setting.IsEnabled)
+                    continue;
+
+                if (Directory.Exists(setting.Path))
+                {
+                    devDllFiles.AddRange(new DirectoryInfo(setting.Path).GetFiles("*.dll", SearchOption.AllDirectories));
+                }
+                else if (File.Exists(setting.Path))
+                {
+                    devDllFiles.Add(new FileInfo(setting.Path));
+                }
+            }
+
+            foreach (var dllFile in devDllFiles)
+            {
+                try
+                {
+                    // Manifests are now required for devPlugins
+                    var manifestFile = LocalPluginManifest.GetManifestFile(dllFile);
+                    if (!manifestFile.Exists)
+                    {
+                        Log.Error("DLL at {DllPath} has no manifest, this is no longer valid", dllFile.FullName);
+                        continue;
+                    }
+
+                    var manifest = LocalPluginManifest.Load(manifestFile);
+                    if (manifest == null)
+                    {
+                        Log.Error("Could not deserialize manifest for DLL at {DllPath}", dllFile.FullName);
+                        continue;
+                    }
+
+                    if (manifest != null && manifest.InternalName.IsNullOrEmpty())
+                    {
+                        Log.Error("InternalName for dll at {Path} was null", manifestFile.FullName);
+                        continue;
+                    }
+
+                    devPluginDefs.Add(new PluginDef(dllFile, manifest, true));
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Could not load manifest for dev at {Directory}", dllFile.FullName);
+                }
+            }
+
+            devPluginDefs.Sort(PluginDef.Sorter);
+
+            // Dev plugins should load first.
+            pluginDefs.InsertRange(0, devPluginDefs);
+        }
 
         async Task LoadPluginOnBoot(string logPrefix, PluginDef pluginDef, CancellationToken token)
         {


### PR DESCRIPTION
This PR adds a new "Enable Developer Mode" checkbox to the settings, enabling various other deveoper-specific settings, such as:

- Dev Plugin Locations
- Enable ImGui asserts
- Always enable ImGui asserts at startup
- The Scan Dev Plugins button in the Plugin Installer

The Developer Menu option in the Title Screen Menu was only shown on tracks other than release (e.g. stg), but now it's also shown when Developer Mode is enabled. (I also made it a toggle.)
