### PR TITLE
Change GamepadModeNotifierWindow sounds

### DIFF
--- a/Dalamud/Interface/Internal/Windows/GamepadModeNotifierWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/GamepadModeNotifierWindow.cs
@@ -27,7 +27,8 @@ internal class GamepadModeNotifierWindow : Window
         this.Size = Vector2.Zero;
         this.SizeCondition = ImGuiCond.Always;
         this.IsOpen = false;
-
+        this.OnOpenSfxId = 51;
+        this.OnCloseSfxId = 52;
         this.RespectCloseHotkey = false;
     }
 


### PR DESCRIPTION
This backdrop overlay played the default window open/close sounds.
I've changed it to use the sounds of the games Virtual Mouse Mode for funsies.

Would probably require some feedback from controller users, as I don't use controllers to play the game.
If this is too confusing or annoying, we can also disable the sounds or pick some other ones.

Preview (Virtual Mouse Mode vs. GamepadModeNotifierWindow - sound on!):

https://github.com/user-attachments/assets/2f981347-52a2-4c6a-a6c9-5d607c258c81
