### PR TITLE
Revert hooks on the Framework thread on shutdown

### DIFF
--- a/Dalamud/Hooking/Internal/HookManager.cs
+++ b/Dalamud/Hooking/Internal/HookManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 
+using Dalamud.Game;
 using Dalamud.Logging.Internal;
 using Dalamud.Memory;
 using Dalamud.Utility;
@@ -22,6 +23,9 @@ internal class HookManager : IInternalDisposableService
     /// Logger shared with <see cref="Unhooker"/>.
     /// </summary>
     internal static readonly ModuleLog Log = ModuleLog.Create<HookManager>();
+
+    [ServiceManager.ServiceDependency]
+    private readonly Framework framework = Service<Framework>.Get();
 
     [ServiceManager.ServiceConstructor]
     private HookManager()
@@ -78,9 +82,12 @@ internal class HookManager : IInternalDisposableService
     /// <inheritdoc/>
     void IInternalDisposableService.DisposeService()
     {
-        RevertHooks();
-        TrackedHooks.Clear();
-        Unhookers.Clear();
+        this.framework.Run(() =>
+        {
+            RevertHooks();
+            TrackedHooks.Clear();
+            Unhookers.Clear();
+        }).Wait();
     }
 
     /// <summary>

--- a/Dalamud/Hooking/Internal/HookManager.cs
+++ b/Dalamud/Hooking/Internal/HookManager.cs
@@ -82,6 +82,7 @@ internal class HookManager : IInternalDisposableService
     /// <inheritdoc/>
     void IInternalDisposableService.DisposeService()
     {
+        // Reduce chances of trampling code that is currently executing by reverting on main thread
         this.framework.Run(() =>
         {
             RevertHooks();


### PR DESCRIPTION
The `HookManager.DisposeService` function is not run on the main thread, so when the game shuts down it will revert those bytes as the game tries to call the functions.
Just wait for it to be done on the framework thread and all is good.