### PR TITLE
Enable automatic reloading by default for dev plugins

### DIFF
--- a/Dalamud/Configuration/Internal/DevPluginSettings.cs
+++ b/Dalamud/Configuration/Internal/DevPluginSettings.cs
@@ -21,7 +21,7 @@ internal sealed class DevPluginSettings
     /// <summary>
     /// Gets or sets a value indicating whether this plugin should automatically reload on file change.
     /// </summary>
-    public bool AutomaticReloading { get; set; } = false;
+    public bool AutomaticReloading { get; set; } = true;
 
     /// <summary>
     /// Gets or sets an ID uniquely identifying this specific instance of a devPlugin.


### PR DESCRIPTION
This default setting seems to make more sense.