### PR TITLE
Don't collapse plugins when installing, and during search if they are in the same spot

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -290,14 +290,12 @@ internal class PluginInstallerWindow : Window, IDisposable
         _ = pluginManager.ReloadAllReposAsync();
         _ = pluginManager.ScanDevPluginsAsync();
 
+        this.adaptiveSort = true;
+
         if (!this.isSearchTextPrefilled)
         {
-            this.searchText = string.Empty;
-            this.sortKind = PluginSortKind.Alphabetical;
-            this.filterText = Locs.SortBy_Alphabetical;
+            this.ClearSearch();
         }
-
-        this.adaptiveSort = true;
 
         if (this.updateStatus == OperationStatus.Complete || this.updateStatus == OperationStatus.Idle)
         {
@@ -332,7 +330,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         if (this.isSearchTextPrefilled)
         {
             this.isSearchTextPrefilled = false;
-            this.searchText = string.Empty;
+            this.ClearSearch();
         }
     }
 
@@ -370,13 +368,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         if (string.IsNullOrEmpty(text))
         {
             this.isSearchTextPrefilled = false;
-            this.searchText = string.Empty;
-            if (this.sortKind == PluginSortKind.SearchScore)
-            {
-                this.sortKind = PluginSortKind.Alphabetical;
-                this.filterText = Locs.SortBy_Alphabetical;
-                this.ResortPlugins();
-            }
+            this.ClearSearch();
         }
         else
         {
@@ -386,6 +378,24 @@ internal class PluginInstallerWindow : Window, IDisposable
             this.filterText = Locs.SortBy_SearchScore;
             this.ResortPlugins();
         }
+    }
+
+    /// <summary>
+    /// Clear the search text and reset all associated state (sort mode, category highlights, open collapsibles).
+    /// </summary>
+    private void ClearSearch()
+    {
+        var prevSearchText = this.searchText;
+        this.searchText = string.Empty;
+
+        if (this.adaptiveSort || this.sortKind == PluginSortKind.SearchScore)
+        {
+            this.sortKind = PluginSortKind.Alphabetical;
+            this.filterText = Locs.SortBy_Alphabetical;
+            this.ResortPlugins();
+        }
+
+        this.UpdateCategoriesOnSearchChange(prevSearchText);
     }
 
     /// <summary>
@@ -739,8 +749,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             ImGui.SetNextItemWidth(searchClearButtonWidth);
             if (ImGuiComponents.IconButton(FontAwesomeIcon.Times))
             {
-                this.searchText = string.Empty;
-                searchTextChanged = true;
+                this.ClearSearch();
             }
 
             if (searchTextChanged)
@@ -1605,7 +1614,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                     this.categoryManager.CurrentGroupKind = groupInfo.GroupKind;
 
                     // Reset search text when switching groups
-                    this.searchText = string.Empty;
+                    this.ClearSearch();
                 }
 
                 ImGui.Indent();

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -116,7 +116,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
     [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:Elements should appear in the correct order", Justification = "Makes sense like this")]
     private List<RemotePluginManifest> pluginListAvailable = [];
-    private List<RemotePluginManifest> pluginListAvailableLastReorder = [];
+    private List<RemotePluginManifest> pluginListAvailableLastResort = [];
     private List<LocalPlugin> pluginListInstalled = [];
     private List<AvailablePluginUpdate> pluginListUpdatable = [];
     private bool hasDevPlugins = false;
@@ -392,8 +392,9 @@ internal class PluginInstallerWindow : Window, IDisposable
         {
             this.sortKind = PluginSortKind.Alphabetical;
             this.filterText = Locs.SortBy_Alphabetical;
-            this.ResortPlugins();
         }
+
+        this.ResortPlugins();
 
         this.UpdateCategoriesOnSearchChange(prevSearchText);
     }
@@ -3905,7 +3906,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
     private void ResortPlugins()
     {
-        this.pluginListAvailableLastReorder = this.pluginListAvailable;
+        this.pluginListAvailableLastResort = this.pluginListAvailable;
 
         switch (this.sortKind)
         {
@@ -4003,7 +4004,7 @@ internal class PluginInstallerWindow : Window, IDisposable
             // Check if the search results are different, and close collapsibles whose slot now contains a different plugin
             if (previousSearchText != null)
             {
-                var previousSearchResults = this.pluginListAvailableLastReorder.Where(rm => !this.IsManifestFiltered(rm)).ToArray();
+                var previousSearchResults = this.pluginListAvailableLastResort.Where(rm => !this.IsManifestFiltered(rm)).ToArray();
                 if (!previousSearchResults.SequenceEqual(pluginsMatchingSearch))
                 {
                     this.openPluginCollapsibles.RemoveAll(

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -116,6 +116,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
     [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:Elements should appear in the correct order", Justification = "Makes sense like this")]
     private List<RemotePluginManifest> pluginListAvailable = [];
+    private List<RemotePluginManifest> pluginListAvailableLastReorder = [];
     private List<LocalPlugin> pluginListInstalled = [];
     private List<AvailablePluginUpdate> pluginListUpdatable = [];
     private bool hasDevPlugins = false;
@@ -3895,6 +3896,8 @@ internal class PluginInstallerWindow : Window, IDisposable
 
     private void ResortPlugins()
     {
+        this.pluginListAvailableLastReorder = this.pluginListAvailable;
+
         switch (this.sortKind)
         {
             case PluginSortKind.Alphabetical:
@@ -3983,20 +3986,22 @@ internal class PluginInstallerWindow : Window, IDisposable
         if (string.IsNullOrEmpty(this.searchText))
         {
             this.categoryManager.SetCategoryHighlightsForPlugins(Array.Empty<RemotePluginManifest>());
-
-            // Reset here for good measure, as we're returning from a search
-            this.openPluginCollapsibles.Clear();
         }
         else
         {
             var pluginsMatchingSearch = this.pluginListAvailable.Where(rm => !this.IsManifestFiltered(rm)).ToArray();
 
-            // Check if the search results are different, and clear the open collapsibles if they are
+            // Check if the search results are different, and close collapsibles whose slot now contains a different plugin
             if (previousSearchText != null)
             {
-                var previousSearchResults = this.pluginListAvailable.Where(rm => !this.IsManifestFiltered(rm)).ToArray();
+                var previousSearchResults = this.pluginListAvailableLastReorder.Where(rm => !this.IsManifestFiltered(rm)).ToArray();
                 if (!previousSearchResults.SequenceEqual(pluginsMatchingSearch))
-                    this.openPluginCollapsibles.Clear();
+                {
+                    this.openPluginCollapsibles.RemoveAll(
+                        i => i >= pluginsMatchingSearch.Length ||
+                             i >= previousSearchResults.Length ||
+                             pluginsMatchingSearch[i].InternalName != previousSearchResults[i].InternalName);
+                }
             }
 
             this.categoryManager.SetCategoryHighlightsForPlugins(pluginsMatchingSearch);


### PR DESCRIPTION
Also a small bugfix for category highlights being incorrect and the results sometimes being incorrect after searching and swapping.