### PR TITLE
Add Atk collision prevention for hovered ImGui windows

### DIFF
--- a/Dalamud/Game/Internal/DalamudAtkTweaks.cs
+++ b/Dalamud/Game/Internal/DalamudAtkTweaks.cs
@@ -32,11 +32,9 @@ internal sealed unsafe class DalamudAtkTweaks : IInternalDisposableService
     private static readonly ModuleLog Log = ModuleLog.Create<DalamudAtkTweaks>();
 
     private readonly Hook<AgentHUD.Delegates.OpenSystemMenu> hookAgentHudOpenSystemMenu;
-
-    // TODO: Make this into events in Framework.Gui
-    private readonly Hook<UIModule.Delegates.ExecuteMainCommand> hookUiModuleExecuteMainCommand;
-
+    private readonly Hook<UIModule.Delegates.ExecuteMainCommand> hookUiModuleExecuteMainCommand; // TODO: Make this into events in Framework.Gui
     private readonly Hook<AtkUnitBase.Delegates.ReceiveGlobalEvent> hookAtkUnitBaseReceiveGlobalEvent;
+    private readonly Hook<RaptureAtkUnitManager.Delegates.GetAddonCollision> hookGetAddonCollision;
 
     [ServiceManager.ServiceDependency]
     private readonly DalamudConfiguration configuration = Service<DalamudConfiguration>.Get();
@@ -58,6 +56,7 @@ internal sealed unsafe class DalamudAtkTweaks : IInternalDisposableService
         this.hookAgentHudOpenSystemMenu = Hook<AgentHUD.Delegates.OpenSystemMenu>.FromAddress(AgentHUD.Addresses.OpenSystemMenu.Value, this.AgentHudOpenSystemMenuDetour);
         this.hookUiModuleExecuteMainCommand = Hook<UIModule.Delegates.ExecuteMainCommand>.FromAddress((nint)UIModule.StaticVirtualTablePointer->ExecuteMainCommand, this.UiModuleExecuteMainCommandDetour);
         this.hookAtkUnitBaseReceiveGlobalEvent = Hook<AtkUnitBase.Delegates.ReceiveGlobalEvent>.FromAddress((nint)AtkUnitBase.StaticVirtualTablePointer->ReceiveGlobalEvent, this.AtkUnitBaseReceiveGlobalEventDetour);
+        this.hookGetAddonCollision = Hook<RaptureAtkUnitManager.Delegates.GetAddonCollision>.FromAddress((nint)RaptureAtkUnitManager.StaticVirtualTablePointer->GetAddonCollision, this.RaptureAtkUnitManagerGetAddonCollisionDetour);
 
         // this.contextMenu.ContextMenuOpened += this.ContextMenuOnContextMenuOpened;
 
@@ -68,6 +67,7 @@ internal sealed unsafe class DalamudAtkTweaks : IInternalDisposableService
         this.hookAgentHudOpenSystemMenu.Enable();
         this.hookUiModuleExecuteMainCommand.Enable();
         this.hookAtkUnitBaseReceiveGlobalEvent.Enable();
+        this.hookGetAddonCollision.Enable();
     }
 
     /// <summary>Finalizes an instance of the <see cref="DalamudAtkTweaks"/> class.</summary>
@@ -94,6 +94,7 @@ internal sealed unsafe class DalamudAtkTweaks : IInternalDisposableService
             this.hookAgentHudOpenSystemMenu.Dispose();
             this.hookUiModuleExecuteMainCommand.Dispose();
             this.hookAtkUnitBaseReceiveGlobalEvent.Dispose();
+            this.hookGetAddonCollision.Dispose();
 
             // this.contextMenu.ContextMenuOpened -= this.ContextMenuOnContextMenuOpened;
         }
@@ -230,6 +231,22 @@ internal sealed unsafe class DalamudAtkTweaks : IInternalDisposableService
         }
 
         this.hookAtkUnitBaseReceiveGlobalEvent.Original(thisPtr, eventType, eventParam, atkEvent, atkEventData);
