### PR TITLE
feat: Allow blocking chat commands in macros

### DIFF
--- a/Dalamud/Game/Command/CommandInfo.cs
+++ b/Dalamud/Game/Command/CommandInfo.cs
@@ -31,6 +31,12 @@ public interface IReadOnlyCommandInfo
     /// Gets the display order of this command. Defaults to alphabetical ordering.
     /// </summary>
     int DisplayOrder { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this command is permitted to run in macros. Defaults to true.
+    /// API16 WARNING - THIS WILL DEFAULT TO FALSE.
+    /// </summary>
+    bool AllowedInMacros { get; }
 }
 
 /// <summary>
@@ -59,4 +65,7 @@ public sealed class CommandInfo : IReadOnlyCommandInfo
 
     /// <inheritdoc/>
     public int DisplayOrder { get; set; } = -1;
+
+    /// <inheritdoc/>
+    public bool AllowedInMacros { get; set; } = true;
 }

--- a/Dalamud/Game/Command/CommandInfo.cs
+++ b/Dalamud/Game/Command/CommandInfo.cs
@@ -34,7 +34,6 @@ public interface IReadOnlyCommandInfo
 
     /// <summary>
     /// Gets a value indicating whether this command is permitted to run in macros. Defaults to true.
-    /// API16 WARNING - THIS WILL DEFAULT TO FALSE.
     /// </summary>
     bool AllowedInMacros { get; }
 }

--- a/Dalamud/Game/Command/CommandManager.cs
+++ b/Dalamud/Game/Command/CommandManager.cs
@@ -1,10 +1,14 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+
+using CheapLoc;
 
 using Dalamud.Console;
 using Dalamud.Game.Gui;
+using Dalamud.Game.Gui.Toast;
 using Dalamud.Hooking;
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
@@ -99,11 +103,20 @@ internal sealed unsafe class CommandManager : IInternalDisposableService, IComma
         if (!this.commandMap.TryGetValue(command, out var handler)) // Command was not found.
             return false;
 
-        if (!handler.AllowedInMacros && this.IsMacroRunning())
+        if (!handler.AllowedInMacros &&
+            (this.GetCurrentMacroLine()?.StartsWith($"/{command}", StringComparison.OrdinalIgnoreCase) ?? false))
         {
             Log.Warning("Command {CommandName} is not allowed to be run in macros.", command);
-            Service<ChatGui>.Get().PrintError($"Command {command} cannot be run in a macro.");
-            return false;
+
+            if (!RaptureShellModule.Instance()->SuppressMacroErrors)
+            {
+                var msg = Loc.Localize("CommandHandlerMacroBlocked", $"Command {command} cannot be run in a macro.");
+                Service<ChatGui>.Get().PrintError(msg);
+                Service<ToastGui>.Get().ShowError(msg);
+            }
+
+            // We handled the command, just refused to run it. Suppress the game's failure message.
+            return true;
         }
 
         this.DispatchCommand(command, argument, handler);
@@ -246,10 +259,10 @@ internal sealed unsafe class CommandManager : IInternalDisposableService, IComma
         return this.ProcessCommand(command->ToString()) ? 0 : result;
     }
 
-    private unsafe bool IsMacroRunning()
+    private unsafe string? GetCurrentMacroLine()
     {
         var shellModule = RaptureShellModule.Instance();
-        return shellModule->MacroCurrentLine != 0;
+        return shellModule->MacroCurrentLine == 0 ? null : shellModule->MacroLineText.ToString();
     }
 
     /// <inheritdoc />

--- a/Dalamud/Game/Command/CommandManager.cs
+++ b/Dalamud/Game/Command/CommandManager.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 
 using Dalamud.Console;
+using Dalamud.Game.Gui;
 using Dalamud.Hooking;
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
@@ -14,6 +15,7 @@ using Dalamud.Utility;
 
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Client.UI.Shell;
 using FFXIVClientStructs.FFXIV.Component.Shell;
 
 namespace Dalamud.Game.Command;
@@ -96,6 +98,13 @@ internal sealed unsafe class CommandManager : IInternalDisposableService, IComma
 
         if (!this.commandMap.TryGetValue(command, out var handler)) // Command was not found.
             return false;
+
+        if (!handler.AllowedInMacros && this.IsMacroRunning())
+        {
+            Log.Warning("Command {CommandName} is not allowed to be run in macros.", command);
+            Service<ChatGui>.Get().PrintError($"Command {command} cannot be run in a macro.");
+            return false;
+        }
 
         this.DispatchCommand(command, argument, handler);
         return true;
@@ -235,6 +244,12 @@ internal sealed unsafe class CommandManager : IInternalDisposableService, IComma
         if (result != -1) return result;
 
         return this.ProcessCommand(command->ToString()) ? 0 : result;
+    }
+
+    private unsafe bool IsMacroRunning()
+    {
+        var shellModule = RaptureShellModule.Instance();
+        return shellModule->MacroCurrentLine != 0;
     }
 
     /// <inheritdoc />

--- a/Dalamud/Game/Command/CommandManager.cs
+++ b/Dalamud/Game/Command/CommandManager.cs
@@ -115,7 +115,7 @@ internal sealed unsafe class CommandManager : IInternalDisposableService, IComma
                 Service<ToastGui>.Get().ShowError(msg);
             }
 
-            // We handled the command, just refused to run it. Suppress the game's failure message.
+            // We handled the command, just refused to run it. Suppress the game's failure message
             return true;
         }
 


### PR DESCRIPTION
Add a new parameter to CommandInfo named `AllowedInMacros`. This parameter (currently defaulting to `true`) will permit this command to be run from within a macro context. If set to false, the command may not be run while a macro is active.

Ideally, this option will default to `false` in API16, requiring plugin developers *opt in* to macro execution. This would prevent potential edge cases where a macro can call a plugin command that in turn triggers actions that normally cannot be done within the context of a macro.

At present, this implementation doesn't actually determine if the command is *in* the macro or is just running while a macro is active. If this is desired, it should be addable without too much effort, but I wanted to keep the initial proposal simple.