### PR TITLE
Optimize UnlockState.Update a tiny bit

### DIFF
--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -299,7 +299,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     }
 
     /// <inheritdoc/>
-    public Debouncer CreateDebouncer(TimeSpan delay, Action action)
+    public IDebouncer CreateDebouncer(TimeSpan delay, Action action)
     {
         return new Debouncer(this, delay, action);
     }
@@ -587,7 +587,7 @@ internal class FrameworkPluginScoped : IInternalDisposableService, IFramework
         => this.frameworkService.RunOnTick(func, delay, delayTicks, cancellationToken);
 
     /// <inheritdoc/>
-    public Debouncer CreateDebouncer(TimeSpan delay, Action action)
+    public IDebouncer CreateDebouncer(TimeSpan delay, Action action)
         => this.frameworkService.CreateDebouncer(delay, action);
 
     private void OnUpdateForward(IFramework framework)

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -6,8 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Dalamud.Configuration.Internal;
-using Dalamud.Game.Gui;
-using Dalamud.Game.Gui.Toast;
 using Dalamud.Hooking;
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
@@ -300,6 +298,12 @@ internal sealed class Framework : IInternalDisposableService, IFramework
             this.frameworkThreadTaskScheduler).Unwrap();
     }
 
+    /// <inheritdoc/>
+    public Debouncer CreateDebouncer(TimeSpan delay, Action action)
+    {
+        return new Debouncer(this, delay, action);
+    }
+
     /// <summary>
     /// Dispose of managed and unmanaged resources.
     /// </summary>
@@ -581,6 +585,10 @@ internal class FrameworkPluginScoped : IInternalDisposableService, IFramework
     /// <inheritdoc/>
     public Task RunOnTick(Func<Task> func, TimeSpan delay = default, int delayTicks = default, CancellationToken cancellationToken = default)
         => this.frameworkService.RunOnTick(func, delay, delayTicks, cancellationToken);