+    }
+
+    private void RaptureAtkUnitManagerGetAddonCollisionDetour(RaptureAtkUnitManager* thisPtr, AddonCollision* collisionInfo, short x, short y)
+    {
+        if (WindowSystem.ShouldInhibitAtkCollisions)
+        {
+            if (collisionInfo != null)
+            {
+                collisionInfo->UnitBase = null;
+                collisionInfo->CollisionNode = null;
+            }
+
+            return;
+        }
+
+        this.hookGetAddonCollision.Original(thisPtr, collisionInfo, x, y);
     }
 
     private void AgentHudOpenSystemMenuDetour(AgentHUD* thisPtr, AtkValue* atkValueArgs, uint menuSize)

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -1245,6 +1245,7 @@ internal partial class InterfaceManager : IInternalDisposableService
         WindowSystem.HasAnyWindowSystemFocus = false;
         WindowSystem.FocusedWindowSystemNamespace = string.Empty;
         WindowSystem.ShouldInhibitAtkCloseEvents = false;
+        WindowSystem.ShouldInhibitAtkCollisions = false;
 
         if (this.IsDispatchingEvents)
         {

--- a/Dalamud/Interface/Windowing/IWindow.cs
+++ b/Dalamud/Interface/Windowing/IWindow.cs
@@ -28,9 +28,19 @@ public interface IWindow
     bool IsFocused { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the window is hovered.
+    /// </summary>
+    bool IsHovered { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether this window is to be closed with a hotkey, like Escape, and keep game addons open in turn if it is closed.
     /// </summary>
     bool RespectCloseHotkey { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this window inhibits the game cursor from interacting with native elements underneath the hovered window.
+    /// </summary>
+    bool InhibitAtkCollision { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether this window should not generate sound effects when opening and closing.

--- a/Dalamud/Interface/Windowing/Window.cs
+++ b/Dalamud/Interface/Windowing/Window.cs
@@ -46,7 +46,13 @@ public abstract class Window : IWindow
     public bool IsFocused { get; set; }
 
     /// <inheritdoc/>
+    public bool IsHovered { get; set; }
+
+    /// <inheritdoc/>
     public bool RespectCloseHotkey { get; set; } = true;
+
+    /// <inheritdoc/>
+    public bool InhibitAtkCollision { get; set; } = true;
 
     /// <inheritdoc/>
     public bool DisableWindowSounds { get; set; } = false;

--- a/Dalamud/Interface/Windowing/WindowHost.cs
+++ b/Dalamud/Interface/Windowing/WindowHost.cs
@@ -145,6 +145,7 @@ public class WindowHost
                 this.Window.OnClose();
 
                 this.Window.IsFocused = false;
+                this.Window.IsHovered = false;
 
                 if (internalDrawParams.Flags.HasFlag(WindowDrawFlags.UseSoundEffects) && !this.Window.DisableWindowSounds)
                 {
@@ -533,6 +534,7 @@ public class WindowHost
         }
 
         this.Window.IsFocused = ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows);
+        this.Window.IsHovered = ImGui.IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows);
 
         if (internalDrawParams.Flags.HasFlag(WindowDrawFlags.UseFocusManagement) && !this.Window.IsPinned)
         {

--- a/Dalamud/Interface/Windowing/WindowSystem.cs
+++ b/Dalamud/Interface/Windowing/WindowSystem.cs
@@ -59,6 +59,12 @@ public class WindowSystem : IWindowSystem
     internal static bool ShouldInhibitAtkCloseEvents { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether ATK collisions should be inhibited while any window is hovered.
+    /// Does not respect windows that are pinned or clickthrough.
+    /// </summary>
+    internal static bool ShouldInhibitAtkCollisions { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating the default blur strength for windows in this <see cref="WindowSystem"/>.
     /// This is used for windows that do not have a specific override set in their preset.
     /// Range [0f,1f].
@@ -172,6 +178,11 @@ public class WindowSystem : IWindowSystem
 
         ShouldInhibitAtkCloseEvents |= this.windows.Any(w => w.Window.IsFocused &&
                                                             w.Window.RespectCloseHotkey &&
+                                                            !w.Window.IsPinned &&
+                                                            !w.Window.IsClickthrough);
+
+        ShouldInhibitAtkCollisions |= this.windows.Any(w => w.Window.IsHovered &&
+                                                            w.Window.InhibitAtkCollision &&
                                                             !w.Window.IsPinned &&
                                                             !w.Window.IsClickthrough);
 


### PR DESCRIPTION
This PR adds the ability for Dalamuds ImGui windows to prevent cursor collisions to be registered by the game underneath them.

https://github.com/user-attachments/assets/c206cbef-33bf-4a1d-b1bb-040c8b54772d

It's late and I'm too tired to think of a better name for `IWindow.InhibitAtkCollision`. Sorrey.

