### PR TITLE
External Drag & Drop Bug

### DIFF
--- a/Dalamud/Interface/DragDrop/DragDropTarget.cs
+++ b/Dalamud/Interface/DragDrop/DragDropTarget.cs
@@ -44,6 +44,7 @@ internal partial class DragDropManager : DragDropManager.IDropTarget
         if (pDataObj.QueryGetData(ref this.formatEtc) != 0)
         {
             pdwEffect = 0;
+            (this.Files, this.Directories, this.Extensions) = ([], [], new HashSet<string>());
         }
         else
         {


### PR DESCRIPTION
Fix drag drop retaining the last list of paths when dragging something in an unrecognized format.