### PR TITLE
Add new `BitmapFontIcon`s

### DIFF
--- a/Dalamud/Game/Text/SeStringHandling/BitmapFontIcon.cs
+++ b/Dalamud/Game/Text/SeStringHandling/BitmapFontIcon.cs
@@ -789,4 +789,34 @@ public enum BitmapFontIcon : uint
     /// The Event Tutorial icon.
     /// </summary>
     EventTutorial = 182,
+
+    /// <summary>
+    /// The Beastmaster icon.
+    /// </summary>
+    Beastmaster = 183,
+
+    /// <summary>
+    /// A red star icon.
+    /// </summary>
+    RedStar = 184,
+
+    /// <summary>
+    /// A blunt damage icon.
+    /// </summary>
+    BluntDamage = 185,
+
+    /// <summary>
+    /// A piecing damage icon.
+    /// </summary>
+    PiercingDamage = 186,
+
+    /// <summary>
+    /// A slashing damage icon.
+    /// </summary>
+    SlashingDamage = 187,
+
+    /// <summary>
+    /// A magical damage icon.
+    /// </summary>
+    MagicalDamage = 188,
 }


### PR DESCRIPTION
Added new `BitmapFontIcon` entries.

<img width="73" height="264" alt="image" src="https://github.com/user-attachments/assets/c43225d9-b0dd-46f0-a1e1-1322e25f70de" />

`Beastmaster`
`RedStar` (Used for NSO)
`BluntDamage`
`PiercingDamage`
`SlashingDamage`
`MagicalDamage`