### PR TITLE
Fix NRE in DrawListTextureWrap when non-active children are present

### DIFF
--- a/Dalamud/Interface/Textures/TextureWraps/Internal/DrawListTextureWrap/WindowPrinter.cs
+++ b/Dalamud/Interface/Textures/TextureWraps/Internal/DrawListTextureWrap/WindowPrinter.cs
@@ -73,7 +73,12 @@ internal sealed unsafe partial class DrawListTextureWrap
                 _ => 1,
             };
             for (var i = 0; i < window.DC.ChildWindows.Size; i++)
-                res += CountDrawList(window.DC.ChildWindows[i]);
+            {
+                var child = window.DC.ChildWindows[i];
+                if (IsWindowActiveAndVisible(child)) // Clipped children may have been marked not active
+                    res += CountDrawList(child);
+            }
+
             return res;
         }
     }


### PR DESCRIPTION
ResizeAndDrawWindow:

1. Calls CountDrawList to size a stackalloc'd draw list. This currently includes non-active (e.g. fully clipped) children in its count.
2. Calls AddWindowToDrawData to populate that draw list. That method *excludes* non-active children, so it only partially populates the draw list (if there are non-active children).
3. Then walks over the draw list, *including* the unpopulated elements, to do some bookkeeping. Those unpopulated elements are null pointers.

This commit makes CountDrawList also exclude non-active children, so that it matches what AddWindowToDrawData does.

Fixes https://github.com/goatcorp/Dalamud/issues/2791

---

Hi, first time contributor :wave:

* I wasn't able to test this before maintenance, so **this PR is currently untested** (but it does compile... lol)
* Not quite sure how to fully build Dalamud on Linux (in a way that I can test it), so, uh, we'll see how that goes.
* I think there's room to refactor these methods into a single walk instead of multiple passes, but I wanted to avoid that complexity here. Happy to file a follow-up PR if that is desired though!