### PR TITLE
Use Lock.Scope throughout the project

### DIFF
--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -263,12 +263,11 @@ internal class AddonLifecyclePluginScoped : IInternalDisposableService, IAddonLi
     /// <inheritdoc/>
     void IInternalDisposableService.DisposeService()
     {
-        lock (this.listenerLock)
+        using var scope = this.listenerLock.EnterScope();
+
+        foreach (var listener in this.eventListeners)
         {
-            foreach (var listener in this.eventListeners)
-            {
-                this.addonLifecycleService.UnregisterListener(listener);
-            }
+            this.addonLifecycleService.UnregisterListener(listener);
         }
     }
 
@@ -286,11 +285,10 @@ internal class AddonLifecyclePluginScoped : IInternalDisposableService, IAddonLi
     {
         var listener = new AddonLifecycleEventListener(eventType, addonName, handler);
 
-        lock (this.listenerLock)
-        {
-            this.eventListeners.Add(listener);
-            this.addonLifecycleService.RegisterListener(listener);
-        }
+        using var scope = this.listenerLock.EnterScope();
+
+        this.eventListeners.Add(listener);
+        this.addonLifecycleService.RegisterListener(listener);
     }
 
     /// <inheritdoc/>
@@ -311,18 +309,17 @@ internal class AddonLifecyclePluginScoped : IInternalDisposableService, IAddonLi
     /// <inheritdoc/>
     public void UnregisterListener(AddonEvent eventType, string addonName, IAddonLifecycle.AddonEventDelegate? handler = null)
     {
-        lock (this.listenerLock)
-        {
-            this.eventListeners.RemoveAll(entry =>
-            {
-                if (entry.EventType != eventType) return false;
-                if (entry.AddonName != addonName) return false;
-                if (handler is not null && entry.FunctionDelegate != handler) return false;
+        using var scope = this.listenerLock.EnterScope();
 
-                this.addonLifecycleService.UnregisterListener(entry);
-                return true;
-            });
-        }
+        this.eventListeners.RemoveAll(entry =>
+        {
+            if (entry.EventType != eventType) return false;
+            if (entry.AddonName != addonName) return false;
+            if (handler is not null && entry.FunctionDelegate != handler) return false;
+
+            this.addonLifecycleService.UnregisterListener(entry);
+            return true;
+        });
     }
 
     /// <inheritdoc/>
@@ -334,18 +331,17 @@ internal class AddonLifecyclePluginScoped : IInternalDisposableService, IAddonLi
     /// <inheritdoc/>
     public void UnregisterListener(params IAddonLifecycle.AddonEventDelegate[] handlers)
     {
+        using var scope = this.listenerLock.EnterScope();
+
         foreach (var handler in handlers)
         {
-            lock (this.listenerLock)
+            this.eventListeners.RemoveAll(entry =>
             {
-                this.eventListeners.RemoveAll(entry =>
-                {
-                    if (entry.FunctionDelegate != handler) return false;
+                if (entry.FunctionDelegate != handler) return false;
 
-                    this.addonLifecycleService.UnregisterListener(entry);
-                    return true;
-                });
-            }
+                this.addonLifecycleService.UnregisterListener(entry);
+                return true;
+            });
         }
     }
 

--- a/Dalamud/Game/Agent/AgentLifecycle.cs
+++ b/Dalamud/Game/Agent/AgentLifecycle.cs
@@ -318,12 +318,11 @@ internal class AgentLifecyclePluginScoped : IInternalDisposableService, IAgentLi
     /// <inheritdoc/>
     void IInternalDisposableService.DisposeService()
     {
-        lock (this.listenerLock)
+        using var scope = this.listenerLock.EnterScope();
+
+        foreach (var listener in this.eventListeners)
         {
-            foreach (var listener in this.eventListeners)
-            {
-                this.agentLifecycleService.UnregisterListener(listener);
-            }
+            this.agentLifecycleService.UnregisterListener(listener);
         }
     }
 
@@ -341,11 +340,10 @@ internal class AgentLifecyclePluginScoped : IInternalDisposableService, IAgentLi
     {
         var listener = new AgentLifecycleEventListener(eventType, agentId, handler);
 
-        lock (this.listenerLock)
-        {
-            this.eventListeners.Add(listener);
-            this.agentLifecycleService.RegisterListener(listener);
-        }
+        using var scope = this.listenerLock.EnterScope();
+
+        this.eventListeners.Add(listener);
+        this.agentLifecycleService.RegisterListener(listener);
     }
 
     /// <inheritdoc/>
@@ -366,18 +364,17 @@ internal class AgentLifecyclePluginScoped : IInternalDisposableService, IAgentLi
     /// <inheritdoc/>
     public void UnregisterListener(AgentEvent eventType, AgentId agentId, IAgentLifecycle.AgentEventDelegate? handler = null)
     {
-        lock (this.listenerLock)
-        {
-            this.eventListeners.RemoveAll(entry =>
-            {
-                if (entry.EventType != eventType) return false;
-                if (entry.AgentId != agentId) return false;
-                if (handler is not null && entry.FunctionDelegate != handler) return false;
+        using var scope = this.listenerLock.EnterScope();
 
-                this.agentLifecycleService.UnregisterListener(entry);
-                return true;
-            });
-        }
+        this.eventListeners.RemoveAll(entry =>
+        {
+            if (entry.EventType != eventType) return false;
+            if (entry.AgentId != agentId) return false;
+            if (handler is not null && entry.FunctionDelegate != handler) return false;
+
+            this.agentLifecycleService.UnregisterListener(entry);
+            return true;
+        });
     }
 
     /// <inheritdoc/>
@@ -389,18 +386,17 @@ internal class AgentLifecyclePluginScoped : IInternalDisposableService, IAgentLi
     /// <inheritdoc/>
     public void UnregisterListener(params IAgentLifecycle.AgentEventDelegate[] handlers)
     {
+        using var scope = this.listenerLock.EnterScope();
+
         foreach (var handler in handlers)
         {
-            lock (this.listenerLock)
+            this.eventListeners.RemoveAll(entry =>
             {
-                this.eventListeners.RemoveAll(entry =>
-                {
-                    if (entry.FunctionDelegate != handler) return false;
+                if (entry.FunctionDelegate != handler) return false;
 
-                    this.agentLifecycleService.UnregisterListener(entry);
-                    return true;
-                });
-            }
+                this.agentLifecycleService.UnregisterListener(entry);
+                return true;
+            });
         }
     }
 

--- a/Dalamud/Game/Gui/ChatGui.cs
+++ b/Dalamud/Game/Gui/ChatGui.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 using Dalamud.Configuration.Internal;
 using Dalamud.Game.Chat;
@@ -42,6 +43,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
 
     private readonly Queue<XivChatEntry> chatQueue = new();
     private readonly Dictionary<(string PluginName, uint CommandId), Action<uint, SeString>> dalamudLinkHandlers = [];
+    private readonly Lock dalamudLinkHandlersLock = new();
     private readonly List<nint> seenLogMessageObjects = [];
 
     private readonly Hook<RaptureLogModule.Delegates.PrintMessage> printMessageHook;
@@ -105,7 +107,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
             if (copy is not null)
                 return copy;
 
