### PR TITLE
Save shared Stack Lock in TaskTimingHandles

### DIFF
--- a/Dalamud/Utility/Timing/TimingHandle.cs
+++ b/Dalamud/Utility/Timing/TimingHandle.cs
@@ -11,7 +11,7 @@ namespace Dalamud.Utility.Timing;
 [DebuggerDisplay("{Name} - {Duration}")]
 public sealed class TimingHandle : TimingEvent, IDisposable, IComparable<TimingHandle>
 {
-    private readonly Lock stackLock = new();
+    private readonly Lock stackLock;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TimingHandle"/> class.
@@ -20,7 +20,7 @@ public sealed class TimingHandle : TimingEvent, IDisposable, IComparable<TimingH
     internal TimingHandle(string name)
         : base(name)
     {
-        this.Stack = Timings.TaskTimingHandles;
+        (this.stackLock, this.Stack) = Timings.TaskTimingHandles;
 
         using (this.StackLockScope)
             this.Parent = this.Stack.LastOrDefault();

--- a/Dalamud/Utility/Timing/Timings.cs
+++ b/Dalamud/Utility/Timing/Timings.cs
@@ -36,18 +36,18 @@ public static class Timings
     /// </summary>
     internal static readonly Lock EventsLock = new();
 
-    private static readonly AsyncLocal<Tuple<int?, List<TimingHandle>>> TaskTimingHandleStorage = new();
+    private static readonly AsyncLocal<Tuple<int?, Tuple<Lock, List<TimingHandle>>>> TaskTimingHandleStorage = new();
 
     /// <summary>
     /// Gets or sets all active timings of current thread.
     /// </summary>
-    internal static List<TimingHandle> TaskTimingHandles
+    internal static Tuple<Lock, List<TimingHandle>> TaskTimingHandles
     {
         get
         {
             if (TaskTimingHandleStorage.Value == null || TaskTimingHandleStorage.Value.Item1 != Task.CurrentId)
-                TaskTimingHandleStorage.Value = Tuple.Create<int?, List<TimingHandle>>(Task.CurrentId, []);
-            return TaskTimingHandleStorage.Value!.Item2!;
+                TaskTimingHandleStorage.Value = Tuple.Create(Task.CurrentId, Tuple.Create<Lock, List<TimingHandle>>(new Lock(), []));
+            return TaskTimingHandleStorage.Value.Item2;
         }
         set => TaskTimingHandleStorage.Value = Tuple.Create(Task.CurrentId, value);
     }


### PR DESCRIPTION
`TimingHandle` grabs a Task-depending `List<TimingHandle>` from `Timings.TaskTimingHandles`, but provided its own `Lock` for it.
This PR changes `Timings.TaskTimingHandles` to also provide a Task-depending `Lock`.