### PR TITLE
Fix resetting UI language to English when saving any Dalamud settings

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/LanguageChooserSettingsEntry.cs
@@ -18,6 +18,7 @@ internal sealed class LanguageChooserSettingsEntry : SettingsEntry
     private readonly string[] locLanguages;
 
     private int langIndex = -1;
+    private int loadedLangIndex = -1;
 
     public LanguageChooserSettingsEntry()
     {
@@ -60,12 +61,20 @@ internal sealed class LanguageChooserSettingsEntry : SettingsEntry
         this.langIndex = Array.IndexOf(this.languages, Service<DalamudConfiguration>.Get().EffectiveLanguage);
         if (this.langIndex == -1)
             this.langIndex = 0;
+
+        this.loadedLangIndex = this.langIndex;
     }
 
     public override void Save()
     {
-        Service<Localization>.Get().SetupWithLangCode(this.languages[this.langIndex]);
-        Service<DalamudConfiguration>.Get().LanguageOverride = this.languages[this.langIndex];
+        if (this.langIndex == this.loadedLangIndex)
+            return;
+
+        var language = this.languages[this.langIndex];
+
+        Service<DalamudConfiguration>.Get().LanguageOverride = language;
+        Service<Localization>.Get().SetupWithLangCode(language);
+        this.loadedLangIndex = this.langIndex;
     }
 
     public override void Draw()

--- a/Dalamud/Localization.cs
+++ b/Dalamud/Localization.cs
@@ -120,17 +120,7 @@ public class Localization : IServiceType
 
         Loc.SetupWithFallbacks(this.assembly);
 
-        foreach (var d in Delegate.EnumerateInvocationList(this.LocalizationChanged))
-        {
-            try
-            {
-                d(FallbackLangCode);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Exception during raise of {handler}", d.Method);
-            }
-        }
+        this.InvokeLocalizationChanged(FallbackLangCode, () => Loc.SetupWithFallbacks(this.assembly));
     }
 
     /// <summary>
@@ -149,24 +139,15 @@ public class Localization : IServiceType
 
         try
         {
-            Loc.Setup(this.ReadLocData(langCode), this.assembly);
+            var locData = this.ReadLocData(langCode);
+            Loc.Setup(locData, this.assembly);
+
+            this.InvokeLocalizationChanged(langCode, () => Loc.Setup(locData, this.assembly));
         }
         catch (Exception ex)
         {
             Log.Error(ex, "Could not load loc {0}. Setting up fallbacks.", langCode);
             this.SetupWithFallbacks();
-        }
-
-        foreach (var d in Delegate.EnumerateInvocationList(this.LocalizationChanged))
-        {
-            try
-            {
-                d(langCode);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Exception during raise of {handler}", d.Method);
-            }
         }
     }
 
@@ -208,5 +189,32 @@ public class Localization : IServiceType
         }
 
         return File.ReadAllText(Path.Combine(this.locResourceDirectory, $"{this.locResourcePrefix}{langCode}.json"));
+    }
+
+    private void InvokeLocalizationChanged(string langCode, Action restoreLocalization)
+    {
+        foreach (var d in Delegate.EnumerateInvocationList(this.LocalizationChanged))
+        {
+            try
+            {
+                restoreLocalization();
+                d(langCode);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Exception during raise of {handler}", d.Method);
+            }
+            finally
+            {
+                try
+                {
+                    restoreLocalization();
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Exception restoring localization after raise of {handler}", d.Method);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Currently, if any plugin (such as Orchestrion) subscribes to the `LocalizationChanged` event, saving dalamud settings may cause this handler to execute earlier than dalamud itself, resulting in dalamud using a corrupted CheapLoc state, causing all strings to fallback to English before the next restart.

<img width="952" height="497" alt="c3ac117ffc057332fbf4ffc5a5099c14" src="https://github.com/user-attachments/assets/1bd02ae6-a73a-4d3b-944a-7033006e81eb" />


I did two things in this PR:

1. Restore Dalamud localization state before and after each `LocalizationChanged` subscriber invocation so plugin handlers cannot leak CheapLoc setup side effects into later subscribers or the final Dalamud state.
2. Avoid reapplying the language settings when the language did not change.