### PR TITLE
Add Reveal in File Explorer to DevPlugins

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -3245,6 +3245,15 @@ internal class PluginInstallerWindow : Window, IDisposable
                 this.ResortPlugins();
             }
 
+            if (plugin is LocalDevPlugin)
+            {
+                ImGui.Separator();
+
+                // Reveal in File Explorer
+                if (ImGui.MenuItem(Locs.PluginContext_RevealInFileExplorer))
+                    Util.RevealInFileExplorer(plugin.DllFile.ToString());
+            }
+
             ImGui.Separator();
 
             if (ImGui.MenuItem(Locs.PluginContext_DeletePluginConfigReload))
@@ -4501,6 +4510,8 @@ internal class PluginInstallerWindow : Window, IDisposable
         public static string PluginContext_PinPlugin => Loc.Localize("InstallerPinPlugin", "Pin to top");
 
         public static string PluginContext_UnpinPlugin => Loc.Localize("InstallerUnpinPlugin", "Unpin from top");
+
+        public static string PluginContext_RevealInFileExplorer => Loc.Localize("InstallerUnpinPlugin", "Reveal in File Explorer");
 
         #endregion
 

--- a/Dalamud/Utility/Util.cs
+++ b/Dalamud/Utility/Util.cs
@@ -505,6 +505,26 @@ public static partial class Util
         }).Start(url);
 
     /// <summary>
+    /// Opens the native file explorer and highlights (selects) the specified file or folder.
+    /// </summary>
+    /// <param name="filePath">The absolute path to the file or directory to reveal.</param>
+    public static unsafe void RevealInFileExplorer(string filePath)
+    {
+        Task.Run(() =>
+        {
+            if (!Path.Exists(filePath))
+                return;
+
+            fixed (char* pFilePath = filePath)
+            {
+                ITEMIDLIST* list = TerraFX.Interop.Windows.Windows.ILCreateFromPathW(pFilePath);
+                TerraFX.Interop.Windows.Windows.SHOpenFolderAndSelectItems(list, 0, null, 0);
+                TerraFX.Interop.Windows.Windows.ILFree(list);
+            }
+        });
+    }
+
+    /// <summary>
     /// Perform a "zipper merge" (A, 1, B, 2, C, 3) of multiple enumerables, allowing for lists to end early.
     /// </summary>
     /// <param name="sources">A set of enumerable sources to combine.</param>


### PR DESCRIPTION
This PR adds a new "Reveal in File Explorer" context menu to LocalDevPlugins in the Plugin Installer to quickly navigate into the dev plugins directory:

<img width="725" height="175" alt="Screenshot 1" src="https://github.com/user-attachments/assets/d0303da6-6b43-4963-859c-9a36b1c934f7" />

On click, it opens the explorer with the .dll highlighted:

<img width="631" height="170" alt="Screenshot 2" src="https://github.com/user-attachments/assets/f5ad27aa-7dde-4337-98c6-07ec99959dbb" />

Since I only have a Windows machine, I cannot test how it behaves on Linux/OSX.