### PR TITLE
Fix MinHook enabling

### DIFF
--- a/Dalamud/Hooking/Internal/MinHookHook.cs
+++ b/Dalamud/Hooking/Internal/MinHookHook.cs
@@ -80,9 +80,7 @@ internal class MinHookHook<T> : Hook<T> where T : Delegate
         this.CheckDisposed();
 
         if (!this.minHookImpl.Enabled)
-            return;
-
-        this.minHookImpl.Enable();
+            this.minHookImpl.Enable();
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
I wanted to test MinHook on Linux, and found that it didn't work. It looks like it regressed in 2c735e9ec on May 9, 2025.

Tested locally with `DALAMUD_FORCE_MINHOOK=true`. Hooks appear to work with this change. /xlstats shows MinHook backend, title screen has the `mh!` indicator.