### PR TITLE
Fix Window.IsClickthrough not updating

### DIFF
--- a/Dalamud/Interface/Windowing/WindowHost.cs
+++ b/Dalamud/Interface/Windowing/WindowHost.cs
@@ -380,6 +380,7 @@ public class WindowHost
                             Loc.Localize("WindowSystemContextActionClickthrough", "Make clickthrough"),
                             ref isClickthrough))
                     {
+                        this.Window.IsClickthrough = isClickthrough;
                         this.presetDirty = true;
                     }
 


### PR DESCRIPTION
title, the changed local value is never applied back to the window.