### PR TITLE
Update EmbeddedInfoType

### DIFF
--- a/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
@@ -962,6 +962,19 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
                 context.Builder.PopLink();
                 return;
 
+            // TODO: use updated LinkMacroPayloadType
+            case "EventTutorial":
+                context.Builder.PushLink((LinkMacroPayloadType)14 /*LinkMacroPayloadType.EventTutorial*/, eRowIdValue, 0u, 0u, text.AsSpan());
+                context.Builder.Append(text);
+                context.Builder.PopLink();
+                return;
+
+            case "Emote":
+                context.Builder.PushLink((LinkMacroPayloadType)15 /*LinkMacroPayloadType.Emote*/, eRowIdValue, 0u, 0u, text.AsSpan());
+                context.Builder.Append(text);
+                context.Builder.PopLink();
+                return;
+
             default:
                 context.Builder.Append(text);
                 return;

--- a/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
+++ b/Dalamud/Game/Text/Evaluator/SeStringEvaluator.cs
@@ -963,6 +963,19 @@ internal class SeStringEvaluator : IServiceType, ISeStringEvaluator
                 context.Builder.PopLink();
                 return;
 
+            // TODO: use updated LinkMacroPayloadType
+            case "EventTutorial":
+                context.Builder.PushLink((LinkMacroPayloadType)14 /*LinkMacroPayloadType.EventTutorial*/, eRowIdValue, 0u, 0u, text.AsSpan());
+                context.Builder.Append(text);
+                context.Builder.PopLink();
+                return;
+
+            case "Emote":
+                context.Builder.PushLink((LinkMacroPayloadType)15 /*LinkMacroPayloadType.Emote*/, eRowIdValue, 0u, 0u, text.AsSpan());
+                context.Builder.Append(text);
+                context.Builder.PopLink();
+                return;
+
             default:
                 context.Builder.Append(text);
                 return;

--- a/Dalamud/Game/Text/SeStringHandling/Payload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payload.cs
@@ -241,6 +241,9 @@ public abstract partial class Payload
     /// <summary>
     /// This represents the type of embedded info in a payload.
     /// </summary>
