### PR TITLE
Restore listings hidden by the price comparison window

### DIFF
--- a/Dalamud/Game/Network/Internal/MarketBoardUploaders/IMarketBoardUploader.cs
+++ b/Dalamud/Game/Network/Internal/MarketBoardUploaders/IMarketBoardUploader.cs
@@ -15,8 +15,9 @@ internal interface IMarketBoardUploader
     /// <param name="item">The item request data being uploaded.</param>
     /// <param name="uploaderId">The uploaders ContentId.</param>
     /// <param name="worldId">The uploaders WorldId.</param>
+    /// <param name="activeRetainerId">The retainer summoned when the listings were observed, or null if none was.</param>
     /// <returns>An async task.</returns>
-    Task Upload(MarketBoardItemRequest item, ulong uploaderId, uint worldId);
+    Task Upload(MarketBoardItemRequest item, ulong uploaderId, uint worldId, ulong? activeRetainerId);
 
     /// <summary>
     /// Upload tax rate data.

--- a/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
+++ b/Dalamud/Game/Network/Internal/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -7,6 +9,7 @@ using Dalamud.Game.Network.Structures;
 using Dalamud.Networking.Http;
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 using Serilog;
 
@@ -32,7 +35,7 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
         this.httpClient = happyHttpClient.SharedHttpClient;
 
     /// <inheritdoc/>
-    public async Task Upload(MarketBoardItemRequest request, ulong uploaderId, uint worldId)
+    public async Task Upload(MarketBoardItemRequest request, ulong uploaderId, uint worldId, ulong? activeRetainerId)
     {
         Log.Verbose("Starting Universalis upload");
 
@@ -91,6 +94,11 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
                 Quantity = marketBoardHistoryListing.Quantity,
                 Timestamp = ((DateTimeOffset)marketBoardHistoryListing.PurchaseTime).ToUnixTimeSeconds(),
             });
+        }
+
+        if (activeRetainerId is { } retainerId)
+        {
+            await this.RestoreHiddenListings(uploadObject, retainerId);
         }
 
         var uploadPath = "/upload";
@@ -176,5 +184,57 @@ internal class UniversalisMarketBoardUploader : IMarketBoardUploader
         // ====================================================================================
 
         Log.Verbose("Universalis purchase upload completed");
+    }
+
+    /// <summary>
+    /// A summoned retainer's listings are withheld from the price comparison window, so a
+    /// snapshot taken there reads as a removal for listings that are still live. Restores
+    /// them from Universalis' own rows: the game never tells a client what listing IDs its
+    /// listings were assigned, and a reconstructed ID would post as an add and a remove
+    /// rather than as a no-op.
+    /// </summary>
+    /// <param name="uploadObject">The upload being assembled.</param>
+    /// <param name="retainerId">The summoned retainer.</param>
+    /// <returns>An async task.</returns>
+    private async Task RestoreHiddenListings(UniversalisItemUploadRequest uploadObject, ulong retainerId)
+    {
+        JToken listings;
+        try
+        {
+            var response = await this.httpClient.GetAsync(
+                $"{ApiBase}/api/v2/{uploadObject.WorldId}/{uploadObject.ItemId}?entries=0&statsWithin=0&fields=listings");
+            response.EnsureSuccessStatusCode();
+            listings = JObject.Parse(await response.Content.ReadAsStringAsync())["listings"];
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Could not fetch listings for item#{CatalogId}; uploading unmodified", uploadObject.ItemId);
+            return;
+        }
+
+        if (listings == null)
+        {
+            Log.Warning("Listings response for item#{CatalogId} had no listings key; uploading unmodified", uploadObject.ItemId);
+            return;
+        }
+
+        var retainer = retainerId.ToString();
+        var known = listings.ToObject<List<UniversalisItemListingsEntry>>();
+
+        // Add rejects a listing the snapshot already carries, and a second copy of one the
+        // API returned twice - which it does, so filtering against the snapshot is not enough.
+        var present = uploadObject.Listings.Select(l => l.ListingId).ToHashSet();
+        var hidden = known.Where(l => l.RetainerId == retainer && present.Add(l.ListingId)).ToList();
+
+        Log.Verbose(
+            "item#{CatalogId}: snapshot has {SnapshotCount}, Universalis has {KnownCount}, " +
+            "restoring {HiddenCount} hidden from retainer#{RetainerId}",
+            uploadObject.ItemId,
+            present.Count,
+            known.Count,
+            hidden.Count,
+            retainerId);
+
+        uploadObject.Listings.AddRange(hidden);
     }
 }

--- a/Dalamud/Game/Network/Internal/NetworkHandlers.cs
+++ b/Dalamud/Game/Network/Internal/NetworkHandlers.cs
@@ -17,6 +17,7 @@ using Dalamud.Networking.Http;
 using Dalamud.Utility;
 
 using FFXIVClientStructs.FFXIV.Client.Enums;
+using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Event;
 using FFXIVClientStructs.FFXIV.Client.Game.Network;
 using FFXIVClientStructs.FFXIV.Client.Network;
@@ -255,6 +256,18 @@ internal unsafe class NetworkHandlers : IInternalDisposableService
         return (playerState.ContentId, playerState.CurrentWorld.RowId);
     }
 
