### PR TITLE
Clear the RTV before copying

### DIFF
--- a/Dalamud/Interface/Textures/Internal/TextureManager.FromExistingTexture.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManager.FromExistingTexture.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -311,6 +312,8 @@ internal sealed partial class TextureManager
                 .ThrowOnError();
 
             wrapAux.CtxPtr->OMSetRenderTargets(1u, rtvCopyTemp.GetAddressOf(), null);
+            var clearColor = default(Vector4);
+            wrapAux.CtxPtr->ClearRenderTargetView(rtvCopyTemp.Get(), &clearColor.X);
             simpleDrawer.Draw(wrapAux.CtxPtr, wrapAux.SrvPtr, args.Uv0, args.Uv1Effective);
             if (args.MakeOpaque)
                 simpleDrawer.StripAlpha(wrapAux.CtxPtr);


### PR DESCRIPTION
Saving multiple different textures of same specifications to an image file resulted in images effectively getting layered. New textures are not guaranteed to be cleared it seems.