### PR TITLE
Add 30 seconds InputTimer check to IsClientIdle

### DIFF
--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -228,7 +228,7 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
         unsafe
         {
             var inputTimerModule = InputTimerModule.Instance();
-            if (inputTimerModule != null && inputTimerModule->InputTimer is not 0 and < 30)
+            if (inputTimerModule != null && inputTimerModule->Status == 1 && inputTimerModule->InputTimer < 30)
                 return false;
         }
 

--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -18,6 +18,7 @@ using FFXIVClientStructs.FFXIV.Client.Game.Network;
 using FFXIVClientStructs.FFXIV.Client.Network;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 
 using Lumina.Excel.Sheets;
 
@@ -221,7 +222,15 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
     public bool IsClientIdle(out ConditionFlag blockingFlag)
     {
         blockingFlag = 0;
-        if (this.objectTable.LocalPlayer is null) return true;
+        if (this.objectTable.LocalPlayer is null)
+            return true;
+
+        unsafe
+        {
+            var inputTimerModule = InputTimerModule.Instance();
+            if (inputTimerModule != null && inputTimerModule->AfkTimeLimit != 0 && inputTimerModule->AfkTimer < 30)
+                return false;
+        }
 
         var condition = Service<Conditions.Condition>.GetNullable();
 

--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -228,7 +228,7 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
         unsafe
         {
             var inputTimerModule = InputTimerModule.Instance();
-            if (inputTimerModule != null && inputTimerModule->AfkTimeLimit != 0 && inputTimerModule->AfkTimer < 30)
+            if (inputTimerModule != null && inputTimerModule->InputTimer is not 0 and < 30)
                 return false;
         }
 

--- a/Dalamud/Plugin/Services/IClientState.cs
+++ b/Dalamud/Plugin/Services/IClientState.cs
@@ -129,7 +129,7 @@ public interface IClientState : IDalamudService
 
     /// <summary>
     /// Check whether the client is currently "idle". This means a player is not logged in, is not actively in combat
-    /// or doing anything that we may not want to disrupt, and 30 seconds of the AfkTimer has passed.
+    /// or doing anything that we may not want to disrupt, and 30 seconds of the InputTimer has passed.
     /// </summary>
     /// <param name="blockingFlag">An outvar containing the first observed condition blocking the "idle" state. 0 if idle.</param>
     /// <returns>Returns true if the client is idle, false otherwise.</returns>
@@ -137,7 +137,7 @@ public interface IClientState : IDalamudService
 
     /// <summary>
     /// Check whether the client is currently "idle". This means a player is not logged in, is not actively in combat
-    /// or doing anything that we may not want to disrupt, and 30 seconds of the AfkTimer has passed.
+    /// or doing anything that we may not want to disrupt, and 30 seconds of the InputTimer has passed.
     /// </summary>
     /// <returns>Returns true if the client is idle, false otherwise.</returns>
     public bool IsClientIdle() => this.IsClientIdle(out _);

--- a/Dalamud/Plugin/Services/IClientState.cs
+++ b/Dalamud/Plugin/Services/IClientState.cs
@@ -128,16 +128,16 @@ public interface IClientState : IDalamudService
     public bool IsGPosing { get; }
 
     /// <summary>
-    /// Check whether the client is currently "idle". This means a player is not logged in, or is notctively in combat
-    /// or doing anything that we may not want to disrupt.
+    /// Check whether the client is currently "idle". This means a player is not logged in, is not actively in combat
+    /// or doing anything that we may not want to disrupt, and 30 seconds of the AfkTimer has passed.
     /// </summary>
     /// <param name="blockingFlag">An outvar containing the first observed condition blocking the "idle" state. 0 if idle.</param>
     /// <returns>Returns true if the client is idle, false otherwise.</returns>
     public bool IsClientIdle(out ConditionFlag blockingFlag);
 
     /// <summary>
-    /// Check whether the client is currently "idle". This means a player is not logged in, or is notctively in combat
-    /// or doing anything that we may not want to disrupt.
+    /// Check whether the client is currently "idle". This means a player is not logged in, is not actively in combat
+    /// or doing anything that we may not want to disrupt, and 30 seconds of the AfkTimer has passed.
     /// </summary>
     /// <returns>Returns true if the client is idle, false otherwise.</returns>
     public bool IsClientIdle() => this.IsClientIdle(out _);


### PR DESCRIPTION
Recently my plugins updated as I was teleporting and crashed.
It may have crashed because of other reasons, but it felt like a bad time to update plugins nevertheless.
So I thought it might be wise to wait a certain amount of time since the last user input.
I chose 30 seconds for now, but we can adjust this if necessary.