### PR TITLE
Basic AppContainer sandboxing support

### DIFF
--- a/Dalamud.Boot/xivfixes.cpp
+++ b/Dalamud.Boot/xivfixes.cpp
@@ -737,6 +737,60 @@ void xivfixes::faster_decompression(bool bApply) {
     }
 }
 
+void xivfixes::appcontainer_known_folders(bool bApply) {
+    static const char* LogTag = "[xivfixes:appcontainer_known_folders]";
+    static std::optional<hooks::import_hook<decltype(SHGetSpecialFolderLocation)>> s_hookSHGetSpecialFolderLocation;
+
+    if (bApply) {
+        if (!g_startInfo.BootEnabledGameFixes.contains("appcontainer_known_folders")) {
+            logging::I("{} Turned off via environment variable.", LogTag);
+            return;
+        }
+
+        BOOL isAppContainer = FALSE;
+        if (HANDLE hToken; OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken)) {
+            DWORD returnLength = 0;
+            if (!GetTokenInformation(hToken, TokenIsAppContainer, &isAppContainer, sizeof isAppContainer, &returnLength))
+                isAppContainer = FALSE;
+            CloseHandle(hToken);
+        }
+
+        if (!isAppContainer) {
+            logging::I("{} Not running in an AppContainer; skipping.", LogTag);
+            return;
+        }
+
+        // Inside an AppContainer, SHGetSpecialFolderLocation(CSIDL_PERSONAL) fails with E_ACCESSDENIED
+        s_hookSHGetSpecialFolderLocation.emplace(
+            "shell32.dll!SHGetSpecialFolderLocation (import, appcontainer_known_folders)",
+            "shell32.dll", "SHGetSpecialFolderLocation", 0);
+
+        s_hookSHGetSpecialFolderLocation->set_detour([](HWND hwnd, int csidl, PIDLIST_ABSOLUTE* ppidl) noexcept -> HRESULT {
+            const auto result = s_hookSHGetSpecialFolderLocation->call_original(hwnd, csidl, ppidl);
+            if (SUCCEEDED(result) || (csidl & CSIDL_FLAG_DONT_VERIFY))
+                return result;
+
+            const auto retried = s_hookSHGetSpecialFolderLocation->call_original(hwnd, csidl | CSIDL_FLAG_DONT_VERIFY, ppidl);
+            if (SUCCEEDED(retried)) {
+                logging::I("{} csidl=0x{:X} failed with 0x{:X}. Resolved with CSIDL_FLAG_DONT_VERIFY",
+                    LogTag, csidl, static_cast<uint32_t>(result));
+            } else {
+                logging::W("{} csidl=0x{:X} failed with 0x{:X}. Retry with CSIDL_FLAG_DONT_VERIFY also failed with 0x{:X}",
+                    LogTag, csidl, static_cast<uint32_t>(result), static_cast<uint32_t>(retried));
+            }
+
+            return retried;
+        });
+
+        logging::I("{} Enable", LogTag);
+    } else {
+        if (s_hookSHGetSpecialFolderLocation) {
+            logging::I("{} Disable", LogTag);
+            s_hookSHGetSpecialFolderLocation.reset();
+        }
+    }
+}
+
 void xivfixes::apply_all(bool bApply) {
     for (const auto& [taskName, taskFunction] : std::initializer_list<std::pair<const char*, void(*)(bool)>>
         {
@@ -749,6 +803,7 @@ void xivfixes::apply_all(bool bApply) {
             { "symbol_load_patches", &symbol_load_patches },
             { "disable_game_debugging_protection", &disable_game_debugging_protection },
             { "faster_decompression", &faster_decompression },
+            { "appcontainer_known_folders", &appcontainer_known_folders },
         }
         ) {
         try {

--- a/Dalamud.Boot/xivfixes.h
+++ b/Dalamud.Boot/xivfixes.h
@@ -10,6 +10,7 @@ namespace xivfixes {
     void symbol_load_patches(bool bApply);
     void disable_game_debugging_protection(bool bApply);
     void faster_decompression(bool bApply);
+    void appcontainer_known_folders(bool bApply);
 
     void apply_all(bool bApply);
 }

--- a/Dalamud.Injector/AppContainerHelper.cs
+++ b/Dalamud.Injector/AppContainerHelper.cs
@@ -1,0 +1,537 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+using Serilog;
+
+// ReSharper disable InconsistentNaming
+
+namespace Dalamud.Injector
+{
+    /// <summary>
+    /// Helpers for creating AppContainer profiles, capability SIDs, filesystem grants and loopback exemption.
+    /// </summary>
+    internal static class AppContainerHelper
+    {
+        // We use specific rights rather than GENERIC_* so that the ACE we write is identical to what we later
+        // compare against in HasAccess, because the kernel maps specific rights to generic ones
+
+        /// <summary>
+        /// Access mask for read and execute grants.
+        /// </summary>
+        public const uint AccessReadExecute = PInvoke.FILE_GENERIC_READ | PInvoke.FILE_GENERIC_EXECUTE;
+
+        /// <summary>
+        /// Access mask for modify grants (read/write/execute/delete).
+        /// </summary>
+        public const uint AccessModify = PInvoke.FILE_GENERIC_READ | PInvoke.FILE_GENERIC_WRITE | PInvoke.FILE_GENERIC_EXECUTE | PInvoke.DELETE;
+
+        // HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS)
+        private const int HResultAlreadyExists = unchecked((int)0x800700B7);
+
+        private static readonly Dictionary<string, uint> WellKnownCapabilityRids = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "internetClient", PInvoke.SECURITY_CAPABILITY_INTERNET_CLIENT },
+            { "internetClientServer", PInvoke.SECURITY_CAPABILITY_INTERNET_CLIENT_SERVER },
+            { "privateNetworkClientServer", PInvoke.SECURITY_CAPABILITY_PRIVATE_NETWORK_CLIENT_SERVER },
+        };
+
+        /// <summary>
+        /// Create or open the AppContainer profile and prepare caps.
+        /// </summary>
+        /// <param name="containerName">The internal name of the container.</param>
+        /// <param name="displayName">The display name of the container.</param>
+        /// <param name="description">The description of the container.</param>
+        /// <param name="capabilityNames">
+        /// Names of capabilities the container should have access to.
+        /// Well-known ones are mapped to fixed RIDs, others are derived by name instead.
+        /// </param>
+        /// <returns>A launch context that can be used to start processes in a containerized manner.</returns>
+        public static AppContainerLaunchContext CreateContext(string containerName, string displayName, string description, IReadOnlyList<string> capabilityNames)
+        {
+            var ctx = new AppContainerLaunchContext();
+            try
+            {
+                var capSids = new List<IntPtr>();
+                foreach (var name in capabilityNames)
+                {
+                    if (WellKnownCapabilityRids.TryGetValue(name, out var rid))
+                    {
+                        var authority = new PInvoke.SID_IDENTIFIER_AUTHORITY
+                        {
+                            Value = new byte[] { 0, 0, 0, 0, 0, 15 }, // SECURITY_APP_PACKAGE_AUTHORITY
+                        };
+
+                        if (!PInvoke.AllocateAndInitializeSid(
+                                ref authority,
+                                2,
+                                PInvoke.SECURITY_CAPABILITY_BASE_RID,
+                                rid,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                out var sid))
+                        {
+                            throw new Win32Exception(Marshal.GetLastWin32Error());
+                        }
+
+                        ctx.AddOwnedSid(sid, true);
+                        capSids.Add(sid);
+                    }
+                    else
+                    {
+                        // Need to derive SIDs for named caps
+                        if (!PInvoke.DeriveCapabilitySidsFromName(
+                                name,
+                                out var groupSids,
+                                out var groupCount,
+                                out var sids,
+                                out var sidCount))
+                        {
+                            throw new Win32Exception(Marshal.GetLastWin32Error());
+                        }
+
+                        for (var i = 0; i < groupCount; i++)
+                            ctx.AddOwnedSid(Marshal.ReadIntPtr(groupSids, i * IntPtr.Size), false);
+                        PInvoke.LocalFree(groupSids);
+
+                        for (var i = 0; i < sidCount; i++)
+                        {
+                            var sid = Marshal.ReadIntPtr(sids, i * IntPtr.Size);
+                            ctx.AddOwnedSid(sid, false);
+                            capSids.Add(sid);
+                        }
+
+                        PInvoke.LocalFree(sids);
+                    }
+                }
+
+                ctx.BuildCapabilityArray(capSids);
+
+                var hr = PInvoke.CreateAppContainerProfile(
+                    containerName,
+                    displayName,
+                    description,
+                    ctx.CapabilitiesPtr,
+                    (uint)ctx.CapabilityCount,
+                    out var containerSid);
+
+                if (hr == HResultAlreadyExists)
+                {
+                    Marshal.ThrowExceptionForHR(
+                        PInvoke.DeriveAppContainerSidFromAppContainerName(containerName, out containerSid));
+                }
+                else
+                {
+                    Marshal.ThrowExceptionForHR(hr);
+                }
+
+                ctx.SetContainerSid(containerSid);
+                return ctx;
+            }
+            catch
+            {
+                ctx.Dispose();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Check whether the given SID already has at least the provided access on a path.
+        /// </summary>
+        /// <param name="path">Path of an existing file or directory.</param>
+        /// <param name="sid">The SID to check.</param>
+        /// <param name="accessMask">The required access mask.</param>
+        /// <returns>Whether the SID already holds the required access.</returns>
+        public static bool HasAccess(string path, IntPtr sid, uint accessMask)
+        {
+            var err = PInvoke.GetNamedSecurityInfoW(
+                path,
+                PInvoke.SE_FILE_OBJECT,
+                PInvoke.DACL_SECURITY_INFORMATION,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                out var dacl,
+                IntPtr.Zero,
+                out var securityDescriptor);
+            if (err != 0)
+                return false;
+
+            try
+            {
+                if (dacl == IntPtr.Zero)
+                    return false;
+
+                var trustee = BuildTrustee(sid);
+                if (PInvoke.GetEffectiveRightsFromAclW(dacl, ref trustee, out var effective) != 0)
+                    return false;
+
+                return (effective & accessMask) == accessMask;
+            }
+            finally
+            {
+                if (securityDescriptor != IntPtr.Zero)
+                    PInvoke.LocalFree(securityDescriptor);
+            }
+        }
+
+        /// <summary>
+        /// Ensure the given SID has at least accessMask on a path, writing the DACL when the access
+        /// is not already present.
+        /// </summary>
+        /// <param name="path">Path of an existing file or directory.</param>
+        /// <param name="sid">The SID to grant to.</param>
+        /// <param name="accessMask">The required access mask.</param>
+        /// <returns>What was needed to satisfy the request.</returns>
+        /// <exception cref="Win32Exception">Thrown when a win32 error other than access denied occurs.</exception>
+        public static GrantResult EnsureAccess(string path, IntPtr sid, uint accessMask)
+        {
+            if (HasAccess(path, sid, accessMask))
+                return GrantResult.AlreadyGranted;
+
+            try
+            {
+                GrantAccess(path, sid, accessMask);
+                return GrantResult.Granted;
+            }
+            catch (Win32Exception ex) when (ex.NativeErrorCode == PInvoke.ERROR_ACCESS_DENIED)
+            {
+                // Writing a DACL needs WRITE_DAC
+                return GrantResult.AccessDenied;
+            }
+        }
+
+        /// <summary>
+        /// Grant the given SID access to a filesystem path (inheritable to children).
+        /// </summary>
+        /// <param name="path">Path of an existing file or directory.</param>
+        /// <param name="sid">The SID to grant to.</param>
+        /// <param name="accessMask">The access mask to grant.</param>
+        /// <exception cref="Win32Exception">Thrown when a win32 error occurs.</exception>
+        public static void GrantAccess(string path, IntPtr sid, uint accessMask)
+        {
+            var err = PInvoke.GetNamedSecurityInfoW(
+                path,
+                PInvoke.SE_FILE_OBJECT,
+                PInvoke.DACL_SECURITY_INFORMATION,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                out var oldDacl,
+                IntPtr.Zero,
+                out var securityDescriptor);
+            if (err != 0)
+                throw new Win32Exception((int)err, $"GetNamedSecurityInfo failed for {path}");
+
+            var newDacl = IntPtr.Zero;
+            try
+            {
+                var ea = new PInvoke.EXPLICIT_ACCESS_W
+                {
+                    grfAccessPermissions = accessMask,
+                    grfAccessMode = PInvoke.GRANT_ACCESS,
+                    grfInheritance = PInvoke.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+                    Trustee = BuildTrustee(sid),
+                };
+
+                err = PInvoke.SetEntriesInAclW(1, ref ea, oldDacl, out newDacl);
+                if (err != 0)
+                    throw new Win32Exception((int)err, $"SetEntriesInAcl failed for {path}");
+
+                err = PInvoke.SetNamedSecurityInfoW(
+                    path,
+                    PInvoke.SE_FILE_OBJECT,
+                    PInvoke.DACL_SECURITY_INFORMATION,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    newDacl,
+                    IntPtr.Zero);
+                if (err != 0)
+                    throw new Win32Exception((int)err, $"SetNamedSecurityInfo failed for {path}");
+            }
+            finally
+            {
+                if (newDacl != IntPtr.Zero)
+                    PInvoke.LocalFree(newDacl);
+                if (securityDescriptor != IntPtr.Zero)
+                    PInvoke.LocalFree(securityDescriptor);
+            }
+        }
+
+        /// <summary>
+        /// Try to add the container SID to the network isolation loopback exemption list.
+        /// Requires elevation and returns false/logs when not possible.
+        /// </summary>
+        /// <param name="ctx">The launch context.</param>
+        /// <returns>Whether the exemption is in place.</returns>
+        public static bool TryAddLoopbackExemption(AppContainerLaunchContext ctx)
+        {
+            try
+            {
+                var err = PInvoke.NetworkIsolationGetAppContainerConfig(out var count, out var existing);
+                if (err != 0)
+                {
+                    Log.Warning("NetworkIsolationGetAppContainerConfig failed: {Err}", err);
+                    return false;
+                }
+
+                var entrySize = Marshal.SizeOf<PInvoke.SID_AND_ATTRIBUTES>();
+                for (var i = 0; i < count; i++)
+                {
+                    var entry = Marshal.PtrToStructure<PInvoke.SID_AND_ATTRIBUTES>(existing + (i * entrySize));
+                    if (entry.Sid != IntPtr.Zero && PInvoke.EqualSid(entry.Sid, ctx.ContainerSid))
+                    {
+                        Log.Verbose("Loopback exemption already present for {Sid}", ctx.ContainerSidString);
+                        return true;
+                    }
+                }
+
+                // Set() replaces the whole list so we need to append instead
+                var newList = Marshal.AllocHGlobal(entrySize * (int)(count + 1));
+                try
+                {
+                    for (var i = 0; i < count; i++)
+                    {
+                        var entry = Marshal.PtrToStructure<PInvoke.SID_AND_ATTRIBUTES>(existing + (i * entrySize));
+                        Marshal.StructureToPtr(entry, newList + (i * entrySize), false);
+                    }
+
+                    Marshal.StructureToPtr(
+                        new PInvoke.SID_AND_ATTRIBUTES { Sid = ctx.ContainerSid, Attributes = 0 },
+                        newList + ((int)count * entrySize),
+                        false);
+
+                    err = PInvoke.NetworkIsolationSetAppContainerConfig(count + 1, newList);
+                    if (err != 0)
+                    {
+                        Log.Warning(
+                            "Could not add loopback exemption (error {Err}). " +
+                            "Make sure you are running this elevated or run this once from an elevated prompt instead: CheckNetIsolation.exe LoopbackExempt -a -p={Sid}",
+                            err,
+                            ctx.ContainerSidString);
+                        return false;
+                    }
+
+                    Log.Information("Loopback exemption added for {Sid}", ctx.ContainerSidString);
+                    return true;
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(newList);
+
+                    // TODO: Free existing?
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to configure loopback exemption");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Whether the current process is running elevated.
+        /// </summary>
+        /// <returns>True if running with an elevated token.</returns>
+        public static bool IsElevated()
+        {
+            using var identity = System.Security.Principal.WindowsIdentity.GetCurrent();
+            return new System.Security.Principal.WindowsPrincipal(identity)
+                .IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
+        }
+
+        /// <summary>
+        /// Convert a SID to its string form.
+        /// </summary>
+        /// <param name="sid">The SID.</param>
+        /// <returns>The SID in string form.</returns>
+        internal static string SidToString(IntPtr sid)
+        {
+            if (!PInvoke.ConvertSidToStringSidW(sid, out var strPtr))
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            try
+            {
+                return Marshal.PtrToStringUni(strPtr) ?? string.Empty;
+            }
+            finally
+            {
+                PInvoke.LocalFree(strPtr);
+            }
+        }
+
+        private static PInvoke.TRUSTEE_W BuildTrustee(IntPtr sid) => new()
+        {
+            pMultipleTrustee = IntPtr.Zero,
+            MultipleTrusteeOperation = 0, // NO_MULTIPLE_TRUSTEE
+            TrusteeForm = PInvoke.TRUSTEE_IS_SID,
+            TrusteeType = PInvoke.TRUSTEE_IS_WELL_KNOWN_GROUP,
+            ptstrName = sid,
+        };
+
+        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1307:Accessible fields should begin with upper-case letter", Justification = "WINAPI conventions")]
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1121:Use built-in type alias", Justification = "WINAPI conventions")]
+        [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:Fields should be private", Justification = "WINAPI conventions")]
+        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1306:Field names should begin with lower-case letter", Justification = "WINAPI conventions")]
+        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "WINAPI conventions")]
+        [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "WINAPI conventions")]
+        internal static class PInvoke
+        {
+            public const uint DELETE = 0x00010000;
+
+            public const uint FILE_GENERIC_READ = 0x00120089;
+            public const uint FILE_GENERIC_WRITE = 0x00120116;
+            public const uint FILE_GENERIC_EXECUTE = 0x001200A0;
+
+            public const int ERROR_ACCESS_DENIED = 5;
+
+            public const uint SE_GROUP_ENABLED = 0x00000004;
+
+            public const uint SECURITY_CAPABILITY_BASE_RID = 3;
+            public const uint SECURITY_CAPABILITY_INTERNET_CLIENT = 1;
+            public const uint SECURITY_CAPABILITY_INTERNET_CLIENT_SERVER = 2;
+            public const uint SECURITY_CAPABILITY_PRIVATE_NETWORK_CLIENT_SERVER = 3;
+
+            public const int SE_FILE_OBJECT = 1;
+            public const uint DACL_SECURITY_INFORMATION = 4;
+
+            public const int GRANT_ACCESS = 1;
+            public const uint SUB_CONTAINERS_AND_OBJECTS_INHERIT = 0x3;
+            public const int TRUSTEE_IS_SID = 0;
+            public const int TRUSTEE_IS_WELL_KNOWN_GROUP = 5;
+
+            [DllImport("userenv.dll", CharSet = CharSet.Unicode)]
+            public static extern int CreateAppContainerProfile(
+                string pszAppContainerName,
+                string pszDisplayName,
+                string pszDescription,
+                IntPtr pCapabilities,
+                uint dwCapabilityCount,
+                out IntPtr ppSidAppContainerSid);
+
+            [DllImport("userenv.dll", CharSet = CharSet.Unicode)]
+            public static extern int DeriveAppContainerSidFromAppContainerName(
+                string pszAppContainerName,
+                out IntPtr ppsidAppContainerSid);
+
+            [DllImport("kernelbase.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool DeriveCapabilitySidsFromName(
+                string capName,
+                out IntPtr capabilityGroupSids,
+                out uint capabilityGroupSidCount,
+                out IntPtr capabilitySids,
+                out uint capabilitySidCount);
+
+            [DllImport("advapi32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool AllocateAndInitializeSid(
+                ref SID_IDENTIFIER_AUTHORITY pIdentifierAuthority,
+                byte nSubAuthorityCount,
+                uint nSubAuthority0,
+                uint nSubAuthority1,
+                uint nSubAuthority2,
+                uint nSubAuthority3,
+                uint nSubAuthority4,
+                uint nSubAuthority5,
+                uint nSubAuthority6,
+                uint nSubAuthority7,
+                out IntPtr pSid);
+
+            [DllImport("advapi32.dll")]
+            public static extern IntPtr FreeSid(IntPtr pSid);
+
+            [DllImport("advapi32.dll")]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool EqualSid(IntPtr pSid1, IntPtr pSid2);
+
+            [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool ConvertSidToStringSidW(IntPtr sid, out IntPtr stringSid);
+
+            [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+            public static extern uint GetNamedSecurityInfoW(
+                string pObjectName,
+                int objectType,
+                uint securityInfo,
+                IntPtr ppsidOwner,
+                IntPtr ppsidGroup,
+                out IntPtr ppDacl,
+                IntPtr ppSacl,
+                out IntPtr ppSecurityDescriptor);
+
+            [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+            public static extern uint GetEffectiveRightsFromAclW(
+                IntPtr pAcl,
+                ref TRUSTEE_W pTrustee,
+                out uint pAccessRights);
+
+            [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+            public static extern uint SetEntriesInAclW(
+                uint cCountOfExplicitEntries,
+                ref EXPLICIT_ACCESS_W pListOfExplicitEntries,
+                IntPtr oldAcl,
+                out IntPtr newAcl);
+
+            [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+            public static extern uint SetNamedSecurityInfoW(
+                string pObjectName,
+                int objectType,
+                uint securityInfo,
+                IntPtr psidOwner,
+                IntPtr psidGroup,
+                IntPtr pDacl,
+                IntPtr pSacl);
+
+            [DllImport("firewallapi.dll")]
+            public static extern uint NetworkIsolationGetAppContainerConfig(
+                out uint pdwNumPublicAppCs,
+                out IntPtr appContainerSids);
+
+            [DllImport("firewallapi.dll")]
+            public static extern uint NetworkIsolationSetAppContainerConfig(
+                uint dwNumPublicAppCs,
+                IntPtr appContainerSids);
+
+            [DllImport("kernel32.dll")]
+            public static extern IntPtr LocalFree(IntPtr hMem);
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct SID_IDENTIFIER_AUTHORITY
+            {
+                [MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]
+                public byte[] Value;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct SID_AND_ATTRIBUTES
+            {
+                public IntPtr Sid;
+                public uint Attributes;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct TRUSTEE_W
+            {
+                public IntPtr pMultipleTrustee;
+                public int MultipleTrusteeOperation;
+                public int TrusteeForm;
+                public int TrusteeType;
+                public IntPtr ptstrName;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct EXPLICIT_ACCESS_W
+            {
+                public uint grfAccessPermissions;
+                public int grfAccessMode;
+                public uint grfInheritance;
+                public TRUSTEE_W Trustee;
+            }
+        }
+    }
+}

--- a/Dalamud.Injector/AppContainerLaunchContext.cs
+++ b/Dalamud.Injector/AppContainerLaunchContext.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Dalamud.Injector
+{
+    /// <summary>
+    /// Owns the native resources needed to launch a process inside an AppContainer.
+    /// Notably, the container SID and the prepared capability array for SECURITY_CAPABILITIES.
+    /// </summary>
+    public sealed class AppContainerLaunchContext : IDisposable
+    {
+        private readonly List<(IntPtr Ptr, bool IsFreeSid)> ownedSids = new();
+        private IntPtr capabilitiesPtr = IntPtr.Zero;
+
+        /// <summary>
+        /// Gets a pointer to the AppContainer SID.
+        /// </summary>
+        public IntPtr ContainerSid { get; private set; } = IntPtr.Zero;
+
+        /// <summary>
+        /// Gets the string form of the AppContainer SID (S-1-15-2-...).
+        /// </summary>
+        public string ContainerSidString { get; private set; } = string.Empty;
+
+        /// <summary>
+        /// Gets a pointer to a native SID_AND_ATTRIBUTES array for SECURITY_CAPABILITIES.
+        /// </summary>
+        public IntPtr CapabilitiesPtr => this.capabilitiesPtr;
+
+        /// <summary>
+        /// Gets the number of capability entries.
+        /// </summary>
+        public int CapabilityCount { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the directory the child process should use as TEMP/TMP, if any.
+        /// </summary>
+        public string? TempDirectoryOverride { get; set; }
+
+        /// <summary>
+        /// Gets or sets the runtime directory to pass to the child as DALAMUD_RUNTIME.
+        /// Set in sandbox mode so Dalamud.Boot doesn't have to resolve it through the shell APIs.
+        /// </summary>
+        public string? RuntimeDirectoryOverride { get; set; }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (this.capabilitiesPtr != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(this.capabilitiesPtr);
+                this.capabilitiesPtr = IntPtr.Zero;
+            }
+
+            foreach (var (ptr, isFreeSid) in this.ownedSids)
+            {
+                if (isFreeSid)
+                    AppContainerHelper.PInvoke.FreeSid(ptr);
+                else
+                    AppContainerHelper.PInvoke.LocalFree(ptr);
+            }
+
+            this.ownedSids.Clear();
+            this.ContainerSid = IntPtr.Zero;
+        }
+
+        /// <summary>
+        /// Set the container SID pointer owned by this context.
+        /// </summary>
+        /// <param name="sid">The SID, allocated by the profile APIs (freed with FreeSid).</param>
+        internal void SetContainerSid(IntPtr sid)
+        {
+            this.ContainerSid = sid;
+            this.ownedSids.Add((sid, true));
+            this.ContainerSidString = AppContainerHelper.SidToString(sid);
+        }
+
+        /// <summary>
+        /// Take ownership of capability SID.
+        /// </summary>
+        /// <param name="sid">The SID.</param>
+        /// <param name="isFreeSid">Whether it must be freed with FreeSid (true) or LocalFree (false).</param>
+        internal void AddOwnedSid(IntPtr sid, bool isFreeSid) => this.ownedSids.Add((sid, isFreeSid));
+
+        /// <summary>
+        /// Convert the given capability SIDs into a native SID_AND_ATTRIBUTES array.
+        /// </summary>
+        /// <param name="capabilitySids">The capability SIDs, already owned by this context.</param>
+        internal void BuildCapabilityArray(IReadOnlyList<IntPtr> capabilitySids)
+        {
+            this.CapabilityCount = capabilitySids.Count;
+            if (this.CapabilityCount == 0)
+                return;
+
+            var entrySize = Marshal.SizeOf<AppContainerHelper.PInvoke.SID_AND_ATTRIBUTES>();
+            this.capabilitiesPtr = Marshal.AllocHGlobal(entrySize * this.CapabilityCount);
+            for (var i = 0; i < this.CapabilityCount; i++)
+            {
+                var entry = new AppContainerHelper.PInvoke.SID_AND_ATTRIBUTES
+                {
+                    Sid = capabilitySids[i],
+                    Attributes = AppContainerHelper.PInvoke.SE_GROUP_ENABLED,
+                };
+                Marshal.StructureToPtr(entry, this.capabilitiesPtr + (i * entrySize), false);
+            }
+        }
+    }
+}

--- a/Dalamud.Injector/GameStart.cs
+++ b/Dalamud.Injector/GameStart.cs
@@ -25,10 +25,11 @@ namespace Dalamud.Injector
         /// <param name="dontFixAcl">Don't actually fix the ACL.</param>
         /// <param name="beforeResume">Action to execute before the process is started.</param>
         /// <param name="waitForGameWindow">Wait for the game window to be ready before proceeding.</param>
+        /// <param name="appContainer">If set, launch the process inside this AppContainer.</param>
         /// <returns>The started process.</returns>
         /// <exception cref="Win32Exception">Thrown when a win32 error occurs.</exception>
         /// <exception cref="GameStartException">Thrown when the process did not start correctly.</exception>
-        public static Process LaunchGame(string workingDir, string exePath, string arguments, bool dontFixAcl, Action<Process> beforeResume, bool waitForGameWindow = true)
+        public static Process LaunchGame(string workingDir, string exePath, string arguments, bool dontFixAcl, Action<Process> beforeResume, bool waitForGameWindow = true, AppContainerLaunchContext? appContainer = null)
         {
             Process? process = null;
 
@@ -74,11 +75,6 @@ namespace Dalamud.Injector
                     bInheritHandle = false,
                 };
 
-                var lpStartupInfo = new PInvoke.STARTUPINFO
-                {
-                    cb = Marshal.SizeOf<PInvoke.STARTUPINFO>(),
-                };
-
                 var compatLayerPrev = Environment.GetEnvironmentVariable("__COMPAT_LAYER");
 
                 if (!string.IsNullOrEmpty(compatLayerPrev) && !compatLayerPrev.Contains("RunAsInvoker"))
@@ -90,9 +86,88 @@ namespace Dalamud.Injector
                     Environment.SetEnvironmentVariable("__COMPAT_LAYER", "RunAsInvoker");
                 }
 
+                // If we have an app container, we override TEMP and TMP because the regular windows temp folder
+                // is unsafe to grant
+                var tempPrev = Environment.GetEnvironmentVariable("TEMP");
+                var tmpPrev = Environment.GetEnvironmentVariable("TMP");
+                var tempOverride = appContainer?.TempDirectoryOverride;
+                if (tempOverride != null)
+                {
+                    Environment.SetEnvironmentVariable("TEMP", tempOverride);
+                    Environment.SetEnvironmentVariable("TMP", tempOverride);
+                }
+
+                var runtimePrev = Environment.GetEnvironmentVariable("DALAMUD_RUNTIME");
+                var runtimeOverride = appContainer?.RuntimeDirectoryOverride;
+                if (runtimeOverride != null)
+                    Environment.SetEnvironmentVariable("DALAMUD_RUNTIME", runtimeOverride);
+
+                var attributeList = IntPtr.Zero;
+                var securityCapabilitiesPtr = IntPtr.Zero;
                 try
                 {
-                    if (!PInvoke.CreateProcess(
+                    bool created;
+                    if (appContainer != null)
+                    {
+                        var attributeListSize = IntPtr.Zero;
+                        PInvoke.InitializeProcThreadAttributeList(IntPtr.Zero, 1, 0, ref attributeListSize);
+                        attributeList = Marshal.AllocHGlobal(attributeListSize);
+                        if (!PInvoke.InitializeProcThreadAttributeList(attributeList, 1, 0, ref attributeListSize))
+                        {
+                            throw new Win32Exception(Marshal.GetLastWin32Error());
+                        }
+
+                        var securityCapabilities = new PInvoke.SECURITY_CAPABILITIES
+                        {
+                            AppContainerSid = appContainer.ContainerSid,
+                            Capabilities = appContainer.CapabilitiesPtr,
+                            CapabilityCount = (uint)appContainer.CapabilityCount,
+                            Reserved = 0,
+                        };
+                        securityCapabilitiesPtr = Marshal.AllocHGlobal(Marshal.SizeOf<PInvoke.SECURITY_CAPABILITIES>());
+                        Marshal.StructureToPtr(securityCapabilities, securityCapabilitiesPtr, false);
+
+                        if (!PInvoke.UpdateProcThreadAttribute(
+                                attributeList,
+                                0,
+                                (IntPtr)PInvoke.PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES,
+                                securityCapabilitiesPtr,
+                                (IntPtr)Marshal.SizeOf<PInvoke.SECURITY_CAPABILITIES>(),
+                                IntPtr.Zero,
+                                IntPtr.Zero))
+                        {
+                            throw new Win32Exception(Marshal.GetLastWin32Error());
+                        }
+
+                        var lpStartupInfoEx = new PInvoke.STARTUPINFOEX
+                        {
+                            StartupInfo = new PInvoke.STARTUPINFO
+                            {
+                                cb = Marshal.SizeOf<PInvoke.STARTUPINFOEX>(),
+                            },
+                            lpAttributeList = attributeList,
+                        };
+
+                        created = PInvoke.CreateProcess(
+                            null,
+                            $"\"{exePath}\" {arguments}",
+                            ref lpProcessAttributes,
+                            IntPtr.Zero,
+                            false,
+                            PInvoke.CREATE_SUSPENDED | PInvoke.EXTENDED_STARTUPINFO_PRESENT,
+                            IntPtr.Zero,
+                            workingDir,
+                            ref lpStartupInfoEx,
+                            out lpProcessInformation);
+                    }
+                    else
+                    {
+                        var lpStartupInfo = new PInvoke.STARTUPINFO
+                        {
+                            cb = Marshal.SizeOf<PInvoke.STARTUPINFO>(),
+                        };
+
+                        created = PInvoke.CreateProcess(
                             null,
                             $"\"{exePath}\" {arguments}",
                             ref lpProcessAttributes,
@@ -102,7 +177,10 @@ namespace Dalamud.Injector
                             IntPtr.Zero,
                             workingDir,
                             ref lpStartupInfo,
-                            out lpProcessInformation))
+                            out lpProcessInformation);
+                    }
+
+                    if (!created)
                     {
                         throw new Win32Exception(Marshal.GetLastWin32Error());
                     }
@@ -110,6 +188,23 @@ namespace Dalamud.Injector
                 finally
                 {
                     Environment.SetEnvironmentVariable("__COMPAT_LAYER", compatLayerPrev);
+                    if (tempOverride != null)
+                    {
+                        Environment.SetEnvironmentVariable("TEMP", tempPrev);
+                        Environment.SetEnvironmentVariable("TMP", tmpPrev);
+                    }
+
+                    if (runtimeOverride != null)
+                        Environment.SetEnvironmentVariable("DALAMUD_RUNTIME", runtimePrev);
+
+                    if (attributeList != IntPtr.Zero)
+                    {
+                        PInvoke.DeleteProcThreadAttributeList(attributeList);
+                        Marshal.FreeHGlobal(attributeList);
+                    }
+
+                    if (securityCapabilitiesPtr != IntPtr.Zero)
+                        Marshal.FreeHGlobal(securityCapabilitiesPtr);
                 }
 
                 if (!dontFixAcl)
@@ -359,6 +454,10 @@ namespace Dalamud.Injector
             public const UInt32 SECURITY_DESCRIPTOR_REVISION = 1;
 
             public const UInt32 CREATE_SUSPENDED = 0x00000004;
+            public const UInt32 EXTENDED_STARTUPINFO_PRESENT = 0x00080000;
+
+            // ProcThreadAttributeValue(ProcThreadAttributeSecurityCapabilities = 9, FALSE, TRUE, FALSE)
+            public const UInt32 PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES = 0x00020009;
 
             public const UInt32 TOKEN_QUERY = 0x0008;
             public const UInt32 TOKEN_ADJUST_PRIVILEGES = 0x0020;
@@ -479,6 +578,39 @@ namespace Dalamud.Injector
                string lpCurrentDirectory,
                [In] ref STARTUPINFO lpStartupInfo,
                out PROCESS_INFORMATION lpProcessInformation);
+
+            [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+            public static extern bool CreateProcess(
+               string? lpApplicationName,
+               string? lpCommandLine,
+               ref SECURITY_ATTRIBUTES lpProcessAttributes,
+               IntPtr lpThreadAttributes,
+               bool bInheritHandles,
+               UInt32 dwCreationFlags,
+               IntPtr lpEnvironment,
+               string lpCurrentDirectory,
+               [In] ref STARTUPINFOEX lpStartupInfo,
+               out PROCESS_INFORMATION lpProcessInformation);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            public static extern bool InitializeProcThreadAttributeList(
+                IntPtr lpAttributeList,
+                int dwAttributeCount,
+                int dwFlags,
+                ref IntPtr lpSize);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            public static extern bool UpdateProcThreadAttribute(
+                IntPtr lpAttributeList,
+                uint dwFlags,
+                IntPtr attribute,
+                IntPtr lpValue,
+                IntPtr cbSize,
+                IntPtr lpPreviousValue,
+                IntPtr lpReturnSize);
+
+            [DllImport("kernel32.dll")]
+            public static extern void DeleteProcThreadAttributeList(IntPtr lpAttributeList);
 
             [DllImport("kernel32.dll", SetLastError = true)]
             public static extern bool CloseHandle(IntPtr hObject);
@@ -625,6 +757,22 @@ namespace Dalamud.Injector
                 public IntPtr hStdInput;
                 public IntPtr hStdOutput;
                 public IntPtr hStdError;
+            }
+
+            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+            public struct STARTUPINFOEX
+            {
+                public STARTUPINFO StartupInfo;
+                public IntPtr lpAttributeList;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct SECURITY_CAPABILITIES
+            {
+                public IntPtr AppContainerSid;
+                public IntPtr Capabilities;
+                public UInt32 CapabilityCount;
+                public UInt32 Reserved;
             }
 
             [StructLayout(LayoutKind.Sequential)]

--- a/Dalamud.Injector/GrantResult.cs
+++ b/Dalamud.Injector/GrantResult.cs
@@ -1,0 +1,23 @@
+namespace Dalamud.Injector
+{
+    /// <summary>
+    /// Outcome of ensuring an AppContainer has access to a path.
+    /// </summary>
+    public enum GrantResult
+    {
+        /// <summary>
+        /// The container already held the requested access. The DACL wasn't modified.
+        /// </summary>
+        AlreadyGranted,
+
+        /// <summary>
+        /// The access was granted by writing the DACL.
+        /// </summary>
+        Granted,
+
+        /// <summary>
+        /// The DACL could not be written.
+        /// </summary>
+        AccessDenied,
+    }
+}

--- a/Dalamud.Injector/Program.cs
+++ b/Dalamud.Injector/Program.cs
@@ -535,11 +535,12 @@ namespace Dalamud.Injector
             if (particularCommand is null or "sandbox-prepare")
             {
                 Console.WriteLine("{0} sandbox-prepare [-h/--help] [-g path/to/ffxiv_dx11.exe] [--game=path/to/ffxiv_dx11.exe]", exeName);
-                Console.WriteLine("{0}                 [--sandbox-config=path/to/dalamudSandbox.json]", exeSpaces);
+                Console.WriteLine("{0}                 [--sandbox-config=path/to/dalamudSandbox.json] [--write-config]", exeSpaces);
                 Console.WriteLine("{0}   Prepares the environment to properly run with --sandbox. Run once from an", exeSpaces);
                 Console.WriteLine("{0}   elevated command prompt. Paths you don't own and the loopback excemption require running with this at least once.", exeSpaces);
-                Console.WriteLine("{0}   Sandboxing applies to every launch when \"enabled\" is set in the sandbox configuration.", exeSpaces);
+                Console.WriteLine("{0}   Sandboxing applies to every launch when \"enabledGlobally\" is set in the sandbox configuration.", exeSpaces);
                 Console.WriteLine("{0}   --no-sandbox opts a single launch out of that.", exeSpaces);
+                Console.WriteLine("{0}   --write-config creates a configuration at the default location, if there isn't one yet.", exeSpaces);
             }
 
             Console.WriteLine("Specifying dalamud start info: [--dalamud-working-directory=path] [--dalamud-configuration-path=path]");
@@ -1174,6 +1175,7 @@ namespace Dalamud.Injector
             string? gamePath = null;
             string? sandboxConfigPath = null;
             var showHelp = false;
+            var writeConfig = false;
 
             for (var i = 2; i < args.Count; i++)
             {
@@ -1185,6 +1187,8 @@ namespace Dalamud.Injector
                     gamePath = args[i].Split('=', 2)[1];
                 else if (args[i].StartsWith("--sandbox-config="))
                     sandboxConfigPath = args[i].Split('=', 2)[1];
+                else if (args[i] == "--write-config")
+                    writeConfig = true;
                 else
                     Log.Warning($"\"{args[i]}\" is not a valid command line argument, ignoring.");
             }
@@ -1211,6 +1215,21 @@ namespace Dalamud.Injector
             var config = SandboxConfiguration.Load(
                 sandboxConfigPath ?? SandboxConfiguration.DefaultPath,
                 sandboxConfigPath != null);
+
+            if (writeConfig)
+            {
+                if (config.TryWrite(SandboxConfiguration.DefaultPath))
+                {
+                    Log.Information("Wrote a sandbox configuration to {Path}", SandboxConfiguration.DefaultPath);
+                }
+                else
+                {
+                    Log.Warning(
+                        "Not writing a sandbox configuration, {Path} already exists. Delete it first if you want a fresh one.",
+                        SandboxConfiguration.DefaultPath);
+                }
+            }
+
             var layout = BuildSandboxLayout(startInfo, config, gamePath);
 
             using var ctx = AppContainerHelper.CreateContext(
@@ -1248,7 +1267,7 @@ namespace Dalamud.Injector
             {
                 Log.Information(
                     "Launches that don't pass --sandbox will still be unsandboxed. Set \"enabledGlobally\": true in {Path} to sandbox every launch.",
-                    sandboxConfigPath ?? SandboxConfiguration.DefaultPath);
+                    SandboxConfiguration.DefaultPath);
             }
 
             return 0;

--- a/Dalamud.Injector/Program.cs
+++ b/Dalamud.Injector/Program.cs
@@ -1041,6 +1041,9 @@ namespace Dalamud.Injector
             Add(startInfo.AssetDirectory, AppContainerHelper.AccessReadExecute);
 
             // Modify for state
+            if (!string.IsNullOrEmpty(startInfo.AssetDirectory))
+                Add(Path.Combine(startInfo.AssetDirectory, "..", "local"),  AppContainerHelper.AccessModify, true);
+
             Add(startInfo.PluginDirectory, AppContainerHelper.AccessModify, true);
             Add(dataDir, AppContainerHelper.AccessModify);
             Add(Path.GetDirectoryName(startInfo.ConfigurationPath!), AppContainerHelper.AccessModify);

--- a/Dalamud.Injector/Program.cs
+++ b/Dalamud.Injector/Program.cs
@@ -528,7 +528,7 @@ namespace Dalamud.Injector
                 Console.WriteLine("{0}        [--handle-owner=inherited-handle-value]", exeSpaces);
                 Console.WriteLine("{0}        [--without-dalamud] [--no-fix-acl]", exeSpaces);
                 Console.WriteLine("{0}        [--no-wait]", exeSpaces);
-                Console.WriteLine("{0}        [--sandbox] [--sandbox-config=path/to/dalamudSandbox.json]", exeSpaces);
+                Console.WriteLine("{0}        [--sandbox] [--no-sandbox] [--sandbox-config=path/to/dalamudSandbox.json]", exeSpaces);
                 Console.WriteLine("{0}        [-- game_arg1=value1 game_arg2=value2 ...]", exeSpaces);
             }
 
@@ -538,6 +538,8 @@ namespace Dalamud.Injector
                 Console.WriteLine("{0}                 [--sandbox-config=path/to/dalamudSandbox.json]", exeSpaces);
                 Console.WriteLine("{0}   Prepares the environment to properly run with --sandbox. Run once from an", exeSpaces);
                 Console.WriteLine("{0}   elevated command prompt. Paths you don't own and the loopback excemption require running with this at least once.", exeSpaces);
+                Console.WriteLine("{0}   Sandboxing applies to every launch when \"enabled\" is set in the sandbox configuration.", exeSpaces);
+                Console.WriteLine("{0}   --no-sandbox opts a single launch out of that.", exeSpaces);
             }
 
             Console.WriteLine("Specifying dalamud start info: [--dalamud-working-directory=path] [--dalamud-configuration-path=path]");
@@ -679,7 +681,9 @@ namespace Dalamud.Injector
             var noFixAcl = false;
             var waitForGameWindow = true;
             var encryptArguments = false;
-            var useSandbox = false;
+
+            // null = not specified on command line, use config
+            bool? useSandbox = null;
             string? sandboxConfigPath = null;
 
             var parsingGameArgument = false;
@@ -715,9 +719,14 @@ namespace Dalamud.Injector
                 {
                     useSandbox = true;
                 }
+                else if (args[i] == "--no-sandbox")
+                {
+                    useSandbox = false;
+                }
                 else if (args[i].StartsWith("--sandbox-config="))
                 {
-                    useSandbox = true;
+                    // When using --sandbox-config assume sandboxing, but never when --no-sandbox
+                    useSandbox ??= true;
                     sandboxConfigPath = args[i].Split('=', 2)[1];
                 }
                 else if (args[i] == "-g")
@@ -895,8 +904,18 @@ namespace Dalamud.Injector
             }
 
             AppContainerLaunchContext? sandboxContext = null;
-            if (useSandbox)
-                sandboxContext = SetupSandbox(dalamudStartInfo, sandboxConfigPath, gamePath);
+            if (useSandbox != false)
+            {
+                var sandboxConfig = SandboxConfiguration.Load(
+                    sandboxConfigPath ?? SandboxConfiguration.DefaultPath,
+                    sandboxConfigPath != null);
+
+                if (useSandbox != true && sandboxConfig.EnabledGlobally)
+                    Log.Information("[SANDBOX] Enabled by configuration at '{DefaultConfigPath}'. Pass --no-sandbox to disable.", SandboxConfiguration.DefaultPath);
+
+                if (useSandbox == true || sandboxConfig.EnabledGlobally)
+                    sandboxContext = SetupSandbox(dalamudStartInfo, sandboxConfig, gamePath);
+            }
 
             Process process;
             try
@@ -962,12 +981,10 @@ namespace Dalamud.Injector
         /// <summary>
         /// Prepare the AppContainer sandbox by loading the config and changing/migrating paths as necessary.
         /// </summary>
-        private static SandboxLayout BuildSandboxLayout(DalamudStartInfo startInfo, string? sandboxConfigPath, string gamePath)
+        private static SandboxLayout BuildSandboxLayout(DalamudStartInfo startInfo, SandboxConfiguration config, string gamePath)
         {
             var appDataDir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             var xivlauncherDir = Path.Combine(appDataDir, "XIVLauncher");
-
-            var config = SandboxConfiguration.Load(sandboxConfigPath ?? Path.Combine(xivlauncherDir, "dalamudSandbox.json"));
 
             // XL root must never be readable or writable from the sandbox, so we need to move all data
             // into a subfolder that we can grant access to
@@ -1107,15 +1124,15 @@ namespace Dalamud.Injector
             return denied;
         }
 
-        private static AppContainerLaunchContext? SetupSandbox(DalamudStartInfo startInfo, string? sandboxConfigPath, string gamePath)
+        private static AppContainerLaunchContext? SetupSandbox(DalamudStartInfo startInfo, SandboxConfiguration config, string gamePath)
         {
             if (startInfo.Platform != OSPlatform.Windows)
             {
-                Log.Warning("[SANDBOX] AppContainer sandboxing is only supported on Windows, ignoring --sandbox");
+                Log.Warning("[SANDBOX] AppContainer sandboxing is only supported on Windows, launching without a sandbox");
                 return null;
             }
 
-            var layout = BuildSandboxLayout(startInfo, sandboxConfigPath, gamePath);
+            var layout = BuildSandboxLayout(startInfo, config, gamePath);
 
             var ctx = AppContainerHelper.CreateContext(
                 layout.Config.ContainerName,
@@ -1191,7 +1208,10 @@ namespace Dalamud.Injector
             var elevated = AppContainerHelper.IsElevated();
             Log.Information("Running {Elevated}elevated.", elevated ? string.Empty : "un");
 
-            var layout = BuildSandboxLayout(startInfo, sandboxConfigPath, gamePath);
+            var config = SandboxConfiguration.Load(
+                sandboxConfigPath ?? SandboxConfiguration.DefaultPath,
+                sandboxConfigPath != null);
+            var layout = BuildSandboxLayout(startInfo, config, gamePath);
 
             using var ctx = AppContainerHelper.CreateContext(
                 layout.Config.ContainerName,
@@ -1223,6 +1243,14 @@ namespace Dalamud.Injector
             }
 
             Log.Information("Sandbox preparation complete! You can now launch with --sandbox (no elevation needed).");
+
+            if (!config.EnabledGlobally)
+            {
+                Log.Information(
+                    "Launches that don't pass --sandbox will still be unsandboxed. Set \"enabledGlobally\": true in {Path} to sandbox every launch.",
+                    sandboxConfigPath ?? SandboxConfiguration.DefaultPath);
+            }
+
             return 0;
         }
 

--- a/Dalamud.Injector/Program.cs
+++ b/Dalamud.Injector/Program.cs
@@ -42,6 +42,7 @@ namespace Dalamud.Injector
 
                 Init(args);
                 args.Remove("-v"); // Remove "verbose" flag
+                args.Remove("--verbose");
 
                 if (args.Count >= 2 && args[1].ToLowerInvariant() == "launch-test")
                 {
@@ -136,7 +137,7 @@ namespace Dalamud.Injector
 
         private static void Init(List<string> args)
         {
-            InitLogging(args.Any(x => x == "-v"), args);
+            InitLogging(args.Any(x => x is "-v" or "--verbose"), args);
             InitUnhandledException(args);
 
             var cwd = new FileInfo(Assembly.GetExecutingAssembly().Location).Directory
@@ -1137,6 +1138,8 @@ namespace Dalamud.Injector
             }
 
             var layout = BuildSandboxLayout(startInfo, config, gamePath);
+
+            Log.Verbose("[SANDBOX] Using sandbox layout: {Layout}", JsonConvert.SerializeObject(layout));
 
             var ctx = AppContainerHelper.CreateContext(
                 layout.Config.ContainerName,

--- a/Dalamud.Injector/Program.cs
+++ b/Dalamud.Injector/Program.cs
@@ -90,7 +90,11 @@ namespace Dalamud.Injector
                 args.Remove("--crash-handler-console");
 
                 var mainCommand = args[1].ToLowerInvariant();
-                if (mainCommand.Length > 0 && mainCommand.Length <= 6 && "inject"[..mainCommand.Length] == mainCommand)
+                if (mainCommand == "sandbox-prepare")
+                {
+                    return ProcessSandboxPrepareCommand(args, startInfo);
+                }
+                else if (mainCommand.Length > 0 && mainCommand.Length <= 6 && "inject"[..mainCommand.Length] == mainCommand)
                 {
                     return ProcessInjectCommand(args, startInfo);
                 }
@@ -473,6 +477,7 @@ namespace Dalamud.Injector
                 "symbol_load_patches",
                 "disable_game_debugging_protection",
                 "faster_decompression",
+                "appcontainer_known_folders",
             };
             startInfo.BootDotnetOpenProcessHookMode = 0;
             startInfo.BootWaitMessageBox |= args.Contains("--msgbox1") ? 1 : 0;
@@ -523,7 +528,16 @@ namespace Dalamud.Injector
                 Console.WriteLine("{0}        [--handle-owner=inherited-handle-value]", exeSpaces);
                 Console.WriteLine("{0}        [--without-dalamud] [--no-fix-acl]", exeSpaces);
                 Console.WriteLine("{0}        [--no-wait]", exeSpaces);
+                Console.WriteLine("{0}        [--sandbox] [--sandbox-config=path/to/dalamudSandbox.json]", exeSpaces);
                 Console.WriteLine("{0}        [-- game_arg1=value1 game_arg2=value2 ...]", exeSpaces);
+            }
+
+            if (particularCommand is null or "sandbox-prepare")
+            {
+                Console.WriteLine("{0} sandbox-prepare [-h/--help] [-g path/to/ffxiv_dx11.exe] [--game=path/to/ffxiv_dx11.exe]", exeName);
+                Console.WriteLine("{0}                 [--sandbox-config=path/to/dalamudSandbox.json]", exeSpaces);
+                Console.WriteLine("{0}   Prepares the environment to properly run with --sandbox. Run once from an", exeSpaces);
+                Console.WriteLine("{0}   elevated command prompt. Paths you don't own and the loopback excemption require running with this at least once.", exeSpaces);
             }
 
             Console.WriteLine("Specifying dalamud start info: [--dalamud-working-directory=path] [--dalamud-configuration-path=path]");
@@ -665,6 +679,8 @@ namespace Dalamud.Injector
             var noFixAcl = false;
             var waitForGameWindow = true;
             var encryptArguments = false;
+            var useSandbox = false;
+            string? sandboxConfigPath = null;
 
             var parsingGameArgument = false;
             for (var i = 2; i < args.Count; i++)
@@ -694,6 +710,15 @@ namespace Dalamud.Injector
                 else if (args[i] == "--no-fix-acl" || args[i] == "--no-acl-fix")
                 {
                     noFixAcl = true;
+                }
+                else if (args[i] == "--sandbox")
+                {
+                    useSandbox = true;
+                }
+                else if (args[i].StartsWith("--sandbox-config="))
+                {
+                    useSandbox = true;
+                    sandboxConfigPath = args[i].Split('=', 2)[1];
                 }
                 else if (args[i] == "-g")
                 {
@@ -800,50 +825,9 @@ namespace Dalamud.Injector
 
             if (gamePath == null)
             {
-                try
-                {
-                    if (dalamudStartInfo.Platform == OSPlatform.Windows)
-                    {
-                        gamePath = FindGamePathFromLauncherConfig();
-                        Log.Information("Using game installation path configuration from from XIVLauncher: {0}", gamePath);
-                    }
-                    else if (dalamudStartInfo.Platform == OSPlatform.Linux)
-                    {
-                        var homeDir = $"Z:\\home\\{Environment.UserName}";
-                        var xivlauncherDir = Path.Combine(homeDir, ".xlcore");
-                        var launcherConfigPath = Path.Combine(xivlauncherDir, "launcher.ini");
-                        var config = File.ReadAllLines(launcherConfigPath)
-                            .Where(line => line.Contains('='))
-                            .ToDictionary(line => line.Split('=')[0], line => line.Split('=')[1]);
-                        gamePath = Path.Combine("Z:" + config["GamePath"].Replace('/', '\\'), "game", "ffxiv_dx11.exe");
-                        Log.Information("Using game installation path configuration from from XIVLauncher Core: {0}", gamePath);
-                    }
-                    else
-                    {
-                        var homeDir = $"Z:\\Users\\{Environment.UserName}";
-                        var xomlauncherDir = Path.Combine(homeDir, "Library", "Application Support", "XIV on Mac");
-                        // we could try to parse the binary plist file here if we really wanted to...
-                        gamePath = Path.Combine(xomlauncherDir, "ffxiv", "game", "ffxiv_dx11.exe");
-                        Log.Information("Using default game installation path from XOM: {0}", gamePath);
-                    }
-                }
-                catch (Exception)
-                {
-                    Log.Error("Failed to read launcher config to get the set-up game path, please specify one using -g");
-                    return -1;
-                }
-
+                gamePath = ResolveGamePath(dalamudStartInfo);
                 if (gamePath == null)
-                {
-                    Log.Error("Game path not specified and could not be determined from launcher config, please specify one using -g");
                     return -1;
-                }
-
-                if (!File.Exists(gamePath))
-                {
-                    Log.Error("File not found: {0}", gamePath);
-                    return -1;
-                }
             }
 
             if (useFakeArguments)
@@ -910,23 +894,36 @@ namespace Dalamud.Injector
                 gameArgumentString = string.Join(" ", gameArguments.Select(x => EncodeParameterArgument(x)));
             }
 
-            var process = GameStart.LaunchGame(
-                Path.GetDirectoryName(gamePath) ?? throw new DirectoryNotFoundException($"Could not determine parent directory of {gamePath}."),
-                gamePath,
-                gameArgumentString,
-                noFixAcl,
-                p =>
-                {
-                    if (!withoutDalamud && dalamudStartInfo.LoadMethod == LoadMethod.Entrypoint)
+            AppContainerLaunchContext? sandboxContext = null;
+            if (useSandbox)
+                sandboxContext = SetupSandbox(dalamudStartInfo, sandboxConfigPath, gamePath);
+
+            Process process;
+            try
+            {
+                process = GameStart.LaunchGame(
+                    Path.GetDirectoryName(gamePath) ?? throw new DirectoryNotFoundException($"Could not determine parent directory of {gamePath}."),
+                    gamePath,
+                    gameArgumentString,
+                    noFixAcl,
+                    p =>
                     {
-                        var startInfo = AdjustStartInfo(dalamudStartInfo, gamePath);
-                        Log.Information("Using start info: {0}", JsonConvert.SerializeObject(startInfo));
-                        Marshal.ThrowExceptionForHR(
-                            RewriteRemoteEntryPointW(p.Handle, gamePath, JsonConvert.SerializeObject(startInfo)));
-                        Log.Verbose("RewriteRemoteEntryPointW called!");
-                    }
-                },
-                waitForGameWindow);
+                        if (!withoutDalamud && dalamudStartInfo.LoadMethod == LoadMethod.Entrypoint)
+                        {
+                            var startInfo = AdjustStartInfo(dalamudStartInfo, gamePath);
+                            Log.Information("Using start info: {0}", JsonConvert.SerializeObject(startInfo));
+                            Marshal.ThrowExceptionForHR(
+                                RewriteRemoteEntryPointW(p.Handle, gamePath, JsonConvert.SerializeObject(startInfo)));
+                            Log.Verbose("RewriteRemoteEntryPointW called!");
+                        }
+                    },
+                    waitForGameWindow,
+                    sandboxContext);
+            }
+            finally
+            {
+                sandboxContext?.Dispose();
+            }
 
             Log.Verbose("Game process started with PID {0}", process.Id);
 
@@ -960,6 +957,393 @@ namespace Dalamud.Injector
 
             Log.CloseAndFlush();
             return 0;
+        }
+
+        /// <summary>
+        /// Prepare the AppContainer sandbox by loading the config and changing/migrating paths as necessary.
+        /// </summary>
+        private static SandboxLayout BuildSandboxLayout(DalamudStartInfo startInfo, string? sandboxConfigPath, string gamePath)
+        {
+            var appDataDir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            var xivlauncherDir = Path.Combine(appDataDir, "XIVLauncher");
+
+            var config = SandboxConfiguration.Load(sandboxConfigPath ?? Path.Combine(xivlauncherDir, "dalamudSandbox.json"));
+
+            // XL root must never be readable or writable from the sandbox, so we need to move all data
+            // into a subfolder that we can grant access to
+            var dataDir = Path.Combine(xivlauncherDir, "dalamudUserData");
+            var logsDir = Path.Combine(dataDir, "logs");
+            var tempDir = Path.Combine(dataDir, "temp");
+            Directory.CreateDirectory(dataDir);
+            Directory.CreateDirectory(logsDir);
+            Directory.CreateDirectory(tempDir);
+
+            var configDir = Path.GetDirectoryName(Path.GetFullPath(startInfo.ConfigurationPath!));
+            if (PathsEqual(configDir, xivlauncherDir))
+            {
+                var configFileName = Path.GetFileName(startInfo.ConfigurationPath!);
+                MigrateFileToSandbox(Path.Combine(xivlauncherDir, configFileName), Path.Combine(dataDir, configFileName));
+                MigrateFileToSandbox(Path.Combine(xivlauncherDir, "dalamudVfs.db"), Path.Combine(dataDir, "dalamudVfs.db"));
+                MigrateFileToSandbox(Path.Combine(xivlauncherDir, "dalamudUI.ini"), Path.Combine(dataDir, "dalamudUI.ini"));
+                MigrateDirectoryToSandbox(Path.Combine(xivlauncherDir, "pluginConfigs"), Path.Combine(dataDir, "pluginConfigs"));
+
+                startInfo.ConfigurationPath = Path.Combine(dataDir, configFileName);
+                Log.Information("[SANDBOX] Redirected configuration path to {Path}", startInfo.ConfigurationPath);
+            }
+
+            if (PathsEqual(startInfo.LogPath, xivlauncherDir) ||
+                IsAtOrUnder(startInfo.LogPath, startInfo.WorkingDirectory))
+            {
+                startInfo.LogPath = logsDir;
+                Log.Information("[SANDBOX] Redirected log path to {Path}", startInfo.LogPath);
+            }
+
+            startInfo.BootLogPath = GetLogPath(startInfo.LogPath, "dalamud.boot", startInfo.LogName);
+
+            var grants = new List<SandboxGrant>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            void Add(string? path, uint access, bool create = false)
+            {
+                if (string.IsNullOrEmpty(path))
+                    return;
+
+                path = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+                if (!seen.Add($"{path}|{access}"))
+                    return;
+
+                grants.Add(new SandboxGrant(path, access, create));
+            }
+
+            // Read/execute for binaries and static data
+            var runtimeDir = Environment.GetEnvironmentVariable("DALAMUD_RUNTIME") ?? Path.Combine(xivlauncherDir, "runtime");
+            Add(Path.GetDirectoryName(gamePath), AppContainerHelper.AccessReadExecute);
+            Add(startInfo.WorkingDirectory, AppContainerHelper.AccessReadExecute);
+            Add(runtimeDir, AppContainerHelper.AccessReadExecute);
+            Add(startInfo.AssetDirectory, AppContainerHelper.AccessReadExecute);
+
+            // Modify for state
+            Add(startInfo.PluginDirectory, AppContainerHelper.AccessModify, true);
+            Add(dataDir, AppContainerHelper.AccessModify);
+            Add(Path.GetDirectoryName(startInfo.ConfigurationPath!), AppContainerHelper.AccessModify);
+            Add(startInfo.LogPath, AppContainerHelper.AccessModify);
+            Add(Path.Combine(xivlauncherDir, "devPlugins"), AppContainerHelper.AccessModify);
+            Add(
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "My Games", "FINAL FANTASY XIV - A Realm Reborn"),
+                AppContainerHelper.AccessModify,
+                true);
+            if (!string.IsNullOrEmpty(startInfo.TempDirectory))
+                Add(startInfo.TempDirectory, AppContainerHelper.AccessModify, true);
+
+            foreach (var allowed in config.AllowedPaths)
+            {
+                Add(
+                    Environment.ExpandEnvironmentVariables(allowed.Path),
+                    allowed.Write ? AppContainerHelper.AccessModify : AppContainerHelper.AccessReadExecute);
+            }
+
+            // Sanity check all grants against folders that we should absolutely never grant modify to
+            foreach (var grant in grants.Where(x => x.Access == AppContainerHelper.AccessModify))
+            {
+                string? violated = null;
+                if (PathsEqual(grant.Path, xivlauncherDir))
+                    violated = "the XIVLauncher root";
+                else if (IsAtOrUnder(grant.Path, startInfo.WorkingDirectory))
+                    violated = "Dalamud's working directory (holds Dalamud's own binaries)";
+                else if (IsAtOrUnder(grant.Path, runtimeDir))
+                    violated = "the .NET runtime directory";
+                else if (IsAtOrUnder(grant.Path, Path.GetDirectoryName(gamePath)))
+                    violated = "the game installation directory";
+
+                if (violated != null)
+                {
+                    throw new CommandLineException(
+                        $"Refusing to grant the sandbox write access to {grant.Path}: it is inside {violated}. " +
+                        "This must stay read-only for the sandbox to be meaningful.");
+                }
+            }
+
+            return new SandboxLayout(config, tempDir, runtimeDir, grants);
+        }
+
+        /// <summary>
+        /// Apply or verify the sandbox layout's grants against the actual container.
+        /// Paths whose DACL could not be written are returned rather than throwing, since we might not
+        /// have permissions to set DACLs on some objects and need to tell the user that elevation is required.
+        /// </summary>
+        private static List<SandboxGrant> ApplySandboxGrants(SandboxLayout layout, AppContainerLaunchContext ctx, bool verbose)
+        {
+            var denied = new List<SandboxGrant>();
+
+            foreach (var grant in layout.Grants)
+            {
+                if (grant.Create)
+                    Directory.CreateDirectory(grant.Path);
+
+                if (!Directory.Exists(grant.Path) && !File.Exists(grant.Path))
+                {
+                    Log.Verbose("[SANDBOX] Skipping nonexistent path {Path}", grant.Path);
+                    continue;
+                }
+
+                var access = grant.Access == AppContainerHelper.AccessModify ? "modify" : "read/execute";
+                switch (AppContainerHelper.EnsureAccess(grant.Path, ctx.ContainerSid, grant.Access))
+                {
+                    case GrantResult.AlreadyGranted:
+                        if (verbose)
+                            Log.Information("[SANDBOX] Already has {Access}: {Path}", access, grant.Path);
+                        break;
+
+                    case GrantResult.Granted:
+                        Log.Information("[SANDBOX] Granted {Access} on {Path}", access, grant.Path);
+                        break;
+
+                    case GrantResult.AccessDenied:
+                        denied.Add(grant);
+                        break;
+                }
+            }
+
+            return denied;
+        }
+
+        private static AppContainerLaunchContext? SetupSandbox(DalamudStartInfo startInfo, string? sandboxConfigPath, string gamePath)
+        {
+            if (startInfo.Platform != OSPlatform.Windows)
+            {
+                Log.Warning("[SANDBOX] AppContainer sandboxing is only supported on Windows, ignoring --sandbox");
+                return null;
+            }
+
+            var layout = BuildSandboxLayout(startInfo, sandboxConfigPath, gamePath);
+
+            var ctx = AppContainerHelper.CreateContext(
+                layout.Config.ContainerName,
+                "Dalamud",
+                "FFXIV running under Dalamud's AppContainer sandbox",
+                layout.Config.Capabilities);
+
+            try
+            {
+                ctx.TempDirectoryOverride = layout.TempDirectory;
+                ctx.RuntimeDirectoryOverride = layout.RuntimeDirectory;
+                Log.Information("[SANDBOX] Using AppContainer {Name} ({Sid})", layout.Config.ContainerName, ctx.ContainerSidString);
+
+                var denied = ApplySandboxGrants(layout, ctx, false);
+                if (denied.Count > 0)
+                {
+                    throw new SandboxPreparationRequiredException(
+                        denied.Select(x => x.Path).ToList(),
+                        layout.Config.ContainerName);
+                }
+
+                if (layout.Config.LoopbackExempt)
+                    AppContainerHelper.TryAddLoopbackExemption(ctx);
+
+                return ctx;
+            }
+            catch
+            {
+                ctx.Dispose();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Prepares persistent filesystem ACLs and the loopback excemption, if necessary.
+        /// </summary>
+        private static int ProcessSandboxPrepareCommand(List<string> args, DalamudStartInfo startInfo)
+        {
+            string? gamePath = null;
+            string? sandboxConfigPath = null;
+            var showHelp = false;
+
+            for (var i = 2; i < args.Count; i++)
+            {
+                if (args[i] == "-h" || args[i] == "--help")
+                    showHelp = true;
+                else if (args[i] == "-g")
+                    gamePath = args[++i];
+                else if (args[i].StartsWith("--game="))
+                    gamePath = args[i].Split('=', 2)[1];
+                else if (args[i].StartsWith("--sandbox-config="))
+                    sandboxConfigPath = args[i].Split('=', 2)[1];
+                else
+                    Log.Warning($"\"{args[i]}\" is not a valid command line argument, ignoring.");
+            }
+
+            if (showHelp)
+            {
+                ProcessHelpCommand(args, "sandbox-prepare");
+                return 0;
+            }
+
+            if (startInfo.Platform != OSPlatform.Windows)
+            {
+                Log.Error("AppContainer sandboxing is only supported on Windows.");
+                return -1;
+            }
+
+            gamePath ??= ResolveGamePath(startInfo);
+            if (gamePath == null)
+                return -1;
+
+            var elevated = AppContainerHelper.IsElevated();
+            Log.Information("Running {Elevated}elevated.", elevated ? string.Empty : "un");
+
+            var layout = BuildSandboxLayout(startInfo, sandboxConfigPath, gamePath);
+
+            using var ctx = AppContainerHelper.CreateContext(
+                layout.Config.ContainerName,
+                "Dalamud",
+                "FFXIV running under Dalamud's AppContainer sandbox",
+                layout.Config.Capabilities);
+
+            Log.Information(
+                "[SANDBOX] AppContainer {Name} ({Sid})",
+                layout.Config.ContainerName,
+                ctx.ContainerSidString);
+
+            var denied = ApplySandboxGrants(layout, ctx, true);
+
+            if (layout.Config.LoopbackExempt)
+                AppContainerHelper.TryAddLoopbackExemption(ctx);
+
+            if (denied.Count > 0)
+            {
+                Log.Error(
+                    "Could not write the DACL on {Count} path(s):{Paths}",
+                    denied.Count,
+                    string.Concat(denied.Select(x => $"{Environment.NewLine}    {x.Path}")));
+                Log.Error(
+                    elevated
+                        ? "This is unexpected while elevated and probably a bug. Check that the paths are not read-only or on a filesystem without ACL support."
+                        : "Re-run this command from an elevated command prompt.");
+                return -1;
+            }
+
+            Log.Information("Sandbox preparation complete! You can now launch with --sandbox (no elevation needed).");
+            return 0;
+        }
+
+        private static bool PathsEqual(string? a, string? b)
+        {
+            if (a == null || b == null)
+                return false;
+
+            return string.Equals(
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(a)),
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(b)),
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsAtOrUnder(string? path, string? ancestor)
+        {
+            if (path == null || ancestor == null)
+                return false;
+
+            if (PathsEqual(path, ancestor))
+                return true;
+
+            var full = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+            var root = Path.TrimEndingDirectorySeparator(Path.GetFullPath(ancestor)) + Path.DirectorySeparatorChar;
+            return full.StartsWith(root, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static void MigrateFileToSandbox(string source, string target)
+        {
+            try
+            {
+                if (!File.Exists(source) || File.Exists(target))
+                    return;
+
+                File.Copy(source, target);
+                Log.Information("[SANDBOX] Migrated {Source} to {Target}", source, target);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[SANDBOX] Could not migrate {Source} to {Target}", source, target);
+            }
+        }
+
+        private static void MigrateDirectoryToSandbox(string source, string target)
+        {
+            try
+            {
+                if (!Directory.Exists(source) || Directory.Exists(target))
+                    return;
+
+                static void CopyRecursively(DirectoryInfo from, DirectoryInfo to)
+                {
+                    foreach (var dir in from.GetDirectories())
+                        CopyRecursively(dir, to.CreateSubdirectory(dir.Name));
+
+                    foreach (var file in from.GetFiles())
+                        file.CopyTo(Path.Combine(to.FullName, file.Name));
+                }
+
+                CopyRecursively(new DirectoryInfo(source), Directory.CreateDirectory(target));
+                Log.Information("[SANDBOX] Migrated {Source} to {Target}", source, target);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[SANDBOX] Could not migrate {Source} to {Target}", source, target);
+            }
+        }
+
+        /// <summary>
+        /// Determine the game path from the platform's launcher configuration.
+        /// Logs and returns null when it could not be determined.
+        /// </summary>
+        private static string? ResolveGamePath(DalamudStartInfo dalamudStartInfo)
+        {
+            string? gamePath;
+            try
+            {
+                if (dalamudStartInfo.Platform == OSPlatform.Windows)
+                {
+                    gamePath = FindGamePathFromLauncherConfig();
+                    Log.Information("Using game installation path configuration from from XIVLauncher: {0}", gamePath);
+                }
+                else if (dalamudStartInfo.Platform == OSPlatform.Linux)
+                {
+                    var homeDir = $"Z:\\home\\{Environment.UserName}";
+                    var xivlauncherDir = Path.Combine(homeDir, ".xlcore");
+                    var launcherConfigPath = Path.Combine(xivlauncherDir, "launcher.ini");
+                    var config = File.ReadAllLines(launcherConfigPath)
+                        .Where(line => line.Contains('='))
+                        .ToDictionary(line => line.Split('=')[0], line => line.Split('=')[1]);
+                    gamePath = Path.Combine("Z:" + config["GamePath"].Replace('/', '\\'), "game", "ffxiv_dx11.exe");
+                    Log.Information("Using game installation path configuration from from XIVLauncher.Core: {0}", gamePath);
+                }
+                else
+                {
+                    var homeDir = $"Z:\\Users\\{Environment.UserName}";
+                    var xomlauncherDir = Path.Combine(homeDir, "Library", "Application Support", "XIV on Mac");
+                    // we could try to parse the binary plist file here if we really wanted to...
+                    gamePath = Path.Combine(xomlauncherDir, "ffxiv", "game", "ffxiv_dx11.exe");
+                    Log.Information("Using default game installation path from XOM: {0}", gamePath);
+                }
+            }
+            catch (Exception)
+            {
+                Log.Error("Failed to read launcher config to get the set-up game path, please specify one using -g");
+                return null;
+            }
+
+            if (gamePath == null)
+            {
+                Log.Error("Game path not specified and could not be determined from launcher config, please specify one using -g");
+                return null;
+            }
+
+            if (!File.Exists(gamePath))
+            {
+                Log.Error("File not found: {0}", gamePath);
+                return null;
+            }
+
+            return gamePath;
         }
 
         private static string? FindGamePathFromLauncherConfig()
@@ -1184,6 +1568,27 @@ namespace Dalamud.Injector
             public CommandLineException(string cause)
                 : base(cause)
             {
+            }
+        }
+
+        private sealed record SandboxGrant(string Path, uint Access, bool Create);
+
+        private sealed record SandboxLayout(SandboxConfiguration Config, string TempDirectory, string RuntimeDirectory, List<SandboxGrant> Grants);
+
+        private sealed class SandboxPreparationRequiredException(List<string> paths, string containerName)
+            : Exception(BuildMessage(paths, containerName))
+        {
+            private static string BuildMessage(List<string> paths, string containerName)
+            {
+                var exeName = Path.GetFileNameWithoutExtension(Environment.ProcessPath) ?? "Dalamud.Injector";
+                var sb = new StringBuilder();
+                sb.AppendLine($"The sandbox ({containerName}) is missing filesystem permissions and they could not be granted:");
+                foreach (var path in paths)
+                    sb.AppendLine($" => {path}");
+                sb.AppendLine();
+                sb.AppendLine("Run this once from an elevated command prompt, then launch normally:");
+                sb.Append($"    {exeName}.exe sandbox-prepare");
+                return sb.ToString();
             }
         }
     }

--- a/Dalamud.Injector/SandboxConfiguration.cs
+++ b/Dalamud.Injector/SandboxConfiguration.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using Newtonsoft.Json;
+using Serilog;
+
+namespace Dalamud.Injector
+{
+    /// <summary>
+    /// User configuration for the AppContainer sandbox, read by the injector before launching the game.
+    /// </summary>
+    internal sealed class SandboxConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the AppContainer profile name.
+        /// </summary>
+        [JsonProperty("containerName")]
+        public string ContainerName { get; set; } = "dalamud.game";
+
+        /// <summary>
+        /// Gets or sets the capabilities granted to the container token.
+        /// </summary>
+        [JsonProperty("capabilities")]
+        public List<string> Capabilities { get; set; } = ["internetClient", "privateNetworkClientServer"];
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the injector should try to allow localhost connections
+        /// for the container.
+        /// </summary>
+        [JsonProperty("loopbackExempt")]
+        public bool LoopbackExempt { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional paths the sandboxed process may access.
+        /// </summary>
+        [JsonProperty("allowedPaths")]
+        public List<SandboxAllowedPath> AllowedPaths { get; set; } = new();
+
+        /// <summary>
+        /// Load a configuration from the given path, falling back to defaults if it doesn't exist or can't be parsed.
+        /// </summary>
+        /// <param name="path">Path to the JSON configuration file.</param>
+        /// <returns>The configuration.</returns>
+        public static SandboxConfiguration Load(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    var loaded = JsonConvert.DeserializeObject<SandboxConfiguration>(File.ReadAllText(path));
+                    if (loaded != null)
+                    {
+                        Log.Information("[SANDBOX] Loaded sandbox configuration from {Path}", path);
+                        return loaded;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[SANDBOX] Could not read sandbox configuration at {Path}, using defaults", path);
+            }
+
+            return new SandboxConfiguration();
+        }
+
+        /// <summary>
+        /// An additional path grant for the sandboxed process.
+        /// </summary>
+        internal sealed class SandboxAllowedPath
+        {
+            /// <summary>
+            /// Gets or sets the path. Environment variables (%VAR%) are expanded.
+            /// </summary>
+            [JsonProperty("path")]
+            public string Path { get; set; } = string.Empty;
+
+            /// <summary>
+            /// Gets or sets a value indicating whether write (modify) access is granted.
+            /// </summary>
+            [JsonProperty("write")]
+            public bool Write { get; set; }
+        }
+    }
+}

--- a/Dalamud.Injector/SandboxConfiguration.cs
+++ b/Dalamud.Injector/SandboxConfiguration.cs
@@ -13,6 +13,22 @@ namespace Dalamud.Injector
     internal sealed class SandboxConfiguration
     {
         /// <summary>
+        /// Gets the default location of the sandbox configuration, read even when no sandbox arguments were
+        /// passed on the command line.
+        /// </summary>
+        public static string DefaultPath => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "XIVLauncher",
+            "dalamudSandbox.json");
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the game should be launched in the sandbox without command line
+        /// arguments.
+        /// </summary>
+        [JsonProperty("enabledGlobally")]
+        public bool EnabledGlobally { get; set; }
+
+        /// <summary>
         /// Gets or sets the AppContainer profile name.
         /// </summary>
         [JsonProperty("containerName")]
@@ -38,30 +54,44 @@ namespace Dalamud.Injector
         public List<SandboxAllowedPath> AllowedPaths { get; set; } = new();
 
         /// <summary>
-        /// Load a configuration from the given path, falling back to defaults if it doesn't exist or can't be parsed.
+        /// Load a configuration from the given path, or defaults if mustExist is false.
         /// </summary>
         /// <param name="path">Path to the JSON configuration file.</param>
+        /// <param name="mustExist">Whether a missing file is an error.</param>
         /// <returns>The configuration.</returns>
-        public static SandboxConfiguration Load(string path)
+        public static SandboxConfiguration Load(string path, bool mustExist)
         {
+            if (!File.Exists(path))
+            {
+                if (mustExist)
+                    throw new FileNotFoundException($"No sandbox configuration at {path}.", path);
+
+                Log.Verbose("[SANDBOX] No sandbox configuration at {Path}, using defaults", path);
+                return new SandboxConfiguration();
+            }
+
+            SandboxConfiguration? loaded;
             try
             {
-                if (File.Exists(path))
-                {
-                    var loaded = JsonConvert.DeserializeObject<SandboxConfiguration>(File.ReadAllText(path));
-                    if (loaded != null)
-                    {
-                        Log.Information("[SANDBOX] Loaded sandbox configuration from {Path}", path);
-                        return loaded;
-                    }
-                }
+                loaded = JsonConvert.DeserializeObject<SandboxConfiguration>(File.ReadAllText(path));
             }
             catch (Exception ex)
             {
-                Log.Warning(ex, "[SANDBOX] Could not read sandbox configuration at {Path}, using defaults", path);
+                throw new InvalidDataException(
+                    $"Could not read the sandbox configuration at {path}. " +
+                    "Fix the file or pass --no-sandbox to launch without a sandbox.",
+                    ex);
             }
 
-            return new SandboxConfiguration();
+            if (loaded == null)
+            {
+                throw new InvalidDataException(
+                    $"The sandbox configuration at {path} is empty. " +
+                    "Fix the file or pass --no-sandbox to launch without a sandbox.");
+            }
+
+            Log.Information("[SANDBOX] Loaded sandbox configuration from {Path}", path);
+            return loaded;
         }
 
         /// <summary>

--- a/Dalamud.Injector/SandboxConfiguration.cs
+++ b/Dalamud.Injector/SandboxConfiguration.cs
@@ -37,7 +37,7 @@ namespace Dalamud.Injector
         /// <summary>
         /// Gets or sets the capabilities granted to the container token.
         /// </summary>
-        [JsonProperty("capabilities")]
+        [JsonProperty("capabilities", ObjectCreationHandling = ObjectCreationHandling.Replace)]
         public List<string> Capabilities { get; set; } = ["internetClient", "privateNetworkClientServer"];
 
         /// <summary>

--- a/Dalamud.Injector/SandboxConfiguration.cs
+++ b/Dalamud.Injector/SandboxConfiguration.cs
@@ -95,6 +95,24 @@ namespace Dalamud.Injector
         }
 
         /// <summary>
+        /// Write this configuration to the given path, unless a file is already there.
+        /// </summary>
+        /// <param name="path">Path to the JSON configuration file to create.</param>
+        /// <returns>Whether the file was written.</returns>
+        public bool TryWrite(string path)
+        {
+            if (File.Exists(path))
+                return false;
+
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+
+            File.WriteAllText(path, JsonConvert.SerializeObject(this, Formatting.Indented));
+            return true;
+        }
+
+        /// <summary>
         /// An additional path grant for the sandboxed process.
         /// </summary>
         internal sealed class SandboxAllowedPath

--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -56,8 +56,30 @@ internal sealed class Dalamud : IServiceType
 
         // Directory resolved signatures(CS, our own) will be cached in
         var cacheDir = new DirectoryInfo(Path.Combine(this.StartInfo.WorkingDirectory!, "cachedSigs"));
-        if (!cacheDir.Exists)
-            cacheDir.Create();
+
+        // When running sandboxed, we can't write to the working dir. Fall back to the config dir.
+        // TODO: Should this be the default?
+        try
+        {
+            if (!cacheDir.Exists)
+                cacheDir.Create();
+        }
+        catch (UnauthorizedAccessException)
+        {
+            var configDir = Path.GetDirectoryName(this.StartInfo.ConfigurationPath!)
+                            ?? throw new DirectoryNotFoundException("Could not determine the configuration directory.");
+            var scope = new DirectoryInfo(this.StartInfo.WorkingDirectory!).Name;
+            var fallbackDir = new DirectoryInfo(Path.Combine(configDir, "cachedSigs", scope));
+
+            Log.Information(
+                "Signature cache directory {Path} is not writable, falling back to {Fallback}",
+                cacheDir.FullName,
+                fallbackDir.FullName);
+
+            cacheDir = fallbackDir;
+            if (!cacheDir.Exists)
+                cacheDir.Create();
+        }
 
         // Set up the SigScanner for our target module
         TargetSigScanner scanner;

--- a/Dalamud/Interface/Internal/DalamudInterface.cs
+++ b/Dalamud/Interface/Internal/DalamudInterface.cs
@@ -756,6 +756,12 @@ internal class DalamudInterface : IInternalDisposableService
     {
         var condition = Service<Condition>.Get();
 
+        var windowPos = ImGui.GetMainViewport().Pos + new Vector2(20);
+
+        using var style = ImRaii.PushStyle(ImGuiStyleVar.WindowPadding, Vector2.Zero);
+        style.Push(ImGuiStyleVar.WindowBorderSize, 0);
+        style.Push(ImGuiStyleVar.FrameBorderSize, 0);
+
         if (!this.isImGuiDrawDevMenu && !condition.Any())
         {
             using var color = ImRaii.PushColor(ImGuiCol.Button, Vector4.Zero);
@@ -766,11 +772,6 @@ internal class DalamudInterface : IInternalDisposableService
             color.Push(ImGuiCol.BorderShadow, new Vector4(0, 0, 0, 1));
             color.Push(ImGuiCol.WindowBg, new Vector4(0, 0, 0, 1));
 
-            using var style = ImRaii.PushStyle(ImGuiStyleVar.WindowPadding, Vector2.Zero);
-            style.Push(ImGuiStyleVar.WindowBorderSize, 0);
-            style.Push(ImGuiStyleVar.FrameBorderSize, 0);
-
-            var windowPos = ImGui.GetMainViewport().Pos + new Vector2(20);
             ImGui.SetNextWindowPos(windowPos, ImGuiCond.Always);
             ImGui.SetNextWindowBgAlpha(1);
 
@@ -782,24 +783,28 @@ internal class DalamudInterface : IInternalDisposableService
             }
 
             ImGui.End();
+        }
 
-            if (EnvironmentConfiguration.DalamudUseSafetyHook)
+        if (EnvironmentConfiguration.DalamudUseSafetyHook || Util.IsAppContainer())
+        {
+            ImGui.SetNextWindowPos(windowPos, ImGuiCond.Always);
+            ImGui.SetNextWindowBgAlpha(1);
+
+            if (ImGui.Begin(
+                    "Disclaimer"u8,
+                    ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoBackground |
+                    ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove |
+                    ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoMouseInputs |
+                    ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoSavedSettings))
             {
-                ImGui.SetNextWindowPos(windowPos, ImGuiCond.Always);
-                ImGui.SetNextWindowBgAlpha(1);
-
-                if (ImGui.Begin(
-                        "Disclaimer"u8,
-                        ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoBackground |
-                        ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove |
-                        ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoMouseInputs |
-                        ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoSavedSettings))
-                {
+                if (EnvironmentConfiguration.DalamudUseSafetyHook)
                     ImGui.TextColoredWrapped(ImGuiColors.AttentionForeground, "sh!"u8);
-                }
 
-                ImGui.End();
+                if (Util.IsAppContainer())
+                    ImGui.TextColoredWrapped(ImGuiColors.AttentionForeground, "ac!"u8);
             }
+
+            ImGui.End();
         }
     }
 

--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -71,6 +71,7 @@ public static partial class Util
 
     private static ulong moduleStartAddr;
     private static ulong moduleEndAddr;
+    private static bool? isAppContainer;
 
     /// <inheritdoc cref="DescribeAddress(nint)"/>
     public static unsafe string DescribeAddress(void* p) => DescribeAddress((nint)p);
@@ -615,6 +616,41 @@ public static partial class Util
             if (i >= 64 || !Path.Exists(tempPath))
                 return tempPath;
         }
+    }
+
+    /// <summary>
+    /// Determine if the current process is running inside an AppContainer sandbox.
+    /// </summary>
+    /// <returns>Returns true if running in an AppContainer.</returns>
+    internal static unsafe bool IsAppContainer()
+    {
+        if (isAppContainer is { } cached)
+            return cached;
+
+        var result = false;
+        HANDLE token;
+        if (TerraFX.Interop.Windows.Windows.OpenProcessToken(
+                TerraFX.Interop.Windows.Windows.GetCurrentProcess(),
+                TOKEN.TOKEN_QUERY,
+                &token))
+        {
+            BOOL value;
+            uint returnLength;
+            if (TerraFX.Interop.Windows.Windows.GetTokenInformation(
+                    token,
+                    TOKEN_INFORMATION_CLASS.TokenIsAppContainer,
+                    &value,
+                    (uint)sizeof(BOOL),
+                    &returnLength))
+            {
+                result = value;
+            }
+
+            TerraFX.Interop.Windows.Windows.CloseHandle(token);
+        }
+
+        isAppContainer = result;
+        return result;
     }
 
     /// <summary>

--- a/lib/CoreCLR/boot.cpp
+++ b/lib/CoreCLR/boot.cpp
@@ -48,7 +48,8 @@ static wchar_t* GetRuntimePath()
     }
 
     // Detect Windows first
-    result = SHGetKnownFolderPath(FOLDERID_RoamingAppData, KF_FLAG_DEFAULT, nullptr, &_appdata);
+    // Doesn't work inside app containers without KF_FLAG_DONT_VERIFY
+    result = SHGetKnownFolderPath(FOLDERID_RoamingAppData, KF_FLAG_DONT_VERIFY, nullptr, &_appdata);
 
     if (result != 0)
     {


### PR DESCRIPTION
Docs page with usage instructions, goals and known issues here: https://github.com/goatcorp/Dalamud/wiki/Sandboxing

Partly based on Mino's original prototypes and the appcontainer notes from Windows Internals 7th edition. This is the most basic thing we can have while still being somewhat effective, or at least as effective as sandboxing on Windows can be without a lot more invasive work.

The non-appcontainer path is completely unmodified and shouldn't behave any differently.