### PR TITLE
Fix DalamudInterface.ToggleStyleEditorWindow

### DIFF
--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -503,7 +503,7 @@ internal class DalamudInterface : IInternalDisposableService
     /// <summary>
     /// Toggles the <see cref="StyleEditorWindow"/>.
     /// </summary>
-    public void ToggleStyleEditorWindow() => this.selfTestWindow.Toggle();
+    public void ToggleStyleEditorWindow() => this.styleEditorWindow.Toggle();
 
     /// <summary>
     /// Toggles the <see cref="ProfilerWindow"/>.


### PR DESCRIPTION
This unused function was toggling the wrong window.