### PR TITLE
Cleaner Dalamud shutdown

### DIFF
--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -10,7 +10,6 @@ using Dalamud.Common;
 using Dalamud.Configuration.Internal;
 using Dalamud.Game;
 using Dalamud.Hooking.Internal.Verification;
-using Dalamud.Interface.Internal;
 using Dalamud.Plugin.Internal;
 using Dalamud.Storage;
 using Dalamud.Utility;

--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -195,6 +195,7 @@ internal sealed unsafe class Dalamud : IServiceType
     public void WaitForUnload()
     {
         this.unloadSignal.WaitOne();
+        this.unloadSignal.Dispose();
     }
 
     /// <summary>

--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -10,6 +10,7 @@ using Dalamud.Common;
 using Dalamud.Configuration.Internal;
 using Dalamud.Game;
 using Dalamud.Hooking.Internal.Verification;
+using Dalamud.Interface.Internal;
 using Dalamud.Plugin.Internal;
 using Dalamud.Storage;
 using Dalamud.Utility;
@@ -33,7 +34,7 @@ namespace Dalamud;
 /// The main Dalamud class containing all subsystems.
 /// </summary>
 [ServiceManager.ProvidedService]
-internal sealed unsafe class Dalamud : IServiceType
+internal sealed class Dalamud : IServiceType
 {
     #region Internals
 
@@ -186,7 +187,15 @@ internal sealed unsafe class Dalamud : IServiceType
             Windows.Win32.PInvoke.CreateMutex(attribs, false, "DALAMUD_CRASHES_NO_MORE");
         }
 
-        this.unloadSignal.Set();
+        Task.Run(() =>
+        {
+            if (Service<PluginManager>.GetNullable() is { } pluginManager)
+                pluginManager.UnloadAllPlugins().Wait();
+
+            ServiceManager.UnloadAllServices();
+
+            this.unloadSignal.Set();
+        });
     }
 
     /// <summary>
@@ -219,7 +228,7 @@ internal sealed unsafe class Dalamud : IServiceType
     /// <summary>
     /// Helper function to set the exception handler.
     /// </summary>
-    private static nint SetExceptionHandler(nint newFilter)
+    private static unsafe nint SetExceptionHandler(nint newFilter)
     {
         var oldFilter =
             Windows.Win32.PInvoke.SetUnhandledExceptionFilter((delegate* unmanaged[Stdcall]<global::Windows.Win32.System.Diagnostics.Debug.EXCEPTION_POINTERS*, int>)newFilter);

--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -188,9 +188,6 @@ internal sealed class Dalamud : IServiceType
 
         Task.Run(() =>
         {
-            if (Service<PluginManager>.GetNullable() is { } pluginManager)
-                pluginManager.UnloadAllPlugins().Wait();
-
             ServiceManager.UnloadAllServices();
 
             this.unloadSignal.Set();

--- a/Dalamud/EntryPoint.cs
+++ b/Dalamud/EntryPoint.cs
@@ -56,7 +56,7 @@ public sealed class EntryPoint
         if ((info.BootWaitMessageBox & 4) != 0)
             Windows.Win32.PInvoke.MessageBox(HWND.Null, "Press OK to continue (BeforeDalamudConstruct)", "Dalamud Boot", MESSAGEBOX_STYLE.MB_OK);
 
-        new Thread(() => RunThread(info, mainThreadContinueEvent)).Start();
+        new Thread(() => RunThread(info, mainThreadContinueEvent)) { Name = "Dalamud EntryPoint" }.Start();
     }
 
     /// <summary>

--- a/Dalamud/EntryPoint.cs
+++ b/Dalamud/EntryPoint.cs
@@ -144,8 +144,6 @@ public sealed class EntryPoint
 
         TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
 
-        var unloadFailed = false;
-
         try
         {
             if (info.DelayInitializeMs > 0)
@@ -176,16 +174,6 @@ public sealed class EntryPoint
                             FFXIVClientStructs.ThisAssembly.Git.Commits);
 
             dalamud.WaitForUnload();
-
-            try
-            {
-                ServiceManager.UnloadAllServices();
-            }
-            catch (Exception ex)
-            {
-                Log.Fatal(ex, "Could not unload services.");
-                unloadFailed = true;
-            }
         }
         catch (Exception ex)
         {
@@ -209,11 +197,6 @@ public sealed class EntryPoint
             Log.CloseAndFlush();
             SerilogEventSink.Instance.LogLine -= SerilogOnLogLine;
         }
-
-        // If we didn't unload services correctly, we need to kill the process.
-        // We will never signal to Framework.
-        if (unloadFailed)
-            Environment.Exit(-1);
     }
 
     private static void SerilogOnLogLine(object? sender, (string Line, LogEvent LogEvent) ev)

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -6,8 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Dalamud.Configuration.Internal;
-using Dalamud.Game.Gui;
-using Dalamud.Game.Gui.Toast;
 using Dalamud.Hooking;
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
@@ -298,14 +296,9 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     /// </summary>
     void IInternalDisposableService.DisposeService()
     {
-        this.RunOnFrameworkThread(() =>
-        {
-            // ReSharper disable once AccessToDisposedClosure
-            this.updateHook.Disable();
-
-            // ReSharper disable once AccessToDisposedClosure
-            this.destroyHook.Disable();
-        }).Wait();
+        foreach (var k in this.tickDelayedTaskCompletionSources.Keys)
+            k.SetCanceled(this.frameworkDestroy.Token);
+        this.tickDelayedTaskCompletionSources.Clear();
 
         this.updateHook.Dispose();
         this.destroyHook.Dispose();
@@ -472,14 +465,10 @@ internal sealed class Framework : IInternalDisposableService, IFramework
         if (!ServiceManager.IsUnloaded)
         {
             this.RunFrameworkTick();
-            return false;
+            return false; // keep looping until we have unloaded every service
         }
 
-        foreach (var k in this.tickDelayedTaskCompletionSources.Keys)
-            k.SetCanceled(this.frameworkDestroy.Token);
-        this.tickDelayedTaskCompletionSources.Clear();
-
-        return this.destroyHook.OriginalDisposeSafe(thisPtr); // once this returns true, it exits the loop
+        return this.destroyHook.OriginalDisposeSafe(thisPtr);
     }
 }
 

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -330,6 +330,9 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     /// </summary>
     internal void UnloadDalamud()
     {
+        if (!this.frameworkDestroy.IsCancellationRequested)
+            return;
+
         this.frameworkDestroy.Cancel();
         this.DispatchUpdateEvents = false;
 

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -330,7 +330,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     /// </summary>
     internal void UnloadDalamud()
     {
-        if (!this.frameworkDestroy.IsCancellationRequested)
+        if (this.frameworkDestroy.IsCancellationRequested)
             return;
 
         this.frameworkDestroy.Cancel();

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -456,21 +456,27 @@ internal sealed class Framework : IInternalDisposableService, IFramework
 
     private unsafe bool HandleFrameworkDestroy(CSFramework* thisPtr)
     {
-        this.frameworkDestroy.Cancel();
-        this.DispatchUpdateEvents = false;
-        foreach (var k in this.tickDelayedTaskCompletionSources.Keys)
-            k.SetCanceled(this.frameworkDestroy.Token);
-        this.tickDelayedTaskCompletionSources.Clear();
+        if (!this.frameworkDestroy.IsCancellationRequested)
+        {
+            Log.Information("Framework::Destroy!");
 
-        // All the same, for now...
-        this.lifecycle.SetShuttingDown();
-        this.lifecycle.SetUnloading();
+            this.frameworkDestroy.Cancel();
+            this.DispatchUpdateEvents = false;
+            foreach (var k in this.tickDelayedTaskCompletionSources.Keys)
+                k.SetCanceled(this.frameworkDestroy.Token);
+            this.tickDelayedTaskCompletionSources.Clear();
 
-        Log.Information("Framework::Destroy!");
-        Service<Dalamud>.Get().Unload();
-        this.frameworkThreadTaskScheduler.Run();
-        ServiceManager.WaitForServiceUnload();
-        Log.Information("Framework::Destroy OK!");
+            // All the same, for now...
+            this.lifecycle.SetShuttingDown();
+            this.lifecycle.SetUnloading();
+
+            this.frameworkThreadTaskScheduler.Run();
+
+            Service<Dalamud>.Get().Unload();
+        }
+
+        if (!ServiceManager.IsUnloaded)
+            return false;
 
         return this.destroyHook.OriginalDisposeSafe(thisPtr);
     }

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -326,6 +326,21 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     }
 
     /// <summary>
+    /// Cancels CancellationTokenSources, sets GameLifecycle to shutting down and unloads Dalamud services.
+    /// </summary>
+    internal void UnloadDalamud()
+    {
+        this.frameworkDestroy.Cancel();
+        this.DispatchUpdateEvents = false;
+
+        // All the same, for now...
+        this.lifecycle.SetShuttingDown();
+        this.lifecycle.SetUnloading();
+
+        Service<Dalamud>.Get().Unload();
+    }
+
+    /// <summary>
     /// Profiles each sub-delegate in the eventDelegate and logs to StatsHistory.
     /// </summary>
     /// <param name="eventDelegate">The Delegate to Profile.</param>
@@ -451,15 +466,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
         if (!this.frameworkDestroy.IsCancellationRequested)
         {
             Log.Information("Framework::Destroy!");
-
-            this.frameworkDestroy.Cancel();
-            this.DispatchUpdateEvents = false;
-
-            // All the same, for now...
-            this.lifecycle.SetShuttingDown();
-            this.lifecycle.SetUnloading();
-
-            Service<Dalamud>.Get().Unload();
+            this.UnloadDalamud();
         }
 
         if (!ServiceManager.IsUnloaded)

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -123,6 +123,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     {
         if (ServiceManager.UnloadCancellationToken.IsCancellationRequested) // Gone
             return Task.FromCanceled(this.frameworkDestroy.Token);
+
         if (numTicks <= 0 || this.frameworkThreadTaskScheduler.BoundThread == null) // Nonsense or before first tick
             return Task.CompletedTask;
 
@@ -204,9 +205,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
             if (delay == default && delayTicks == default)
                 return this.RunOnFrameworkThread(func);
 
-            var cts = new CancellationTokenSource();
-            cts.Cancel();
-            return Task.FromCanceled<T>(cts.Token);
+            return Task.FromCanceled<T>(ServiceManager.UnloadCancellationToken);
         }
 
         if (cancellationToken == default)
@@ -230,9 +229,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
             if (delay == default && delayTicks == default)
                 return this.RunOnFrameworkThread(action);
 
-            var cts = new CancellationTokenSource();
-            cts.Cancel();
-            return Task.FromCanceled(cts.Token);
+            return Task.FromCanceled(ServiceManager.UnloadCancellationToken);
         }
 
         if (cancellationToken == default)
