### PR TITLE
ConvertToKernelTexture: Support non-immutable textures

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TexWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TexWidget.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Dalamud.Bindings.ImGui;
@@ -321,7 +322,11 @@ internal class TexWidget : IDataWindowWidget
                             try
                             {
                                 var kt = Service<TextureManager>.Get().ConvertToKernelTexture(source, true);
-                                kt->DecRef();
+                                new Thread(() =>
+                                {
+                                    Thread.Sleep(1000);
+                                    kt->DecRef();
+                                }).Start();
                                 Service<NotificationManager>.Get().AddNotification(
                                     "Test success",
                                     "TexWidget",
@@ -834,10 +839,11 @@ internal class TexWidget : IDataWindowWidget
 
     private unsafe void DrawCreateDrawListTexture()
     {
-        var windows = ImGui.GetCurrentContext().Windows.AsSpan();
+        // note: do not take the snapshot of the data span here, because Combo may create a new window
+        ref var windows = ref ImGui.GetCurrentContext().Windows;
         var selectedWindowIndex = -1;
         var selectedWindowName = "(select one)"u8;
-        for (var i = 0; i < windows.Length; i++)
+        for (var i = 0; i < windows.Size; i++)
         {
             if (windows[i].ID == this.drawListTextureWindowId)
             {
@@ -848,7 +854,7 @@ internal class TexWidget : IDataWindowWidget
 
         using (var combo = ImRaii.Combo("Window"u8, selectedWindowName))
         {
-            for (var i = combo.Success ? 0 : windows.Length; i < windows.Length; ++i)
+            for (var i = combo.Success ? 0 : windows.Size; i < windows.Size; ++i)
             {
                 var sel = i == selectedWindowIndex;
                 if (ImGui.Selectable(GetWindowName(windows[i]), ref sel))
@@ -862,7 +868,7 @@ internal class TexWidget : IDataWindowWidget
 
         ImGui.InputFloat2("Scale"u8, ref this.drawListTextureWrapScale);
 
-        if (ImGui.Button("Create"u8) && selectedWindowIndex >= 0 && selectedWindowIndex < windows.Length)
+        if (ImGui.Button("Create"u8) && selectedWindowIndex >= 0 && selectedWindowIndex < windows.Size)
         {
             var dd = this.textureManager.CreateDrawListTexture();
             dd.ResizeAndDrawWindow(windows[selectedWindowIndex], this.drawListTextureWrapScale);

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TexWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TexWidget.cs
@@ -3,12 +3,15 @@ using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using System.Threading.Tasks;
 
 using Dalamud.Bindings.ImGui;
 using Dalamud.Configuration.Internal;
 using Dalamud.Interface.Components;
+using Dalamud.Interface.ImGuiNotification;
+using Dalamud.Interface.ImGuiNotification.Internal;
 using Dalamud.Interface.Textures;
 using Dalamud.Interface.Textures.Internal.SharedImmediateTextures;
 using Dalamud.Interface.Textures.TextureWraps;
@@ -18,6 +21,8 @@ using Dalamud.Interface.Utility.Raii;
 using Dalamud.Plugin.Services;
 using Dalamud.Storage.Assets;
 using Dalamud.Utility;
+
+using Serilog;
 
 using TerraFX.Interop.DirectX;
 
@@ -71,6 +76,8 @@ internal class TexWidget : IDataWindowWidget
 
     private ImGuiViewportTextureArgs viewportTextureArgs;
     private int viewportIndexInt;
+    private uint drawListTextureWindowId;
+    private Vector2 drawListTextureWrapScale = Vector2.One;
     private string[]? supportedRenderTargetFormatNames;
     private DXGI_FORMAT[]? supportedRenderTargetFormats;
     private int renderTargetChoiceInt;
@@ -219,6 +226,12 @@ internal class TexWidget : IDataWindowWidget
             this.DrawCreateFromImGuiViewportAsync();
         }
 
+        if (ImGui.CollapsingHeader(nameof(ITextureProvider.CreateDrawListTexture)))
+        {
+            using var pushedId = ImRaii.PushId(nameof(this.DrawCreateDrawListTexture));
+            this.DrawCreateDrawListTexture();
+        }
+
         if (ImGui.CollapsingHeader("UV"u8))
         {
             using var pushedId = ImRaii.PushId(nameof(this.DrawUvInput));
@@ -301,6 +314,28 @@ internal class TexWidget : IDataWindowWidget
 
                         ImGui.Text($"RC: Resource({rcres})/View({rcsrv})");
                         ImGui.Text($"{source.Width} x {source.Height} | {source}");
+
+                        ImGui.SameLine();
+                        if (ImGui.Button("Test ConvertToKernelTexture"))
+                        {
+                            try
+                            {
+                                var kt = Service<TextureManager>.Get().ConvertToKernelTexture(source, true);
+                                kt->DecRef();
+                                Service<NotificationManager>.Get().AddNotification(
+                                    "Test success",
+                                    "TexWidget",
+                                    NotificationType.Success);
+                            }
+                            catch (Exception e)
+                            {
+                                Log.Error(e, "Failed to convert texture to kernel texture");
+                                Service<NotificationManager>.Get().AddNotification(
+                                    $"Failed to convert texture to kernel texture: {e.Message}",
+                                    "TexWidget",
+                                    NotificationType.Error);
+                            }
+                        }
                     }
                     else
                     {
@@ -794,6 +829,56 @@ internal class TexWidget : IDataWindowWidget
                         this.viewportTextureArgs with { ViewportId = viewports[this.viewportIndexInt].ID },
                         null),
                 });
+        }
+    }
+
+    private unsafe void DrawCreateDrawListTexture()
+    {
+        var windows = ImGui.GetCurrentContext().Windows.AsSpan();
+        var selectedWindowIndex = -1;
+        var selectedWindowName = "(select one)"u8;
+        for (var i = 0; i < windows.Length; i++)
+        {
+            if (windows[i].ID == this.drawListTextureWindowId)
+            {
+                selectedWindowIndex = i;
+                selectedWindowName = GetWindowName(windows[i]);
+            }
+        }
+
+        using (var combo = ImRaii.Combo("Window"u8, selectedWindowName))
+        {
+            for (var i = combo.Success ? 0 : windows.Length; i < windows.Length; ++i)
+            {
+                var sel = i == selectedWindowIndex;
+                if (ImGui.Selectable(GetWindowName(windows[i]), ref sel))
+                {
+                    selectedWindowIndex = i;
+                    this.drawListTextureWindowId = windows[i].ID;
+                    ImGui.SetItemDefaultFocus();
+                }
+            }
+        }
+
+        ImGui.InputFloat2("Scale"u8, ref this.drawListTextureWrapScale);
+
+        if (ImGui.Button("Create"u8) && selectedWindowIndex >= 0 && selectedWindowIndex < windows.Length)
+        {
+            var dd = this.textureManager.CreateDrawListTexture();
+            dd.ResizeAndDrawWindow(windows[selectedWindowIndex], this.drawListTextureWrapScale);
+            this.addedTextures.Add(new()
+            {
+                Api10 = Task.FromResult<IDalamudTextureWrap>(dd),
+            });
+        }
+
+        return;
+
+        static ReadOnlySpan<byte> GetWindowName(ImGuiWindow* window)
+        {
+            if (window is null || window->Name is null)
+                return "(null)"u8;
+            return MemoryMarshal.CreateReadOnlySpanFromNullTerminated(window->Name);
         }
     }
 

--- a/Dalamud/Interface/Textures/Internal/TextureManager.FromExistingTexture.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManager.FromExistingTexture.cs
@@ -26,9 +26,21 @@ internal sealed partial class TextureManager
     /// <inheritdoc cref="ITextureProvider.ConvertToKernelTexture"/>
     public unsafe Texture* ConvertToKernelTexture(IDalamudTextureWrap wrap, bool leaveWrapOpen = false)
     {
+        const TextureFlags unknownForceAcceptFlag = (TextureFlags)0x1000;
+        // CreateTexture2D:
+        //   if ((flags & 0x1800) || someFunction(gtex, 0)) {
+        //     someFunction2(gtex Notifier part);
+        //     return gtex;
+        //   }
+        // 0x800: Immutable; might be incorrect
+        // What does 0x1000 do? idk but:
+        //   1. skips `someFunction`
+        //   2. `someFunction2` does not touch `flags`
+        // so the value of `flags` does not matter, for now (7.50hf1)
+
         using var wrapAux = new WrapAux(wrap, leaveWrapOpen);
 
-        var flags = TextureFlags.TextureType2D;
+        var flags = TextureFlags.TextureType2D | unknownForceAcceptFlag;
         if (wrapAux.Desc.Usage == D3D11_USAGE.D3D11_USAGE_IMMUTABLE)
             flags |= TextureFlags.Immutable;
         if (wrapAux.Desc.Usage == D3D11_USAGE.D3D11_USAGE_DYNAMIC)
@@ -49,6 +61,11 @@ internal sealed partial class TextureManager
             0, // instructs the game to skip preprocessing it seems
             flags,
             0);
+
+        if (gtex is null)
+            throw new($"{nameof(Texture.CreateTexture2D)} failed");
+
+        gtex->Flags &= ~unknownForceAcceptFlag;
 
         // Kernel::Texture owns these resources. We're passing the ownership to them.
         wrapAux.TexPtr->AddRef();

--- a/Dalamud/Interface/Textures/Internal/TextureManager.FromExistingTexture.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManager.FromExistingTexture.cs
@@ -40,7 +40,7 @@ internal sealed partial class TextureManager
 
         using var wrapAux = new WrapAux(wrap, leaveWrapOpen);
 
-        var flags = TextureFlags.TextureType2D | unknownForceAcceptFlag;
+        var flags = TextureFlags.TextureType2D | unknownForceAcceptFlag | TextureFlags.UserManaged;
         if (wrapAux.Desc.Usage == D3D11_USAGE.D3D11_USAGE_IMMUTABLE)
             flags |= TextureFlags.Immutable;
         if (wrapAux.Desc.Usage == D3D11_USAGE.D3D11_USAGE_DYNAMIC)

--- a/Dalamud/Interface/Textures/TextureWraps/IDrawListTextureWrap.cs
+++ b/Dalamud/Interface/Textures/TextureWraps/IDrawListTextureWrap.cs
@@ -57,4 +57,12 @@ public interface IDrawListTextureWrap : IDalamudTextureWrap
     /// <see cref="ImGui.Begin(ImU8String, ImGuiWindowFlags)"/>.</param>
     /// <param name="scale">Scale to apply to all draw commands in the draw list.</param>
     void ResizeAndDrawWindow(ReadOnlySpan<char> windowName, Vector2 scale);
+
+    /// <inheritdoc cref="ResizeAndDrawWindow(ReadOnlySpan{char}, Vector2)"/>
+    void ResizeAndDrawWindow(ImU8String windowName, Vector2 scale);
+
+    /// <summary>Resizes this texture and draws an ImGui window.</summary>
+    /// <param name="windowPtr">Window to draw.</param>
+    /// <param name="scale">Scale to apply to all draw commands in the draw list.</param>
+    void ResizeAndDrawWindow(ImGuiWindowPtr windowPtr, Vector2 scale);
 }

--- a/Dalamud/Interface/Textures/TextureWraps/Internal/DrawListTextureWrap/WindowPrinter.cs
+++ b/Dalamud/Interface/Textures/TextureWraps/Internal/DrawListTextureWrap/WindowPrinter.cs
@@ -8,15 +8,27 @@ namespace Dalamud.Interface.Textures.TextureWraps.Internal;
 internal sealed unsafe partial class DrawListTextureWrap
 {
     /// <inheritdoc/>
-    public void ResizeAndDrawWindow(ReadOnlySpan<char> windowName, Vector2 scale)
+    public void ResizeAndDrawWindow(ReadOnlySpan<char> windowName, Vector2 scale) =>
+        this.ResizeAndDrawWindow(new ImU8String(windowName), scale);
+
+    /// <inheritdoc/>
+    public void ResizeAndDrawWindow(ImU8String windowName, Vector2 scale)
     {
         var window = ImGuiP.FindWindowByName(windowName);
         if (window.IsNull)
             throw new ArgumentException("Window not found", nameof(windowName));
+        this.ResizeAndDrawWindow(window, scale);
+    }
 
-        this.Size = window.Size;
+    /// <inheritdoc/>
+    public void ResizeAndDrawWindow(ImGuiWindowPtr windowPtr, Vector2 scale)
+    {
+        if (windowPtr.IsNull)
+            throw new ArgumentNullException(nameof(windowPtr));
 
-        var numDrawList = CountDrawList(window);
+        this.Size = windowPtr.Size * scale;
+
+        var numDrawList = CountDrawList(windowPtr);
         var drawLists = stackalloc ImDrawList*[numDrawList];
         var drawData = new ImDrawData
         {
@@ -25,11 +37,11 @@ internal sealed unsafe partial class DrawListTextureWrap
             TotalIdxCount = 0,
             TotalVtxCount = 0,
             CmdLists = drawLists,
-            DisplayPos = window.Pos,
-            DisplaySize = window.Size,
+            DisplayPos = windowPtr.Pos,
+            DisplaySize = windowPtr.Size,
             FramebufferScale = scale,
         };
-        AddWindowToDrawData(window, ref drawLists);
+        AddWindowToDrawData(windowPtr, ref drawLists);
         for (var i = 0; i < numDrawList; i++)
         {
             drawData.TotalVtxCount += drawData.CmdLists[i]->VtxBuffer.Size;


### PR DESCRIPTION
Also:
* Added a few overloads for `ResizeAndDrawWindow` to directly accept `ImGuiWindowPtr`.
* Added `ConvertToKernelTexture` test in `TexWidget`. Only tests if the function succeeds.
* Added `CreateDrawListTexture` section in `TexWidget`.

Used the flag `0x1000` for use with `CreateTexture2D`; flag value seems to be undocumented, and as far as the code is concerned, it's used only to skip the unwanted function calls, and the flag value is cleared once we get the allocated object back.