### PR TITLE
Allow plugin windows to be closed with a gamepad

### DIFF
--- a/Dalamud/Interface/Windowing/WindowHost.cs
+++ b/Dalamud/Interface/Windowing/WindowHost.cs
@@ -555,6 +555,12 @@ public class WindowHost
             }
         }
 
+        // Allow the window to be closed with a gamepad
+        if (ImGui.IsKeyPressed(ImGuiKey.GamepadFaceRight) && !this.Window.IsPinned && this.Window.IsFocused && ImGui.GetCurrentContext() is { NavId: 0, NavFocusScopeId: 0 })
+        {
+            this.Window.IsOpen = false;
+        }
+
         this.fadeOutSize = ImGui.GetWindowSize();
         this.fadeOutOrigin = ImGui.GetWindowPos();
         var isCollapsed = ImGui.IsWindowCollapsed();


### PR DESCRIPTION
Pressing the B (XBOX Controller)/Circle (PlayStation Controller) key will back out of children/inputs, but will not close the window.
This PR changes this to close the focused window on the top level. Excluded are windows that are pinned.