### PR TITLE
Loosen condition requirements for ClientState.IsClientIdle

### DIFF
--- a/Dalamud/Game/ClientState/ClientState.cs
+++ b/Dalamud/Game/ClientState/ClientState.cs
@@ -236,8 +236,12 @@ internal sealed class ClientState : IInternalDisposableService, IClientState
 
         var blockingConditions = condition.AsReadOnlySet().Except([
             ConditionFlag.NormalConditions,
+            ConditionFlag.Emoting,
             ConditionFlag.Jumping,
             ConditionFlag.Mounted,
+            ConditionFlag.InFlight,
+            ConditionFlag.Swimming,
+            ConditionFlag.Diving,
             ConditionFlag.UsingFashionAccessory,
             ConditionFlag.OnFreeTrial]);
 


### PR DESCRIPTION
With the 30s input check, I believe this makes sense.

Adding to the exceptions:
- Emoting (AFKing with an emote)
- InFlight
- Swimming
- Diving

Could also consider a few others, but it would be more debatable, depending how we define the client being idle, such as:
- UsingPartyFinder
- ParticipatingInCrossWorldPartyOrAlliance
- RidingPillion
- InThatPosition (when sitting, but also apparently set in different contexts)

Note: This has **not** been tested, but it should be fine if it builds 🫡.