### PR TITLE
Fix GamepadModeNotifierWindow backdrop and text position

### DIFF
--- a/Dalamud/Interface/Internal/Windows/GamepadModeNotifierWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/GamepadModeNotifierWindow.cs
@@ -38,9 +38,12 @@ internal class GamepadModeNotifierWindow : Window
     {
         var drawList = ImGui.GetBackgroundDrawList();
         drawList.PushClipRectFullScreen();
-        drawList.AddRectFilled(Vector2.Zero, ImGuiHelpers.MainViewport.Size, 0x661A1A1A);
+        drawList.AddRectFilled(
+            ImGuiHelpers.MainViewport.WorkPos,
+            ImGuiHelpers.MainViewport.WorkPos + ImGuiHelpers.MainViewport.Size,
+            0x661A1A1A);
         drawList.AddText(
-            Vector2.One,
+            ImGuiHelpers.MainViewport.WorkPos,
             0xFFFFFFFF,
             Loc.Localize(
                 "DalamudGamepadModeNotifierText",


### PR DESCRIPTION
The overlay is not sticking to the main viewport, making it appear outside the client when in windowed mode with multi-monitor enabled.

The problem:

https://github.com/user-attachments/assets/70fe5c99-498b-44ab-88ca-0ed2774e4a2b

With this fix:


https://github.com/user-attachments/assets/53818438-223e-498a-959e-566e66a4e102

