### PR TITLE
Add warning indicator for non-existing Dev Plugin dll paths

### DIFF
--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
@@ -168,8 +168,10 @@ internal sealed class DevPluginsSettingsEntry : SettingsEntry
             ImGui.Text(locNumber.ToString());
             ImGui.NextColumn();
 
-            ImGui.SetNextItemWidth(-1);
             var path = devPluginLocationSetting.Path;
+            var exists = File.Exists(path);
+            var inputWidth = exists ? -1 : ImGui.GetContentRegionAvail().X - ImGui.GetFrameHeight() - ImGui.GetStyle().ItemSpacing.X;
+            ImGui.SetNextItemWidth(inputWidth);
             if (ImGui.InputText($"##devPluginLocationInput", ref path, 65535, ImGuiInputTextFlags.EnterReturnsTrue))
             {
                 var contains = this.devPluginLocations.Select(loc => loc.Path).Contains(path);
@@ -192,6 +194,15 @@ internal sealed class DevPluginsSettingsEntry : SettingsEntry
                     devPluginLocationSetting.Path = path;
                     this.devPluginLocationsChanged = path != devPluginLocationSetting.Path;
                 }
+            }
+
+            if (!exists)
+            {
+                ImGui.SameLine();
+                ImGuiComponents.HelpMarker(
+                    Loc.Localize("DalamudDevPluginLocationFileDoesNotExist", "File does not exist."),
+                    FontAwesomeIcon.ExclamationTriangle,
+                    Colors.ImGuiColors.WarningForeground);
             }
 
             ImGui.NextColumn();

--- a/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Widgets/DevPluginsSettingsEntry.cs
@@ -16,6 +16,7 @@ using Dalamud.Interface.ImGuiFileDialog;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Plugin.Internal;
+using Dalamud.Utility;
 using Dalamud.Utility.Internal;
 
 namespace Dalamud.Interface.Internal.Windows.Settings.Widgets;
@@ -168,41 +169,31 @@ internal sealed class DevPluginsSettingsEntry : SettingsEntry
             ImGui.Text(locNumber.ToString());
             ImGui.NextColumn();
 
-            var path = devPluginLocationSetting.Path;
-            var exists = File.Exists(path);
-            var inputWidth = exists ? -1 : ImGui.GetContentRegionAvail().X - ImGui.GetFrameHeight() - ImGui.GetStyle().ItemSpacing.X;
-            ImGui.SetNextItemWidth(inputWidth);
-            if (ImGui.InputText($"##devPluginLocationInput", ref path, 65535, ImGuiInputTextFlags.EnterReturnsTrue))
+            var dllPath = devPluginLocationSetting.Path;
+            var hasError = this.TryGetError(dllPath, out var error);
+
+            ImGui.SetNextItemWidth(!hasError ? -1 : ImGui.GetContentRegionAvail().X - ImGui.GetFrameHeight() - ImGui.GetStyle().ItemSpacing.X);
+            if (ImGui.InputText($"##devPluginLocationInput", ref dllPath, 65535, ImGuiInputTextFlags.EnterReturnsTrue) && devPluginLocationSetting.Path != dllPath)
             {
-                var contains = this.devPluginLocations.Select(loc => loc.Path).Contains(path);
-                if (devPluginLocationSetting.Path == path)
+                if (!this.TryGetError(dllPath, out error))
                 {
-                    // no change.
+                    devPluginLocationSetting.Path = dllPath;
+                    this.devPluginLocationsChanged = true;
                 }
-                else if (contains && devPluginLocationSetting.Path != path)
+                else if (error.Loc.Key is "DalamudDevPluginLocationExists" or "DalamudDevPluginInvalid")
                 {
-                    this.devPluginLocationAddError = Loc.Localize("DalamudDevPluginLocationExists", "Location already exists.");
+                    this.devPluginLocationAddError = error.Loc.ToString();
                     Task.Delay(5000).ContinueWith(t => this.devPluginLocationAddError = string.Empty);
-                }
-                else if (!ValidDevPluginPath(path))
-                {
-                    this.devPluginLocationAddError = Loc.Localize("DalamudDevPluginInvalid", "The entered value is not a valid path to a potential Dev Plugin.\nDid you mean to enter it as a custom plugin repository in the fields below instead?");
-                    Task.Delay(5000).ContinueWith(t => this.devPluginLocationAddError = string.Empty);
-                }
-                else
-                {
-                    devPluginLocationSetting.Path = path;
-                    this.devPluginLocationsChanged = path != devPluginLocationSetting.Path;
                 }
             }
 
-            if (!exists)
+            if (hasError)
             {
                 ImGui.SameLine();
                 ImGuiComponents.HelpMarker(
-                    Loc.Localize("DalamudDevPluginLocationFileDoesNotExist", "File does not exist."),
-                    FontAwesomeIcon.ExclamationTriangle,
-                    Colors.ImGuiColors.WarningForeground);
+                    error.Loc.ToString(),
+                    error.Icon,
+                    error.Color ?? Colors.ImGuiColors.WarningForeground);
             }
 
             ImGui.NextColumn();
@@ -308,4 +299,40 @@ internal sealed class DevPluginsSettingsEntry : SettingsEntry
         // Enable ImGui asserts if a dev plugin is added, if no choice was made prior
         Service<DalamudConfiguration>.Get().ImGuiAssertsEnabledAtStartup ??= true;
     }
+
+    private bool TryGetError(string dllPath, out LocationError error)
+    {
+        var dllExists = !dllPath.IsNullOrWhitespace() && File.Exists(dllPath);
+        if (!dllExists)
+        {
+            error = new(LazyLoc.Localize("DalamudDevPluginLocationFileDoesNotExist", "File does not exist."));
+            return true;
+        }
+
+        if (!ValidDevPluginPath(dllPath))
+        {
+            error = new(LazyLoc.Localize("DalamudDevPluginInvalid", "The entered value is not a valid path to a potential Dev Plugin.\nDid you mean to enter it as a custom plugin repository in the fields below instead?"));
+            return true;
+        }
+
+        var manifestPath = Path.ChangeExtension(dllPath, ".json");
+        var manifestExists = !manifestPath.IsNullOrWhitespace() && File.Exists(manifestPath);
+
+        if (!manifestExists)
+        {
+            error = new(LazyLoc.Localize("DalamudDevPluginLocationManifestDoesNotExist", "Manifest does not exist."));
+            return true;
+        }
+
+        if (this.devPluginLocations.Count(loc => loc.Path == dllPath) > 1)
+        {
+            error = new(LazyLoc.Localize("DalamudDevPluginLocationExists", "Location already exists."));
+            return true;
+        }
+
+        error = default;
+        return false;
+    }
+
+    private record struct LocationError(LazyLoc Loc, FontAwesomeIcon Icon = FontAwesomeIcon.ExclamationTriangle, Vector4? Color = null);
 }


### PR DESCRIPTION
This adds a little warning triangle in the Dev Plugin Locations list for paths that don't exist.

Preview:

<img width="315" height="54" alt="Preview" src="https://github.com/user-attachments/assets/b90ed14f-401b-46c8-9ffa-f5995c0b85d1" />