-            lock (this.dalamudLinkHandlers)
+            using (this.dalamudLinkHandlersLock.EnterScope())
             {
                 return this.dalamudLinkHandlersCopy ??=
                            this.dalamudLinkHandlers.ToImmutableDictionary(x => x.Key, x => x.Value);
@@ -222,7 +224,8 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
     internal DalamudLinkPayload AddChatLinkHandler(string pluginName, uint commandId, Action<uint, SeString> commandAction)
     {
         var payload = new DalamudLinkPayload { Plugin = pluginName, CommandId = commandId };
-        lock (this.dalamudLinkHandlers)
+
+        using (this.dalamudLinkHandlersLock.EnterScope())
         {
             this.dalamudLinkHandlers.Add((pluginName, commandId), commandAction);
             this.dalamudLinkHandlersCopy = null;
@@ -237,7 +240,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
     /// <param name="pluginName">The name of the plugin handling the links.</param>
     internal void RemoveChatLinkHandler(string pluginName)
     {
-        lock (this.dalamudLinkHandlers)
+        using (this.dalamudLinkHandlersLock.EnterScope())
         {
             var changed = false;
 
@@ -255,7 +258,7 @@ internal sealed unsafe class ChatGui : IInternalDisposableService, IChatGui
     /// <param name="commandId">The ID of the command to be removed.</param>
     internal void RemoveChatLinkHandler(string pluginName, uint commandId)
     {
-        lock (this.dalamudLinkHandlers)
+        using (this.dalamudLinkHandlersLock.EnterScope())
         {
             if (this.dalamudLinkHandlers.Remove((pluginName, commandId)))
                 this.dalamudLinkHandlersCopy = null;

--- a/Dalamud/Game/Gui/ContextMenu/ContextMenu.cs
+++ b/Dalamud/Game/Gui/ContextMenu/ContextMenu.cs
@@ -110,23 +110,23 @@ internal sealed unsafe class ContextMenu : IInternalDisposableService, IContextM
     /// <inheritdoc/>
     public void AddMenuItem(ContextMenuType menuType, IMenuItem item)
     {
-        lock (this.MenuItemsLock)
-        {
-            if (!this.MenuItems.TryGetValue(menuType, out var items))
-                this.MenuItems[menuType] = items = [];
-            items.Add(item);
-        }
+        using var scope = this.MenuItemsLock.EnterScope();
+
+        if (!this.MenuItems.TryGetValue(menuType, out var items))
+            this.MenuItems.TryAdd(menuType, items = []);
+
+        items.Add(item);
     }
 
     /// <inheritdoc/>
     public bool RemoveMenuItem(ContextMenuType menuType, IMenuItem item)
     {
-        lock (this.MenuItemsLock)
-        {
-            if (!this.MenuItems.TryGetValue(menuType, out var items))
-                return false;
-            return items.Remove(item);
-        }
+        using var scope = this.MenuItemsLock.EnterScope();
+
+        if (!this.MenuItems.TryGetValue(menuType, out var items))
+            return false;
+
+        return items.Remove(item);
     }
 
     /// <summary>
@@ -358,10 +358,10 @@ internal sealed unsafe class ContextMenu : IInternalDisposableService, IContextM
 
             if (this.SelectedMenuType is { } menuType)
             {
-                lock (this.MenuItemsLock)
+                using (this.MenuItemsLock.EnterScope())
                 {
                     if (this.MenuItems.TryGetValue(menuType, out var items))
-                        this.SelectedItems = new(items);
+                        this.SelectedItems = [with(items)];
                     else
                         this.SelectedItems = [];
                 }
@@ -538,7 +538,7 @@ internal class ContextMenuPluginScoped : IInternalDisposableService, IContextMen
 
     private Dictionary<ContextMenuType, List<IMenuItem>> MenuItems { get; } = [];
 
-    private object MenuItemsLock { get; } = new();
+    private Lock MenuItemsLock { get; } = new();
 
     /// <inheritdoc/>
     void IInternalDisposableService.DisposeService()
@@ -547,25 +547,24 @@ internal class ContextMenuPluginScoped : IInternalDisposableService, IContextMen
 
         this.OnMenuOpened = null;
 
-        lock (this.MenuItemsLock)
+        using var scope = this.MenuItemsLock.EnterScope();
+
+        foreach (var (menuType, items) in this.MenuItems)
         {
-            foreach (var (menuType, items) in this.MenuItems)
-            {
-                foreach (var item in items)
-                    this.parentService.RemoveMenuItem(menuType, item);
-            }
+            foreach (var item in items)
+                this.parentService.RemoveMenuItem(menuType, item);
         }
     }
 
     /// <inheritdoc/>
     public void AddMenuItem(ContextMenuType menuType, IMenuItem item)
     {
-        lock (this.MenuItemsLock)
-        {
-            if (!this.MenuItems.TryGetValue(menuType, out var items))
-                this.MenuItems[menuType] = items = [];
-            items.Add(item);
-        }
+        using var scope = this.MenuItemsLock.EnterScope();
+
+        if (!this.MenuItems.TryGetValue(menuType, out var items))
+            this.MenuItems.TryAdd(menuType, items = []);
+
+        items.Add(item);
 
         this.parentService.AddMenuItem(menuType, item);
     }
@@ -573,11 +572,10 @@ internal class ContextMenuPluginScoped : IInternalDisposableService, IContextMen
     /// <inheritdoc/>
     public bool RemoveMenuItem(ContextMenuType menuType, IMenuItem item)
     {
-        lock (this.MenuItemsLock)
-        {
-            if (this.MenuItems.TryGetValue(menuType, out var items))
-                items.Remove(item);
-        }
+        using var scope = this.MenuItemsLock.EnterScope();
+
+        if (this.MenuItems.TryGetValue(menuType, out var items))
+            items.Remove(item);
 
         return this.parentService.RemoveMenuItem(menuType, item);
     }

--- a/Dalamud/Game/Inventory/GameInventory.cs
+++ b/Dalamud/Game/Inventory/GameInventory.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 using Dalamud.Game.Gui;
 using Dalamud.Game.Inventory.InventoryEventArgTypes;
@@ -28,6 +29,7 @@ internal class GameInventory : IInternalDisposableService
 
     private readonly List<GameInventoryPluginScoped> subscribersPendingChange = [];
     private readonly List<GameInventoryPluginScoped> subscribers = [];
+    private readonly Lock subscribersLock = new();
 
     private readonly List<InventoryItemAddedArgs> addedEvents = [];
     private readonly List<InventoryItemRemovedArgs> removedEvents = [];
@@ -60,14 +62,13 @@ internal class GameInventory : IInternalDisposableService
     /// <inheritdoc/>
     void IInternalDisposableService.DisposeService()
     {
-        lock (this.subscribersPendingChange)
-        {
-            this.subscribers.Clear();
-            this.subscribersPendingChange.Clear();
-            this.subscribersChanged = false;
-            this.framework.Update -= this.OnFrameworkUpdate;
-            this.gameGui.AgentUpdate -= this.OnAgentUpdate;
-        }
+        using var scope = this.subscribersLock.EnterScope();
+
+        this.subscribers.Clear();
+        this.subscribersPendingChange.Clear();
+        this.subscribersChanged = false;
+        this.framework.Update -= this.OnFrameworkUpdate;
+        this.gameGui.AgentUpdate -= this.OnAgentUpdate;
     }
 
     /// <summary>
@@ -76,15 +77,15 @@ internal class GameInventory : IInternalDisposableService
     /// <param name="s">The event target.</param>
     public void Subscribe(GameInventoryPluginScoped s)
     {
-        lock (this.subscribersPendingChange)
+        using var scope = this.subscribersLock.EnterScope();
+
+        this.subscribersPendingChange.Add(s);
+        this.subscribersChanged = true;
+
+        if (this.subscribersPendingChange.Count == 1)
         {
-            this.subscribersPendingChange.Add(s);
-            this.subscribersChanged = true;
-            if (this.subscribersPendingChange.Count == 1)
-            {
-                this.inventoriesMightBeChanged = true;
-                this.framework.Update += this.OnFrameworkUpdate;
-            }
+            this.inventoriesMightBeChanged = true;
+            this.framework.Update += this.OnFrameworkUpdate;
         }
     }
 
@@ -94,14 +95,15 @@ internal class GameInventory : IInternalDisposableService
     /// <param name="s">The event target.</param>
     public void Unsubscribe(GameInventoryPluginScoped s)
     {
-        lock (this.subscribersPendingChange)
-        {
-            if (!this.subscribersPendingChange.Remove(s))
-                return;
-            this.subscribersChanged = true;
-            if (this.subscribersPendingChange.Count == 0)
-                this.framework.Update -= this.OnFrameworkUpdate;
-        }
+        using var scope = this.subscribersLock.EnterScope();
+
+        if (!this.subscribersPendingChange.Remove(s))
+            return;
+
+        this.subscribersChanged = true;
+
+        if (this.subscribersPendingChange.Count == 0)
+            this.framework.Update -= this.OnFrameworkUpdate;
     }
 
     private void OnFrameworkUpdate(IFramework framework1)
@@ -157,7 +159,8 @@ internal class GameInventory : IInternalDisposableService
         if (this.subscribersChanged)
         {
             bool isNew;
-            lock (this.subscribersPendingChange)
+
+            using (this.subscribersLock.EnterScope())
             {
                 isNew = this.subscribersPendingChange.Count != 0 && this.subscribers.Count == 0;
                 this.subscribers.Clear();

--- a/Dalamud/Hooking/Internal/FunctionPointerVariableHook.cs
+++ b/Dalamud/Hooking/Internal/FunctionPointerVariableHook.cs
@@ -39,70 +39,69 @@ internal unsafe class FunctionPointerVariableHook<T> : Hook<T>
     internal FunctionPointerVariableHook(IntPtr address, T detour, Assembly callingAssembly)
         : base(address)
     {
-        lock (HookManager.HookEnableSyncRoot)
+        using var scope = HookManager.HookEnableSyncRoot.EnterScope();
+
+        var unhooker = HookManager.RegisterUnhooker(this.Address, 8, 8);
+
+        if (!HookManager.MultiHookTracker.TryGetValue(this.Address, out var indexList))
         {
-            var unhooker = HookManager.RegisterUnhooker(this.Address, 8, 8);
-
-            if (!HookManager.MultiHookTracker.TryGetValue(this.Address, out var indexList))
-            {
-                indexList = HookManager.MultiHookTracker[this.Address] = [];
-            }
-
-            this.detourDelegate = detour;
-            this.pfnDetour = Marshal.GetFunctionPointerForDelegate(detour);
-
-            unsafe
-            {
-                // Note: WINE seemingly tries to clean up all heap allocations on process exit.
-                // We want our allocation to be kept there forever, until no running thread remains.
-                // Therefore we're using VirtualAlloc instead of HeapCreate/HeapAlloc.
-                var pfnThunkBytes = (byte*)Windows.Win32.PInvoke.VirtualAlloc(
-                    null,
-                    12,
-                    VIRTUAL_ALLOCATION_TYPE.MEM_RESERVE | VIRTUAL_ALLOCATION_TYPE.MEM_COMMIT,
-                    PAGE_PROTECTION_FLAGS.PAGE_EXECUTE_READWRITE);
-                if (pfnThunkBytes == null)
-                {
-                    throw new OutOfMemoryException("Failed to allocate memory for import hooks.");
-                }
-
-                // movabs rax, imm
-                pfnThunkBytes[0] = 0x48;
-                pfnThunkBytes[1] = 0xB8;
-
-                // jmp rax
-                pfnThunkBytes[10] = 0xFF;
-                pfnThunkBytes[11] = 0xE0;
-
-                this.pfnThunk = (nint)pfnThunkBytes;
-            }
-
-            this.ppfnThunkJumpTarget = this.pfnThunk + 2;
-
-            if (!Windows.Win32.PInvoke.VirtualProtect(
-                    this.Address.ToPointer(),
-                    (UIntPtr)Marshal.SizeOf<IntPtr>(),
-                    PAGE_PROTECTION_FLAGS.PAGE_EXECUTE_READWRITE,
-                    out var oldProtect))
-            {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-
-            this.pfnOriginal = Marshal.ReadIntPtr(this.Address);
-            this.originalDelegate = Marshal.GetDelegateForFunctionPointer<T>(this.pfnOriginal);
-            Marshal.WriteIntPtr(this.ppfnThunkJumpTarget, this.pfnOriginal);
-            Marshal.WriteIntPtr(this.Address, this.pfnThunk);
-
-            // This really should not fail, but then even if it does, whatever.
-            Windows.Win32.PInvoke.VirtualProtect(this.Address.ToPointer(), (UIntPtr)Marshal.SizeOf<IntPtr>(), oldProtect, out _);
-
-            // Add afterwards, so the hookIdent starts at 0.
-            indexList.Add(this);
-
-            unhooker.TrimAfterHook();
-
-            HookManager.TrackedHooks.TryAdd(this.HookId, new HookInfo(this, detour, callingAssembly));
+            indexList = HookManager.MultiHookTracker[this.Address] = [];
         }
+
+        this.detourDelegate = detour;
+        this.pfnDetour = Marshal.GetFunctionPointerForDelegate(detour);
+
+        unsafe
+        {
+            // Note: WINE seemingly tries to clean up all heap allocations on process exit.
+            // We want our allocation to be kept there forever, until no running thread remains.
+            // Therefore we're using VirtualAlloc instead of HeapCreate/HeapAlloc.
+            var pfnThunkBytes = (byte*)Windows.Win32.PInvoke.VirtualAlloc(
+                null,
+                12,
+                VIRTUAL_ALLOCATION_TYPE.MEM_RESERVE | VIRTUAL_ALLOCATION_TYPE.MEM_COMMIT,
+                PAGE_PROTECTION_FLAGS.PAGE_EXECUTE_READWRITE);
+            if (pfnThunkBytes == null)
+            {
+                throw new OutOfMemoryException("Failed to allocate memory for import hooks.");
+            }
+
+            // movabs rax, imm
+            pfnThunkBytes[0] = 0x48;
+            pfnThunkBytes[1] = 0xB8;
+
+            // jmp rax
+            pfnThunkBytes[10] = 0xFF;
+            pfnThunkBytes[11] = 0xE0;
+
+            this.pfnThunk = (nint)pfnThunkBytes;
+        }
+
+        this.ppfnThunkJumpTarget = this.pfnThunk + 2;
+
+        if (!Windows.Win32.PInvoke.VirtualProtect(
+                this.Address.ToPointer(),
+                (UIntPtr)Marshal.SizeOf<IntPtr>(),
+                PAGE_PROTECTION_FLAGS.PAGE_EXECUTE_READWRITE,
+                out var oldProtect))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        this.pfnOriginal = Marshal.ReadIntPtr(this.Address);
+        this.originalDelegate = Marshal.GetDelegateForFunctionPointer<T>(this.pfnOriginal);
+        Marshal.WriteIntPtr(this.ppfnThunkJumpTarget, this.pfnOriginal);
+        Marshal.WriteIntPtr(this.Address, this.pfnThunk);
+
+        // This really should not fail, but then even if it does, whatever.
+        Windows.Win32.PInvoke.VirtualProtect(this.Address.ToPointer(), (UIntPtr)Marshal.SizeOf<IntPtr>(), oldProtect, out _);
+
+        // Add afterwards, so the hookIdent starts at 0.
+        indexList.Add(this);
+
+        unhooker.TrimAfterHook();
+
+        HookManager.TrackedHooks.TryAdd(this.HookId, new HookInfo(this, detour, callingAssembly));
     }
 
     /// <inheritdoc/>
@@ -127,6 +126,8 @@ internal unsafe class FunctionPointerVariableHook<T> : Hook<T>
         if (this.IsDisposed)
             return;
 
+        using var scope = HookManager.HookEnableSyncRoot.EnterScope();
+
         this.Disable();
 
         HookManager.TrackedHooks.TryRemove(this.HookId, out _);
@@ -140,31 +141,29 @@ internal unsafe class FunctionPointerVariableHook<T> : Hook<T>
     /// <inheritdoc/>
     public override void Enable()
     {
-        lock (HookManager.HookEnableSyncRoot)
-        {
-            this.CheckDisposed();
+        using var scope = HookManager.HookEnableSyncRoot.EnterScope();
 
-            if (this.enabled)
-                return;
+        this.CheckDisposed();
 
-            Marshal.WriteIntPtr(this.ppfnThunkJumpTarget, this.pfnDetour);
-            this.enabled = true;
-        }
+        if (this.enabled)
+            return;
+
+        Marshal.WriteIntPtr(this.ppfnThunkJumpTarget, this.pfnDetour);
+        this.enabled = true;
     }
 
     /// <inheritdoc/>
     public override void Disable()
     {
-        lock (HookManager.HookEnableSyncRoot)
-        {
-            if (this.IsDisposed)
-                return;
+        using var scope = HookManager.HookEnableSyncRoot.EnterScope();
 
-            if (!this.enabled)
-                return;
+        if (this.IsDisposed)
+            return;
 
-            Marshal.WriteIntPtr(this.ppfnThunkJumpTarget, this.pfnOriginal);
-            this.enabled = false;
-        }
+        if (!this.enabled)
+            return;
+
+        Marshal.WriteIntPtr(this.ppfnThunkJumpTarget, this.pfnOriginal);
+        this.enabled = false;
     }
 }

--- a/Dalamud/Hooking/Internal/MinHookHook.cs
+++ b/Dalamud/Hooking/Internal/MinHookHook.cs
@@ -19,24 +19,23 @@ internal class MinHookHook<T> : Hook<T> where T : Delegate
     internal MinHookHook(IntPtr address, T detour, Assembly callingAssembly)
         : base(address)
     {
-        lock (HookManager.HookEnableSyncRoot)
-        {
-            var unhooker = HookManager.RegisterUnhooker(this.Address);
+        using var scope = HookManager.HookEnableSyncRoot.EnterScope();
 
-            if (!HookManager.MultiHookTracker.TryGetValue(this.Address, out var indexList))
-                indexList = HookManager.MultiHookTracker[this.Address] = [];
+        var unhooker = HookManager.RegisterUnhooker(this.Address);
 
-            var index = (ulong)indexList.Count;
+        if (!HookManager.MultiHookTracker.TryGetValue(this.Address, out var indexList))
+            indexList = HookManager.MultiHookTracker[this.Address] = [];
 
-            this.minHookImpl = new MinSharp.Hook<T>(this.Address, detour, index);
+        var index = (ulong)indexList.Count;
 
-            // Add afterwards, so the hookIdent starts at 0.
-            indexList.Add(this);
+        this.minHookImpl = new MinSharp.Hook<T>(this.Address, detour, index);
 
-            unhooker.TrimAfterHook();
+        // Add afterwards, so the hookIdent starts at 0.
+        indexList.Add(this);
 
-            HookManager.TrackedHooks.TryAdd(this.HookId, new HookInfo(this, detour, callingAssembly));
-        }
+        unhooker.TrimAfterHook();
+
+        HookManager.TrackedHooks.TryAdd(this.HookId, new HookInfo(this, detour, callingAssembly));
     }
 
     /// <inheritdoc/>
@@ -61,13 +60,12 @@ internal class MinHookHook<T> : Hook<T> where T : Delegate
         if (this.IsDisposed)
             return;
 
-        lock (HookManager.HookEnableSyncRoot)
-        {
-            this.minHookImpl.Dispose();
+        using var scope = HookManager.HookEnableSyncRoot.EnterScope();
 
-            var index = HookManager.MultiHookTracker[this.Address].IndexOf(this);
-            HookManager.MultiHookTracker[this.Address][index] = null;
-        }
+        this.minHookImpl.Dispose();
+
+        var index = HookManager.MultiHookTracker[this.Address].IndexOf(this);
+        HookManager.MultiHookTracker[this.Address][index] = null;
 
         HookManager.TrackedHooks.TryRemove(this.HookId, out _);
 
@@ -77,29 +75,27 @@ internal class MinHookHook<T> : Hook<T> where T : Delegate
     /// <inheritdoc/>
     public override void Enable()
     {
-        lock (HookManager.HookEnableSyncRoot)
-        {
-            this.CheckDisposed();
+        using var scope = HookManager.HookEnableSyncRoot.EnterScope();
 
-            if (!this.minHookImpl.Enabled)
-                return;
+        this.CheckDisposed();
 
-            this.minHookImpl.Enable();
-        }
+        if (!this.minHookImpl.Enabled)
+            return;
+
+        this.minHookImpl.Enable();
     }
 
     /// <inheritdoc/>
     public override void Disable()
     {
-        lock (HookManager.HookEnableSyncRoot)
-        {
-            if (this.IsDisposed)
-                return;
+        using var scope = HookManager.HookEnableSyncRoot.EnterScope();
 
-            if (!this.minHookImpl.Enabled)
-                return;
+        if (this.IsDisposed)
+            return;
 
-            this.minHookImpl.Disable();
-        }
+        if (!this.minHookImpl.Enabled)
+            return;
+
+        this.minHookImpl.Disable();
     }
 }

--- a/Dalamud/Hooking/Internal/ReloadedHook.cs
+++ b/Dalamud/Hooking/Internal/ReloadedHook.cs
@@ -21,17 +21,16 @@ internal class ReloadedHook<T> : Hook<T> where T : Delegate
     internal ReloadedHook(IntPtr address, T detour, Assembly callingAssembly)
         : base(address)
     {
-        lock (HookManager.HookEnableSyncRoot)
-        {
-            var unhooker = HookManager.RegisterUnhooker(address);
-            this.hookImpl = ReloadedHooks.Instance.CreateHook<T>(detour, address.ToInt64());
-            this.hookImpl.Activate();
-            this.hookImpl.Disable();
+        using var scope = HookManager.HookEnableSyncRoot.EnterScope();
 
-            unhooker.TrimAfterHook();
+        var unhooker = HookManager.RegisterUnhooker(address);
+        this.hookImpl = ReloadedHooks.Instance.CreateHook<T>(detour, address.ToInt64());
+        this.hookImpl.Activate();
+        this.hookImpl.Disable();
 
-            HookManager.TrackedHooks.TryAdd(this.HookId, new HookInfo(this, detour, callingAssembly));
-        }
+        unhooker.TrimAfterHook();
+
+        HookManager.TrackedHooks.TryAdd(this.HookId, new HookInfo(this, detour, callingAssembly));
     }
 
     /// <inheritdoc/>
@@ -56,6 +55,8 @@ internal class ReloadedHook<T> : Hook<T> where T : Delegate
         if (this.IsDisposed)
             return;
 
+        using var scope = HookManager.HookEnableSyncRoot.EnterScope();
+
         HookManager.TrackedHooks.TryRemove(this.HookId, out _);
 
         this.Disable();
@@ -66,28 +67,26 @@ internal class ReloadedHook<T> : Hook<T> where T : Delegate
     /// <inheritdoc/>
     public override void Enable()
     {
-        lock (HookManager.HookEnableSyncRoot)
-        {
-            this.CheckDisposed();
+        using var scope = HookManager.HookEnableSyncRoot.EnterScope();
 
-            if (!this.hookImpl.IsHookEnabled)
-                this.hookImpl.Enable();
-        }
+        this.CheckDisposed();
+
+        if (!this.hookImpl.IsHookEnabled)
+            this.hookImpl.Enable();
     }
 
     /// <inheritdoc/>
     public override void Disable()
     {
-        lock (HookManager.HookEnableSyncRoot)
-        {
-            if (this.IsDisposed)
-                return;
+        using var scope = HookManager.HookEnableSyncRoot.EnterScope();
 
-            if (!this.hookImpl.IsHookActivated)
-                return;
+        if (this.IsDisposed)
+            return;
 
-            if (this.hookImpl.IsHookEnabled)
-                this.hookImpl.Disable();
-        }
+        if (!this.hookImpl.IsHookActivated)
+            return;
+
+        if (this.hookImpl.IsHookEnabled)
+            this.hookImpl.Disable();
     }
 }

--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.Filters.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.Filters.cs
@@ -83,27 +83,26 @@ public partial class FileDialog
 
     private void ApplyFilteringOnFileList()
     {
-        lock (this.filesLock)
+        using var scope = this.filesLock.EnterScope();
+
+        this.filteredFiles.Clear();
+
+        foreach (var file in this.files)
         {
-            this.filteredFiles.Clear();
-
-            foreach (var file in this.files)
+            var show = true;
+            if (!string.IsNullOrEmpty(this.searchBuffer) && !file.FileName.Contains(this.searchBuffer, StringComparison.InvariantCultureIgnoreCase))
             {
-                var show = true;
-                if (!string.IsNullOrEmpty(this.searchBuffer) && !file.FileName.Contains(this.searchBuffer, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    show = false;
-                }
+                show = false;
+            }
 
-                if (this.IsDirectoryMode() && file.Type != FileStructType.Directory)
-                {
-                    show = false;
-                }
+            if (this.IsDirectoryMode() && file.Type != FileStructType.Directory)
+            {
+                show = false;
+            }
 
-                if (show)
-                {
-                    this.filteredFiles.Add(file);
-                }
+            if (show)
+            {
+                this.filteredFiles.Add(file);
             }
         }
     }

--- a/Dalamud/Interface/ImGuiFileDialog/FileDialog.UI.cs
+++ b/Dalamud/Interface/ImGuiFileDialog/FileDialog.UI.cs
@@ -380,63 +380,62 @@ public partial class FileDialog
             {
                 var clipper = ImGui.ImGuiListClipper();
 
-                lock (this.filesLock)
+                using var scope = this.filesLock.EnterScope();
+
+                clipper.Begin(this.filteredFiles.Count);
+                while (clipper.Step())
                 {
-                    clipper.Begin(this.filteredFiles.Count);
-                    while (clipper.Step())
+                    for (var i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
                     {
-                        for (var i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
+                        if (i < 0) continue;
+
+                        var file = this.filteredFiles[i];
+                        var selected = this.selectedFileNames.Contains(file.FileName);
+                        var needToBreak = false;
+
+                        var dir = file.Type == FileStructType.Directory;
+                        var item = !dir ? GetIcon(file.Ext) : new IconColorItem
                         {
-                            if (i < 0) continue;
+                            Color = dirTextColor,
+                            Icon = FontAwesomeIcon.Folder,
+                        };
 
-                            var file = this.filteredFiles[i];
-                            var selected = this.selectedFileNames.Contains(file.FileName);
-                            var needToBreak = false;
+                        ImGui.PushStyleColor(ImGuiCol.Text, selected ? selectedTextColor : item.Color);
 
-                            var dir = file.Type == FileStructType.Directory;
-                            var item = !dir ? GetIcon(file.Ext) : new IconColorItem
-                            {
-                                Color = dirTextColor,
-                                Icon = FontAwesomeIcon.Folder,
-                            };
+                        ImGui.TableNextRow();
 
-                            ImGui.PushStyleColor(ImGuiCol.Text, selected ? selectedTextColor : item.Color);
-
-                            ImGui.TableNextRow();
-
-                            if (ImGui.TableNextColumn())
-                            {
-                                needToBreak = this.SelectableItem(file, selected, item.Icon);
-                            }
-
-                            if (ImGui.TableNextColumn())
-                            {
-                                ImGui.Text(file.Ext);
-                            }
-
-                            if (ImGui.TableNextColumn())
-                            {
-                                if (file.Type == FileStructType.File)
-                                {
-                                    ImGui.Text(file.FormattedFileSize + " ");
-                                }
-                                else
-                                {
-                                    ImGui.Text(" "u8);
-                                }
-                            }
-
-                            if (ImGui.TableNextColumn())
-                            {
-                                var sz = ImGui.CalcTextSize(file.FileModifiedDate);
-                                ImGui.SetNextItemWidth(sz.X + Scaled(5));
-                                ImGui.Text(file.FileModifiedDate + " ");
-                            }
-
-                            ImGui.PopStyleColor();
-
-                            if (needToBreak) break;
+                        if (ImGui.TableNextColumn())
+                        {
+                            needToBreak = this.SelectableItem(file, selected, item.Icon);
                         }
+
+                        if (ImGui.TableNextColumn())
+                        {
+                            ImGui.Text(file.Ext);
+                        }
+
+                        if (ImGui.TableNextColumn())
+                        {
+                            if (file.Type == FileStructType.File)
+                            {
+                                ImGui.Text(file.FormattedFileSize + " ");
+                            }
+                            else
+                            {
+                                ImGui.Text(" "u8);
+                            }
+                        }
+
+                        if (ImGui.TableNextColumn())
+                        {
+                            var sz = ImGui.CalcTextSize(file.FileModifiedDate);
+                            ImGui.SetNextItemWidth(sz.X + Scaled(5));
+                            ImGui.Text(file.FileModifiedDate + " ");
+                        }
+
+                        ImGui.PopStyleColor();
+
+                        if (needToBreak) break;
                     }
 
                     clipper.End();

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TexWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TexWidget.cs
@@ -181,7 +181,7 @@ internal class TexWidget : IDataWindowWidget
                 this.DrawLoadedTextures(this.textureManager.Shared.ForDebugManifestResourceTextures);
         }
 
-        using (this.textureManager.Shared.ForDebugInvalidatedTexturesScope)
+        using (this.textureManager.Shared.ForDebugInvalidatedTexturesLockScope)
         {
             using var pushedId = ImRaii.PushId("invalidatedTextures"u8);
             if (ImGui.CollapsingHeader($"Invalidated: {this.textureManager.Shared.ForDebugInvalidatedTextures.Count:n0}###header"))

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TexWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TexWidget.cs
@@ -181,7 +181,7 @@ internal class TexWidget : IDataWindowWidget
                 this.DrawLoadedTextures(this.textureManager.Shared.ForDebugManifestResourceTextures);
         }
 
-        lock (this.textureManager.Shared.ForDebugInvalidatedTextures)
+        using (this.textureManager.Shared.ForDebugInvalidatedTexturesScope)
         {
             using var pushedId = ImRaii.PushId("invalidatedTextures"u8);
             if (ImGui.CollapsingHeader($"Invalidated: {this.textureManager.Shared.ForDebugInvalidatedTextures.Count:n0}###header"))

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/TexWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/TexWidget.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -154,7 +154,7 @@ internal class TexWidget : IDataWindowWidget
             conf.QueueSave();
         }
 
-        lock (this.textureManager.BlameTracker)
+        using (this.textureManager.BlameTrackerLock.EnterScope())
         {
             using var pushedId = ImRaii.PushId("blames"u8);
             var allBlames = this.textureManager.BlameTracker;

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -55,7 +55,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
     private readonly DateTime timeLoaded;
 
-    private readonly object listLock = new();
+    private readonly Lock listLock = new();
 
     private readonly ProfileManagerWidget profileManagerWidget;
 
@@ -342,18 +342,17 @@ internal class PluginInstallerWindow : Window, IDisposable
     /// <inheritdoc/>
     public override void Draw()
     {
-        lock (this.listLock)
-        {
-            this.DrawHeader();
-            this.DrawPluginCategories();
-            this.DrawFooter();
-            this.DrawErrorModal();
-            this.DrawUpdateModal();
-            this.DrawTestingWarningModal();
-            this.DrawDeletePluginConfigWarningModal();
-            this.DrawFeedbackModal();
-            this.DrawProgressOverlay();
-        }
+        using var scope = this.listLock.EnterScope();
+
+        this.DrawHeader();
+        this.DrawPluginCategories();
+        this.DrawFooter();
+        this.DrawErrorModal();
+        this.DrawUpdateModal();
+        this.DrawTestingWarningModal();
+        this.DrawDeletePluginConfigWarningModal();
+        this.DrawFeedbackModal();
+        this.DrawProgressOverlay();
     }
 
     /// <summary>
@@ -839,7 +838,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                         this.filterText = selectable.Localization;
                         this.adaptiveSort = false;
 
-                        lock (this.listLock)
+                        using (this.listLock.EnterScope())
                         {
                             this.ResortPlugins();
 
@@ -4112,7 +4111,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         var pluginManager = Service<PluginManager>.Get();
         var configuration = Service<DalamudConfiguration>.Get();
 
-        lock (this.listLock)
+        using (this.listLock.EnterScope())
         {
             // By removing installed plugins only when the available plugin list changes (basically when the window is
             // opened), plugins that have been newly installed remain in the available plugin list as installed.
@@ -4131,7 +4130,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         var pluginManager = Service<PluginManager>.Get();
         using var pmLock = pluginManager.GetSyncScope();
 
-        lock (this.listLock)
+        using (this.listLock.EnterScope())
         {
             this.pluginListInstalled = pluginManager.InstalledPlugins.ToList();
             this.pluginListUpdatable = pluginManager.UpdatablePlugins.ToList();

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/DelegateFontHandle.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/DelegateFontHandle.cs
@@ -56,7 +56,7 @@ internal sealed class DelegateFontHandle : FontHandle
         /// <inheritdoc/>
         public void Dispose()
         {
-            lock (this.syncRoot)
+            using (this.syncRoot.EnterScope())
                 this.handles.Clear();
         }
 
@@ -64,7 +64,7 @@ internal sealed class DelegateFontHandle : FontHandle
         public IFontHandle NewFontHandle(FontAtlasBuildStepDelegate buildStepDelegate)
         {
             var key = new DelegateFontHandle(this, buildStepDelegate);
-            lock (this.syncRoot)
+            using (this.syncRoot.EnterScope())
                 this.handles.Add(key);
             this.RebuildRecommend.InvokeSafely();
             return key;
@@ -76,14 +76,14 @@ internal sealed class DelegateFontHandle : FontHandle
             if (handle is not DelegateFontHandle cgfh)
                 return;
 
-            lock (this.syncRoot)
+            using (this.syncRoot.EnterScope())
                 this.handles.Remove(cgfh);
         }
 
         /// <inheritdoc/>
         public IFontHandleSubstance NewSubstance(IRefCountable dataRoot)
         {
-            lock (this.syncRoot)
+            using (this.syncRoot.EnterScope())
                 return new HandleSubstance(this, dataRoot, this.handles.ToArray());
         }
     }

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.BuildToolkit.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 using Dalamud.Bindings.ImGui;
 using Dalamud.Configuration.Internal;
@@ -26,6 +27,7 @@ namespace Dalamud.Interface.ManagedFontAtlas.Internals;
 internal sealed partial class FontAtlasFactory
 {
     private static readonly Dictionary<ulong, List<(char Left, char Right, float Distance)>> PairAdjustmentsCache = [];
+    private static readonly Lock PairAdjustmentsCacheLock = new();
 
     /// <summary>
     /// Implementations for <see cref="IFontAtlasBuildToolkitPreBuild"/> and
@@ -184,7 +186,7 @@ internal sealed partial class FontAtlasFactory
                 var hashIdent = (uint)dataHash.ToHashCode() | ((ulong)dataSize << 32);
 
                 List<(char Left, char Right, float Distance)> pairAdjustments;
-                lock (PairAdjustmentsCache)
+                using (PairAdjustmentsCacheLock.EnterScope())
                 {
                     if (!PairAdjustmentsCache.TryGetValue(hashIdent, out pairAdjustments))
                     {

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.Implementation.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.Implementation.cs
@@ -309,7 +309,7 @@ internal sealed partial class FontAtlasFactory
             this.factory.BackendTask.ContinueWith(
                 r =>
                 {
-                    lock (this.syncRoot)
+                    using (this.syncRoot.EnterScope())
                     {
                         if (this.disposed)
                             return;
@@ -328,7 +328,7 @@ internal sealed partial class FontAtlasFactory
         /// </summary>
         ~DalamudFontAtlas()
         {
-            lock (this.syncRoot)
+            using (this.syncRoot.EnterScope())
             {
                 this.buildTask.ToDisposableIgnoreExceptions().Dispose();
                 this.builtData?.Release();
@@ -359,7 +359,7 @@ internal sealed partial class FontAtlasFactory
         {
             get
             {
-                lock (this.syncRoot)
+                using (this.syncRoot.EnterScope())
                     return this.builtData?.Atlas ?? default;
             }
         }
@@ -386,7 +386,7 @@ internal sealed partial class FontAtlasFactory
 
             try
             {
-                lock (this.syncRoot)
+                using (this.syncRoot.EnterScope())
                 {
                     this.disposed = true;
                     this.buildTask.ToDisposableIgnoreExceptions().Dispose();
@@ -483,7 +483,7 @@ internal sealed partial class FontAtlasFactory
             try
             {
                 var rebuildIndex = Interlocked.Increment(ref this.buildIndex);
-                lock (this.syncRoot)
+                using (this.syncRoot.EnterScope())
                 {
                     if (!this.buildTask.IsCompleted)
                         throw new InvalidOperationException("Font rebuild is already in progress.");
@@ -535,7 +535,7 @@ internal sealed partial class FontAtlasFactory
                     $"{nameof(FontAtlasAutoRebuildMode.OnNewFrame)}.");
             }
 
-            lock (this.syncRoot)
+            using (this.syncRoot.EnterScope())
             {
                 var scale = this.IsGlobalScaled ? ImGuiHelpers.GlobalScale : 1f;
                 var rebuildIndex = Interlocked.Increment(ref this.buildIndex);
@@ -544,7 +544,7 @@ internal sealed partial class FontAtlasFactory
                 async Task<FontAtlasBuiltData?> BuildInner(Task<FontAtlasBuiltData> unused)
                 {
                     Log.Verbose("[{name}] Building from {source}.", this.Name, nameof(this.BuildFontsAsync));
-                    lock (this.syncRoot)
+                    using (this.syncRoot.EnterScope())
                     {
                         if (this.buildIndex != rebuildIndex)
                             return null;
@@ -567,7 +567,7 @@ internal sealed partial class FontAtlasFactory
             var fontsAndLocks = new List<(FontHandle FontHandle, ILockedImFont Lock)>();
             using var garbage = new DisposeSafety.ScopedFinalizer();
 
-            lock (this.syncRoot)
+            using (this.syncRoot.EnterScope())
             {
                 if (this.buildIndex != rebuildIndex)
                 {
@@ -629,7 +629,7 @@ internal sealed partial class FontAtlasFactory
 
         private async Task<FontAtlasBuiltData> RebuildFontsPrivateReal(bool isAsync, float scale)
         {
-            lock (this.syncRoot)
+            using (this.syncRoot.EnterScope())
             {
                 // this lock ensures that this.buildTask is properly set.
             }

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/GamePrebakedFontHandle.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/GamePrebakedFontHandle.cs
@@ -142,7 +142,7 @@ internal class GamePrebakedFontHandle : FontHandle
         {
             var handle = new GamePrebakedFontHandle(this, style);
             bool suggestRebuild;
-            lock (this.syncRoot)
+            using (this.syncRoot.EnterScope())
             {
                 this.handles.Add(handle);
                 this.gameFontsRc[style] = this.gameFontsRc.GetValueOrDefault(style, 0) + 1;
@@ -161,7 +161,7 @@ internal class GamePrebakedFontHandle : FontHandle
             if (handle is not GamePrebakedFontHandle ggfh)
                 return;
 
-            lock (this.syncRoot)
+            using (this.syncRoot.EnterScope())
             {
                 this.handles.Remove(ggfh);
                 if (!this.gameFontsRc.ContainsKey(ggfh.FontStyle))
@@ -175,7 +175,7 @@ internal class GamePrebakedFontHandle : FontHandle
         /// <inheritdoc/>
         public IFontHandleSubstance NewSubstance(IRefCountable dataRoot)
         {
-            lock (this.syncRoot)
+            using (this.syncRoot.EnterScope())
                 return new HandleSubstance(this, dataRoot, this.handles.ToArray(), this.gameFontsRc.Keys);
         }
     }

--- a/Dalamud/Interface/Textures/Internal/SharedImmediateTextures/SharedImmediateTexture.cs
+++ b/Dalamud/Interface/Textures/Internal/SharedImmediateTextures/SharedImmediateTexture.cs
@@ -24,6 +24,7 @@ internal abstract class SharedImmediateTexture
     private static long instanceCounter;
 
     private readonly Lock reviveLock = new();
+    private readonly Lock ownerPluginsLock = new();
     private readonly List<LocalPlugin> ownerPlugins = [];
 
     private bool resourceReleased;
@@ -119,7 +120,7 @@ internal abstract class SharedImmediateTexture
                 // ... Once that's done, TAR may revive the object safely.
                 while (true)
                 {
-                    lock (this.reviveLock)
+                    using (this.reviveLock.EnterScope())
                     {
                         if (this.resourceReleased)
                         {
@@ -240,7 +241,7 @@ internal abstract class SharedImmediateTexture
     /// <param name="plugin">The plugin to add.</param>
     public void AddOwnerPlugin(LocalPlugin plugin)
     {
-        lock (this.ownerPlugins)
+        using (this.ownerPluginsLock.EnterScope())
         {
             if (!this.ownerPlugins.Contains(plugin))
             {
@@ -270,7 +271,7 @@ internal abstract class SharedImmediateTexture
     protected void LoadUnderlyingWrap()
     {
         int addLen;
-        lock (this.ownerPlugins)
+        using (this.ownerPluginsLock.EnterScope())
         {
             this.UnderlyingWrap = Service<TextureManager>.Get().DynamicPriorityTextureLoader.LoadAsync(
                 this,
@@ -287,7 +288,7 @@ internal abstract class SharedImmediateTexture
             {
                 if (!r.IsCompletedSuccessfully)
                     return;
-                lock (this.ownerPlugins)
+                using (this.ownerPluginsLock.EnterScope())
                 {
                     foreach (var op in this.ownerPlugins.Take(addLen))
                         Service<TextureManager>.Get().Blame(r.Result, op);
@@ -312,7 +313,7 @@ internal abstract class SharedImmediateTexture
 
         while (true)
         {
-            lock (this.reviveLock)
+            using (this.reviveLock.EnterScope())
             {
                 if (!this.resourceReleased)
                 {

--- a/Dalamud/Interface/Textures/Internal/TextureManager.BlameTracker.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManager.BlameTracker.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Textures.TextureWraps;
@@ -45,6 +46,9 @@ internal sealed partial class TextureManager
     /// <remarks>Returned value must be used inside a lock.</remarks>
     public List<IBlameableDalamudTextureWrap> BlameTracker { get; } = [];
 
+    /// <summary>Gets the lock for the list containing all the loaded textures from plugins.</summary>
+    public Lock BlameTrackerLock { get; } = new();
+
     /// <summary>Gets the blame for a texture wrap.</summary>
     /// <param name="textureWrap">The texture wrap.</param>
     /// <returns>The blame, if it exists.</returns>
@@ -84,7 +88,7 @@ internal sealed partial class TextureManager
 
         if (isNew)
         {
-            lock (this.BlameTracker)
+            using (this.BlameTrackerLock.EnterScope())
                 this.BlameTracker.Add(blame);
         }
 
@@ -116,7 +120,7 @@ internal sealed partial class TextureManager
 
         if (isNew)
         {
-            lock (this.BlameTracker)
+            using (this.BlameTrackerLock.EnterScope())
                 this.BlameTracker.Add(blame);
         }
 
@@ -125,7 +129,7 @@ internal sealed partial class TextureManager
 
     private void BlameTrackerUpdate(IFramework unused)
     {
-        lock (this.BlameTracker)
+        using (this.BlameTrackerLock.EnterScope())
         {
             for (var i = 0; i < this.BlameTracker.Count;)
             {

--- a/Dalamud/Interface/Textures/Internal/TextureManager.SharedTextures.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManager.SharedTextures.cs
@@ -94,12 +94,11 @@ internal sealed partial class TextureManager
         public ICollection<SharedImmediateTexture> ForDebugManifestResourceTextures => this.manifestResourceDict.Values;
 
         /// <summary>Gets all the loaded textures that are invalidated from <see cref="InvalidatePaths"/>.</summary>
-        /// <remarks><c>lock</c> on use of the value returned from this property.</remarks>
-        [SuppressMessage(
-            "ReSharper",
-            "InconsistentlySynchronizedField",
-            Justification = "Debug use only; users are expected to lock around this")]
+        /// <remarks>Use <see cref="ForDebugInvalidatedTexturesLockScope"/> to read this property.</remarks>
         public ICollection<SharedImmediateTexture> ForDebugInvalidatedTextures => this.invalidatedTextures;
+
+        /// <summary>Gets a lock scope for <see cref="ForDebugInvalidatedTextures"/>.</summary>
+        public Lock.Scope ForDebugInvalidatedTexturesLockScope => this.invalidatedTexturesLock.EnterScope();
 
         private SharedTextureManager NonDisposed =>
             this.disposingCancellationTokenSource.IsCancellationRequested

--- a/Dalamud/Interface/Textures/Internal/TextureManager.SharedTextures.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManager.SharedTextures.cs
@@ -65,6 +65,7 @@ internal sealed partial class TextureManager
         private readonly ConcurrentDictionary<string, SharedImmediateTexture> fileDict = new();
         private readonly ConcurrentDictionary<(Assembly, string), SharedImmediateTexture> manifestResourceDict = new();
         private readonly HashSet<SharedImmediateTexture> invalidatedTextures = [];
+        private readonly Lock invalidatedTexturesLock = new();
 
         private readonly Thread sharedTextureReleaseThread;
 
@@ -191,7 +192,7 @@ internal sealed partial class TextureManager
             {
                 if (r.ReleaseSelfReference(true) != 0)
                 {
-                    lock (this.invalidatedTextures)
+                    using (this.invalidatedTexturesLock.EnterScope())
                         this.invalidatedTextures.Add(r);
                 }
             }
@@ -211,12 +212,8 @@ internal sealed partial class TextureManager
                 RemoveFinalReleased(this.fileDict);
                 RemoveFinalReleased(this.manifestResourceDict);
 
-                // ReSharper disable once InconsistentlySynchronizedField
-                if (this.invalidatedTextures.Count != 0)
-                {
-                    lock (this.invalidatedTextures)
-                        this.invalidatedTextures.RemoveWhere(TextureFinalReleasePredicate);
-                }
+                using (this.invalidatedTexturesLock.EnterScope())
+                    this.invalidatedTextures.RemoveWhere(TextureFinalReleasePredicate);
 
                 try
                 {

--- a/Dalamud/Interface/TitleScreenMenu/TitleScreenMenu.cs
+++ b/Dalamud/Interface/TitleScreenMenu/TitleScreenMenu.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 
 using Dalamud.Game.ClientState.Keys;
 using Dalamud.Interface.Textures;
@@ -23,6 +24,7 @@ internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
     internal const uint TextureSize = 64;
 
     private readonly List<TitleScreenMenuEntry> entries = [];
+    private readonly Lock entriesLock = new();
     private TitleScreenMenuEntry[]? entriesView;
 
     [ServiceManager.ServiceConstructor]
@@ -40,10 +42,10 @@ internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
     {
         get
         {
-            lock (this.entries)
+            using (this.entriesLock.EnterScope())
             {
                 if (this.entries.Count == 0)
-                    return Array.Empty<TitleScreenMenuEntry>();
+                    return [];
 
                 return this.entriesView ??= this.entries.OrderByDescending(x => x.IsInternal).ToArray();
             }
@@ -57,10 +59,10 @@ internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
     {
         get
         {
-            lock (this.entries)
+            using (this.entriesLock.EnterScope())
             {
                 if (this.entries.Count == 0)
-                    return Array.Empty<TitleScreenMenuEntry>();
+                    return [];
 
                 return this.entriesView ??= this.entries.OrderByDescending(x => x.IsInternal).ToArray();
             }
@@ -78,7 +80,7 @@ internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
     public ITitleScreenMenuEntry AddPluginEntry(string text, ISharedImmediateTexture texture, Action onTriggered)
     {
         TitleScreenMenuEntry entry;
-        lock (this.entries)
+        using (this.entriesLock.EnterScope())
         {
             var entriesOfAssembly = this.entries.Where(x => x.CallingAssembly == Assembly.GetCallingAssembly()).ToList();
             var priority = entriesOfAssembly.Count != 0
@@ -120,7 +122,7 @@ internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
     public ITitleScreenMenuEntry AddPluginEntry(ulong priority, string text, ISharedImmediateTexture texture, Action onTriggered)
     {
         TitleScreenMenuEntry entry;
-        lock (this.entries)
+        using (this.entriesLock.EnterScope())
         {
             entry = new(Assembly.GetCallingAssembly(), priority, text, texture, onTriggered);
             var i = this.entries.BinarySearch(entry);
@@ -137,7 +139,7 @@ internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
     /// <inheritdoc/>
     public void RemoveEntry(IReadOnlyTitleScreenMenuEntry entry)
     {
-        lock (this.entries)
+        using (this.entriesLock.EnterScope())
         {
             this.entries.RemoveAll(pluginEntry => pluginEntry == entry);
             this.entriesView = null;
@@ -158,7 +160,7 @@ internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
     internal TitleScreenMenuEntry AddEntryCore(ulong priority, string text, ISharedImmediateTexture texture, Action onTriggered)
     {
         TitleScreenMenuEntry entry;
-        lock (this.entries)
+        using (this.entriesLock.EnterScope())
         {
             entry = new(null, priority, text, texture, onTriggered)
             {
@@ -188,7 +190,7 @@ internal class TitleScreenMenu : IServiceType, ITitleScreenMenu
         params VirtualKey[] showConditionKeys)
     {
         TitleScreenMenuEntry entry;
-        lock (this.entries)
+        using (this.entriesLock.EnterScope())
         {
             var entriesOfAssembly = this.entries.Where(x => x.CallingAssembly == null).ToList();
             var priority = entriesOfAssembly.Count != 0

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1760,32 +1760,32 @@ internal class PluginManager : IInternalDisposableService
         {
             var installedVersion = plugin.Manifest.AssemblyVersion;
 
-                var updates = this.AvailablePlugins
-                                  .Where(remoteManifest => plugin.Manifest.InternalName == remoteManifest.InternalName)
-                                  .Where(remoteManifest => plugin.Manifest.InstalledFromUrl == remoteManifest.SourceRepo.PluginMasterUrl || !remoteManifest.SourceRepo.IsThirdParty)
-                                  .Where(remoteManifest => remoteManifest.MinimumDalamudVersion == null || Versioning.GetAssemblyVersionParsed() >= remoteManifest.MinimumDalamudVersion)
-                                  .Where(remoteManifest => !remoteManifest.IsTestingExclusive || this.UseTesting(remoteManifest))
-                                  .Where(remoteManifest =>
-                                  {
-                                      var useTesting = this.UseTesting(remoteManifest);
-                                      var candidateApiLevel = useTesting && remoteManifest.TestingDalamudApiLevel != null
-                                                                  ? remoteManifest.TestingDalamudApiLevel.Value
-                                                                  : remoteManifest.DalamudApiLevel;
+            var updates = this.AvailablePlugins
+                              .Where(remoteManifest => plugin.Manifest.InternalName == remoteManifest.InternalName)
+                              .Where(remoteManifest => plugin.Manifest.InstalledFromUrl == remoteManifest.SourceRepo.PluginMasterUrl || !remoteManifest.SourceRepo.IsThirdParty)
+                              .Where(remoteManifest => remoteManifest.MinimumDalamudVersion == null || Versioning.GetAssemblyVersionParsed() >= remoteManifest.MinimumDalamudVersion)
+                              .Where(remoteManifest => !remoteManifest.IsTestingExclusive || this.UseTesting(remoteManifest))
+                              .Where(remoteManifest =>
+                              {
+                                  var useTesting = this.UseTesting(remoteManifest);
+                                  var candidateApiLevel = useTesting && remoteManifest.TestingDalamudApiLevel != null
+                                                              ? remoteManifest.TestingDalamudApiLevel.Value
+                                                              : remoteManifest.DalamudApiLevel;
 
-                                    return candidateApiLevel == DalamudApiLevel;
-                                })
-                                .Select(remoteManifest =>
-                                {
-                                    var useTesting = this.UseTesting(remoteManifest);
-                                    var candidateVersion = useTesting
-                                                                ? remoteManifest.TestingAssemblyVersion
-                                                                : remoteManifest.AssemblyVersion;
-                                    var isUpdate = candidateVersion > installedVersion;
+                                  return candidateApiLevel == DalamudApiLevel;
+                              })
+                              .Select(remoteManifest =>
+                              {
+                                  var useTesting = this.UseTesting(remoteManifest);
+                                  var candidateVersion = useTesting
+                                                              ? remoteManifest.TestingAssemblyVersion
+                                                              : remoteManifest.AssemblyVersion;
+                                  var isUpdate = candidateVersion > installedVersion;
 
-                                    return (isUpdate, useTesting, candidateVersion, remoteManifest);
-                                })
-                                .Where(tpl => tpl.isUpdate)
-                                .ToList();
+                                  return (isUpdate, useTesting, candidateVersion, remoteManifest);
+                              })
+                              .Where(tpl => tpl.isUpdate)
+                              .ToList();
 
             if (updates.Count > 0)
             {

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -276,7 +276,7 @@ internal class PluginManager : IInternalDisposableService
     /// You must NEVER use this in async code.
     /// </summary>
     /// <returns>The aforementioned disposable.</returns>
-    public IDisposable GetSyncScope() => new ScopedSyncRoot(this.pluginListLock);
+    public Lock.Scope GetSyncScope() => this.pluginListLock.EnterScope();
 
     /// <summary>
     /// Print to chat any plugin updates and whether they were successful.

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -54,7 +54,7 @@ internal class PluginManager : IInternalDisposableService
 
     private static readonly ModuleLog Log = ModuleLog.Create<PluginManager>();
 
-    private readonly object pluginListLock = new();
+    private readonly Lock pluginListLock = new();
     private readonly DirectoryInfo pluginDirectory;
     private readonly BannedPlugin[]? bannedPlugins;
 
@@ -171,7 +171,7 @@ internal class PluginManager : IInternalDisposableService
         get
         {
             var res = 0;
-            lock (this.pluginListLock)
+            using (this.pluginListLock.EnterScope())
             {
                 foreach (var p in this.installedPluginsList)
                 {
@@ -191,10 +191,8 @@ internal class PluginManager : IInternalDisposableService
     {
         get
         {
-            lock (this.pluginListLock)
-            {
+            using (this.pluginListLock.EnterScope())
                 return this.installedPluginsList.ToList();
-            }
         }
     }
 
@@ -205,10 +203,8 @@ internal class PluginManager : IInternalDisposableService
     {
         get
         {
-            lock (this.pluginListLock)
-            {
+            using (this.pluginListLock.EnterScope())
                 return this.availablePluginsList.ToList();
-            }
         }
     }
 
@@ -219,10 +215,8 @@ internal class PluginManager : IInternalDisposableService
     {
         get
         {
-            lock (this.pluginListLock)
-            {
+            using (this.pluginListLock.EnterScope())
                 return this.updatablePluginsList.ToList();
-            }
         }
     }
 
@@ -771,7 +765,7 @@ internal class PluginManager : IInternalDisposableService
             Log.Verbose("Scanned dev plugin at {Path}", loadLocation.Path);
 
             // This file is already known to us
-            lock (this.pluginListLock)
+            using (this.pluginListLock.EnterScope())
             {
                 if (this.installedPluginsList.Any(lp => lp.DllFile.FullName == fileInfo.FullName))
                     continue;
@@ -835,10 +829,8 @@ internal class PluginManager : IInternalDisposableService
         if (plugin.State != PluginState.Unloaded && plugin.HasEverStartedLoad)
             throw new InvalidPluginOperationException($"Unable to remove {plugin.Name}, not unloaded and had loaded before");
 
-        lock (this.pluginListLock)
-        {
+        using (this.pluginListLock.EnterScope())
             this.installedPluginsList.Remove(plugin);
-        }
 
         this.NotifyInstalledPluginsChanged();
         this.NotifyAvailablePluginsChanged();
@@ -1213,7 +1205,7 @@ internal class PluginManager : IInternalDisposableService
             if (declaringType == null)
                 continue;
 
-            lock (this.pluginListLock)
+            using (this.pluginListLock.EnterScope())
             {
                 foreach (var plugin in this.installedPluginsList)
                 {
@@ -1234,7 +1226,7 @@ internal class PluginManager : IInternalDisposableService
     /// <param name="affectedInternalNames">The affected plugins.</param>
     public void NotifyPluginsForStateChange(PluginListInvalidationKind kind, IEnumerable<string> affectedInternalNames)
     {
-        lock (this.pluginListLock)
+        using (this.pluginListLock.EnterScope())
         {
             foreach (var installedPlugin in this.installedPluginsList)
             {
@@ -1570,7 +1562,7 @@ internal class PluginManager : IInternalDisposableService
 
         // Track the plugin as soon as it is instantiated to prevent it from being loaded twice,
         // if the installer or DevPlugin scanner is attempting to add plugins while we are still loading boot plugins
-        lock (this.pluginListLock)
+        using (this.pluginListLock.EnterScope())
         {
             // Check if this plugin is already loaded
             if (this.installedPluginsList.Any(lp => lp.DllFile.FullName == dllFile.FullName))
@@ -1760,13 +1752,13 @@ internal class PluginManager : IInternalDisposableService
     {
         Log.Debug("Starting plugin update check...");
 
-        lock (this.pluginListLock)
-        {
-            this.updatablePluginsList.Clear();
+        using var scope = this.pluginListLock.EnterScope();
 
-            foreach (var plugin in this.installedPluginsList)
-            {
-                var installedVersion = plugin.Manifest.AssemblyVersion;
+        this.updatablePluginsList.Clear();
+
+        foreach (var plugin in this.installedPluginsList)
+        {
+            var installedVersion = plugin.Manifest.AssemblyVersion;
 
                 var updates = this.AvailablePlugins
                                   .Where(remoteManifest => plugin.Manifest.InternalName == remoteManifest.InternalName)
@@ -1780,26 +1772,25 @@ internal class PluginManager : IInternalDisposableService
                                                                   ? remoteManifest.TestingDalamudApiLevel.Value
                                                                   : remoteManifest.DalamudApiLevel;
 
-                                      return candidateApiLevel == DalamudApiLevel;
-                                  })
-                                  .Select(remoteManifest =>
-                                  {
-                                      var useTesting = this.UseTesting(remoteManifest);
-                                      var candidateVersion = useTesting
-                                                                 ? remoteManifest.TestingAssemblyVersion
-                                                                 : remoteManifest.AssemblyVersion;
-                                      var isUpdate = candidateVersion > installedVersion;
+                                    return candidateApiLevel == DalamudApiLevel;
+                                })
+                                .Select(remoteManifest =>
+                                {
+                                    var useTesting = this.UseTesting(remoteManifest);
+                                    var candidateVersion = useTesting
+                                                                ? remoteManifest.TestingAssemblyVersion
+                                                                : remoteManifest.AssemblyVersion;
+                                    var isUpdate = candidateVersion > installedVersion;
 
-                                      return (isUpdate, useTesting, candidateVersion, remoteManifest);
-                                  })
-                                  .Where(tpl => tpl.isUpdate)
-                                  .ToList();
+                                    return (isUpdate, useTesting, candidateVersion, remoteManifest);
+                                })
+                                .Where(tpl => tpl.isUpdate)
+                                .ToList();
 
-                if (updates.Count > 0)
-                {
-                    var update = updates.Aggregate((t1, t2) => t1.candidateVersion > t2.candidateVersion ? t1 : t2);
-                    this.updatablePluginsList.Add(new AvailablePluginUpdate(plugin, update.remoteManifest, update.useTesting));
-                }
+            if (updates.Count > 0)
+            {
+                var update = updates.Aggregate((t1, t2) => t1.candidateVersion > t2.candidateVersion ? t1 : t2);
+                this.updatablePluginsList.Add(new AvailablePluginUpdate(plugin, update.remoteManifest, update.useTesting));
             }
         }
 
@@ -1838,18 +1829,17 @@ internal class PluginManager : IInternalDisposableService
     /// <param name="notify">Whether to notify that available plugins have changed afterwards.</param>
     private void RefilterAvailablePlugins(bool notify = true)
     {
-        lock (this.pluginListLock)
-        {
-            this.availablePluginsList.Clear();
-            this.availablePluginsList.AddRange(this.Repos
-                                                   .SelectMany(repo => repo.PluginMaster)
-                                                   .Where(this.IsManifestEligible)
-                                                   .Where(IsManifestVisible));
+        using var scope = this.pluginListLock.EnterScope();
 
-            if (notify)
-            {
-                this.NotifyAvailablePluginsChanged();
-            }
+        this.availablePluginsList.Clear();
+        this.availablePluginsList.AddRange(this.Repos
+                                                .SelectMany(repo => repo.PluginMaster)
+                                                .Where(this.IsManifestEligible)
+                                                .Where(IsManifestVisible));
+
+        if (notify)
+        {
+            this.NotifyAvailablePluginsChanged();
         }
     }
 

--- a/Dalamud/Plugin/Internal/Profiles/Profile.cs
+++ b/Dalamud/Plugin/Internal/Profiles/Profile.cs
@@ -1,10 +1,10 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Dalamud.Configuration.Internal;
-using Dalamud.Game.Player;
 using Dalamud.Logging.Internal;
 using Dalamud.Utility;
 
@@ -21,6 +21,7 @@ internal class Profile
     private readonly ProfileModelV1 modelV1;
 
     private readonly Dictionary<Guid, bool> ephemeralWantOverrides = new();
+    private readonly Lock profileLock = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Profile"/> class.
@@ -170,7 +171,7 @@ internal class Profile
     /// <returns>Null if this profile does not declare the plugin, true if the profile declares the plugin and wants it enabled, false if the profile declares the plugin and does not want it enabled.</returns>
     public bool? WantsPlugin(Guid workingPluginId)
     {
-        lock (this)
+        using (this.profileLock.EnterScope())
         {
             if (this.ephemeralWantOverrides.TryGetValue(workingPluginId, out var overrideState))
             {
@@ -213,7 +214,7 @@ internal class Profile
     {
         Debug.Assert(workingPluginId != Guid.Empty, "Trying to add plugin with empty guid");
 
-        lock (this)
+        using (this.profileLock.EnterScope())
         {
             var existing = this.modelV1.Plugins.FirstOrDefault(x => x.WorkingPluginId == workingPluginId);
             if (existing != null)
@@ -262,7 +263,7 @@ internal class Profile
     public async Task RemoveAsync(Guid workingPluginId, bool apply = true, bool checkDefault = true)
     {
         ProfileModelV1.ProfileModelV1Plugin entry;
-        lock (this)
+        using (this.profileLock.EnterScope())
         {
             entry = this.modelV1.Plugins.FirstOrDefault(x => x.WorkingPluginId == workingPluginId);
             if (entry == null)
@@ -319,7 +320,7 @@ internal class Profile
     /// <param name="newGuid">Guid to use.</param>
     public void MigrateProfilesToGuidsForPlugin(string internalName, Guid newGuid)
     {
-        lock (this)
+        using (this.profileLock.EnterScope())
         {
             foreach (var plugin in this.modelV1.Plugins)
             {

--- a/Dalamud/Plugin/Internal/Profiles/ProfileManager.cs
+++ b/Dalamud/Plugin/Internal/Profiles/ProfileManager.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 
 using CheapLoc;
@@ -25,6 +26,7 @@ internal partial class ProfileManager : IServiceType
     private readonly DalamudConfiguration config;
 
     private readonly List<Profile> profiles = [];
+    private readonly Lock profilesLock = new();
 
     private volatile bool isBusy = false;
 
@@ -47,7 +49,7 @@ internal partial class ProfileManager : IServiceType
     {
         get
         {
-            lock (this.profiles)
+            using (this.profilesLock.EnterScope())
                 return this.profiles.First(x => x.IsDefaultProfile);
         }
     }
@@ -84,7 +86,7 @@ internal partial class ProfileManager : IServiceType
 
         var currentCharacterContentId = FindApplicableContentIdFromGameState() ?? 0;
 
-        lock (this.profiles)
+        using (this.profilesLock.EnterScope())
         {
             foreach (var profile in this.profiles)
             {
@@ -118,7 +120,7 @@ internal partial class ProfileManager : IServiceType
     /// <returns>Whether the plugin is in any profile.</returns>
     public bool IsInAnyProfile(Guid workingPluginId)
     {
-        lock (this.profiles)
+        using (this.profilesLock.EnterScope())
             return this.profiles.Any(x => x.WantsPlugin(workingPluginId) != null);
     }
 
@@ -229,7 +231,7 @@ internal partial class ProfileManager : IServiceType
         Log.Information("Getting want states... (reason={Reason}, cid={ContentId})", reason, currentCharacterContentId);
 
         List<ProfilePluginEntry> wantActive;
-        lock (this.profiles)
+        using (this.profilesLock.EnterScope())
         {
             wantActive = this.profiles
                              .Where(x => x.IsEnabled && x.CheckWantsActiveFromGameState(currentCharacterContentId ?? 0))
@@ -319,7 +321,7 @@ internal partial class ProfileManager : IServiceType
     /// <param name="newGuid">Guid to use.</param>
     public void MigrateProfilesToGuidsForPlugin(string internalName, Guid newGuid)
     {
-        lock (this.profiles)
+        using (this.profilesLock.EnterScope())
         {
             foreach (var profile in this.profiles)
                 profile.MigrateProfilesToGuidsForPlugin(internalName, newGuid);

--- a/Dalamud/Plugin/Ipc/Internal/CallGate.cs
+++ b/Dalamud/Plugin/Ipc/Internal/CallGate.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Threading;
 
 namespace Dalamud.Plugin.Ipc.Internal;
 
@@ -10,6 +11,7 @@ namespace Dalamud.Plugin.Ipc.Internal;
 internal class CallGate : IServiceType
 {
     private readonly Dictionary<string, CallGateChannel> gates = [];
+    private readonly Lock gatesLock = new();
 
     private ImmutableDictionary<string, CallGateChannel>? gatesCopy;
 
@@ -28,7 +30,7 @@ internal class CallGate : IServiceType
             var copy = this.gatesCopy;
             if (copy is not null)
                 return copy;
-            lock (this.gates)
+            using (this.gatesLock.EnterScope())
                 return this.gatesCopy ??= this.gates.ToImmutableDictionary(x => x.Key, x => x.Value);
         }
     }
@@ -40,7 +42,7 @@ internal class CallGate : IServiceType
     /// <returns>A CallGate registered under the given name.</returns>
     public CallGateChannel GetOrCreateChannel(string name)
     {
-        lock (this.gates)
+        using (this.gatesLock.EnterScope())
         {
             if (!this.gates.TryGetValue(name, out var gate))
             {
@@ -57,7 +59,7 @@ internal class CallGate : IServiceType
     /// </summary>
     public void PurgeEmptyGates()
     {
-        lock (this.gates)
+        using (this.gatesLock.EnterScope())
         {
             var changed = false;
             foreach (var (k, v) in this.Gates)

--- a/Dalamud/Plugin/Ipc/Internal/CallGateChannel.cs
+++ b/Dalamud/Plugin/Ipc/Internal/CallGateChannel.cs
@@ -20,6 +20,7 @@ namespace Dalamud.Plugin.Ipc.Internal;
 internal class CallGateChannel
 {
     private readonly ThreadLocal<IpcContext> ipcExecutionContext = new();
+    private readonly Lock subscriptionsLock = new();
 
     /// <summary>
     /// The actual storage.
@@ -56,7 +57,7 @@ internal class CallGateChannel
             var copy = this.subscriptionsCopy;
             if (copy is not null)
                 return copy;
-            lock (this.subscriptions)
+            using (this.subscriptionsLock.EnterScope())
                 return this.subscriptionsCopy ??= this.subscriptions.ToImmutableList();
         }
     }
@@ -79,7 +80,7 @@ internal class CallGateChannel
     /// <inheritdoc cref="CallGatePubSubBase.Subscribe"/>
     internal void Subscribe(Delegate action)
     {
-        lock (this.subscriptions)
+        using (this.subscriptionsLock.EnterScope())
         {
             this.subscriptionsCopy = null;
             this.subscriptions.Add(action);
@@ -89,7 +90,7 @@ internal class CallGateChannel
     /// <inheritdoc cref="CallGatePubSubBase.Unsubscribe"/>
     internal void Unsubscribe(Delegate action)
     {
-        lock (this.subscriptions)
+        using (this.subscriptionsLock.EnterScope())
         {
             this.subscriptionsCopy = null;
             this.subscriptions.Remove(action);

--- a/Dalamud/Plugin/Ipc/Internal/DataCache.cs
+++ b/Dalamud/Plugin/Ipc/Internal/DataCache.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.ExceptionServices;
+using System.Threading;
 
 using Dalamud.Plugin.Ipc.Exceptions;
 
@@ -23,6 +24,9 @@ internal readonly struct DataCache
     /// <summary> A distinct list of plugin IDs that are using this data. </summary>
     /// <remarks> Also used as a reference count tracker. </remarks>
     internal readonly List<DataCachePluginId> UserPluginIds;
+
+    /// <summary> A lock for the distinct list of plugin IDs that are using this data. </summary>
+    internal readonly Lock UserPluginIdsLock;
 
     /// <summary> The type the data was registered as. </summary>
     internal readonly Type Type;
@@ -100,7 +104,7 @@ internal readonly struct DataCache
                 ex = null;
 
                 // Register the access history. The effective working ID is unique per plugin and persists between reloads, so only add it once.
-                lock (this.UserPluginIds)
+                using (this.UserPluginIdsLock.EnterScope())
                 {
                     if (this.UserPluginIds.All(c => c.EffectiveWorkingId != callingPluginId.EffectiveWorkingId))
                     {

--- a/Dalamud/Plugin/Ipc/Internal/DataCache.cs
+++ b/Dalamud/Plugin/Ipc/Internal/DataCache.cs
@@ -46,6 +46,7 @@ internal readonly struct DataCache
         this.Tag = tag;
         this.CreatorPluginId = creatorPluginId;
         this.UserPluginIds = [];
+        this.UserPluginIdsLock = new();
         this.Data = data;
         this.Type = type;
     }

--- a/Dalamud/Plugin/Ipc/Internal/DataShare.cs
+++ b/Dalamud/Plugin/Ipc/Internal/DataShare.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 
 using Dalamud.Plugin.Ipc.Exceptions;
 
@@ -20,6 +21,7 @@ internal class DataShare : IServiceType
     /// effectively preventing calling the data generator multiple times concurrently.
     /// </summary>
     private readonly Dictionary<string, Lazy<DataCache>> caches = [];
+    private readonly Lock cachesLock = new();
 
     [ServiceManager.ServiceConstructor]
     private DataShare()
@@ -43,7 +45,7 @@ internal class DataShare : IServiceType
         where T : class
     {
         Lazy<DataCache> cacheLazy;
-        lock (this.caches)
+        using (this.cachesLock.EnterScope())
         {
             if (!this.caches.TryGetValue(tag, out cacheLazy))
                 this.caches[tag] = cacheLazy = new(() => DataCache.From(tag, callingPluginId, dataGenerator));
@@ -61,7 +63,7 @@ internal class DataShare : IServiceType
     public void RelinquishData(string tag, DataCachePluginId callingPluginId)
     {
         DataCache cache;
-        lock (this.caches)
+        using (this.cachesLock.EnterScope())
         {
             if (!this.caches.TryGetValue(tag, out var cacheLazy))
                 return;
@@ -105,7 +107,7 @@ internal class DataShare : IServiceType
     {
         data = null;
         Lazy<DataCache> cacheLazy;
-        lock (this.caches)
+        using (this.cachesLock.EnterScope())
         {
             if (!this.caches.TryGetValue(tag, out cacheLazy))
                 return false;
@@ -129,7 +131,7 @@ internal class DataShare : IServiceType
         where T : class
     {
         Lazy<DataCache> cacheLazy;
-        lock (this.caches)
+        using (this.cachesLock.EnterScope())
         {
             if (!this.caches.TryGetValue(tag, out cacheLazy))
                 throw new KeyNotFoundException($"The data cache [{tag}] is not registered.");
@@ -144,7 +146,7 @@ internal class DataShare : IServiceType
     /// <returns>All currently subscribed tags, their creator names and all their users.</returns>
     internal IEnumerable<(string Tag, DataCachePluginId CreatorPluginId, DataCachePluginId[] UserPluginIds)> GetAllShares()
     {
-        lock (this.caches)
+        using (this.cachesLock.EnterScope())
         {
             return this.caches.Select(
                 kvp => (kvp.Key, kvp.Value.Value.CreatorPluginId, kvp.Value.Value.UserPluginIds.ToArray()));

--- a/Dalamud/Plugin/Ipc/Internal/DataShare.cs
+++ b/Dalamud/Plugin/Ipc/Internal/DataShare.cs
@@ -69,8 +69,13 @@ internal class DataShare : IServiceType
                 return;
 
             cache = cacheLazy.Value;
-            if (!cache.UserPluginIds.Remove(callingPluginId) || cache.UserPluginIds.Count > 0)
-                return;
+
+            using (cache.UserPluginIdsLock.EnterScope())
+            {
+                if (!cache.UserPluginIds.Remove(callingPluginId) || cache.UserPluginIds.Count > 0)
+                    return;
+            }
+
             if (!this.caches.Remove(tag))
                 return;
         }
@@ -149,7 +154,11 @@ internal class DataShare : IServiceType
         using (this.cachesLock.EnterScope())
         {
             return this.caches.Select(
-                kvp => (kvp.Key, kvp.Value.Value.CreatorPluginId, kvp.Value.Value.UserPluginIds.ToArray()));
+                kvp =>
+                {
+                    using var scope = kvp.Value.Value.UserPluginIdsLock.EnterScope();
+                    return (kvp.Key, kvp.Value.Value.CreatorPluginId, kvp.Value.Value.UserPluginIds.ToArray());
+                });
         }
     }
 }

--- a/Dalamud/Service/ServiceManager.cs
+++ b/Dalamud/Service/ServiceManager.cs
@@ -45,6 +45,7 @@ internal static class ServiceManager
 
     [SuppressMessage("ReSharper", "CollectionNeverQueried.Local", Justification = "Debugging purposes")]
     private static readonly List<Type> LoadedServices = [];
+    private static readonly Lock LoadedServicesLock = new();
 #endif
 
     private static readonly TaskCompletionSource BlockingServicesLoadedTaskCompletionSource =
@@ -153,7 +154,7 @@ internal static class ServiceManager
         }
 
 #if DEBUG
-        lock (LoadedServices)
+        using (LoadedServicesLock.EnterScope())
         {
             ProvideAllServices();
         }
@@ -375,7 +376,7 @@ internal static class ServiceManager
                     {
                         if (task.IsFaulted)
                             return;
-                        lock (LoadedServices)
+                        using (LoadedServicesLock.EnterScope())
                         {
                             LoadedServices.Add(serviceType);
                         }
@@ -516,7 +517,7 @@ internal static class ServiceManager
         }
 
 #if DEBUG
-        lock (LoadedServices)
+        using (LoadedServicesLock.EnterScope())
         {
             LoadedServices.Clear();
         }

--- a/Dalamud/Storage/ReliableFileStorage.cs
+++ b/Dalamud/Storage/ReliableFileStorage.cs
@@ -124,7 +124,7 @@ internal class ReliableFileStorage : IInternalDisposableService
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
-        lock (this.syncRoot)
+        using (this.syncRoot.EnterScope())
         {
             if (this.db == null)
             {

--- a/Dalamud/Storage/ReliableFileStoragePluginScoped.cs
+++ b/Dalamud/Storage/ReliableFileStoragePluginScoped.cs
@@ -90,7 +90,7 @@ public class ReliableFileStoragePluginScoped : IReliableFileStorage, IInternalDi
         var task = Task.Run(() => this.storage.WriteAllBytesAsync(path, bytes, this.plugin.EffectiveWorkingPluginId));
 
         // Track the task so we can wait for it on dispose
-        lock (this.pendingLock)
+        using (this.pendingLock.EnterScope())
         {
             if (this.isDisposing)
                 throw new ObjectDisposedException(nameof(ReliableFileStoragePluginScoped));
@@ -101,7 +101,7 @@ public class ReliableFileStoragePluginScoped : IReliableFileStorage, IInternalDi
         // Remove when done, if the task is already done this runs synchronously here and removes immediately
         _ = task.ContinueWith(t =>
         {
-            lock (this.pendingLock)
+            using (this.pendingLock.EnterScope())
             {
                 this.pendingWrites.Remove(t);
             }
@@ -173,7 +173,7 @@ public class ReliableFileStoragePluginScoped : IReliableFileStorage, IInternalDi
     public void DisposeService()
     {
         Task[] tasksSnapshot;
-        lock (this.pendingLock)
+        using (this.pendingLock.EnterScope())
         {
             // Mark disposing to reject new writes.
             this.isDisposing = true;

--- a/Dalamud/Utility/DisposeSafety.cs
+++ b/Dalamud/Utility/DisposeSafety.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Dalamud.Utility;
@@ -141,6 +142,7 @@ public static class DisposeSafety
     public class ScopedFinalizer : IDisposeCallback, IAsyncDisposable
     {
         private readonly List<object> objects = [];
+        private readonly Lock objectsLock = new();
 
         /// <inheritdoc/>
         public event Action<IDisposeCallback>? BeforeDispose;
@@ -151,7 +153,7 @@ public static class DisposeSafety
         /// <inheritdoc cref="Stack{T}.EnsureCapacity"/>
         public void EnsureCapacity(int capacity)
         {
-            lock (this.objects)
+            using (this.objectsLock.EnterScope())
                 this.objects.EnsureCapacity(capacity);
         }
 
@@ -162,7 +164,7 @@ public static class DisposeSafety
         {
             if (d is not null)
             {
-                lock (this.objects)
+                using (this.objectsLock.EnterScope())
                     this.objects.Add(this.CheckAdd(d));
             }
 
@@ -175,7 +177,7 @@ public static class DisposeSafety
         {
             if (d is not null)
             {
-                lock (this.objects)
+                using (this.objectsLock.EnterScope())
                     this.objects.Add(this.CheckAdd(d));
             }
 
@@ -188,7 +190,7 @@ public static class DisposeSafety
         {
             if (d is not null)
             {
-                lock (this.objects)
+                using (this.objectsLock.EnterScope())
                     this.objects.Add(this.CheckAdd(d));
             }
 
@@ -200,7 +202,7 @@ public static class DisposeSafety
         {
             if (d != default)
             {
-                lock (this.objects)
+                using (this.objectsLock.EnterScope())
                     this.objects.Add(this.CheckAdd(d));
             }
 
@@ -213,7 +215,7 @@ public static class DisposeSafety
         /// <param name="ds">Disposables.</param>
         public void AddRange(IEnumerable<IDisposable?> ds)
         {
-            lock (this.objects)
+            using (this.objectsLock.EnterScope())
                 this.objects.AddRange(ds.Where(d => d is not null).Select(d => (object)this.CheckAdd(d)));
         }
 
@@ -223,7 +225,7 @@ public static class DisposeSafety
         /// <param name="ds">Actions.</param>
         public void AddRange(IEnumerable<Action?> ds)
         {
-            lock (this.objects)
+            using (this.objectsLock.EnterScope())
                 this.objects.AddRange(ds.Where(d => d is not null).Select(d => (object)this.CheckAdd(d)));
         }
 
@@ -233,7 +235,7 @@ public static class DisposeSafety
         /// <param name="ds">Func{Task}s.</param>
         public void AddRange(IEnumerable<Func<Task>?> ds)
         {
-            lock (this.objects)
+            using (this.objectsLock.EnterScope())
                 this.objects.AddRange(ds.Where(d => d is not null).Select(d => (object)this.CheckAdd(d)));
         }
 
@@ -243,7 +245,7 @@ public static class DisposeSafety
         /// <param name="ds">GCHandles.</param>
         public void AddRange(IEnumerable<GCHandle> ds)
         {
-            lock (this.objects)
+            using (this.objectsLock.EnterScope())
                 this.objects.AddRange(ds.Select(d => (object)this.CheckAdd(d)));
         }
 
@@ -253,7 +255,7 @@ public static class DisposeSafety
         /// <remarks>Use this after successful initialization of multiple disposables.</remarks>
         public void Cancel()
         {
-            lock (this.objects)
+            using (this.objectsLock.EnterScope())
             {
                 foreach (var o in this.objects)
                     this.CheckRemove(o);
@@ -310,7 +312,7 @@ public static class DisposeSafety
             while (true)
             {
                 object obj;
-                lock (this.objects)
+                using (this.objectsLock.EnterScope())
                 {
                     if (this.objects.Count == 0)
                         break;
@@ -343,7 +345,7 @@ public static class DisposeSafety
                 }
             }
 
-            lock (this.objects)
+            using (this.objectsLock.EnterScope())
                 this.objects.TrimExcess();
 
             if (exceptions is not null)
@@ -371,7 +373,7 @@ public static class DisposeSafety
             while (true)
             {
                 object obj;
-                lock (this.objects)
+                using (this.objectsLock.EnterScope())
                 {
                     if (this.objects.Count == 0)
                         break;
@@ -407,7 +409,7 @@ public static class DisposeSafety
                 }
             }
 
-            lock (this.objects)
+            using (this.objectsLock.EnterScope())
                 this.objects.TrimExcess();
 
             if (exceptions is not null)
@@ -443,7 +445,7 @@ public static class DisposeSafety
         private void OnItemDisposed(IDisposeCallback obj)
         {
             obj.BeforeDispose -= this.OnItemDisposed;
-            lock (this.objects)
+            using (this.objectsLock.EnterScope())
                 this.objects.Remove(obj);
         }
     }

--- a/Dalamud/Utility/DynamicPriorityQueueLoader.cs
+++ b/Dalamud/Utility/DynamicPriorityQueueLoader.cs
@@ -16,6 +16,7 @@ internal class DynamicPriorityQueueLoader : IDisposable
     private readonly Channel<WorkItem> newItemChannel;
     private readonly Channel<object?> workTokenChannel;
     private readonly List<WorkItem> workItemPending = [];
+    private readonly Lock workItemPendingLock = new();
 
     private bool disposing;
 
@@ -104,7 +105,7 @@ internal class DynamicPriorityQueueLoader : IDisposable
             while (newWorks.Count < batchAddSize && reader.TryRead(out var newWork))
                 newWorks.Add(newWork);
 
-            lock (this.workItemPending)
+            using (this.workItemPendingLock.EnterScope())
                 this.workItemPending.AddRange(newWorks);
 
             for (var i = newWorks.Count; i > 0; i--)
@@ -137,7 +138,7 @@ internal class DynamicPriorityQueueLoader : IDisposable
     /// <remarks>The order of items of <see cref="workItemPending"/> is undefined after this function.</remarks>
     private WorkItem? ExtractHighestPriorityWorkItem()
     {
-        lock (this.workItemPending)
+        using (this.workItemPendingLock.EnterScope())
         {
             for (var startIndex = 0; startIndex < this.workItemPending.Count - 1;)
             {

--- a/Dalamud/Utility/Timing/TimingHandle.cs
+++ b/Dalamud/Utility/Timing/TimingHandle.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 
 namespace Dalamud.Utility.Timing;
 
@@ -10,6 +11,8 @@ namespace Dalamud.Utility.Timing;
 [DebuggerDisplay("{Name} - {Duration}")]
 public sealed class TimingHandle : TimingEvent, IDisposable, IComparable<TimingHandle>
 {
+    private readonly Lock stackLock = new();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="TimingHandle"/> class.
     /// </summary>
@@ -19,7 +22,7 @@ public sealed class TimingHandle : TimingEvent, IDisposable, IComparable<TimingH
     {
         this.Stack = Timings.TaskTimingHandles;
 
-        lock (this.Stack)
+        using (this.StackLockScope)
             this.Parent = this.Stack.LastOrDefault();
 
         if (this.Parent != null)
@@ -37,7 +40,7 @@ public sealed class TimingHandle : TimingEvent, IDisposable, IComparable<TimingH
         this.EndTime = this.StartTime;
         this.IsMainThread = ThreadSafety.IsMainThread;
 
-        lock (this.Stack)
+        using (this.StackLockScope)
             this.Stack.Add(this);
     }
 
@@ -62,6 +65,11 @@ public sealed class TimingHandle : TimingEvent, IDisposable, IComparable<TimingH
     public List<TimingHandle> Stack { get; private set; }
 
     /// <summary>
+    /// Gets the attached timing handle stack.
+    /// </summary>
+    public Lock.Scope StackLockScope => this.stackLock.EnterScope();
+
+    /// <summary>
     /// Gets the parent timing.
     /// </summary>
     public TimingHandle? Parent { get; private set; }
@@ -81,12 +89,12 @@ public sealed class TimingHandle : TimingEvent, IDisposable, IComparable<TimingH
     {
         this.EndTime = Timings.Stopwatch.Elapsed.TotalMilliseconds;
 
-        lock (this.Stack)
+        using (this.StackLockScope)
             this.Stack.Remove(this);
 
         if (this.Duration > 1 || this.ChildCount > 0)
         {
-            lock (Timings.AllTimings)
+            using (Timings.AllTimingsLock.EnterScope())
             {
                 Timings.AllTimings.Add(this, this);
             }

--- a/Dalamud/Utility/Timing/Timings.cs
+++ b/Dalamud/Utility/Timing/Timings.cs
@@ -22,9 +22,19 @@ public static class Timings
     internal static readonly SortedList<TimingHandle, TimingHandle> AllTimings = [];
 
     /// <summary>
+    /// A lock scope for all concluded timings.
+    /// </summary>
+    internal static readonly Lock AllTimingsLock = new();
+
+    /// <summary>
     /// List of all timing events.
     /// </summary>
     internal static readonly List<TimingEvent> Events = [];
+
+    /// <summary>
+    /// A lock for the list of all timing events.
+    /// </summary>
+    internal static readonly Lock EventsLock = new();
 
     private static readonly AsyncLocal<Tuple<int?, List<TimingHandle>>> TaskTimingHandleStorage = new();
 
@@ -123,7 +133,7 @@ public static class Timings
         [CallerFilePath] string sourceFilePath = "",
         [CallerLineNumber] int sourceLineNumber = 0)
     {
-        lock (Events)
+        using (EventsLock.EnterScope())
         {
             Events.Add(new TimingEvent(name)
             {


### PR DESCRIPTION
While a `lock` block on a `Lock` object is translated into an `EnterScope` call on compile, doing it explicitly feels cleaner and also uncovered that a couple locks were still on `object`s/`List`s instead. Using `lock` on an `object` makes it use the legacy `Monitor` class, which has some overhead.

I suggest to review without whitespace changes. :)
Hope I didn't break anything. 😇