+
+    /// <inheritdoc/>
+    public Debouncer CreateDebouncer(TimeSpan delay, Action action)
+        => this.frameworkService.CreateDebouncer(delay, action);
 
     private void OnUpdateForward(IFramework framework)
     {

--- a/Dalamud/Game/Text/Noun/NounProcessor.cs
+++ b/Dalamud/Game/Text/Noun/NounProcessor.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 
-using Dalamud.Configuration.Internal;
 using Dalamud.Data;
 using Dalamud.Game.Text.Noun.Enums;
 using Dalamud.Logging.Internal;
@@ -81,7 +80,7 @@ internal class NounProcessor : IServiceType
     private const int PluralColumnIdx = 2;
     private const int PossessivePronounColumnIdx = 3;
     private const int StartsWithVowelColumnIdx = 4;
-    private const int Unknown5ColumnIdx = 5; // probably used in Chinese texts
+    private const int Unknown5ColumnIdx = 5;
     private const int PronounColumnIdx = 6;
     private const int ArticleColumnIdx = 7;
 
@@ -89,9 +88,6 @@ internal class NounProcessor : IServiceType
 
     [ServiceManager.ServiceDependency]
     private readonly DataManager dataManager = Service<DataManager>.Get();
-
-    [ServiceManager.ServiceDependency]
-    private readonly DalamudConfiguration dalamudConfiguration = Service<DalamudConfiguration>.Get();
 
     private readonly ConcurrentDictionary<NounParams, ReadOnlySeString> cache = [];
 

--- a/Dalamud/Game/UnlockState/UnlockState.cs
+++ b/Dalamud/Game/UnlockState/UnlockState.cs
@@ -345,14 +345,14 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
     /// <inheritdoc/>
     public unsafe bool IsItemUnlocked(Item row)
     {
-        if (row.ItemAction.RowId == 0)
-            return false;
-
         if (!this.IsLoaded)
             return false;
 
-        // To avoid the ExdModule.GetItemRowById call, which can return null if the excel page
-        // is not loaded, we're going to imitate the IsItemActionUnlocked call first:
+        if (!this.IsItemUnlockable(row))
+            return false;
+
+        // To avoid the ExdModule.GetItemRowById call, which can take quite long and might return null
+        // if the excel page is not loaded, we're going to imitate the IsItemActionUnlocked call first:
         switch ((ItemActionAction)row.ItemAction.Value.Action.RowId)
         {
             case ItemActionAction.Companion:

--- a/Dalamud/Game/UnlockState/UnlockState.cs
+++ b/Dalamud/Game/UnlockState/UnlockState.cs
@@ -50,7 +50,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
     [ServiceManager.ServiceDependency]
     private readonly RecipeData recipeData = Service<RecipeData>.Get();
 
-    private readonly Debouncer updateDebouncer;
+    private readonly IDebouncer updateDebouncer;
     private readonly ConcurrentDictionary<Type, HashSet<uint>> cachedUnlockedRowIds = [];
     private readonly Hook<CSAchievement.Delegates.SetAchievementCompleted> setAchievementCompletedHook;
     private readonly Hook<TitleList.Delegates.SetTitleUnlocked> setTitleUnlockedHook;

--- a/Dalamud/Game/UnlockState/UnlockState.cs
+++ b/Dalamud/Game/UnlockState/UnlockState.cs
@@ -8,6 +8,7 @@ using Dalamud.IoC;
 using Dalamud.IoC.Internal;
 using Dalamud.Logging.Internal;
 using Dalamud.Plugin.Services;
+using Dalamud.Utility;
 
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.InstanceContent;
@@ -41,11 +42,15 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
     private readonly ClientState.ClientState clientState = Service<ClientState.ClientState>.Get();
 
     [ServiceManager.ServiceDependency]
+    private readonly Framework framework = Service<Framework>.Get();
+
+    [ServiceManager.ServiceDependency]
     private readonly GameGui gameGui = Service<GameGui>.Get();
 
     [ServiceManager.ServiceDependency]
     private readonly RecipeData recipeData = Service<RecipeData>.Get();
 
+    private readonly Debouncer updateDebouncer;
     private readonly ConcurrentDictionary<Type, HashSet<uint>> cachedUnlockedRowIds = [];
     private readonly Hook<CSAchievement.Delegates.SetAchievementCompleted> setAchievementCompletedHook;
     private readonly Hook<TitleList.Delegates.SetTitleUnlocked> setTitleUnlockedHook;
@@ -55,6 +60,8 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
     [ServiceManager.ServiceConstructor]
     private UnlockState()
     {
+        this.updateDebouncer = this.framework.CreateDebouncer(TimeSpan.FromMilliseconds(500), this.Update);
+
         this.clientState.Login += this.OnLogin;
         this.clientState.Logout += this.OnLogout;
         this.gameGui.AgentUpdate += this.OnAgentUpdate;
@@ -103,6 +110,8 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
         this.setTitleUnlockedHook.Dispose();
         this.setOrnamentUnlockedHook.Dispose();
         this.setGlassesStyleUnlockedHook.Dispose();
+
+        this.updateDebouncer.Dispose();
     }
 
     /// <inheritdoc/>
@@ -732,7 +741,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
 
     private void OnLogin()
     {
-        this.Update();
+        this.updateDebouncer.Debounce();
     }
 
     private void OnLogout(int type, int code)
@@ -743,7 +752,7 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
     private void OnAgentUpdate(AgentUpdateFlag agentUpdateFlag)
     {
         if (agentUpdateFlag.HasFlag(AgentUpdateFlag.UnlocksUpdate))
-            this.Update();
+            this.updateDebouncer.Debounce();
     }
 
     private void SetAchievementCompletedDetour(CSAchievement* thisPtr, uint id)

--- a/Dalamud/Game/UnlockState/UnlockState.cs
+++ b/Dalamud/Game/UnlockState/UnlockState.cs
@@ -389,7 +389,11 @@ internal unsafe class UnlockState : IInternalDisposableService, IUnlockState
             case ItemActionAction.Glasses:
                 return CSPlayerState.Instance()->IsGlassesUnlocked((ushort)row.AdditionalData.RowId);
 
-            case ItemActionAction.SoulShards when PublicContentOccultCrescent.GetState() is var occultCrescentState && occultCrescentState != null:
+            case ItemActionAction.SoulShards:
+                var occultCrescentState = PublicContentOccultCrescent.GetState();
+                if (occultCrescentState == null)
+                    return false;
+
                 var supportJobId = (byte)row.ItemAction.Value.Data[0];
                 return supportJobId < occultCrescentState->SupportJobLevels.Length && occultCrescentState->SupportJobLevels[supportJobId] != 0;
 

--- a/Dalamud/Plugin/Services/IFramework.cs
+++ b/Dalamud/Plugin/Services/IFramework.cs
@@ -2,6 +2,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Dalamud.Interface.Internal.Windows.Data.Widgets;
+using Dalamud.Utility;
 
 namespace Dalamud.Plugin.Services;
 
@@ -290,4 +291,13 @@ public interface IFramework : IDalamudService
     /// version of <c>RunOnFrameworkThread</c>.</para>
     /// </remarks>
     public Task RunOnTick(Func<Task> func, TimeSpan delay = default, int delayTicks = default, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a new <see cref="Debouncer"/> instance.
+    /// </summary>
+    /// <param name="delay">The delay to wait after the last request before executing the action.</param>
+    /// <param name="action">The delegate to execute when the debounce period elapses.</param>
+    /// <returns>A new, thread-safe <see cref="Debouncer"/> instance. The caller is responsible for disposing of this instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="action"/> is <see langword="null"/>.</exception>
+    public Debouncer CreateDebouncer(TimeSpan delay, Action action);
 }

--- a/Dalamud/Plugin/Services/IFramework.cs
+++ b/Dalamud/Plugin/Services/IFramework.cs
@@ -293,11 +293,11 @@ public interface IFramework : IDalamudService
     public Task RunOnTick(Func<Task> func, TimeSpan delay = default, int delayTicks = default, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Creates a new <see cref="Debouncer"/> instance.
+    /// Creates a new <see cref="IDebouncer"/> instance.
     /// </summary>
     /// <param name="delay">The delay to wait after the last request before executing the action.</param>
     /// <param name="action">The delegate to execute when the debounce period elapses.</param>
     /// <returns>A new, thread-safe <see cref="Debouncer"/> instance. The caller is responsible for disposing of this instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="action"/> is <see langword="null"/>.</exception>
-    public Debouncer CreateDebouncer(TimeSpan delay, Action action);
+    public IDebouncer CreateDebouncer(TimeSpan delay, Action action);
 }

--- a/Dalamud/Utility/Debouncer.cs
+++ b/Dalamud/Utility/Debouncer.cs
@@ -8,7 +8,26 @@ namespace Dalamud.Utility;
 /// Provides a thread-safe mechanism to debounce actions, ensuring that a rapid succession 
 /// of calls only triggers the action after a specified delay has elapsed since the last call.
 /// </summary>
-public class Debouncer : IDisposable
+public interface IDebouncer : IDisposable
+{
+    /// <summary>
+    /// Gets a value indicating whether the action is queued to be executed.
+    /// </summary>
+    bool IsPending { get; }
+
+    /// <summary>
+    /// Requests the execution of the action.
+    /// </summary>
+    void Debounce();
+
+    /// <summary>
+    /// Cancels the pending execution of the action.
+    /// </summary>
+    void Cancel();
+}
+
+/// <inheritdoc/>
+internal class Debouncer : IDebouncer
 {
     private readonly IFramework framework;
     private readonly TimeSpan delay;
@@ -34,9 +53,7 @@ public class Debouncer : IDisposable
         this.action = action;
     }
 
-    /// <summary>
-    /// Gets a value indicating whether the action is queued to be executed.
-    /// </summary>
+    /// <inheritdoc/>
     public bool IsPending => this.cts != null;
 
     /// <inheritdoc/>
@@ -52,9 +69,7 @@ public class Debouncer : IDisposable
         this.isDisposed = true;
     }
 
-    /// <summary>
-    /// Requests the execution of the action.
-    /// </summary>
+    /// <inheritdoc/>
     public void Debounce()
     {
         using var scope = this.debouncerLock.EnterScope();
@@ -71,9 +86,7 @@ public class Debouncer : IDisposable
         this.framework.RunOnTick(this.OnTick, this.delay, cancellationToken: this.cts.Token);
     }
 
-    /// <summary>
-    /// Cancels the pending execution of the action.
-    /// </summary>
+    /// <inheritdoc/>
     public void Cancel()
     {
         using var scope = this.debouncerLock.EnterScope();

--- a/Dalamud/Utility/Debouncer.cs
+++ b/Dalamud/Utility/Debouncer.cs
@@ -14,9 +14,8 @@ public class Debouncer : IDisposable
     private readonly TimeSpan delay;
     private readonly Action action;
     private readonly Lock debouncerLock = new();
-    private CancellationTokenSource cts = new();
+    private CancellationTokenSource? cts;
     private DateTime targetTime = DateTime.MinValue;
-    private bool isPending;
     private bool isDisposed;
 
     /// <summary>
@@ -35,6 +34,11 @@ public class Debouncer : IDisposable
         this.action = action;
     }
 
+    /// <summary>
+    /// Gets a value indicating whether the action is queued to be executed.
+    /// </summary>
+    public bool IsPending => this.cts != null;
+
     /// <inheritdoc/>
     public void Dispose()
     {
@@ -43,9 +47,9 @@ public class Debouncer : IDisposable
         if (this.isDisposed)
             return;
 
+        this.Cancel();
+
         this.isDisposed = true;
-        this.cts.Cancel();
-        this.cts.Dispose();
     }
 
     /// <summary>
@@ -60,15 +64,23 @@ public class Debouncer : IDisposable
 
         this.targetTime = DateTime.UtcNow + this.delay;
 
-        if (this.isPending)
+        if (this.IsPending)
             return;
 
-        this.cts.Cancel();
-        this.cts.Dispose();
         this.cts = new();
-
-        this.isPending = true;
         this.framework.RunOnTick(this.OnTick, this.delay, cancellationToken: this.cts.Token);
+    }
+
+    /// <summary>
+    /// Cancels the pending execution of the action.
+    /// </summary>
+    public void Cancel()
+    {
+        using var scope = this.debouncerLock.EnterScope();
+
+        this.cts?.Cancel();
+        this.cts?.Dispose();
+        this.cts = null;
     }
 
     private void OnTick()
@@ -81,12 +93,13 @@ public class Debouncer : IDisposable
             var now = DateTime.UtcNow;
             if (now < this.targetTime)
             {
-                this.isPending = true;
                 this.framework.RunOnTick(this.OnTick, this.targetTime - now, cancellationToken: this.cts.Token);
                 return;
             }
 
-            this.isPending = false;
+            this.cts?.Cancel();
+            this.cts?.Dispose();
+            this.cts = null;
         }
 
         this.action();

