### PR TITLE
Fix crash on null third repo URL

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -574,10 +574,11 @@ internal sealed class DalamudConfiguration : IInternalDisposableService
         try
         {
             deserialized.SetDefaults();
+            deserialized.Cleanup();
         }
         catch (Exception e)
         {
-            Log.Error(e, "Failed to set defaults for DalamudConfiguration");
+            Log.Error(e, "Failed to set defaults or cleanup for DalamudConfiguration");
         }
 
         return deserialized;
@@ -659,6 +660,12 @@ internal sealed class DalamudConfiguration : IInternalDisposableService
 
         this.DevMode ??= this.DevPluginLoadLocations.Count != 0 || this.DevBarOpenAtStartup;
 #pragma warning restore CS0618
+    }
+
+    private void Cleanup()
+    {
+        // Unsure of the cause, but a null URL repo is possible
+        this.ThirdRepoList.RemoveAll(repo => repo.Url.IsNullOrEmpty());
     }
 
     private void Save()

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/ThirdRepoSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/ThirdRepoSettingsEntry.cs
@@ -164,7 +164,7 @@ internal class ThirdRepoSettingsEntry : SettingsEntry
         {
             var isEnabled = thirdRepoSetting.IsEnabled;
 
-            id.Push(thirdRepoSetting.Url);
+            id.Push($"url{repoNumber}");
 
             ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth() / 2) - 8 - (ImGui.CalcTextSize(repoNumber.ToString()).X / 2));
             ImGui.Text(repoNumber.ToString());

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/ThirdRepoSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/ThirdRepoSettingsEntry.cs
@@ -36,13 +36,13 @@ internal class ThirdRepoSettingsEntry : SettingsEntry
     public override void OnClose()
     {
         this.thirdRepoList =
-            [.. Service<DalamudConfiguration>.Get().ThirdRepoList.Select(x => x.Clone())];
+            [.. Service<DalamudConfiguration>.Get().ThirdRepoList.Where(repo => !repo.Url.IsNullOrEmpty()).Select(x => x.Clone())];
     }
 
     public override void Load()
     {
         this.thirdRepoList =
-            [.. Service<DalamudConfiguration>.Get().ThirdRepoList.Select(x => x.Clone())];
+            [.. Service<DalamudConfiguration>.Get().ThirdRepoList.Where(repo => !repo.Url.IsNullOrEmpty()).Select(x => x.Clone())];
         this.thirdRepoListChanged = false;
     }
 

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -429,7 +429,7 @@ internal class PluginManager : IInternalDisposableService
     {
         var repos = new List<PluginRepository> { this.MainRepo };
         repos.AddRange(this.configuration.ThirdRepoList
-                           .Where(repo => repo.IsEnabled)
+                           .Where(repo => repo.IsEnabled && !repo.Url.IsNullOrEmpty())
                            .DistinctBy(x => x.Url)
                            .Select(repo => new PluginRepository(this.happyHttpClient, repo.Url, repo.IsEnabled)));
 


### PR DESCRIPTION
Fixes #2844.
Unsure how that null even happens.

~~Should Dalamud fix it directly when loading the config by removing the null entry?
I suppose leaving it in allows the user to tell there is an issue with a repo that was probably fine before. It shows as an error message in the installer and there is an empty entry in the settings.~~