### PR TITLE
Improve Window Blur

### DIFF
--- a/Dalamud/Interface/Windowing/WindowHost.cs
+++ b/Dalamud/Interface/Windowing/WindowHost.cs
@@ -31,7 +31,7 @@ namespace Dalamud.Interface.Windowing;
 public class WindowHost
 {
     private const float FadeInOutTime = 0.072f;
-    private const float BlurNoiseOpacity = 0.17f;
+    private const float BlurNoiseOpacity = 0.60f;
     private const float MaxBlurStrength = 14f;
     private const string AdditionsPopupName = "WindowSystemContextActions";
 
@@ -297,7 +297,7 @@ public class WindowHost
                         effectiveBlurFactor * MaxBlurStrength,
                         ImGui.GetStyle().WindowRounding,
                         tintColor: ImGui.GetStyle().Colors[ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows) ? (int)ImGuiCol.TitleBgActive : (int)ImGuiCol.TitleBg] * BlurTintMultiplier,
-                        noiseOpacity: BlurNoiseOpacity * effectiveWindowBgAlpha);
+                        noiseOpacity: BlurNoiseOpacity * (effectiveWindowBgAlpha / 10.0f));
                 }
             }
 
@@ -433,6 +433,10 @@ public class WindowHost
                                       100f, "%.1f%%"))
                 {
                     this.internalAlpha = Math.Clamp(alpha / 100f, 0.2f, 1f);
+                }
+
+                if (ImGui.IsItemDeactivatedAfterEdit())
+                {
                     this.presetDirty = true;
                 }
 
@@ -457,6 +461,10 @@ public class WindowHost
                     if (ImGui.SliderFloat(Loc.Localize("WindowSystemContextActionBlur", "Background Blur"), ref blurOverride, 0f, 100f, "%.1f%%"))
                     {
                         this.internalBlurFactorOverride = blurOverride / 100f;
+                    }
+
+                    if (ImGui.IsItemDeactivatedAfterEdit())
+                    {
                         this.presetDirty = true;
                     }
 


### PR DESCRIPTION
Currently when window alpha is turned way down it gets *super* grainy and looks really bad:

<img width="739" height="709" alt="image" src="https://github.com/user-attachments/assets/41b59ba6-110f-4e06-82e0-a94ebd9fcd41" />

<img width="638" height="375" alt="image" src="https://github.com/user-attachments/assets/fce9d616-8f28-4bb1-a8e1-74f12623855f" />

This PR adjusts the grain to still be mostly the same strength at high opacity, but to mellow it out more at low opacity.

The result is a much cleaner grain that is still pleasantly visible:

https://github.com/user-attachments/assets/918325e8-091d-4f8d-8f40-174d52a11573

Additionally, I changed the preset dirty flag to only trigger a write to config file once the sliders are deactivated 👍 