### PR TITLE
Do not rely on LocalPlayer in ClientState.IsClientIdle

### DIFF
--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -18,7 +18,6 @@ using FFXIVClientStructs.FFXIV.Client.Game.Network;
 using FFXIVClientStructs.FFXIV.Client.Network;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
-using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 
 using Lumina.Excel.Sheets;
 
@@ -222,15 +221,7 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
     public bool IsClientIdle(out ConditionFlag blockingFlag)
     {
         blockingFlag = 0;
-        if (this.objectTable.LocalPlayer is null)
-            return true;
-
-        unsafe
-        {
-            var inputTimerModule = InputTimerModule.Instance();
-            if (inputTimerModule != null && inputTimerModule->Status == 1 && inputTimerModule->InputTimer < 30)
-                return false;
-        }
+        if (this.objectTable.LocalPlayer is null) return true;
 
         var condition = Service<Conditions.Condition>.GetNullable();
 

--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -221,7 +221,8 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
     public bool IsClientIdle(out ConditionFlag blockingFlag)
     {
         blockingFlag = 0;
-        if (this.objectTable.LocalPlayer is null) return true;
+        if (!this.IsLoggedIn)
+            return true;
 
         var condition = Service<Conditions.Condition>.GetNullable();
 

--- a/Dalamud/Plugin/Services/IClientState.cs
+++ b/Dalamud/Plugin/Services/IClientState.cs
@@ -128,16 +128,16 @@ public interface IClientState : IDalamudService
     public bool IsGPosing { get; }
 
     /// <summary>
-    /// Check whether the client is currently "idle". This means a player is not logged in, is not actively in combat
-    /// or doing anything that we may not want to disrupt, and 30 seconds of the InputTimer has passed.
+    /// Check whether the client is currently "idle". This means a player is not logged in, or is notctively in combat
+    /// or doing anything that we may not want to disrupt.
     /// </summary>
     /// <param name="blockingFlag">An outvar containing the first observed condition blocking the "idle" state. 0 if idle.</param>
     /// <returns>Returns true if the client is idle, false otherwise.</returns>
     public bool IsClientIdle(out ConditionFlag blockingFlag);
 
     /// <summary>
-    /// Check whether the client is currently "idle". This means a player is not logged in, is not actively in combat
-    /// or doing anything that we may not want to disrupt, and 30 seconds of the InputTimer has passed.
+    /// Check whether the client is currently "idle". This means a player is not logged in, or is notctively in combat
+    /// or doing anything that we may not want to disrupt.
     /// </summary>
     /// <returns>Returns true if the client is idle, false otherwise.</returns>
     public bool IsClientIdle() => this.IsClientIdle(out _);

--- a/Dalamud/Plugin/Services/IClientState.cs
+++ b/Dalamud/Plugin/Services/IClientState.cs
@@ -128,7 +128,7 @@ public interface IClientState : IDalamudService
     public bool IsGPosing { get; }
 
     /// <summary>
-    /// Check whether the client is currently "idle". This means a player is not logged in, or is notctively in combat
+    /// Opinionated check whether the client is currently "idle". This means a player is not logged in, or is not actively in combat
     /// or doing anything that we may not want to disrupt.
     /// </summary>
     /// <param name="blockingFlag">An outvar containing the first observed condition blocking the "idle" state. 0 if idle.</param>
@@ -136,7 +136,7 @@ public interface IClientState : IDalamudService
     public bool IsClientIdle(out ConditionFlag blockingFlag);
 
     /// <summary>
-    /// Check whether the client is currently "idle". This means a player is not logged in, or is notctively in combat
+    /// Opinionated check whether the client is currently "idle". This means a player is not logged in, or is not actively in combat
     /// or doing anything that we may not want to disrupt.
     /// </summary>
     /// <returns>Returns true if the client is idle, false otherwise.</returns>


### PR DESCRIPTION
The LocalPlayer is null during loading screens, causing plugins to be updated when the game is loading a new territory. Bad timing in my opinion. So I switched it to checking if the user not is logged in instead.

Since the InputTimer was an attempt to fix that, I've reverted #2781 with this.