### PR TITLE
Guard plugin image payload loading

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginImageCache.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginImageCache.cs
@@ -268,6 +268,28 @@ internal class PluginImageCache : IInternalDisposableService
         return false;
     }
 
+    private static bool IsSupportedImagePayload(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < 4)
+            return false;
+
+        // WIC-supported image formats we expect from plugin repositories.
+        if (bytes is [0x89, 0x50, 0x4E, 0x47, ..]) // PNG
+            return true;
+        if (bytes is [0xFF, 0xD8, 0xFF, ..]) // JPEG
+            return true;
+        if (bytes is [0x47, 0x49, 0x46, 0x38, ..]) // GIF
+            return true;
+        if (bytes is [0x42, 0x4D, ..]) // BMP
+            return true;
+        if (bytes is [0x49, 0x49, 0x2A, 0x00, ..] or [0x4D, 0x4D, 0x00, 0x2A, ..]) // TIFF
+            return true;
+        if (bytes is [0x00, 0x00, 0x01, 0x00, ..]) // ICO
+            return true;
+
+        return TexFileExtensions.IsPossiblyTexFile2D(bytes);
+    }
+
     private async Task<IDalamudTextureWrap?> TryLoadImage(
         byte[]? bytes,
         string name,
@@ -279,6 +301,12 @@ internal class PluginImageCache : IInternalDisposableService
     {
         if (bytes == null)
             return null;
+
+        if (!IsSupportedImagePayload(bytes))
+        {
+            Log.Error($"Could not load {name} for {manifest.InternalName} at {loc}: response did not look like a supported image.");
+            return null;
+        }
 
         var textureManager = await Service<TextureManager>.GetAsync();
 


### PR DESCRIPTION
## Summary

This adds a small payload sniff before `PluginImageCache` hands downloaded plugin icons/images to the texture manager.

If a plugin repository icon URL returns a successful HTTP response that is not actually image data, the plugin installer now logs the bad payload and skips it instead of sending arbitrary bytes through WIC/TexFile decoding.

## Motivation

While testing under XIVLauncher.Core/Wine, opening `/xlplugins` caused the plugin installer to fetch some icon URLs that ended in `.png` but redirected to JSON (`application/json`). Dalamud then attempted to decode those JSON bytes as an image/TexFile, logged texture decode failures, and the runtime later crashed.

Example failing path from logs:

- `PluginImageCache.TryLoadImage`
- `TextureManager.CreateFromImageAsync`
- `TextureManager.Wic.NoThrottleCreateFromWicStream`
- fallback `NoThrottleCreateFromTexFile`
- `The file is not a TexFile`

The immediate bad responses were from plugin icon URLs that looked image-like but returned JSON after redirect.

## Changes

- Adds `IsSupportedImagePayload(...)` to `PluginImageCache`.
- Allows expected image magic headers: PNG, JPEG, GIF, BMP, TIFF, ICO.
- Preserves support for FFXIV `TexFile` payloads via `TexFileExtensions.IsPossiblyTexFile2D`.
- Rejects unsupported payloads before invoking WIC/TexFile decode.

## Validation

`dotnet build Dalamud/Dalamud.csproj -c Debug`