### PR TITLE
Add Name to ConfigChangeEvent

### DIFF
--- a/Dalamud/Game/Config/ConfigChangeEvent.cs
+++ b/Dalamud/Game/Config/ConfigChangeEvent.cs
@@ -1,14 +1,16 @@
-﻿namespace Dalamud.Game.Config;
+namespace Dalamud.Game.Config;
 
 /// <summary>
 /// Represents a change in the configuration.
 /// </summary>
-/// <param name="Option">The option tha twas changed.</param>
-public abstract record ConfigChangeEvent(Enum Option);
+/// <param name="Option">The option that was changed.</param>
+/// <param name="Name">The name of the option that was changed.</param>
+public abstract record ConfigChangeEvent(Enum Option, string Name);
 
 /// <summary>
 /// Represents a generic change in the configuration.
 /// </summary>
 /// <param name="ConfigOption">The option that was changed.</param>
+/// <param name="Name">The name of the option that was changed.</param>
 /// <typeparam name="T">The type of the option.</typeparam>
-public record ConfigChangeEvent<T>(T ConfigOption) : ConfigChangeEvent(ConfigOption) where T : Enum;
+public record ConfigChangeEvent<T>(T ConfigOption, string Name) : ConfigChangeEvent(ConfigOption, Name) where T : Enum;

--- a/Dalamud/Game/Config/ConfigChangeEvent.cs
+++ b/Dalamud/Game/Config/ConfigChangeEvent.cs
@@ -1,16 +1,85 @@
+using Dalamud.Utility;
+
 namespace Dalamud.Game.Config;
 
 /// <summary>
 /// Represents a change in the configuration.
 /// </summary>
-/// <param name="Option">The option that was changed.</param>
-/// <param name="Name">The name of the option that was changed.</param>
-public abstract record ConfigChangeEvent(Enum Option, string Name);
+[Api16ToDo("Remove ctor(Enum option) and Deconstruct function, which were added to not break the API when Name was added.")]
+public abstract record ConfigChangeEvent
+{
+    /// <summary> Initializes a new instance of the <see cref="ConfigChangeEvent"/> class. </summary>
+    /// <param name="option">The option that was changed.</param>
+    public ConfigChangeEvent(Enum option)
+    {
+        this.Option = option;
+        this.Name = string.Empty;
+    }
+
+    /// <summary> Initializes a new instance of the <see cref="ConfigChangeEvent"/> class. </summary>
+    /// <param name="option">The option that was changed.</param>
+    /// <param name="name">The name of the option that was changed.</param>
+    public ConfigChangeEvent(Enum option, string name)
+    {
+        this.Option = option;
+        this.Name = name;
+    }
+
+    /// <summary>
+    /// Gets the option that was changed.
+    /// </summary>
+    public Enum Option { get; init; }
+
+    /// <summary>
+    /// Gets the name of the option that was changed.
+    /// </summary>
+    public string Name { get; init; }
+
+    /// <summary>
+    /// Deconstructs the <see cref="ConfigChangeEvent"/> record.
+    /// </summary>
+    /// <param name="option">The option that was changed.</param>
+    public void Deconstruct(out Enum option)
+    {
+        option = this.Option;
+    }
+}
 
 /// <summary>
 /// Represents a generic change in the configuration.
 /// </summary>
-/// <param name="ConfigOption">The option that was changed.</param>
-/// <param name="Name">The name of the option that was changed.</param>
 /// <typeparam name="T">The type of the option.</typeparam>
-public record ConfigChangeEvent<T>(T ConfigOption, string Name) : ConfigChangeEvent(ConfigOption, Name) where T : Enum;
+[Api16ToDo("Remove ctor(T option) and Deconstruct function, which were added to not break the API when Name was added.")]
+public record ConfigChangeEvent<T> : ConfigChangeEvent where T : Enum
+{
+    /// <summary> Initializes a new instance of the <see cref="ConfigChangeEvent{T}"/> class. </summary>
+    /// <param name="option">The option that was changed.</param>
+    public ConfigChangeEvent(T option)
+        : base(option)
+    {
+        this.ConfigOption = option;
+    }
+
+    /// <summary> Initializes a new instance of the <see cref="ConfigChangeEvent{T}"/> class. </summary>
+    /// <param name="option">The option that was changed.</param>
+    /// <param name="name">The name of the option that was changed.</param>
+    public ConfigChangeEvent(T option, string name)
+        : base(option, name)
+    {
+        this.ConfigOption = option;
+    }
+
+    /// <summary>
+    /// Gets the option that was changed.
+    /// </summary>
+    public T ConfigOption { get; init; }
+
+    /// <summary>
+    /// Deconstructs the <see cref="ConfigChangeEvent{T}"/> record.
+    /// </summary>
+    /// <param name="configOption">The option that was changed.</param>
+    public void Deconstruct(out T configOption)
+    {
+        configOption = this.ConfigOption;
+    }
+}

--- a/Dalamud/Game/Config/GameConfigSection.cs
+++ b/Dalamud/Game/Config/GameConfigSection.cs
@@ -542,7 +542,7 @@ public class GameConfigSection
         }
 
         if (enumObject == null) return null;
-        var eventArgs = new ConfigChangeEvent<TEnum>((TEnum)enumObject);
+        var eventArgs = new ConfigChangeEvent<TEnum>((TEnum)enumObject, entry->Name.ToString());
         this.Changed?.InvokeSafely(this, eventArgs);
         return eventArgs;
     }


### PR DESCRIPTION
Using the name as string is safer to check than the enum that might not have been updated.
The IGameConfig API allows getting config options by string, but the ConfigChangeEvent only contains the enum value.
This PR adds the name as string to the ConfigChangeEvent.