### PR TITLE
Always take frame padding into account for title bar buttons

### DIFF
--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -238,6 +238,12 @@ public interface IUiBuilder
     bool PluginUISoundEffectsEnabled { get; }
 
     /// <summary>
+    /// Gets a value indicating whether the user has enabled the "Add a button to the title bar of plugin windows to
+    /// open additional options" setting.
+    /// </summary>
+    bool PluginUIAdditionalOptionsEnabled { get; }
+
+    /// <summary>
     /// Loads an ULD file that can load textures containing multiple icons in a single texture.
     /// </summary>
     /// <param name="uldPath">The path of the requested ULD file.</param>
@@ -588,6 +594,9 @@ public sealed class UiBuilder : IDisposable, IUiBuilder
 
     /// <inheritdoc />
     public bool PluginUISoundEffectsEnabled => Service<DalamudConfiguration>.Get().EnablePluginUISoundEffects;
+
+    /// <inheritdoc />
+    public bool PluginUIAdditionalOptionsEnabled => Service<DalamudConfiguration>.Get().EnablePluginUiAdditionalOptions;
 
     /// <summary>
     /// Gets or sets a value indicating whether statistics about UI draw time should be collected.

--- a/Dalamud/Interface/Windowing/WindowHost.cs
+++ b/Dalamud/Interface/Windowing/WindowHost.cs
@@ -741,12 +741,8 @@ public class WindowHost
         if (!flags.HasFlag(ImGuiWindowFlags.NoCollapse) && style.WindowMenuButtonPosition == ImGuiDir.Right)
             numNativeButtons++;
 
-        // If there are no native buttons, pad from the right to make some space
-        if (numNativeButtons == 0)
-            padR += style.FramePadding.X;
-
         // Pad to the left, to get out of the way of the native buttons
-        padR += numNativeButtons * (buttonSize + style.ItemInnerSpacing.X);
+        padR += style.FramePadding.X + numNativeButtons * (buttonSize + style.ItemInnerSpacing.X);
 
         Vector2 GetCenter(ImRect rect) => new((rect.Min.X + rect.Max.X) * 0.5f, (rect.Min.Y + rect.Max.Y) * 0.5f);
 


### PR DESCRIPTION
Before:
[Enregistrement d'écran_20260715_083158.webm](https://github.com/user-attachments/assets/c6b38f7e-518d-4930-8585-f3cfaed004b1)

After:
[Enregistrement d'écran_20260715_083826.webm](https://github.com/user-attachments/assets/840800c6-33d0-4640-91d6-6f544f5feb5a)

(Yes, :baguette_bread: file names)

Also exposes the `EnablePluginUiAdditionalOptions` setting so that plugins can calculate where custom title bar buttons will be laid out.