### PR TITLE
Add ITextureReadbackProvider.GetAllRawImagesAsync

### DIFF
--- a/Dalamud/Interface/Textures/Internal/TextureManager.FromExistingTexture.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManager.FromExistingTexture.cs
@@ -197,6 +197,15 @@ internal sealed partial class TextureManager
         return await this.GetRawImageAsync(wrapAux, args, cancellationToken);
     }
 
+    /// <inheritdoc/>
+    public async Task<(int MipLevels, (RawImageSpecification Specification, byte[] RawData)[] Images)>
+        GetAllRawImagesAsync(
+            IDalamudTextureWrap wrap, bool leaveWrapOpen = false, CancellationToken cancellationToken = default)
+    {
+        using var wrapAux = new WrapAux(wrap, leaveWrapOpen);
+        return await this.GetAllRawImagesAsync(wrapAux, cancellationToken);
+    }
+
     private async Task<(RawImageSpecification Specification, byte[] RawData)> GetRawImageAsync(
         WrapAux wrapAux,
         TextureModificationArgs args = default,
@@ -210,9 +219,9 @@ internal sealed partial class TextureManager
         cancellationToken.ThrowIfCancellationRequested();
 
         // ID3D11DeviceContext is not a threadsafe resource, and it must be used from the UI thread.
-        return await this.RunDuringPresent(() => ExtractMappedResource(tex2D, cancellationToken));
+        return await this.RunDuringPresent(() => ExtractMappedSubresource0(tex2D, cancellationToken));
 
-        static unsafe (RawImageSpecification Specification, byte[] RawData) ExtractMappedResource(
+        static unsafe (RawImageSpecification Specification, byte[] RawData) ExtractMappedSubresource0(
             ComPtr<ID3D11Texture2D> tex2D,
             CancellationToken cancellationToken)
         {
@@ -257,6 +266,79 @@ internal sealed partial class TextureManager
             {
                 context.Get()->Unmap(mapWhat, 0);
             }
+        }
+    }
+
+    private async Task<(int MipLevels, (RawImageSpecification Specification, byte[] RawData)[] Images)>
+        GetAllRawImagesAsync(WrapAux wrapAux, CancellationToken cancellationToken = default)
+    {
+        using var tex2D = wrapAux.NewTexRef();
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // ID3D11DeviceContext is not a threadsafe resource, and it must be used from the UI thread.
+        return await this.RunDuringPresent(() => ExtractMappedResource(tex2D, cancellationToken));
+
+        static unsafe (int MipLevels, (RawImageSpecification Specification, byte[] RawData)[] Images)
+            ExtractMappedResource(ComPtr<ID3D11Texture2D> tex2D, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var desc = tex2D.GetDesc();
+
+            using var device = default(ComPtr<ID3D11Device>);
+            tex2D.Get()->GetDevice(device.GetAddressOf());
+            using var context = default(ComPtr<ID3D11DeviceContext>);
+            device.Get()->GetImmediateContext(context.GetAddressOf());
+
+            using var tmpTex =
+                (desc.CPUAccessFlags & (uint)D3D11_CPU_ACCESS_FLAG.D3D11_CPU_ACCESS_READ) == 0
+                    ? device.CreateTexture2D(
+                        desc with
+                        {
+                            SampleDesc = new(1, 0),
+                            Usage = D3D11_USAGE.D3D11_USAGE_STAGING,
+                            BindFlags = 0u,
+                            CPUAccessFlags = (uint)D3D11_CPU_ACCESS_FLAG.D3D11_CPU_ACCESS_READ,
+                            MiscFlags = 0u,
+                        },
+                        tex2D)
+                    : default;
+
+            var mapWhat = (ID3D11Resource*)(tmpTex.IsEmpty() ? tex2D.Get() : tmpTex.Get());
+
+            var images = new (RawImageSpecification Specification, byte[] RawData)[desc.ArraySize * desc.MipLevels];
+            uint subresource = 0;
+
+            for (uint arraySlice = 0; arraySlice < desc.ArraySize; ++arraySlice)
+            {
+                for (uint mipSlice = 0, width = desc.Width, height = desc.Height;
+                     mipSlice < desc.MipLevels;
+                     ++mipSlice, ++subresource, width = (width + 1) >> 1, height = (height + 1) >> 1)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    D3D11_MAPPED_SUBRESOURCE mapped;
+                    context.Get()->Map(mapWhat, subresource, D3D11_MAP.D3D11_MAP_READ, 0, &mapped).ThrowOnError();
+
+                    try
+                    {
+                        var specs = new RawImageSpecification(
+                            (int)width,
+                            (int)height,
+                            (int)desc.Format,
+                            (int)mapped.RowPitch);
+                        var bytes = new Span<byte>(mapped.pData, checked((int)mapped.DepthPitch)).ToArray();
+                        images[subresource] = (specs, bytes);
+                    }
+                    finally
+                    {
+                        context.Get()->Unmap(mapWhat, 0);
+                    }
+                }
+            }
+
+            return ((int)desc.MipLevels, images);
         }
     }
 

