### PR TITLE
Avoid error on disabled rollup workflow

### DIFF
--- a/.github/workflows/rollup.yml
+++ b/.github/workflows/rollup.yml
@@ -1,17 +1,17 @@
 name: Rollup changes to next version
 on:
-  push:
-    branches:
-      - master
+#  push:
+#    branches:
+#      - master
   workflow_dispatch:
 
 jobs:
   check:
     runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        branches:
-#          - api15
+    strategy:
+      matrix:
+        branches:
+          - api15
 
     defaults:
       run:


### PR DESCRIPTION
Fixes this big red scary text!
<img width="566" height="310" alt="image" src="https://github.com/user-attachments/assets/901ffa9f-46d1-4da4-a3c0-5e5be60de556" />

Could also just be skipped instead, but I just restored the way it was disabled before API 15.