### PR TITLE
Optimize SigScanner .text copy

### DIFF
--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -132,8 +132,7 @@ internal sealed unsafe class Dalamud : IServiceType
         SetExceptionHandler(this.DefaultExceptionFilter);
         Log.Debug($"SE default exception filter at {new IntPtr(this.DefaultExceptionFilter):X}");
 
-        var debugSig = "40 55 53 57 48 8D AC 24 70 AD FF FF";
-        this.DebugExceptionFilter = Service<TargetSigScanner>.Get().ScanText(debugSig);
+        this.DebugExceptionFilter = scanner.ScanText("40 55 53 57 48 8D AC 24 70 AD FF FF");
         Log.Debug($"SE debug exception filter at {this.DebugExceptionFilter.ToInt64():X}");
     }
 

--- a/Dalamud/Game/SigScanner.cs
+++ b/Dalamud/Game/SigScanner.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 
 using Dalamud.Plugin.Services;
-using Dalamud.Utility;
 
 using Iced.Intel;
 
@@ -28,8 +27,6 @@ namespace Dalamud.Game;
 /// </summary>
 public class SigScanner : IDisposable, ISigScanner
 {
-    private static byte[]? fileBytes;
-
     private readonly FileInfo? cacheFile;
 
     private nint moduleCopyPtr;
@@ -62,8 +59,6 @@ public class SigScanner : IDisposable, ISigScanner
         if (this.IsCopy)
         {
             this.SetupCopiedSegments();
-
-            fileBytes ??= File.ReadAllBytes(module.FileName);
         }
 
         // Limit the search space to .text section.
@@ -493,9 +488,10 @@ public class SigScanner : IDisposable, ISigScanner
 
                     if (this.IsCopy)
                     {
-                        var source = fileBytes.AsSpan((int)section->PointerToRawData, this.TextSectionSize);
+                        using var stream = new FileStream(module.FileName, FileMode.Open, FileAccess.Read, FileShare.Read);
                         var destination = new Span<byte>((void*)(this.moduleCopyPtr + (nint)this.TextSectionOffset), this.TextSectionSize);
-                        source.CopyTo(destination);
+                        stream.Position = (int)section->PointerToRawData;
+                        stream.ReadExactly(destination);
                     }
 
                     break;

--- a/Dalamud/Service/ServiceManager.cs
+++ b/Dalamud/Service/ServiceManager.cs
@@ -126,7 +126,7 @@ internal static class ServiceManager
     public static CancellationToken UnloadCancellationToken => UnloadCancellationTokenSource.Token;
 
     /// <summary>
-    /// Initializes Provided Services and FFXIVClientStructs.
+    /// Initializes provided Services.
     /// </summary>
     /// <param name="dalamud">Instance of <see cref="Dalamud"/>.</param>
     /// <param name="fs">Instance of <see cref="ReliableFileStorage"/>.</param>


### PR DESCRIPTION
Instead of reading the whole exe into memory and keeping it there, we can just read the .text section via a stream when needed.