### PR TITLE
Fixed numpad return overflow behaviour

### DIFF
--- a/Dalamud/Game/ClientState/Keys/VirtualKey.cs
+++ b/Dalamud/Game/ClientState/Keys/VirtualKey.cs
@@ -6,7 +6,7 @@ namespace Dalamud.Game.ClientState.Keys;
 /// <remarks>
 /// Defined in winuser.h from Windows SDK v6.1.
 /// </remarks>
-public enum VirtualKey : ushort
+public enum VirtualKey : byte
 {
     /// <summary>
     /// This is an addendum to use on functions in which you have to pass a zero value to represent no key code.


### PR DESCRIPTION
Virtual Key needs to be backed by a byte, not a ushort due to behaviour surrounding numpad return, which the virtual key for is 269, this is due to the fact that it is intended to overflow a byte and wrap around to 0x0D, which is return.