### PR TITLE
Don't mutate existing style when using add new style button

### DIFF
--- a/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/StyleEditor/StyleEditorWindow.cs
@@ -102,7 +102,7 @@ public class StyleEditorWindow : Window
         {
             this.SaveStyle();
 
-            var newStyle = config.SavedStyles[this.currentSel];
+            var newStyle = StyleModelV1.Get();
             newStyle.Name = Util.GetRandomName();
             config.SavedStyles.Add(newStyle);
 


### PR DESCRIPTION
Currently, when we grab the "new style" here, we just pull it from the existing list which means the styles are the same style object in memory. This causes the following line to change the name of both new and old styles.

In addition to being unexpected, this may cause a draw error when immediately exiting the window via "Close" and then re-opening the window, as `ChosenStyle` will become invalid (as it contains the name of the previously selected style which was erroneously renamed).