+    /// <summary>
+    /// Gets the summoned retainer, or null if none is summoned. Read when a listings
+    /// batch resolves rather than when it uploads, since the upload is deferred and the
+    /// player may have dismissed the retainer by the time it runs.
+    /// </summary>
+    /// <returns>The summoned retainer's content id, or null.</returns>
+    private static ulong? GetActiveRetainerId()
+    {
+        var retainer = RetainerManager.Instance()->GetActiveRetainer();
+        return retainer == null || retainer->RetainerId == 0 ? null : retainer->RetainerId;
+    }
+
     private void HandleContentsFinderNotificationPacketDetour(ContentsFinderNotificationPacket* packet)
     {
         this.cfPopHook.OriginalDisposeSafe(packet);
@@ -407,14 +420,14 @@ internal unsafe class NetworkHandlers : IInternalDisposableService
                              startObservable
                                  .And(this.OnMarketBoardSalesBatch(startObservable))
                                  .And(this.OnMarketBoardListingsBatch(startObservable))
-                                 .Then((request, sales, listings) => (request, sales, listings, GetUploaderInfo())))
+                                 .Then((request, sales, listings) => (request, sales, listings, GetUploaderInfo(), GetActiveRetainerId())))
                          .Where(this.ShouldUpload)
                          .SubscribeOn(ThreadPoolScheduler.Instance)
                          .Subscribe(
                              data =>
                              {
-                                 var (request, sales, listings, uploaderInfo) = data;
-                                 this.UploadMarketBoardData(request, sales, listings, uploaderInfo.UploaderId, uploaderInfo.WorldId);
+                                 var (request, sales, listings, uploaderInfo, activeRetainerId) = data;
+                                 this.UploadMarketBoardData(request, sales, listings, uploaderInfo.UploaderId, uploaderInfo.WorldId, activeRetainerId);
                              },
                              ex => Log.Error(ex, "Failed to handle Market Board item request event"));
     }
@@ -424,7 +437,8 @@ internal unsafe class NetworkHandlers : IInternalDisposableService
         (uint CatalogId, ICollection<MarketBoardHistory.MarketBoardHistoryListing> Sales) sales,
         List<MarketBoardCurrentOfferings.MarketBoardItemListing> listings,
         ulong uploaderId,
-        uint worldId)
+        uint worldId,
+        ulong? activeRetainerId)
     {
         var catalogId = sales.CatalogId;
         if (listings.Count != request.AmountToArrive)
@@ -436,16 +450,17 @@ internal unsafe class NetworkHandlers : IInternalDisposableService
         }
 
         Log.Verbose(
-            "Market Board request resolved, starting upload: item#{CatalogId} listings#{ListingsObserved} sales#{SalesObserved}",
+            "Market Board request resolved, starting upload: item#{CatalogId} listings#{ListingsObserved} sales#{SalesObserved} retainer#{ActiveRetainerId}",
             catalogId,
             listings.Count,
-            sales.Sales.Count);
+            sales.Sales.Count,
+            activeRetainerId);
 
         request.CatalogId = catalogId;
         request.Listings.AddRange(listings);
         request.History.AddRange(sales.Sales);
 
-        Task.Run(() => this.uploader.Upload(request, uploaderId, worldId))
+        Task.Run(() => this.uploader.Upload(request, uploaderId, worldId, activeRetainerId))
             .ContinueWith(
                 task => Log.Error(task.Exception, "Market Board offerings data upload failed"),
                 TaskContinuationOptions.OnlyOnFaulted);


### PR DESCRIPTION
A summoned retainer's listings are withheld from the price comparison window. A snapshot taken there is missing them, so Universalis diffs it against stored state and publishes listings/remove for listings that are still live. On rarely-uploaded items nothing contradicts that and the removal sticks - measured at a 1.40% failure rate over 4631 remove probes against 0.04% over 2501 add probes, across 6 worlds. It also identifies the uploader: a player adjusting prices leaves a trail of removes on their own retainer's listings, which is how the cause was originally traced to a specific seller.

When a listings batch resolves while a retainer is summoned, that item's current listings are fetched from the v2 REST API and any belonging to the retainer which the snapshot does not already carry are added back. Universalis' own rows are used rather than local knowledge because the game never tells a client what listing IDs its listings were assigned; a reconstructed ID would post as an add and a remove instead of a no-op.

The insert is keyed on listing ID, which covers two cases: a listing the snapshot already carries, and a second copy of one the API returned twice - it does that occasionally, and filtering against the snapshot alone uploaded each restored listing twice. A failed or unusable fetch logs a warning and uploads unmodified.

The retainer is read from RetainerManager rather than inferred from packets, and it is read when the batch resolves rather than inside Upload: the upload is deferred to a Task, so by the time it runs the player may have dismissed the retainer. This matches how uploaderId and worldId are already captured.

Code written by Claude. Hand-checked and tested in-game on 7.55: no retainer is reported for an ordinary market board browse, and a comparison-window snapshot uploads with the retainer's listings restored at their real listing IDs.

The equivalent fix for the ACT plugin / standalone uploader is [goaaats/universalis_act_plugin#142](https://github.com/goaaats/universalis_act_plugin/issues/142). Same approach, agreed with karashiiro; this one needs no coordination to land, since the retainer comes from RetainerManager rather than an opcode that has to be published first.