### PR TITLE
Make plugin updates idempotent

### DIFF
--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -818,14 +818,12 @@ internal class PluginManager : IInternalDisposableService
     /// <param name="repoManifest">The plugin definition.</param>
     /// <param name="useTesting">If the testing version should be used.</param>
     /// <param name="reason">The reason this plugin was loaded.</param>
-    /// <param name="inheritedWorkingPluginId">WorkingPluginId this plugin should inherit.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public async Task<LocalPlugin> InstallPluginAsync(
-        RemotePluginManifest repoManifest, bool useTesting, PluginLoadReason reason,
-        Guid? inheritedWorkingPluginId = null)
+        RemotePluginManifest repoManifest, bool useTesting, PluginLoadReason reason)
     {
         var stream = await this.DownloadPluginAsync(repoManifest, useTesting);
-        return await this.InstallPluginInternalAsync(repoManifest, useTesting, reason, stream, inheritedWorkingPluginId);
+        return await this.InstallPluginInternalAsync(repoManifest, useTesting, reason, stream);
     }
 
     /// <summary>
@@ -1078,27 +1076,7 @@ internal class PluginManager : IInternalDisposableService
 
             try
             {
-                // TODO: Why were we ever doing this? We should never be loading the old version in the first place
-                /*
-                    if (!plugin.IsDisabled)
-                        plugin.Disable();
-                        */
-
-                lock (this.pluginListLock)
-                {
-                    this.installedPluginsList.Remove(plugin);
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error during remove from plugin list (update)");
-                updateStatus.Status = PluginUpdateStatus.StatusKind.FailedUnload;
-                return updateStatus;
-            }
-
-            try
-            {
-                await this.InstallPluginInternalAsync(metadata.UpdateManifest, metadata.UseTesting, PluginLoadReason.Update, updateStream, workingPluginId);
+                await this.InstallPluginInternalAsync(metadata.UpdateManifest, metadata.UseTesting, PluginLoadReason.Update, updateStream, plugin);
             }
             catch (Exception ex)
             {
@@ -1372,9 +1350,14 @@ internal class PluginManager : IInternalDisposableService
     /// <param name="useTesting">If the testing version should be used.</param>
     /// <param name="reason">The reason this plugin was loaded.</param>
     /// <param name="zipStream">Stream of the ZIP archive containing the plugin that is about to be installed.</param>
-    /// <param name="inheritedWorkingPluginId">WorkingPluginId this plugin should inherit.</param>
+    /// <param name="pluginToReplace">The plugin that is being replaced by this installation (used during an update).</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    private async Task<LocalPlugin> InstallPluginInternalAsync(RemotePluginManifest repoManifest, bool useTesting, PluginLoadReason reason, Stream zipStream, Guid? inheritedWorkingPluginId = null)
+    private async Task<LocalPlugin> InstallPluginInternalAsync(
+        RemotePluginManifest repoManifest,
+        bool useTesting,
+        PluginLoadReason reason,
+        Stream zipStream,
+        LocalPlugin? pluginToReplace = null)
     {
         var version = useTesting ? repoManifest.TestingAssemblyVersion : repoManifest.AssemblyVersion;
         Log.Debug($"Installing plugin {repoManifest.Name} (testing={useTesting}, version={version}, reason={reason})");
@@ -1410,8 +1393,8 @@ internal class PluginManager : IInternalDisposableService
         else
         {
             // If we are doing anything other than a fresh install, not having a workingPluginId is an error that must be fixed
-            if (inheritedWorkingPluginId == null)
-                throw new ArgumentNullException(nameof(inheritedWorkingPluginId), "Inherited WorkingPluginId must not be null when updating");
+            if (pluginToReplace == null)
+                throw new ArgumentNullException(nameof(pluginToReplace), "Must be replacing a plugin when updating");
         }
 
         // Ensure that we have a testing opt-in for this plugin if we are installing a testing version
@@ -1485,7 +1468,19 @@ internal class PluginManager : IInternalDisposableService
             if (tempManifest.WorkingPluginId != Guid.Empty)
                 throw new Exception("Plugin shall not specify a WorkingPluginId");
 
-            tempManifest.WorkingPluginId = inheritedWorkingPluginId ?? Guid.NewGuid();
+            Guid? newWorkingPluginId;
+            if (pluginToReplace != null)
+            {
+                newWorkingPluginId = pluginToReplace.EffectiveWorkingPluginId;
+                Log.Verbose("WorkingPluginId: Replace {Name} as {WorkingPluginId}", pluginToReplace.InternalName, newWorkingPluginId);
+            }
+            else
+            {
+                newWorkingPluginId = Guid.NewGuid();
+                Log.Verbose("WorkingPluginId: New {Name} as {WorkingPluginId}", tempManifest.InternalName, newWorkingPluginId);
+            }
+
+            tempManifest.WorkingPluginId = newWorkingPluginId ?? throw new Exception("Failed to pick a new WorkingPluginId");
 
             if (useTesting)
             {
@@ -1512,11 +1507,8 @@ internal class PluginManager : IInternalDisposableService
             var finalManifest = LocalPluginManifest.Load(finalManifestFile) ??
                            throw new Exception("Plugin had no valid manifest after copy");
 
-            Log.Information("Installed plugin {InternalName} (testing={UseTesting})", tempManifest.Name, useTesting);
-            var plugin = await this.LoadPluginAsync(finalDllFile, finalManifest, reason);
-
-            this.NotifyInstalledPluginsChanged();
-            return plugin;
+            Log.Information("Staged plugin {InternalName} (testing={UseTesting})", tempManifest.Name, useTesting);
+            return await this.LoadPluginAsync(finalDllFile, finalManifest, reason, pluginToReplace: pluginToReplace);
         }
         catch
         {
@@ -1548,8 +1540,21 @@ internal class PluginManager : IInternalDisposableService
     /// <param name="devPluginLocation">The location of the dev plugin, if we are loading a dev plugin.</param>
     /// <param name="isBoot">If this plugin is being loaded at boot.</param>
     /// <param name="doNotLoad">Don't load the plugin, just don't do it.</param>
+    /// <param name="pluginToReplace">
+    /// The plugin that is being replaced through this load (used during an update).
+    /// The plugin will be disposed and removed from the list idempotently once the new plugin is ready and valid to be
+    /// added to the loaded plugins list. This is done to avoid having plugins "disappear" after an update, if the update
+    /// fails for whatever reason.
+    /// </param>
     /// <returns>The loaded plugin.</returns>
-    private async Task<LocalPlugin> LoadPluginAsync(FileInfo dllFile, LocalPluginManifest manifest, PluginLoadReason reason, DevPluginLocationSettings? devPluginLocation = null, bool isBoot = false, bool doNotLoad = false)
+    private async Task<LocalPlugin> LoadPluginAsync(
+        FileInfo dllFile,
+        LocalPluginManifest manifest,
+        PluginLoadReason reason,
+        DevPluginLocationSettings? devPluginLocation = null,
+        bool isBoot = false,
+        bool doNotLoad = false,
+        LocalPlugin? pluginToReplace = null)
     {
         // TODO: Split this function - it should only take care of adding the plugin to the list, not loading itself, that should be done through the plugin instance
 
@@ -1586,8 +1591,25 @@ internal class PluginManager : IInternalDisposableService
                 plugin = new LocalPlugin(dllFile, manifest);
             }
 
+            if (pluginToReplace != null)
+            {
+                if (pluginToReplace.IsLoaded)
+                    throw new InvalidOperationException("Plugin must be unloaded before it can be replaced");
+
+                if (!this.installedPluginsList.Remove(pluginToReplace))
+                    throw new InvalidOperationException("Failed to remove plugin that is being replaced");
+
+                Log.Verbose("Removed plugin {Name} v{Version} from loaded plugins list", pluginToReplace.InternalName, pluginToReplace.EffectiveVersion);
+            }
+
             this.installedPluginsList.Add(plugin);
+            this.NotifyInstalledPluginsChanged();
+
+            Log.Verbose("Added plugin {Name} v{Version} to loaded plugins list", manifest.InternalName, manifest.AssemblyVersion);
         }
+
+        // Dispose old plugin instance
+        await (pluginToReplace?.DisposeAsync() ?? ValueTask.CompletedTask);
 
         Log.Verbose("Starting to load plugin {Name} at {FileLocation}", manifest.InternalName, dllFile.FullName);
 

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -1772,6 +1772,7 @@ internal class PluginManager : IInternalDisposableService
                                   .Where(remoteManifest => plugin.Manifest.InternalName == remoteManifest.InternalName)
                                   .Where(remoteManifest => plugin.Manifest.InstalledFromUrl == remoteManifest.SourceRepo.PluginMasterUrl || !remoteManifest.SourceRepo.IsThirdParty)
                                   .Where(remoteManifest => remoteManifest.MinimumDalamudVersion == null || Versioning.GetAssemblyVersionParsed() >= remoteManifest.MinimumDalamudVersion)
+                                  .Where(remoteManifest => !remoteManifest.IsTestingExclusive || this.UseTesting(remoteManifest))
                                   .Where(remoteManifest =>
                                   {
                                       var useTesting = this.UseTesting(remoteManifest);

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -41,6 +41,7 @@ internal class LocalPlugin : IAsyncDisposable
 
     private readonly SemaphoreSlim pluginLoadStateLock = new(1);
 
+    private bool disposed = false;
     private PluginLoader? loader;
     private Type? pluginType;
     private object? instance;
@@ -234,8 +235,11 @@ internal class LocalPlugin : IAsyncDisposable
     public IServiceScope? ServiceScope => this.serviceScope;
 
     /// <inheritdoc/>
-    public virtual async ValueTask DisposeAsync() =>
+    public virtual async ValueTask DisposeAsync()
+    {
+        this.disposed = true;
         await this.ClearAndDisposeAllResources(PluginLoaderDisposalMode.ImmediateDispose);
+    }
 
     /// <summary>
     /// Load this plugin.
@@ -246,6 +250,8 @@ internal class LocalPlugin : IAsyncDisposable
     /// <returns>A task.</returns>
     public async Task LoadAsync(PluginLoadReason reason, bool reloading = false, CancellationToken cancellationToken = default)
     {
+        ObjectDisposedException.ThrowIf(this.disposed, nameof(LocalPlugin));
+
         // Default timeout, if none is passed
         if (cancellationToken == CancellationToken.None)
         {
@@ -388,10 +394,10 @@ internal class LocalPlugin : IAsyncDisposable
                     otherPlugin.instance.GetType().Assembly.GetName().Name;
                 if (otherPluginAssemblyName == assemblyName && otherPluginAssemblyName != null)
                 {
-                    this.State = PluginState.Unloaded;
-                    Log.Debug("Duplicate assembly: {Name}", this.InternalName);
-
-                    throw new DuplicatePluginException(assemblyName);
+                    Log.Warning("Loading {Name}, but another plugin with the same assembly name was already loaded (thisGuid={ThisGuid}, otherGuid={OtherGuid})",
+                                this.InternalName,
+                                this.EffectiveWorkingPluginId,
+                                otherPlugin.EffectiveWorkingPluginId);
                 }
             }
 
@@ -453,6 +459,8 @@ internal class LocalPlugin : IAsyncDisposable
     /// <returns>The task.</returns>
     public async Task UnloadAsync(PluginLoaderDisposalMode disposalMode = PluginLoaderDisposalMode.WaitBeforeDispose)
     {
+        ObjectDisposedException.ThrowIf(this.disposed, nameof(LocalPlugin));
+
         await this.pluginLoadStateLock.WaitAsync();
         try
         {
@@ -515,6 +523,8 @@ internal class LocalPlugin : IAsyncDisposable
     /// <returns>A task.</returns>
     public async Task ReloadAsync()
     {
+        ObjectDisposedException.ThrowIf(this.disposed, nameof(LocalPlugin));
+
         // Don't unload if we're a dev plugin and have an unload error, this is a bad idea but whatever
         if (this.IsDev && this.State != PluginState.UnloadError)
             await this.UnloadAsync(PluginLoaderDisposalMode.None);
@@ -528,6 +538,8 @@ internal class LocalPlugin : IAsyncDisposable
     /// <returns>Whether this plugin shouldn't load.</returns>
     public bool CheckPolicy()
     {
+        ObjectDisposedException.ThrowIf(this.disposed, nameof(LocalPlugin));
+
         var startInfo = Service<Dalamud>.Get().StartInfo;
         var manager = Service<PluginManager>.Get();
 
@@ -546,6 +558,8 @@ internal class LocalPlugin : IAsyncDisposable
     /// <param name="status">Schedule or cancel the deletion.</param>
     public void ScheduleDeletion(bool status = true)
     {
+        ObjectDisposedException.ThrowIf(this.disposed, nameof(LocalPlugin));
+
         this.manifest.ScheduledForDeletion = status;
         this.SaveManifest("scheduling for deletion");
     }
@@ -556,6 +570,8 @@ internal class LocalPlugin : IAsyncDisposable
     /// <returns>The plugin repository this plugin was installed from, or null if it is no longer there or if the plugin is a dev plugin.</returns>
     public PluginRepository? GetSourceRepository()
     {
+        ObjectDisposedException.ThrowIf(this.disposed, nameof(LocalPlugin));
+
         if (this.IsDev)
             return null;
 
@@ -575,7 +591,10 @@ internal class LocalPlugin : IAsyncDisposable
     /// <param name="context">The load context to check.</param>
     /// <returns>Whether this plugin loads in the given load context.</returns>
     public bool LoadsIn(AssemblyLoadContext context)
-        => this.loader?.LoadContext == context;
+    {
+        ObjectDisposedException.ThrowIf(this.disposed, nameof(LocalPlugin));
+        return this.loader?.LoadContext == context;
+    }
 
     /// <summary>
     /// Save this plugin manifest.


### PR DESCRIPTION
Fixes a problem discovered through the manifest changes last patch. When updating, if any operation between the removal of the last version and the load of the new plugin failed, the plugin would effectively disappear from the plugin list, even though it was technically still loaded internally.

Also fixes two other minor issues:
* Removes outdated assumption that two plugins with the same internal name cannot be loaded twice. This is allowed now for devs that know what they're doing
* Fixes issue wherein the installer may have tried to update to a non-existent stable version if a plugin has been moved from stable to testing-only (currently the case with Mini)