### PR TITLE
Add open path options to plugin entries

### DIFF
--- a/Dalamud/Configuration/PluginConfigurations.cs
+++ b/Dalamud/Configuration/PluginConfigurations.cs
@@ -77,7 +77,7 @@ public sealed class PluginConfigurations
     /// <param name="pluginName">The name of the plugin.</param>
     public void Delete(string pluginName)
     {
-        var directory = this.GetDirectoryPath(pluginName);
+        var directory = this.GetConfigDirectory(pluginName);
         if (directory.Exists)
             directory.Delete(true);
 
@@ -95,7 +95,7 @@ public sealed class PluginConfigurations
     {
         try
         {
-            var path = this.GetDirectoryPath(pluginName);
+            var path = this.GetConfigDirectory(pluginName);
             if (!path.Exists)
             {
                 path.Create();
@@ -145,6 +145,13 @@ public sealed class PluginConfigurations
     public FileInfo GetConfigFile(string pluginName) => new(Path.Combine(this.configDirectory.FullName, $"{pluginName}.json"));
 
     /// <summary>
+    /// Get DirectoryInfo to plugin config directory.
+    /// </summary>
+    /// <param name="pluginName">InternalName of the plugin.</param>
+    /// <returns>DirectoryInfo of the config directory.</returns>
+    public DirectoryInfo GetConfigDirectory(string pluginName) => new(Path.Combine(this.configDirectory.FullName, pluginName));
+
+    /// <summary>
     /// Serializes a plugin configuration object.
     /// </summary>
     /// <param name="config">The configuration object.</param>
@@ -173,8 +180,6 @@ public sealed class PluginConfigurations
                 TypeNameHandling = TypeNameHandling.Objects,
             });
     }
-
-    private DirectoryInfo GetDirectoryPath(string pluginName) => new(Path.Combine(this.configDirectory.FullName, pluginName));
 
     private class DalamudAssemblyTypeNameForcingJsonConverter : JsonConverter
     {

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -4518,11 +4518,11 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         public static string PluginContext_UnpinPlugin => Loc.Localize("InstallerUnpinPlugin", "Unpin from top");
 
-        public static string PluginContext_OpenConfigFile => Loc.Localize("InstallerUnpinPlugin", "Open config file");
+        public static string PluginContext_OpenConfigFile => Loc.Localize("InstallerOpenConfigFile", "Open config file");
 
-        public static string PluginContext_OpenConfigFolder => Loc.Localize("InstallerUnpinPlugin", "Open config folder");
+        public static string PluginContext_OpenConfigFolder => Loc.Localize("InstallerOpenConfigFolder", "Open config folder");
 
-        public static string PluginContext_OpenPluginFolder => Loc.Localize("InstallerUnpinPlugin", "Open plugin folder");
+        public static string PluginContext_OpenPluginFolder => Loc.Localize("InstallerOpenPluginFolder", "Open plugin folder");
 
         #endregion
 

--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -3247,6 +3247,22 @@ internal class PluginInstallerWindow : Window, IDisposable
 
             ImGui.Separator();
 
+            // Open plugin folder
+            if (configuration.DevMode == true && ImGui.MenuItem(Locs.PluginContext_OpenPluginFolder))
+                Util.OpenLink(plugin.DllFile.Directory.ToString());
+
+            // Open config file
+            var configFile = pluginManager.PluginConfigs.GetConfigFile(plugin.InternalName);
+            if (configFile.Exists && ImGui.MenuItem(Locs.PluginContext_OpenConfigFile))
+                Util.OpenLink(configFile.ToString());
+
+            // Open config folder
+            var configDir = pluginManager.PluginConfigs.GetConfigDirectory(plugin.InternalName);
+            if (configDir.Exists && ImGui.MenuItem(Locs.PluginContext_OpenConfigFolder))
+                Util.OpenLink(configDir.ToString());
+
+            ImGui.Separator();
+
             if (ImGui.MenuItem(Locs.PluginContext_DeletePluginConfigReload))
             {
                 this.ShowDeletePluginConfigWarningModal(plugin.Manifest.Name, optIn != null).ContinueWith(t =>
@@ -4501,6 +4517,12 @@ internal class PluginInstallerWindow : Window, IDisposable
         public static string PluginContext_PinPlugin => Loc.Localize("InstallerPinPlugin", "Pin to top");
 
         public static string PluginContext_UnpinPlugin => Loc.Localize("InstallerUnpinPlugin", "Unpin from top");
+
+        public static string PluginContext_OpenConfigFile => Loc.Localize("InstallerUnpinPlugin", "Open config file");
+
+        public static string PluginContext_OpenConfigFolder => Loc.Localize("InstallerUnpinPlugin", "Open config folder");
+
+        public static string PluginContext_OpenPluginFolder => Loc.Localize("InstallerUnpinPlugin", "Open plugin folder");
 
         #endregion
 


### PR DESCRIPTION
This PR adds 3 context menu options to plugin entries in the Plugin Installer:

- "Open plugin folder", visible only when the user enabled Dev Mode
- "Open config file", visible for every installed plugin, but only when the config file exists
- "Open config folder", visible for every installed plugin, but only when the config directory exists

<img width="324" height="171" alt="Screenshot" src="https://github.com/user-attachments/assets/aa8d929d-18d1-40b7-997d-7c47463e6c5b" />
