### PR TITLE
Add public gamepad nav toggle to IGamepadState

### DIFF
--- a/Dalamud/Game/ClientState/GamePad/GamepadState.cs
+++ b/Dalamud/Game/ClientState/GamePad/GamepadState.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 
 using Dalamud.Bindings.ImGui;
 using Dalamud.Hooking;
+using Dalamud.Interface.Internal;
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
 using Dalamud.Logging.Internal;
@@ -12,9 +13,7 @@ using FFXIVClientStructs.FFXIV.Client.System.Input;
 namespace Dalamud.Game.ClientState.GamePad;
 
 /// <summary>
-/// Exposes the game gamepad state to dalamud.
-///
-/// Will block game's gamepad input if <see cref="ImGuiConfigFlags.NavEnableGamepad"/> is set.
+/// Exposes the game gamepad state to Dalamud.
 /// </summary>
 [PluginInterface]
 [ServiceManager.EarlyLoadedService]
@@ -25,10 +24,10 @@ internal unsafe class GamepadState : IInternalDisposableService, IGamepadState
 {
     private static readonly ModuleLog Log = ModuleLog.Create<GamepadState>();
 
-    private readonly Hook<PadDevice.Delegates.Poll>? gamepadPoll;
+    [ServiceManager.ServiceDependency]
+    private readonly DalamudInterface dalamudInterface = Service<DalamudInterface>.Get();
 
-    private bool isDisposed;
-
+    private Hook<PadDevice.Delegates.Poll>? gamepadPollHook;
     private int leftStickX;
     private int leftStickY;
     private int rightStickX;
@@ -37,14 +36,39 @@ internal unsafe class GamepadState : IInternalDisposableService, IGamepadState
     [ServiceManager.ServiceConstructor]
     private GamepadState(ClientState clientState)
     {
-        this.gamepadPoll = Hook<PadDevice.Delegates.Poll>.FromAddress((nint)PadDevice.StaticVirtualTablePointer->Poll, this.GamepadPollDetour);
-        this.gamepadPoll?.Enable();
+        this.gamepadPollHook = Hook<PadDevice.Delegates.Poll>.FromAddress((nint)PadDevice.StaticVirtualTablePointer->Poll, this.GamepadPollDetour);
+        this.gamepadPollHook?.Enable();
     }
 
-    /// <summary>
-    /// Gets the pointer to the current instance of the GamepadInput struct.
-    /// </summary>
+    /// <inheritdoc/>
     public IntPtr GamepadInputAddress { get; private set; }
+
+    /// <inheritdoc/>
+    // Internal Note: Ideally, we would use
+    // (ImGui.GetIO().ConfigFlags & ImGuiConfigFlags.NavEnableGamepad) > 0
+    // but this has a race condition during load with the detour which sets up ImGui
+    // and throws if our detour gets called before the other.
+    public bool EnableGamepadNav
+    {
+        get => field;
+        set
+        {
+            field = value;
+
+            var gamepadEnabled = (ImGui.GetIO().BackendFlags & ImGuiBackendFlags.HasGamepad) > 0;
+
+            if (value && gamepadEnabled)
+            {
+                ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.NavEnableGamepad;
+                this.dalamudInterface.OpenGamepadModeNotifierWindow();
+            }
+            else
+            {
+                ImGui.GetIO().ConfigFlags &= ~ImGuiConfigFlags.NavEnableGamepad;
+                this.dalamudInterface.CloseGamepadModeNotifierWindow();
+            }
+        }
+    }
 
     /// <inheritdoc/>
     public Vector2 LeftStick =>
@@ -82,16 +106,6 @@ internal unsafe class GamepadState : IInternalDisposableService, IGamepadState
     /// </summary>
     internal GamepadButtons ButtonsRepeat { get; private set; }
 
-    /// <summary>
-    /// Gets or sets a value indicating whether detour should block gamepad input for game.
-    ///
-    /// Ideally, we would use
-    /// (ImGui.GetIO().ConfigFlags &amp; ImGuiConfigFlags.NavEnableGamepad) > 0
-    /// but this has a race condition during load with the detour which sets up ImGui
-    /// and throws if our detour gets called before the other.
-    /// </summary>
-    internal bool NavEnableGamepad { get; set; }
-
     /// <inheritdoc/>
     public float Pressed(GamepadButtons button) => (this.ButtonsPressed & button) > 0 ? 1 : 0;
 
@@ -109,13 +123,13 @@ internal unsafe class GamepadState : IInternalDisposableService, IGamepadState
     /// </summary>
     void IInternalDisposableService.DisposeService()
     {
-        this.Dispose(true);
-        GC.SuppressFinalize(this);
+        this.gamepadPollHook?.Dispose();
+        this.gamepadPollHook = null;
     }
 
     private nint GamepadPollDetour(PadDevice* gamepadInput)
     {
-        var original = this.gamepadPoll!.Original(gamepadInput);
+        var original = this.gamepadPollHook!.Original(gamepadInput);
         try
         {
             this.GamepadInputAddress = (nint)gamepadInput;
@@ -129,7 +143,7 @@ internal unsafe class GamepadState : IInternalDisposableService, IGamepadState
             this.ButtonsReleased = (GamepadButtons)gamepadInput->GamepadInputData.ButtonsReleased;
             this.ButtonsRepeat = (GamepadButtons)gamepadInput->GamepadInputData.ButtonsRepeat;
 
-            if (this.NavEnableGamepad)
+            if (this.EnableGamepadNav)
             {
                 gamepadInput->GamepadInputData.LeftStickX = 0;
                 gamepadInput->GamepadInputData.LeftStickY = 0;
@@ -176,17 +190,5 @@ internal unsafe class GamepadState : IInternalDisposableService, IGamepadState
             ImGui.GetIO().ConfigFlags &= ~ImGuiConfigFlags.NavEnableGamepad;
             return original;
         }
-    }
-
-    private void Dispose(bool disposing)
-    {
-        if (this.isDisposed) return;
-        if (disposing)
-        {
-            this.gamepadPoll?.Disable();
-            this.gamepadPoll?.Dispose();
-        }
-
-        this.isDisposed = true;
     }
 }

--- a/Dalamud/Interface/Internal/InterfaceManager.cs
+++ b/Dalamud/Interface/Internal/InterfaceManager.cs
@@ -1177,9 +1177,7 @@ internal partial class InterfaceManager : IInternalDisposableService
             && gamepadState.Raw(GamepadButtons.L1) > 0
             && gamepadState.Pressed(GamepadButtons.L3) > 0)
         {
-            io.ConfigFlags ^= ImGuiConfigFlags.NavEnableGamepad;
-            gamepadState.NavEnableGamepad ^= true;
-            dalamudInterface.ToggleGamepadModeNotifierWindow();
+            gamepadState.EnableGamepadNav ^= true;
         }
 
         if (gamepadEnabled && (io.ConfigFlags & ImGuiConfigFlags.NavEnableGamepad) > 0)