@@ -256,9 +253,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
             if (delay == default && delayTicks == default)
                 return this.RunOnFrameworkThread(func);
 
-            var cts = new CancellationTokenSource();
-            cts.Cancel();
-            return Task.FromCanceled<T>(cts.Token);
+            return Task.FromCanceled<T>(ServiceManager.UnloadCancellationToken);
         }
 
         if (cancellationToken == default)
@@ -282,9 +277,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
             if (delay == default && delayTicks == default)
                 return this.RunOnFrameworkThread(func);
 
-            var cts = new CancellationTokenSource();
-            cts.Cancel();
-            return Task.FromCanceled(cts.Token);
+            return Task.FromCanceled(ServiceManager.UnloadCancellationToken);
         }
 
         if (cancellationToken == default)

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -58,7 +58,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
         this.frameworkDestroy = new();
         this.frameworkThreadTaskScheduler = new();
         this.FrameworkThreadTaskFactory = new(
-            this.frameworkDestroy.Token,
+            ServiceManager.UnloadCancellationToken,
             TaskCreationOptions.None,
             TaskContinuationOptions.None,
             this.frameworkThreadTaskScheduler);
@@ -121,7 +121,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     /// <inheritdoc/>
     public Task DelayTicks(long numTicks, CancellationToken cancellationToken = default)
     {
-        if (this.frameworkDestroy.IsCancellationRequested) // Going away
+        if (ServiceManager.UnloadCancellationToken.IsCancellationRequested) // Gone
             return Task.FromCanceled(this.frameworkDestroy.Token);
         if (numTicks <= 0 || this.frameworkThreadTaskScheduler.BoundThread == null) // Nonsense or before first tick
             return Task.CompletedTask;
@@ -165,12 +165,12 @@ internal sealed class Framework : IInternalDisposableService, IFramework
 
     /// <inheritdoc/>
     public Task<T> RunOnFrameworkThread<T>(Func<T> func) =>
-        this.IsInFrameworkUpdateThread || this.IsFrameworkUnloading ? Task.FromResult(func()) : this.RunOnTick(func);
+        this.IsInFrameworkUpdateThread || ServiceManager.UnloadCancellationToken.IsCancellationRequested ? Task.FromResult(func()) : this.RunOnTick(func);
 
     /// <inheritdoc/>
     public Task RunOnFrameworkThread(Action action)
     {
-        if (this.IsInFrameworkUpdateThread || this.IsFrameworkUnloading)
+        if (this.IsInFrameworkUpdateThread || ServiceManager.UnloadCancellationToken.IsCancellationRequested)
         {
             try
             {
@@ -190,16 +190,16 @@ internal sealed class Framework : IInternalDisposableService, IFramework
 
     /// <inheritdoc/>
     public Task<T> RunOnFrameworkThread<T>(Func<Task<T>> func) =>
-        this.IsInFrameworkUpdateThread || this.IsFrameworkUnloading ? func() : this.RunOnTick(func);
+        this.IsInFrameworkUpdateThread || ServiceManager.UnloadCancellationToken.IsCancellationRequested ? func() : this.RunOnTick(func);
 
     /// <inheritdoc/>
     public Task RunOnFrameworkThread(Func<Task> func) =>
-        this.IsInFrameworkUpdateThread || this.IsFrameworkUnloading ? func() : this.RunOnTick(func);
+        this.IsInFrameworkUpdateThread || ServiceManager.UnloadCancellationToken.IsCancellationRequested ? func() : this.RunOnTick(func);
 
     /// <inheritdoc/>
     public Task<T> RunOnTick<T>(Func<T> func, TimeSpan delay = default, int delayTicks = default, CancellationToken cancellationToken = default)
     {
-        if (this.IsFrameworkUnloading)
+        if (ServiceManager.UnloadCancellationToken.IsCancellationRequested)
         {
             if (delay == default && delayTicks == default)
                 return this.RunOnFrameworkThread(func);
@@ -225,7 +225,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     /// <inheritdoc/>
     public Task RunOnTick(Action action, TimeSpan delay = default, int delayTicks = default, CancellationToken cancellationToken = default)
     {
-        if (this.IsFrameworkUnloading)
+        if (ServiceManager.UnloadCancellationToken.IsCancellationRequested)
         {
             if (delay == default && delayTicks == default)
                 return this.RunOnFrameworkThread(action);
@@ -251,7 +251,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     /// <inheritdoc/>
     public Task<T> RunOnTick<T>(Func<Task<T>> func, TimeSpan delay = default, int delayTicks = default, CancellationToken cancellationToken = default)
     {
-        if (this.IsFrameworkUnloading)
+        if (ServiceManager.UnloadCancellationToken.IsCancellationRequested)
         {
             if (delay == default && delayTicks == default)
                 return this.RunOnFrameworkThread(func);
@@ -277,7 +277,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     /// <inheritdoc/>
     public Task RunOnTick(Func<Task> func, TimeSpan delay = default, int delayTicks = default, CancellationToken cancellationToken = default)
     {
-        if (this.IsFrameworkUnloading)
+        if (ServiceManager.UnloadCancellationToken.IsCancellationRequested)
         {
             if (delay == default && delayTicks == default)
                 return this.RunOnFrameworkThread(func);
@@ -370,6 +370,13 @@ internal sealed class Framework : IInternalDisposableService, IFramework
 
     private unsafe bool HandleFrameworkUpdate(CSFramework* thisPtr)
     {
+        this.RunFrameworkTick();
+
+        return this.updateHook.OriginalDisposeSafe(thisPtr);
+    }
+
+    private unsafe void RunFrameworkTick()
+    {
         this.frameworkThreadTaskScheduler.BoundThread ??= Thread.CurrentThread;
 
         ThreadSafety.MarkMainThread();
@@ -387,40 +394,41 @@ internal sealed class Framework : IInternalDisposableService, IFramework
             Log.Error(ex, "Exception in DalamudConfiguration.Update.");
         }
 
+        this.updateStopwatch.Stop();
+        this.UpdateDelta = TimeSpan.FromMilliseconds(this.updateStopwatch.ElapsedMilliseconds);
+        this.updateStopwatch.Restart();
+
+        this.LastUpdate = DateTime.Now;
+        this.LastUpdateUTC = DateTime.UtcNow;
+        this.tickCounter++;
+        foreach (var (k, (expiry, ct)) in this.tickDelayedTaskCompletionSources)
+        {
+            if (ct.IsCancellationRequested)
+                k.SetCanceled(ct);
+            else if (expiry <= this.tickCounter)
+                k.SetResult();
+            else
+                continue;
+
+            this.tickDelayedTaskCompletionSources.Remove(k, out _);
+        }
+
+        if (StatsEnabled)
+        {
+            StatsStopwatch.Restart();
+            this.frameworkThreadTaskScheduler.Run();
+            StatsStopwatch.Stop();
+
+            AddToStats(nameof(this.frameworkThreadTaskScheduler), StatsStopwatch.Elapsed.TotalMilliseconds);
+        }
+        else
+        {
+            this.frameworkThreadTaskScheduler.Run();
+        }
+
+        // Only call Update as long as we're in the actual Framework loop
         if (this.DispatchUpdateEvents)
         {
-            this.updateStopwatch.Stop();
-            this.UpdateDelta = TimeSpan.FromMilliseconds(this.updateStopwatch.ElapsedMilliseconds);
-            this.updateStopwatch.Restart();
-
-            this.LastUpdate = DateTime.Now;
-            this.LastUpdateUTC = DateTime.UtcNow;
-            this.tickCounter++;
-            foreach (var (k, (expiry, ct)) in this.tickDelayedTaskCompletionSources)
-            {
-                if (ct.IsCancellationRequested)
-                    k.SetCanceled(ct);
-                else if (expiry <= this.tickCounter)
-                    k.SetResult();
-                else
-                    continue;
-
-                this.tickDelayedTaskCompletionSources.Remove(k, out _);
-            }
-
-            if (StatsEnabled)
-            {
-                StatsStopwatch.Restart();
-                this.frameworkThreadTaskScheduler.Run();
-                StatsStopwatch.Stop();
-
-                AddToStats(nameof(this.frameworkThreadTaskScheduler), StatsStopwatch.Elapsed.TotalMilliseconds);
-            }
-            else
-            {
-                this.frameworkThreadTaskScheduler.Run();
-            }
-
             if (StatsEnabled && this.Update != null)
             {
                 // Stat Tracking for Framework Updates
@@ -450,8 +458,6 @@ internal sealed class Framework : IInternalDisposableService, IFramework
         }
 
         this.hitchDetector.Stop();
-
-        return this.updateHook.OriginalDisposeSafe(thisPtr);
     }
 
     private unsafe bool HandleFrameworkDestroy(CSFramework* thisPtr)
@@ -462,23 +468,25 @@ internal sealed class Framework : IInternalDisposableService, IFramework
 
             this.frameworkDestroy.Cancel();
             this.DispatchUpdateEvents = false;
-            foreach (var k in this.tickDelayedTaskCompletionSources.Keys)
-                k.SetCanceled(this.frameworkDestroy.Token);
-            this.tickDelayedTaskCompletionSources.Clear();
 
             // All the same, for now...
             this.lifecycle.SetShuttingDown();
             this.lifecycle.SetUnloading();
 
-            this.frameworkThreadTaskScheduler.Run();
-
             Service<Dalamud>.Get().Unload();
         }
 
         if (!ServiceManager.IsUnloaded)
+        {
+            this.RunFrameworkTick();
             return false;
+        }
 
-        return this.destroyHook.OriginalDisposeSafe(thisPtr);
+        foreach (var k in this.tickDelayedTaskCompletionSources.Keys)
+            k.SetCanceled(this.frameworkDestroy.Token);
+        this.tickDelayedTaskCompletionSources.Clear();
+
+        return this.destroyHook.OriginalDisposeSafe(thisPtr); // once this returns true, it exits the loop
     }
 }
 

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -472,13 +472,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
             this.UnloadDalamud();
         }
 
-        if (!ServiceManager.IsUnloaded)
-        {
-            this.RunFrameworkTick();
-            return false; // keep looping until we have unloaded every service
-        }
-
-        return this.destroyHook.OriginalDisposeSafe(thisPtr);
+        return ServiceManager.IsUnloaded && this.destroyHook.OriginalDisposeSafe(thisPtr);
     }
 }
 

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -472,6 +472,9 @@ internal sealed class Framework : IInternalDisposableService, IFramework
             this.UnloadDalamud();
         }
 
+        // BUG: This service gets unloaded during Dalamud unload, which theoretically stops this hook from being called
+        // This would be problematic if Framework wasn't one of the last services to unload, but it's a race we should look into fixing
+
         return ServiceManager.IsUnloaded && this.destroyHook.OriginalDisposeSafe(thisPtr);
     }
 }

--- a/Dalamud/Interface/DragDrop/IDragDropManager.cs
+++ b/Dalamud/Interface/DragDrop/IDragDropManager.cs
@@ -1,12 +1,14 @@
 using System.Collections.Generic;
 
 using Dalamud.Plugin.Services;
+using Dalamud.Utility;
 
 namespace Dalamud.Interface.DragDrop;
 
 /// <summary>
 /// A service to handle external drag and drop from WinAPI.
 /// </summary>
+[Api16ToDo("Change namespace to Dalamud.Plugin.Services")]
 public interface IDragDropManager : IDalamudService
 {
     /// <summary> Gets a value indicating whether Drag and Drop functionality is available at all. </summary>

--- a/Dalamud/Interface/ImGuiBackend/Renderers/Dx11Renderer.cs
+++ b/Dalamud/Interface/ImGuiBackend/Renderers/Dx11Renderer.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 using Dalamud.Bindings.ImGui;
+using Dalamud.Game;
 using Dalamud.Interface.ImGuiBackend.Helpers;
 using Dalamud.Interface.ImGuiBackend.Helpers.D3D11;
 using Dalamud.Interface.Textures;
@@ -738,6 +739,9 @@ internal unsafe partial class Dx11Renderer : IImGuiRenderer
         ObjectDisposedException.ThrowIf(this.device.IsEmpty(), this);
 
         if (this.fontTextures.Count != 0)
+            return;
+
+        if (Service<Framework>.GetNullable() is not { IsFrameworkUnloading: false })
             return;
 
         var io = ImGui.GetIO();

--- a/Dalamud/Interface/Internal/DalamudCommands.cs
+++ b/Dalamud/Interface/Internal/DalamudCommands.cs
@@ -1,4 +1,3 @@
-using System.Configuration;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -156,7 +155,7 @@ internal class DalamudCommands : IServiceType
     private void OnUnloadCommand(string command, string arguments)
     {
         Service<ChatGui>.Get().Print("Unloading...");
-        Service<Dalamud>.Get().Unload();
+        Service<Framework>.Get().UnloadDalamud();
     }
 
     private void OnKillCommand(string command, string arguments)

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -12,6 +12,7 @@ using Dalamud.Bindings.ImGui;
 using Dalamud.Bindings.ImPlot;
 using Dalamud.Configuration.Internal;
 using Dalamud.Console;
+using Dalamud.Game;
 using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Agent;
 using Dalamud.Game.ClientState;
@@ -43,11 +44,12 @@ using Dalamud.Plugin.SelfTest.Internal;
 using Dalamud.Storage.Assets;
 using Dalamud.Utility;
 
-using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 using Serilog.Events;
+
+using CSFramework = FFXIVClientStructs.FFXIV.Client.System.Framework.Framework;
 
 namespace Dalamud.Interface.Internal;
 
@@ -908,7 +910,7 @@ internal class DalamudInterface : IInternalDisposableService
 
                     if (ImGui.MenuItem("Unload Dalamud"u8))
                     {
-                        Service<Dalamud>.Get().Unload();
+                        Service<Framework>.Get().UnloadDalamud();
                     }
 
                     if (ImGui.MenuItem("Restart game"u8))
@@ -961,13 +963,13 @@ internal class DalamudInterface : IInternalDisposableService
 
                         if (ImGui.MenuItem("Set UiModule to NULL"u8))
                         {
-                            var framework = Framework.Instance();
+                            var framework = CSFramework.Instance();
                             framework->UIModule = (UIModule*)0;
                         }
 
                         if (ImGui.MenuItem("Set UiModule to invalid ptr"u8))
                         {
-                            var framework = Framework.Instance();
+                            var framework = CSFramework.Instance();
                             framework->UIModule = (UIModule*)0x12345678;
                         }
 

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -1231,6 +1231,9 @@ internal partial class InterfaceManager : IInternalDisposableService
 
     private void Display()
     {
+        if (this.framework.IsFrameworkUnloading)
+            return;
+
         // this is more or less part of what reshade/etc do to avoid having to manually
         // set the cursor inside the ui
         // This will just tell ImGui to draw its own software cursor instead of using the hardware cursor

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.Implementation.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.Implementation.cs
@@ -446,6 +446,9 @@ internal sealed partial class FontAtlasFactory
         /// <inheritdoc/>
         public void BuildFontsOnNextFrame()
         {
+            if (this.factory.cancellationTokenSource.IsCancellationRequested)
+                return;
+
             if (this.AutoRebuildMode == FontAtlasAutoRebuildMode.Async)
             {
                 throw new InvalidOperationException(
@@ -467,6 +470,9 @@ internal sealed partial class FontAtlasFactory
         /// <inheritdoc/>
         public void BuildFontsImmediately()
         {
+            if (this.factory.cancellationTokenSource.IsCancellationRequested)
+                return;
+
 #if VeryVerboseLog
             Log.Verbose("[{name}] Called: {source}.", this.Name, nameof(this.BuildFontsImmediately));
 #endif
@@ -497,7 +503,7 @@ internal sealed partial class FontAtlasFactory
 
                 var scale = this.IsGlobalScaled ? ImGuiHelpers.GlobalScale : 1f;
                 var r = this.RebuildFontsPrivate(false, scale);
-                r.Wait();
+                r.Wait(this.factory.cancellationTokenSource.Token);
                 if (r.IsCompletedSuccessfully)
                 {
                     this.PromoteBuiltData(rebuildIndex, r.Result, nameof(this.BuildFontsImmediately));
@@ -523,6 +529,9 @@ internal sealed partial class FontAtlasFactory
         /// <inheritdoc/>
         public Task BuildFontsAsync()
         {
+            if (this.factory.cancellationTokenSource.IsCancellationRequested)
+                return Task.CompletedTask;
+
 #if VeryVerboseLog
             Log.Verbose("[{name}] Called: {source}.", this.Name, nameof(this.BuildFontsAsync));
 #endif
@@ -539,7 +548,7 @@ internal sealed partial class FontAtlasFactory
             {
                 var scale = this.IsGlobalScaled ? ImGuiHelpers.GlobalScale : 1f;
                 var rebuildIndex = Interlocked.Increment(ref this.buildIndex);
-                return this.buildTask = this.buildTask.ContinueWith(BuildInner).Unwrap();
+                return this.buildTask = this.buildTask.ContinueWith(BuildInner, this.factory.cancellationTokenSource.Token).Unwrap();
 
                 async Task<FontAtlasBuiltData?> BuildInner(Task<FontAtlasBuiltData> unused)
                 {
@@ -633,6 +642,8 @@ internal sealed partial class FontAtlasFactory
             {
                 // this lock ensures that this.buildTask is properly set.
             }
+
+            this.factory.cancellationTokenSource.Token.ThrowIfCancellationRequested();
 
             var sw = new Stopwatch();
             sw.Start();

--- a/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.cs
+++ b/Dalamud/Interface/ManagedFontAtlas/Internals/FontAtlasFactory.cs
@@ -33,7 +33,7 @@ internal sealed partial class FontAtlasFactory
     : IInternalDisposableService, GamePrebakedFontHandle.IGameFontTextureProvider
 {
     private readonly DisposeSafety.ScopedFinalizer scopedFinalizer = new();
-    private readonly CancellationTokenSource cancellationTokenSource = new();
+    private readonly CancellationTokenSource cancellationTokenSource;
     private readonly IReadOnlyDictionary<GameFontFamilyAndSize, Task<byte[]>> fdtFiles;
     private readonly IReadOnlyDictionary<string, Task<Task<TexFile>[]>> texFiles;
     private readonly IReadOnlyDictionary<string, Task<IDalamudTextureWrap?[]>> prebakedTextureWraps;
@@ -44,12 +44,14 @@ internal sealed partial class FontAtlasFactory
     private FontAtlasFactory(
         DataManager dataManager,
         Framework framework,
+        GameLifecycle gameLifecycle,
         InterfaceManager interfaceManager,
         DalamudAssetManager dalamudAssetManager)
     {
         this.Framework = framework;
         this.InterfaceManager = interfaceManager;
         this.dalamudAssetManager = dalamudAssetManager;
+        this.cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(gameLifecycle.GameShuttingDownToken);
         this.BackendTask = Service<InterfaceManager.InterfaceManagerWithScene>
                          .GetAsync()
                          .ContinueWith(r => r.Result.Manager.Backend);

--- a/Dalamud/Interface/Textures/Internal/TextureManager.SharedTextures.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManager.SharedTextures.cs
@@ -69,13 +69,16 @@ internal sealed partial class TextureManager
 
         private readonly Thread sharedTextureReleaseThread;
 
-        private readonly CancellationTokenSource disposingCancellationTokenSource = new();
+        private readonly CancellationTokenSource disposingCancellationTokenSource;
 
         /// <summary>Initializes a new instance of the <see cref="SharedTextureManager"/> class.</summary>
         /// <param name="textureManager">An instance of <see cref="Interface.Textures.Internal.TextureManager"/>.</param>
         public SharedTextureManager(TextureManager textureManager)
         {
             this.textureManager = textureManager;
+
+            this.disposingCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+                textureManager.gameLifecycle.GameShuttingDownToken);
 
             this.sharedTextureReleaseThread = new(this.ReleaseSharedTextures)
             {

--- a/Dalamud/Interface/Textures/Internal/TextureManager.SharedTextures.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManager.SharedTextures.cs
@@ -219,7 +219,7 @@ internal sealed partial class TextureManager
 
                 try
                 {
-                    this.textureManager.framework.DelayTicks(60).Wait(this.disposingCancellationTokenSource.Token);
+                    this.disposingCancellationTokenSource.Token.WaitHandle.WaitOne(1000);
                 }
                 catch (Exception)
                 {

--- a/Dalamud/Interface/Textures/Internal/TextureManager.cs
+++ b/Dalamud/Interface/Textures/Internal/TextureManager.cs
@@ -49,6 +49,9 @@ internal sealed partial class TextureManager
     private readonly Framework framework = Service<Framework>.Get();
 
     [ServiceManager.ServiceDependency]
+    private readonly GameLifecycle gameLifecycle = Service<GameLifecycle>.Get();
+
+    [ServiceManager.ServiceDependency]
     private readonly InterfaceManager interfaceManager = Service<InterfaceManager>.Get();
 
     private readonly CancellationTokenSource disposeCts = new();

--- a/Dalamud/IoC/Internal/ServiceContainer.cs
+++ b/Dalamud/IoC/Internal/ServiceContainer.cs
@@ -68,6 +68,17 @@ internal class ServiceContainer : IServiceType
     }
 
     /// <summary>
+    /// Unregisters a singleton service from the container.
+    /// </summary>
+    /// <param name="serviceType">The type of the service to remove.</param>
+    public void UnregisterSingleton(Type serviceType)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+
+        this.instances.Remove(serviceType);
+    }
+
+    /// <summary>
     /// Register the interfaces that can resolve this type.
     /// </summary>
     /// <param name="type">The type to register.</param>

--- a/Dalamud/IoC/Internal/ServiceContainer.cs
+++ b/Dalamud/IoC/Internal/ServiceContainer.cs
@@ -35,7 +35,7 @@ internal class ServiceContainer : IServiceType
         // For all other services, this is done through the static constructor of Service{T}.
         this.instances.Add(
             typeof(IServiceContainer),
-            new(new Task<WeakReference>(() => new WeakReference(this), TaskCreationOptions.RunContinuationsAsynchronously), typeof(ServiceContainer), ObjectInstanceVisibility.Internal));
+            new(Task.FromResult(new WeakReference(this)), typeof(ServiceContainer), ObjectInstanceVisibility.Internal));
     }
 
     /// <summary>

--- a/Dalamud/IoC/Internal/ServiceContainer.cs
+++ b/Dalamud/IoC/Internal/ServiceContainer.cs
@@ -58,7 +58,13 @@ internal class ServiceContainer : IServiceType
     {
         ArgumentNullException.ThrowIfNull(instance);
 
-        this.instances[typeof(T)] = new(instance.ContinueWith(x => new WeakReference(x.Result)), typeof(T), visibility);
+        var continuation = instance.ContinueWith(
+            x => new WeakReference(x.Result),
+            ServiceManager.UnloadCancellationToken,
+            TaskContinuationOptions.RunContinuationsAsynchronously,
+            TaskScheduler.Default);
+
+        this.instances[typeof(T)] = new(continuation, typeof(T), visibility);
     }
 
     /// <summary>

--- a/Dalamud/Networking/Http/HappyHttpClient.cs
+++ b/Dalamud/Networking/Http/HappyHttpClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 
@@ -62,6 +62,7 @@ internal class HappyHttpClient : IInternalDisposableService
     /// <inheritdoc/>
     void IInternalDisposableService.DisposeService()
     {
+        this.SharedHttpClient.CancelPendingRequests();
         this.SharedHttpClient.Dispose();
         this.SharedHappyEyeballsCallback.Dispose();
 

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -385,9 +385,10 @@ internal class PluginManager : IInternalDisposableService
     public async Task UnloadAllPlugins()
     {
         var disposablePlugins = this.installedPluginsList
-                .Where(plugin => plugin.State is PluginState.Loaded or PluginState.LoadError);
+                .Where(plugin => plugin.State is PluginState.Loaded or PluginState.LoadError)
+                .ToArray();
 
-        if (!disposablePlugins.Any())
+        if (disposablePlugins.Length == 0)
             return;
 
         Log.Information("==== UNLOADING ALL PLUGINS ====");

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -390,6 +390,8 @@ internal class PluginManager : IInternalDisposableService
         if (!disposablePlugins.Any())
             return;
 
+        Log.Information("==== UNLOADING ALL PLUGINS ====");
+
         // Any unload/dispose operation called from this function log errors on their own.
         // Ignore all errors.
 

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -375,42 +375,44 @@ internal class PluginManager : IInternalDisposableService
     /// <inheritdoc/>
     void IInternalDisposableService.DisposeService()
     {
-        DisposeAsync(
-            this.installedPluginsList
-                .Where(plugin => plugin.State is PluginState.Loaded or PluginState.LoadError)
-                .ToArray(),
-            this.configuration).Wait();
-        return;
+        this.UnloadAllPlugins().Wait();
+    }
 
-        static async Task DisposeAsync(LocalPlugin[] disposablePlugins, DalamudConfiguration configuration)
-        {
-            if (disposablePlugins.Length == 0)
-                return;
+    /// <summary>
+    /// Unloads all loaded plugins.
+    /// </summary>
+    /// <returns>Task that will resolve once all plugins are unloaded.</returns>
+    public async Task UnloadAllPlugins()
+    {
+        var disposablePlugins = this.installedPluginsList
+                .Where(plugin => plugin.State is PluginState.Loaded or PluginState.LoadError);
 
-            // Any unload/dispose operation called from this function log errors on their own.
-            // Ignore all errors.
+        if (!disposablePlugins.Any())
+            return;
 
-            // Unload plugins that requires to be unloaded synchronously,
-            // just in case some plugin codes are still running via callbacks initiated externally.
-            foreach (var plugin in disposablePlugins.Where(plugin => !plugin.Manifest.CanUnloadAsync))
-                await plugin.UnloadAsync(PluginLoaderDisposalMode.None).SuppressException();
+        // Any unload/dispose operation called from this function log errors on their own.
+        // Ignore all errors.
 
-            // Unload plugins that can be unloaded from any thread.
-            await Task.WhenAll(
-                          disposablePlugins.Where(plugin => plugin.Manifest.CanUnloadAsync)
-                                           .Select(plugin => plugin.UnloadAsync(PluginLoaderDisposalMode.None)))
-                      .SuppressException();
+        // Unload plugins that requires to be unloaded synchronously,
+        // just in case some plugin codes are still running via callbacks initiated externally.
+        foreach (var plugin in disposablePlugins.Where(plugin => !plugin.Manifest.CanUnloadAsync))
+            await plugin.UnloadAsync(PluginLoaderDisposalMode.None).SuppressException();
 
-            // Just in case plugins still have tasks running that they didn't cancel when they should have,
-            // give them some time to complete it.
-            // This helps avoid plugins being reloaded from conflicting with itself of previous instance.
-            await Task.Delay(configuration.PluginWaitBeforeFree ?? PluginWaitBeforeFreeDefault);
+        // Unload plugins that can be unloaded from any thread.
+        await Task.WhenAll(
+                      disposablePlugins.Where(plugin => plugin.Manifest.CanUnloadAsync)
+                                       .Select(plugin => plugin.UnloadAsync(PluginLoaderDisposalMode.None)))
+                  .SuppressException();
 
-            // Now that we've waited enough, dispose the whole plugin.
-            // Since plugins should have been unloaded above, this should complete quickly.
-            await Task.WhenAll(disposablePlugins.Select(plugin => plugin.DisposeAsync().AsTask()))
-                      .SuppressException();
-        }
+        // Just in case plugins still have tasks running that they didn't cancel when they should have,
+        // give them some time to complete it.
+        // This helps avoid plugins being reloaded from conflicting with itself of previous instance.
+        await Task.Delay(this.configuration.PluginWaitBeforeFree ?? PluginWaitBeforeFreeDefault);
+
+        // Now that we've waited enough, dispose the whole plugin.
+        // Since plugins should have been unloaded above, this should complete quickly.
+        await Task.WhenAll(disposablePlugins.Select(plugin => plugin.DisposeAsync().AsTask()))
+                  .SuppressException();
     }
 
     /// <summary>

--- a/Dalamud/Service/ExceptionPropagationMode.cs
+++ b/Dalamud/Service/ExceptionPropagationMode.cs
@@ -1,0 +1,22 @@
+namespace Dalamud;
+
+/// <summary>
+/// Specifies how to handle the cases of failed services when calling <see cref="Service{T}.GetNullable"/>.
+/// </summary>
+internal enum ExceptionPropagationMode
+{
+    /// <summary>
+    /// Propagate all exceptions.
+    /// </summary>
+    PropagateAll,
+
+    /// <summary>
+    /// Propagate all exceptions, except for <see cref="Service{T}.UnloadedException"/>.
+    /// </summary>
+    PropagateNonUnloaded,
+
+    /// <summary>
+    /// Treat all exceptions as null.
+    /// </summary>
+    None,
+}

--- a/Dalamud/Service/ServiceManager.cs
+++ b/Dalamud/Service/ServiceManager.cs
@@ -447,75 +447,78 @@ internal static class ServiceManager
     /// </summary>
     public static void UnloadAllServices()
     {
-        UnloadCancellationTokenSource.Cancel();
-
-        var framework = Service<Framework>.GetNullable(ExceptionPropagationMode.None);
-        if (framework is { IsInFrameworkUpdateThread: false, IsFrameworkUnloading: false })
+        try
         {
-            framework.RunOnFrameworkThread(UnloadAllServices).Wait();
-            return;
-        }
+            if (!UnloadCancellationTokenSource.IsCancellationRequested)
+                UnloadCancellationTokenSource.Cancel();
 
-        var dependencyServicesMap = new Dictionary<Type, IReadOnlyCollection<Type>>();
-        var allToUnload = new HashSet<Type>();
-        var unloadOrder = new List<Type>();
-
-        Log.Information("==== COLLECTING SERVICES TO UNLOAD ====");
-
-        foreach (var serviceType in GetConcreteServiceTypes())
-        {
-            if (!serviceType.IsAssignableTo(typeof(IServiceType)))
-                continue;
-
-            // Scoped services shall never be unloaded here.
-            // Their lifetime must be managed by the IServiceScope that owns them. If it leaks, it's their fault.
-            if (serviceType.GetServiceKind() == ServiceKind.ScopedService)
-                continue;
-
-            Log.Verbose("Calling GetDependencyServices for '{ServiceName}'", serviceType.FullName!);
-
-            var typeAsServiceT = ServiceHelpers.GetAsService(serviceType);
-            dependencyServicesMap[serviceType] = ServiceHelpers.GetDependencies(typeAsServiceT, true);
-
-            allToUnload.Add(serviceType);
-        }
-
-        void UnloadService(Type serviceType)
-        {
-            if (unloadOrder.Contains(serviceType))
-                return;
-
-            var deps = dependencyServicesMap[serviceType];
-            foreach (var dep in deps)
+            var framework = Service<Framework>.GetNullable(ExceptionPropagationMode.None);
+            if (framework is { IsInFrameworkUpdateThread: false, IsFrameworkUnloading: false })
             {
-                UnloadService(dep);
+                framework.RunOnFrameworkThread(UnloadAllServices).Wait();
+                return;
             }
 
-            unloadOrder.Add(serviceType);
-            Log.Information("Queue for unload {Type}", serviceType.FullName!);
-        }
+            var dependencyServicesMap = new Dictionary<Type, IReadOnlyCollection<Type>>();
+            var allToUnload = new HashSet<Type>();
+            var unloadOrder = new List<Type>();
 
-        foreach (var serviceType in allToUnload)
-        {
-            UnloadService(serviceType);
-        }
+            Log.Information("==== COLLECTING SERVICES TO UNLOAD ====");
 
-        Log.Information("==== UNLOADING ALL SERVICES ====");
+            foreach (var serviceType in GetConcreteServiceTypes())
+            {
+                if (!serviceType.IsAssignableTo(typeof(IServiceType)))
+                    continue;
 
-        unloadOrder.Reverse();
-        foreach (var type in unloadOrder)
-        {
-            Log.Verbose("Unload {Type}", type.FullName!);
+                // Scoped services shall never be unloaded here.
+                // Their lifetime must be managed by the IServiceScope that owns them. If it leaks, it's their fault.
+                if (serviceType.GetServiceKind() == ServiceKind.ScopedService)
+                    continue;
 
-            typeof(Service<>)
-                    .MakeGenericType(type)
-                    .InvokeMember(
-                        "Unset",
-                        BindingFlags.InvokeMethod | BindingFlags.Static | BindingFlags.NonPublic,
-                        null,
-                        null,
-                        null);
-        }
+                Log.Verbose("Calling GetDependencyServices for '{ServiceName}'", serviceType.FullName!);
+
+                var typeAsServiceT = ServiceHelpers.GetAsService(serviceType);
+                dependencyServicesMap[serviceType] = ServiceHelpers.GetDependencies(typeAsServiceT, true);
+
+                allToUnload.Add(serviceType);
+            }
+
+            void UnloadService(Type serviceType)
+            {
+                if (unloadOrder.Contains(serviceType))
+                    return;
+
+                var deps = dependencyServicesMap[serviceType];
+                foreach (var dep in deps)
+                {
+                    UnloadService(dep);
+                }
+
+                unloadOrder.Add(serviceType);
+                Log.Information("Queue for unload {Type}", serviceType.FullName!);
+            }
+
+            foreach (var serviceType in allToUnload)
+            {
+                UnloadService(serviceType);
+            }
+
+            Log.Information("==== UNLOADING ALL SERVICES ====");
+
+            unloadOrder.Reverse();
+            foreach (var type in unloadOrder)
+            {
+                Log.Verbose("Unload {Type}", type.FullName!);
+
+                typeof(Service<>)
+                        .MakeGenericType(type)
+                        .InvokeMember(
+                            "Unset",
+                            BindingFlags.InvokeMethod | BindingFlags.Static | BindingFlags.NonPublic,
+                            null,
+                            null,
+                            null);
+            }
 
 #if DEBUG
         using (LoadedServicesLock.EnterScope())
@@ -523,6 +526,11 @@ internal static class ServiceManager
             LoadedServices.Clear();
         }
 #endif
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Unexpected error while unloading services");
+        }
 
         IsUnloaded = true;
     }

--- a/Dalamud/Service/ServiceManager.cs
+++ b/Dalamud/Service/ServiceManager.cs
@@ -446,7 +446,7 @@ internal static class ServiceManager
     {
         UnloadCancellationTokenSource.Cancel();
 
-        var framework = Service<Framework>.GetNullable(Service<Framework>.ExceptionPropagationMode.None);
+        var framework = Service<Framework>.GetNullable(ExceptionPropagationMode.None);
         if (framework is { IsInFrameworkUpdateThread: false, IsFrameworkUnloading: false })
         {
             framework.RunOnFrameworkThread(UnloadAllServices).Wait();

--- a/Dalamud/Service/ServiceManager.cs
+++ b/Dalamud/Service/ServiceManager.cs
@@ -53,8 +53,6 @@ internal static class ServiceManager
 
     private static readonly CancellationTokenSource UnloadCancellationTokenSource = new();
 
-    private static ManualResetEvent unloadResetEvent = new(false);
-
     private static LoadingDialog loadingDialog = new();
 
     /// <summary>
@@ -124,6 +122,11 @@ internal static class ServiceManager
     /// during initialization or during regular operation.
     /// </summary>
     public static CancellationToken UnloadCancellationToken => UnloadCancellationTokenSource.Token;
+
+    /// <summary>
+    /// Gets a value indicating whether all services have been unloaded.
+    /// </summary>
+    public static bool IsUnloaded { get; private set; }
 
     /// <summary>
     /// Initializes provided Services.
@@ -453,8 +456,6 @@ internal static class ServiceManager
             return;
         }
 
-        unloadResetEvent.Reset();
-
         var dependencyServicesMap = new Dictionary<Type, IReadOnlyCollection<Type>>();
         var allToUnload = new HashSet<Type>();
         var unloadOrder = new List<Type>();
@@ -523,15 +524,7 @@ internal static class ServiceManager
         }
 #endif
 
-        unloadResetEvent.Set();
-    }
-
-    /// <summary>
-    /// Wait until all services have been unloaded.
-    /// </summary>
-    public static void WaitForServiceUnload()
-    {
-        unloadResetEvent.WaitOne();
+        IsUnloaded = true;
     }
 
     /// <summary>

--- a/Dalamud/Service/ServiceManager.cs
+++ b/Dalamud/Service/ServiceManager.cs
@@ -447,78 +447,75 @@ internal static class ServiceManager
     /// </summary>
     public static void UnloadAllServices()
     {
-        try
+        UnloadCancellationTokenSource.Cancel();
+
+        var framework = Service<Framework>.GetNullable(ExceptionPropagationMode.None);
+        if (framework is { IsInFrameworkUpdateThread: false, IsFrameworkUnloading: false })
         {
-            if (!UnloadCancellationTokenSource.IsCancellationRequested)
-                UnloadCancellationTokenSource.Cancel();
+            framework.RunOnFrameworkThread(UnloadAllServices).Wait();
+            return;
+        }
 
-            var framework = Service<Framework>.GetNullable(ExceptionPropagationMode.None);
-            if (framework is { IsInFrameworkUpdateThread: false, IsFrameworkUnloading: false })
-            {
-                framework.RunOnFrameworkThread(UnloadAllServices).Wait();
+        var dependencyServicesMap = new Dictionary<Type, IReadOnlyCollection<Type>>();
+        var allToUnload = new HashSet<Type>();
+        var unloadOrder = new List<Type>();
+
+        Log.Information("==== COLLECTING SERVICES TO UNLOAD ====");
+
+        foreach (var serviceType in GetConcreteServiceTypes())
+        {
+            if (!serviceType.IsAssignableTo(typeof(IServiceType)))
+                continue;
+
+            // Scoped services shall never be unloaded here.
+            // Their lifetime must be managed by the IServiceScope that owns them. If it leaks, it's their fault.
+            if (serviceType.GetServiceKind() == ServiceKind.ScopedService)
+                continue;
+
+            Log.Verbose("Calling GetDependencyServices for '{ServiceName}'", serviceType.FullName!);
+
+            var typeAsServiceT = ServiceHelpers.GetAsService(serviceType);
+            dependencyServicesMap[serviceType] = ServiceHelpers.GetDependencies(typeAsServiceT, true);
+
+            allToUnload.Add(serviceType);
+        }
+
+        void UnloadService(Type serviceType)
+        {
+            if (unloadOrder.Contains(serviceType))
                 return;
-            }
 
-            var dependencyServicesMap = new Dictionary<Type, IReadOnlyCollection<Type>>();
-            var allToUnload = new HashSet<Type>();
-            var unloadOrder = new List<Type>();
-
-            Log.Information("==== COLLECTING SERVICES TO UNLOAD ====");
-
-            foreach (var serviceType in GetConcreteServiceTypes())
+            var deps = dependencyServicesMap[serviceType];
+            foreach (var dep in deps)
             {
-                if (!serviceType.IsAssignableTo(typeof(IServiceType)))
-                    continue;
-
-                // Scoped services shall never be unloaded here.
-                // Their lifetime must be managed by the IServiceScope that owns them. If it leaks, it's their fault.
-                if (serviceType.GetServiceKind() == ServiceKind.ScopedService)
-                    continue;
-
-                Log.Verbose("Calling GetDependencyServices for '{ServiceName}'", serviceType.FullName!);
-
-                var typeAsServiceT = ServiceHelpers.GetAsService(serviceType);
-                dependencyServicesMap[serviceType] = ServiceHelpers.GetDependencies(typeAsServiceT, true);
-
-                allToUnload.Add(serviceType);
+                UnloadService(dep);
             }
 
-            void UnloadService(Type serviceType)
-            {
-                if (unloadOrder.Contains(serviceType))
-                    return;
+            unloadOrder.Add(serviceType);
+            Log.Information("Queue for unload {Type}", serviceType.FullName!);
+        }
 
-                var deps = dependencyServicesMap[serviceType];
-                foreach (var dep in deps)
-                {
-                    UnloadService(dep);
-                }
+        foreach (var serviceType in allToUnload)
+        {
+            UnloadService(serviceType);
+        }
 
-                unloadOrder.Add(serviceType);
-                Log.Information("Queue for unload {Type}", serviceType.FullName!);
-            }
+        Log.Information("==== UNLOADING ALL SERVICES ====");
 
-            foreach (var serviceType in allToUnload)
-            {
-                UnloadService(serviceType);
-            }
+        unloadOrder.Reverse();
+        foreach (var type in unloadOrder)
+        {
+            Log.Verbose("Unload {Type}", type.FullName!);
 
-            Log.Information("==== UNLOADING ALL SERVICES ====");
-
-            unloadOrder.Reverse();
-            foreach (var type in unloadOrder)
-            {
-                Log.Verbose("Unload {Type}", type.FullName!);
-
-                typeof(Service<>)
-                        .MakeGenericType(type)
-                        .InvokeMember(
-                            "Unset",
-                            BindingFlags.InvokeMethod | BindingFlags.Static | BindingFlags.NonPublic,
-                            null,
-                            null,
-                            null);
-            }
+            typeof(Service<>)
+                    .MakeGenericType(type)
+                    .InvokeMember(
+                        "Unset",
+                        BindingFlags.InvokeMethod | BindingFlags.Static | BindingFlags.NonPublic,
+                        null,
+                        null,
+                        null);
+        }
 
 #if DEBUG
         using (LoadedServicesLock.EnterScope())
@@ -526,11 +523,6 @@ internal static class ServiceManager
             LoadedServices.Clear();
         }
 #endif
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, "Unexpected error while unloading services");
-        }
 
         IsUnloaded = true;
     }

--- a/Dalamud/Service/Service{T}.cs
+++ b/Dalamud/Service/Service{T}.cs
@@ -300,6 +300,18 @@ internal static class Service<T> where T : IServiceType
         if (!instanceTcs.Task.IsCompletedSuccessfully)
             return;
 
+        try
+        {
+            if (Service<ServiceContainer>.GetNullable(ExceptionPropagationMode.None) is { } container)
+            {
+                container.UnregisterSingleton(typeof(T));
+            }
+        }
+        catch (Exception e)
+        {
+            ServiceManager.Log.Warning(e, "Service<{0}>: Failed to notify ServiceContainer during Unset", typeof(T).Name);
+        }
+
         switch (instanceTcs.Task.Result)
         {
             case IInternalDisposableService d:

--- a/Dalamud/Service/Service{T}.cs
+++ b/Dalamud/Service/Service{T}.cs
@@ -39,6 +39,9 @@ internal static class Service<T> where T : IServiceType
             ?? throw new InvalidOperationException(
                 $"{nameof(T)} is missing {nameof(ServiceManager.ServiceAttribute)} annotations.");
 
+        ServiceManager.UnloadCancellationToken.Register(()
+            => instanceTcs.TrySetException(new UnloadedException()));
+
         var exposeToPlugins = Attribute.IsDefined(type, typeof(PluginInterfaceAttribute));
         if (exposeToPlugins)
             ServiceManager.Log.Debug("Service<{0}>: Static ctor called; will be exposed to plugins", type.Name);
@@ -391,7 +394,12 @@ internal static class Service<T> where T : IServiceType
     /// Pull the instance out of the service locator, waiting if necessary.
     /// </summary>
     /// <returns>The object.</returns>
-    private static Task<object> GetAsyncAsObject() => instanceTcs.Task.ContinueWith(r => (object)r.Result);
+    private static Task<object> GetAsyncAsObject() =>
+        instanceTcs.Task.ContinueWith(
+            r => (object)r.Result,
+            ServiceManager.UnloadCancellationToken,
+            TaskContinuationOptions.RunContinuationsAsynchronously,
+            TaskScheduler.Default);
 
     /// <summary>
     /// Exception thrown when service is attempted to be retrieved when it's unloaded.

--- a/Dalamud/Service/Service{T}.cs
+++ b/Dalamud/Service/Service{T}.cs
@@ -54,27 +54,6 @@ internal static class Service<T> where T : IServiceType
         }
     }
 
-    /// <summary>
-    /// Specifies how to handle the cases of failed services when calling <see cref="Service{T}.GetNullable"/>.
-    /// </summary>
-    public enum ExceptionPropagationMode
-    {
-        /// <summary>
-        /// Propagate all exceptions.
-        /// </summary>
-        PropagateAll,
-
-        /// <summary>
-        /// Propagate all exceptions, except for <see cref="UnloadedException"/>.
-        /// </summary>
-        PropagateNonUnloaded,
-
-        /// <summary>
-        /// Treat all exceptions as null.
-        /// </summary>
-        None,
-    }
-
     /// <summary>Does nothing.</summary>
     /// <remarks>Used to invoke the static ctor.</remarks>
     public static void Nop()

--- a/Dalamud/Storage/Assets/IDalamudAssetManager.cs
+++ b/Dalamud/Storage/Assets/IDalamudAssetManager.cs
@@ -1,10 +1,11 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Threading.Tasks;
 
 using Dalamud.Interface.Textures.TextureWraps;
 using Dalamud.Plugin.Services;
+using Dalamud.Utility;
 
 namespace Dalamud.Storage.Assets;
 
@@ -17,6 +18,7 @@ namespace Dalamud.Storage.Assets;
 /// Think of C++ [[nodiscard]]. Also, like the intended meaning of the attribute, such methods will not have
 /// externally visible state changes.
 /// </summary>
+[Api16ToDo("Change namespace to Dalamud.Plugin.Services")]
 public interface IDalamudAssetManager : IDalamudService
 {
     /// <summary>


### PR DESCRIPTION
- Use CancellationTokens throughout Dalamud to properly cancel Tasks when the game is shutting down.
- Prevent fonts from building and textures from being created using CancellationTokens.
- Unregister singletons from ServiceContainer when they are unset.
- Reworked how Dalamud disposes services: first all plugins are unloaded, then internal services. You'll notice it no longer freezes the process while it's waiting for services to be unloaded. It now returns false in HandleFrameworkDestroy until that's done, as the game does it.