### PR TITLE
Make ObjectTable Safe during shutdown

### DIFF
--- a/Dalamud/Game/ClientState/Objects/ObjectTable.cs
+++ b/Dalamud/Game/ClientState/Objects/ObjectTable.cs
@@ -51,6 +51,11 @@ internal sealed partial class ObjectTable : IServiceType, IObjectTable
     {
         get
         {
+            if (Service<Framework>.Get().IsFrameworkUnloading)
+            {
+                return nint.Zero;
+            }
+
             ThreadSafety.AssertMainThread();
 
             return (nint)(&CSGameObjectManager.Instance()->Objects);
@@ -86,6 +91,11 @@ internal sealed partial class ObjectTable : IServiceType, IObjectTable
     {
         get
         {
+            if (Service<Framework>.Get().IsFrameworkUnloading)
+            {
+                return null;
+            }
+
             ThreadSafety.AssertMainThread();
 
             return (index >= objectTableLength || index < 0) ? null : this.cachedObjectTable[index].Update();
@@ -95,6 +105,11 @@ internal sealed partial class ObjectTable : IServiceType, IObjectTable
     /// <inheritdoc/>
     public IGameObject? SearchById(ulong gameObjectId)
     {
+        if (Service<Framework>.Get().IsFrameworkUnloading)
+        {
+            return null;
+        }
+
         ThreadSafety.AssertMainThread();
 
         if (gameObjectId is 0)
@@ -112,6 +127,11 @@ internal sealed partial class ObjectTable : IServiceType, IObjectTable
     /// <inheritdoc/>
     public IGameObject? SearchByEntityId(uint entityId)
     {
+        if (Service<Framework>.Get().IsFrameworkUnloading)
+        {
+            return null;
+        }
+
         ThreadSafety.AssertMainThread();
 
         if (entityId is 0 or 0xE0000000)
@@ -129,6 +149,11 @@ internal sealed partial class ObjectTable : IServiceType, IObjectTable
     /// <inheritdoc/>
     public unsafe nint GetObjectAddress(int index)
     {
+        if (Service<Framework>.Get().IsFrameworkUnloading)
+        {
+            return nint.Zero;
+        }
+
         ThreadSafety.AssertMainThread();
 
         return (index >= objectTableLength || index < 0) ? nint.Zero : (nint)this.cachedObjectTable[index].Address;
@@ -137,6 +162,11 @@ internal sealed partial class ObjectTable : IServiceType, IObjectTable
     /// <inheritdoc/>
     public unsafe IGameObject? CreateObjectReference(nint address)
     {
+        if (Service<Framework>.Get().IsFrameworkUnloading)
+        {
+            return null;
+        }
+
         ThreadSafety.AssertMainThread();
 
         if (address == nint.Zero)
@@ -235,12 +265,27 @@ internal sealed partial class ObjectTable
     /// <inheritdoc/>
     public IEnumerator<IGameObject> GetEnumerator()
     {
+        if (Service<Framework>.Get().IsFrameworkUnloading)
+        {
+            return EmptyEnumerator();
+        }
+
         ThreadSafety.AssertMainThread();
         return new Enumerator(this);
     }
 
     /// <inheritdoc/>
     IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+    /// <summary>
+    /// An empty enumerator that returns the default value of IGameObject.
+    /// For use when the game is unloading to return empty object data safely.
+    /// </summary>
+    /// <returns>An enumerator of empty objects.</returns>
+    private static IEnumerator<IGameObject> EmptyEnumerator()
+    {
+        yield return default;
+    }
 
     private struct Enumerator(ObjectTable owner) : IEnumerator<IGameObject>
     {

--- a/Dalamud/Game/ClientState/Objects/ObjectTable.cs
+++ b/Dalamud/Game/ClientState/Objects/ObjectTable.cs
@@ -267,7 +267,7 @@ internal sealed partial class ObjectTable
     {
         if (Service<Framework>.Get().IsFrameworkUnloading)
         {
-            return EmptyEnumerator();
+            return Enumerable.Empty<IGameObject>().GetEnumerator();
         }
 
         ThreadSafety.AssertMainThread();
@@ -276,16 +276,6 @@ internal sealed partial class ObjectTable
 
     /// <inheritdoc/>
     IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-
-    /// <summary>
-    /// An empty enumerator that returns the default value of IGameObject.
-    /// For use when the game is unloading to return empty object data safely.
-    /// </summary>
-    /// <returns>An enumerator of empty objects.</returns>
-    private static IEnumerator<IGameObject> EmptyEnumerator()
-    {
-        yield return default;
-    }
 
     private struct Enumerator(ObjectTable owner) : IEnumerator<IGameObject>
     {

--- a/Dalamud/Game/ClientState/Objects/ObjectTable.cs
+++ b/Dalamud/Game/ClientState/Objects/ObjectTable.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 
 using Dalamud.Game.ClientState.Objects.Enums;


### PR DESCRIPTION
It's not pretty, but it works, tested access to ObjectTable in VanillaPlus and SimpleTweaks during game shutdown, and no errors were thrown.

This might have potential consequences that I'm not aware of, let me know your thoughts.