+    /// <remarks>
+    /// This is a mirror of <see cref="Lumina.Text.Payloads.LinkMacroPayloadType"/>, offset by +1, and including <c>DalamudLink</c>.
+    /// </remarks>
     public enum EmbeddedInfoType
     {
         /// <summary>
@@ -279,9 +282,39 @@ public abstract partial class Payload
         PartyFinderLink = 0x0A,
 
         /// <summary>
+        /// An AkatsukiNote entry is linked.
+        /// </summary>
+        AkatsukiNote = 0x0B,
+
+        /// <summary>
+        /// A Description entry is linked.
+        /// </summary>
+        Description = 0x0C,
+
+        /// <summary>
+        /// A WKSPioneeringTrail entry is linked.
+        /// </summary>
+        WKSPioneeringTrail = 0x0D,
+
+        /// <summary>
+        /// A MKDLore entry is linked.
+        /// </summary>
+        MKDLore = 0x0E,
+
+        /// <summary>
+        /// A EventTutorial entry is linked.
+        /// </summary>
+        EventTutorial = 0x0F,
+
+        /// <summary>
+        /// A Emote entry is linked.
+        /// </summary>
+        Emote = 0x10,
+
+        /// <summary>
         /// A custom Dalamud link.
         /// </summary>
-        DalamudLink = 0x0F,
+        DalamudLink = LinkTerminator - 1,
 
         /// <summary>
         /// A link terminator.

--- a/Dalamud/Game/Text/SeStringHandling/Payload.cs
+++ b/Dalamud/Game/Text/SeStringHandling/Payload.cs
@@ -241,6 +241,9 @@ public abstract partial class Payload
     /// <summary>
     /// This represents the type of embedded info in a payload.
     /// </summary>
+    /// <remarks>
+    /// This is a mirror of <see cref="Lumina.Text.Payloads.LinkMacroPayloadType"/>, offset by +1, and including <c>DalamudLink</c>.
+    /// </remarks>
     public enum EmbeddedInfoType
     {
         /// <summary>
@@ -279,9 +282,39 @@ public abstract partial class Payload
         PartyFinderLink = 0x0A,
 
         /// <summary>
+        /// An AkatsukiNote entry is linked.
+        /// </summary>
+        AkatsukiNote = 0x0B,
+
+        /// <summary>
+        /// A Description entry is linked.
+        /// </summary>
+        Description = 0x0C,
+
+        /// <summary>
+        /// A WKSPioneeringTrail entry is linked.
+        /// </summary>
+        WKSPioneeringTrail = 0x0D,
+
+        /// <summary>
+        /// A MKDLore entry is linked.
+        /// </summary>
+        MKDLore = 0x0E,
+
+        /// <summary>
+        /// A EventTutorial entry is linked.
+        /// </summary>
+        EventTutorial = 0x0F,
+
+        /// <summary>
+        /// A Emote entry is linked.
+        /// </summary>
+        Emote = 0x10,
+
+        /// <summary>
         /// A custom Dalamud link.
         /// </summary>
-        DalamudLink = 0x0F,
+        DalamudLink = 0x11,
 
         /// <summary>
         /// A link terminator.

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/SeStringCreatorWidget.cs
@@ -111,13 +111,16 @@ internal class SeStringCreatorWidget : IDataWindowWidget
         { LinkMacroPayloadType.Quest, ["RowId"] },
         { LinkMacroPayloadType.Achievement, ["RowId"] },
         { LinkMacroPayloadType.HowTo, ["RowId"] },
-        // PartyFinderNotification
+        { LinkMacroPayloadType.PartyFinderNotification, [] },
         { LinkMacroPayloadType.Status, ["StatusId"] },
         { LinkMacroPayloadType.PartyFinder, ["ListingId", string.Empty, "WorldId"] },
         { LinkMacroPayloadType.AkatsukiNote, ["RowId"] },
         { LinkMacroPayloadType.Description, ["RowId"] },
         { LinkMacroPayloadType.WKSPioneeringTrail, ["RowId", "SubrowId"] },
         { LinkMacroPayloadType.MKDLore, ["RowId"] },
+        // TODO: add new LinkMacroPayloadTypes
+        // { LinkMacroPayloadType.EventTutorial, ["RowId"] },
+        // { LinkMacroPayloadType.Emote, ["Emote"] },
         { DalamudLinkType, ["CommandId", "Extra1", "Extra2", "ExtraString"] },
     };
 
@@ -1091,6 +1094,29 @@ internal class SeStringCreatorWidget : IDataWindowWidget
                         akatsukiNoteRow.ListName.ValueNullable is { } akatsukiNoteStringRow:
                         ImGui.SameLine();
                         ImGui.Text(akatsukiNoteStringRow.Text.ExtractText());
+                        break;
+
+                    case LinkMacroPayloadType.WKSPioneeringTrail when
+                        dataManager.GetSubrowExcelSheet<WKSPioneeringTrail>(this.language).TryGetRow(u32, out var wksPioneeringTrailRow) &&
+                        wksPioneeringTrailRow[0].LogEntry.IsValid:
+                        ImGui.SameLine();
+                        ImGui.Text(wksPioneeringTrailRow[0].LogEntry.Value.DevelopmentLogName.ToString());
+                        break;
+
+                    case LinkMacroPayloadType.MKDLore when dataManager.GetExcelSheet<MKDLore>(this.language).TryGetRow(u32, out var mkdLoreRow):
+                        ImGui.SameLine();
+                        ImGui.Text(mkdLoreRow.Name.ToString());
+                        break;
+
+                    // TODO: use new LinkMacroPayloadTypes
+                    case (LinkMacroPayloadType)14/*LinkMacroPayloadType.EventTutorial*/ when dataManager.GetExcelSheet<EventTutorial>(this.language).TryGetRow(u32, out var eventTutorialRow):
+                        ImGui.SameLine();
+                        ImGui.Text(eventTutorialRow.Singular.ToString());
+                        break;
+
+                    case (LinkMacroPayloadType)15/*LinkMacroPayloadType.Emote*/ when dataManager.GetExcelSheet<Emote>(this.language).TryGetRow(u32, out var emoteRow):
+                        ImGui.SameLine();
+                        ImGui.Text(emoteRow.Name.ToString());
                         break;
                 }
             }


### PR DESCRIPTION
There are 2 new LinkMacroPayloadTypes: EventTutorial (14) and Emote (15).

DalamudLink currently uses 14, blocking EventTutorial links. I've moved it to 1 before LinkTerminator. This will require plugins to be rebuilt, if they use the enum value directly.

The new types were merged to Lumina (https://github.com/NotAdam/Lumina/pull/132), but there was no release yet.
