### PR TITLE
Filter Source out of plugin-specific regex filter

### DIFF
--- a/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/ConsoleWindow.cs
@@ -1041,7 +1041,19 @@ internal class ConsoleWindow : Window, IDisposable
                     continue;
 
                 var allowedLevel = filterEntry.Level <= entry.Level;
-                var matchesContent = filterEntry.FilterRegex?.IsMatch(entry.Line) is not false;
+
+                var contentForMatch = entry.Line;
+                if (entry.Source is not null)
+                {
+                    var sourceTag = $"[{entry.Source}]";
+                    var tagIndex = contentForMatch.IndexOf(sourceTag, StringComparison.InvariantCultureIgnoreCase);
+                    if (tagIndex >= 0)
+                    {
+                        contentForMatch = contentForMatch.Remove(tagIndex, sourceTag.Length);
+                    }
+                }
+
+                var matchesContent = filterEntry.FilterRegex?.IsMatch(contentForMatch) is not false;
 
                 matchesAny |= allowedLevel && matchesContent;
                 if (matchesAny)


### PR DESCRIPTION
With change, only log entries actually containing the filter content in the message will display:
<img width="1234" height="480" alt="image" src="https://github.com/user-attachments/assets/2075c714-a0c5-4fe2-9669-4280e217b1db" />

Without change, every single log entry with the plugin internal name/source will display:
<img width="1234" height="378" alt="image" src="https://github.com/user-attachments/assets/25d6188f-3878-4585-af7f-0b098b826879" />