--- a/Dalamud/Interface/Textures/Internal/TextureManager.FromExistingTexture.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManager.FromExistingTexture.cs
@@ -314,7 +314,7 @@ internal sealed partial class TextureManager
             {
                 for (uint mipSlice = 0, width = desc.Width, height = desc.Height;
                      mipSlice < desc.MipLevels;
-                     ++mipSlice, ++subresource, width = (width + 1) >> 1, height = (height + 1) >> 1)
+                     ++mipSlice, ++subresource, width = Math.Max(width >> 1, 1), height = Math.Max(height >> 1, 1))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 

--- a/Dalamud/Interface/Textures/Internal/TextureManagerPluginScoped.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManagerPluginScoped.cs
@@ -400,6 +400,15 @@ internal sealed class TextureManagerPluginScoped
     }
 
     /// <inheritdoc/>
+    public async Task<(int MipLevels, (RawImageSpecification Specification, byte[] RawData)[] Images)>
+        GetAllRawImagesAsync(
+            IDalamudTextureWrap wrap, bool leaveWrapOpen = false, CancellationToken cancellationToken = default)
+    {
+        var manager = await this.ManagerTask;
+        return await manager.GetAllRawImagesAsync(wrap, leaveWrapOpen, cancellationToken);
+    }
+
+    /// <inheritdoc/>
     public IEnumerable<IBitmapCodecInfo> GetSupportedImageEncoderInfos() =>
         this.ManagerOrThrow.Wic.GetSupportedEncoderInfos();
 

--- a/Dalamud/Plugin/Services/ITextureReadbackProvider.cs
+++ b/Dalamud/Plugin/Services/ITextureReadbackProvider.cs
@@ -11,7 +11,10 @@ namespace Dalamud.Plugin.Services;
 /// <summary>Service that grants you to read instances of <see cref="IDalamudTextureWrap"/>.</summary>
 public interface ITextureReadbackProvider : IDalamudService
 {
-    /// <summary>Gets the raw data of a texture wrap.</summary>
+    /// <summary>
+    /// Gets the raw data of a texture wrap. Only the most detailed mipmap is retrieved,
+    /// and in case of an array texture, only the first slice.
+    /// </summary>
     /// <param name="wrap">The source texture wrap.</param>
     /// <param name="args">The texture modification arguments.</param>
     /// <param name="leaveWrapOpen">Whether to leave <paramref name="wrap"/> non-disposed when the returned
@@ -29,6 +32,28 @@ public interface ITextureReadbackProvider : IDalamudService
     Task<(RawImageSpecification Specification, byte[] RawData)> GetRawImageAsync(
         IDalamudTextureWrap wrap,
         TextureModificationArgs args = default,
+        bool leaveWrapOpen = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the raw data of a texture wrap, including all mipmaps, and in case of an array texture, all slices.
+    /// </summary>
+    /// <param name="wrap">The source texture wrap.</param>
+    /// <param name="leaveWrapOpen">Whether to leave <paramref name="wrap"/> non-disposed when the returned
+    /// <see cref="Task{TResult}"/> completes.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The number of mip levels, the raw data and its specifications.</returns>
+    /// <remarks>
+    /// <para>The number of <c>Images</c> will be a multiple of <c>MipLevels</c>.</para>
+    /// <para>The length of the returned <c>RawData</c> may not match
+    /// <see cref="RawImageSpecification.Height"/> * <see cref="RawImageSpecification.Pitch"/>.</para>
+    /// <para><see cref="RawImageSpecification.Pitch"/> may not be the minimal value required to represent the texture
+    /// bitmap data. For example, if a texture is 4x4 B8G8R8A8, the minimal pitch would be 32, but the function may
+    /// return 64 instead.</para>
+    /// <para>This function may throw an exception.</para>
+    /// </remarks>
+    Task<(int MipLevels, (RawImageSpecification Specification, byte[] RawData)[] Images)> GetAllRawImagesAsync(
+        IDalamudTextureWrap wrap,
         bool leaveWrapOpen = false,
         CancellationToken cancellationToken = default);
 


### PR DESCRIPTION
`GetRawImageAsync` only retrieves the most detailed mip of the texture (and, in case of an array, only the first slice).

This new function retrieves them all, but with the drawback that `TextureModificationArgs` is not supported (i. e. it's as *raw* as it gets).