### PR TITLE
Fix UiBuilder OnDraw

### DIFF
--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -786,18 +786,17 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
 
             ImGui.End();
         }
-
-        try
+        else
         {
-            this.Draw?.Invoke();
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, "[{0}] UiBuilder OnBuildUi caught exception", this.namespaceName);
-            this.Draw = null;
-            this.OpenConfigUi = null;
-
-            this.hasErrorWindow = true;
+            try
+            {
+                this.Draw?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "[{0}] UiBuilder OnBuildUi caught exception", this.namespaceName);
+                this.hasErrorWindow = true;
+            }
         }
 
         this.FrameCount++;

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -769,7 +769,6 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
             this.ShowUi?.InvokeSafely();
         }
 
-        ImGui.PushID(this.namespaceName);
         if (DoStats) this.PluginDrawStatistics.StartUpdate();
 
         if (this.hasErrorWindow)
@@ -804,8 +803,6 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
         this.FrameCount++;
 
         if (DoStats) this.PluginDrawStatistics.EndUpdate();
-
-        ImGui.PopID();
 
         this.hitchDetector.Stop();
     }

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -789,7 +789,7 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
 
         try
         {
-            this.Draw?.InvokeSafely();
+            this.Draw?.Invoke();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Remove PushID/PopID outside Begin...End block

Note: this may break some plugins, in which case those plugins would have been relying on state/memory corruption that happened to be inert.

PushID requires an active window context. When called outside it, `g.CurrentWindow` would be some undefined value, effectively corrupting memory/state.

```cpp
void ImGui::PushID(const char* str_id)
{
    ImGuiContext& g = *GImGui;
    ImGuiWindow* window = g.CurrentWindow;
    ImGuiID id = window->GetID(str_id);
    window->IDStack.push_back(id);
}
```
https://github.com/goatcorp/gc-imgui/blob/33d28f5aa3a8e81aac1fd5843c6476c6175856c0/imgui.cpp#L8074-L8080

UIBuilder had the following pattern:

```cs
ImGui.PushID(this.namespaceName);

if (this.hasErrorWindow) {
  if (ImGui.Begin(...)) {
    ImGui.End()
  }
}

this.Draw.InvokeSafely();

ImGui.PopID();
```

The current code wasn't actually namespacing things; implementing that properly will need some thinking.

## `InvokeSafely` -> `Invoke` for `this.Draw` call inside try block

Either one of them needed to go, because they are redundant. Instead, to accommodate the case when a user decides to resume, do not clear `this.Draw` and just do not call it while error handler window is open.