--- a/Dalamud/Plugin/Services/IGamepadState.cs
+++ b/Dalamud/Plugin/Services/IGamepadState.cs
@@ -1,14 +1,13 @@
 using System.Numerics;
 
-using Dalamud.Bindings.ImGui;
 using Dalamud.Game.ClientState.GamePad;
 
 namespace Dalamud.Plugin.Services;
 
 /// <summary>
-/// Exposes the game gamepad state to dalamud.
+/// Exposes the game gamepad state to Dalamud.
 ///
-/// Will block game's gamepad input if <see cref="ImGuiConfigFlags.NavEnableGamepad"/> is set.
+/// Will block game's gamepad input if <see cref="EnableGamepadNav"/> is set.
 /// </summary>
 public interface IGamepadState : IDalamudService
 {
@@ -16,6 +15,12 @@ public interface IGamepadState : IDalamudService
     /// Gets the pointer to the current instance of the GamepadInput struct.
     /// </summary>
     nint GamepadInputAddress { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether gamepad input is intercepted for ImGui navigation, 
+    /// preventing it from passing through to the game.
+    /// </summary>
+    public bool EnableGamepadNav { get; set; }
 
     /// <summary>
     /// Gets the left analogue sticks tilt vector.


### PR DESCRIPTION
This allows plugins to toggle ImGui's gamepad navigation manually by setting the `EnableGamepadNav` property in `IGamepadState`.

For example, setting EnableGamepadNav to true in an overridden Window.OnOpen function, and to false in an overridden Window.OnClose function, allows plugins to toggle it on and off for this window.

> [!NOTE]
> Currently my other PRs use the old name `NavEnableGamepad`, so the code has to be updated when this is merged.