### PR TITLE
Disable InhibitAtkCollision for Gamepad Mode

### DIFF
--- a/Dalamud/Game/Internal/DalamudAtkTweaks.cs
+++ b/Dalamud/Game/Internal/DalamudAtkTweaks.cs
@@ -235,7 +235,7 @@ internal sealed unsafe class DalamudAtkTweaks : IInternalDisposableService
 
     private void RaptureAtkUnitManagerGetAddonCollisionDetour(RaptureAtkUnitManager* thisPtr, AddonCollision* collisionInfo, short x, short y)
     {
-        if (WindowSystem.ShouldInhibitAtkCollisions)
+        if (WindowSystem.ShouldInhibitAtkCollisions && !UIModule.Instance()->IsPadModeEnabled())
         {
             if (collisionInfo != null)
             {

--- a/Dalamud/Interface/Windowing/IWindow.cs
+++ b/Dalamud/Interface/Windowing/IWindow.cs
@@ -40,6 +40,9 @@ public interface IWindow
     /// <summary>
     /// Gets or sets a value indicating whether this window inhibits the game cursor from interacting with native elements underneath the hovered window.
     /// </summary>
+    /// <remarks>
+    /// This is feature is disabled when Gamepad Mode is enabled.
+    /// </remarks>
     bool InhibitAtkCollision { get; set; }
 
     /// <summary>


### PR DESCRIPTION
Fixes an issue where tooltips are not being shown when Gamepad Mode is enabled and the mouse cursor is hovering an ImGui window.