--- a/Dalamud/Utility/Debouncer.cs
+++ b/Dalamud/Utility/Debouncer.cs
@@ -104,7 +104,7 @@ internal class Debouncer : IDebouncer
                 return;
 
             var now = DateTime.UtcNow;
-            if (now < this.targetTime)
+            if (now < this.targetTime && this.cts != null)
             {
                 this.framework.RunOnTick(this.OnTick, this.targetTime - now, cancellationToken: this.cts.Token);
                 return;

--- a/Dalamud/Utility/Debouncer.cs
+++ b/Dalamud/Utility/Debouncer.cs
@@ -1,0 +1,94 @@
+using System.Threading;
+
+using Dalamud.Plugin.Services;
+
+namespace Dalamud.Utility;
+
+/// <summary>
+/// Provides a thread-safe mechanism to debounce actions, ensuring that a rapid succession 
+/// of calls only triggers the action after a specified delay has elapsed since the last call.
+/// </summary>
+public class Debouncer : IDisposable
+{
+    private readonly IFramework framework;
+    private readonly TimeSpan delay;
+    private readonly Action action;
+    private readonly Lock debouncerLock = new();
+    private CancellationTokenSource cts = new();
+    private DateTime targetTime = DateTime.MinValue;
+    private bool isPending;
+    private bool isDisposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Debouncer"/> class.
+    /// </summary>
+    /// <param name="framework">Dalamuds <see cref="IFramework"/> service.</param>
+    /// <param name="delay">The delay to wait after the last request before executing the action.</param>
+    /// <param name="action">The delegate to execute when the debounce period elapses.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="action"/> is <see langword="null"/>.</exception>
+    public Debouncer(IFramework framework, TimeSpan delay, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        this.framework = framework;
+        this.delay = delay;
+        this.action = action;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        using var scope = this.debouncerLock.EnterScope();
+
+        if (this.isDisposed)
+            return;
+
+        this.isDisposed = true;
+        this.cts.Cancel();
+        this.cts.Dispose();
+    }
+
+    /// <summary>
+    /// Requests the execution of the action.
+    /// </summary>
+    public void Debounce()
+    {
+        using var scope = this.debouncerLock.EnterScope();
+
+        if (this.isDisposed)
+            return;
+
+        this.targetTime = DateTime.UtcNow + this.delay;
+
+        if (this.isPending)
+            return;
+
+        this.cts.Cancel();
+        this.cts.Dispose();
+        this.cts = new();
+
+        this.isPending = true;
+        this.framework.RunOnTick(this.OnTick, this.delay, cancellationToken: this.cts.Token);
+    }
+
+    private void OnTick()
+    {
+        using (this.debouncerLock.EnterScope())
+        {
+            if (this.isDisposed)
+                return;
+
+            var now = DateTime.UtcNow;
+            if (now < this.targetTime)
+            {
+                this.isPending = true;
+                this.framework.RunOnTick(this.OnTick, this.targetTime - now, cancellationToken: this.cts.Token);
+                return;
+            }
+
+            this.isPending = false;
+        }
+
+        this.action();
+    }
+}


### PR DESCRIPTION
This PR adds a public `Debouncer` to `Dalamud.Utilities`, including a handy function `IFramework.CreateDebouncer`, and makes use of it in `UnlockState` to prevent successive `Update` calls.

The `UnlockState.Update` function is called at least twice during login: first because of the Login event, and a second time because `AgentUpdateFlag.UnlocksUpdate` was set.

The Debouncer makes sure that the Update function is called once with a delay of 500ms after the last call.

I've also updated the `IsItemUnlocked` function to check if the item is unlockable in the first place, because falling back to the games native functions would have it to load the Item sheet pages which takes quite long and has no benefit at all anyway since the items are not unlockable.