### PR TITLE
Fixes for windowed mode

### DIFF
--- a/Dalamud/Game/Gui/GameGui.cs
+++ b/Dalamud/Game/Gui/GameGui.cs
@@ -174,7 +174,7 @@ internal sealed unsafe class GameGui : IInternalDisposableService, IGameGui
             return false;
         }
 
-        var ray = camera->ScreenPointToRay(screenPos);
+        var ray = camera->ScreenPointToRay(screenPos - windowPos);
         var result = BGCollisionModule.RaycastMaterialFilter(ray.Origin, ray.Direction, out var hit);
         worldPos = hit.Point;
         return result;

--- a/Dalamud/Interface/ImGuiBackend/InputHandler/Win32InputHandler.cs
+++ b/Dalamud/Interface/ImGuiBackend/InputHandler/Win32InputHandler.cs
@@ -526,7 +526,7 @@ internal sealed unsafe partial class Win32InputHandler : IImGuiInputHandler
             {
                 // Use game window, otherwise, positions are calculated based on the focused window which might not be the game.
                 // Leads to offsets.
-                ClientToScreen(this.hWnd, &mousePos);
+                ScreenToClient(this.hWnd, &mousePos);
             }
 
             io.AddMousePosEvent(mousePos.x, mousePos.y);


### PR DESCRIPTION
This PR fixes two unrelated windowed mode bugs. I tested both changes in local build.

1. ` ImGuiHelpers.MainViewport.Pos` is usually (0,0), but in windowed mode with multi-monitor mode enabled, it holds a non-zero position. Mouse position is its screen position, so the window's position must be subtracted to get the mouse's window position. You can see `WorldToScreen` does the inverse of this.
2. In windowed mode with multi-monitor mode disabled, Dalamud incorrectly uses ClientToScreen to compute mouse position when the mouse position is actually in screen coordinates and needs to be converted to mouse coordinates. You can see the equivalent ImGui logic here: https://github.com/ocornut/imgui/blob/9a5c070308ae97bf0f884b071d0262ae1cad26f7/backends/imgui_impl_win32.cpp#L337