### PR TITLE
Fix flipped check in UpdateMouseData

### DIFF
--- a/Dalamud/Interface/ImGuiBackend/InputHandler/Win32InputHandler.cs
+++ b/Dalamud/Interface/ImGuiBackend/InputHandler/Win32InputHandler.cs
@@ -508,7 +508,7 @@ internal sealed unsafe partial class Win32InputHandler : IImGuiInputHandler
             if (io.WantSetMousePos)
             {
                 var pos = new POINT((int)io.MousePos.X, (int)io.MousePos.Y);
-                if ((io.ConfigFlags & ImGuiConfigFlags.ViewportsEnable) != 0)
+                if ((io.ConfigFlags & ImGuiConfigFlags.ViewportsEnable) == 0)
                     ClientToScreen(this.hWnd, &pos);
                 SetCursorPos(pos.x, pos.y);
             }


### PR DESCRIPTION
This check seems to be accidentally inverted.
When viewports are enabled (the multi-monitor feature), the mouse cursor position is already in the screen space and does not need adjusting.
When they are disabled though, we need to account for the clients position, especially when the game is in windowed mode.

This fixes #2923 (that issue has a video showing the bug).
This shows that it got fixed with this change:

https://github.com/user-attachments/assets/2b105ba1-0207-4e82-8666-5a7867a32a91



