### PR TITLE
Log Framework.Update hitches individually

### DIFF
--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -619,7 +619,7 @@ internal class FrameworkPluginScoped : IInternalDisposableService, IFramework
     {
         this.frameworkService.ProfileAndInvoke(this.Update, this, (ex, handlerName) =>
         {
-            Serilog.Log.Error(ex, "[{InternalName}] Exception in event handler {EventHandlerName}", this.plugin.InternalName, handlerName);
+            Serilog.Log.Error(ex, $"[{this.plugin.InternalName}] Exception in event handler {{EventHandlerName}}", handlerName);
             this.pluginErrorHandler.NotifyError();
         });
     }

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -11,6 +11,7 @@ using Dalamud.IoC;
 using Dalamud.IoC.Internal;
 using Dalamud.Logging.Internal;
 using Dalamud.Plugin.Internal;
+using Dalamud.Plugin.Internal.Types;
 using Dalamud.Plugin.Services;
 using Dalamud.Utility;
 
@@ -29,7 +30,6 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     private static readonly Stopwatch StatsStopwatch = new();
 
     private readonly Stopwatch updateStopwatch = new();
-    private readonly HitchDetector hitchDetector;
 
     private readonly Hook<CSFramework.Delegates.Tick> updateHook;
 
@@ -51,8 +51,6 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     [ServiceManager.ServiceConstructor]
     private unsafe Framework()
     {
-        this.hitchDetector = new HitchDetector("FrameworkUpdate", this.configuration.FrameworkUpdateHitch);
-
         this.frameworkDestroy = new();
         this.frameworkDestroyed = new();
         this.frameworkThreadTaskScheduler = new();
@@ -104,6 +102,11 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     /// Gets the list of update sub-delegates that didn't get updated this frame.
     /// </summary>
     internal List<string> NonUpdatedSubDelegates { get; private set; } = [];
+
+    /// <summary>
+    /// Gets the dictionary of delegates and hitch log time.
+    /// </summary>
+    internal Dictionary<string, DateTime> HitchLogHistory { get; private set; } = [];
 
     /// <summary>
     /// Gets or sets a value indicating whether to dispatch update events.
@@ -353,27 +356,59 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     /// </summary>
     /// <param name="eventDelegate">The Delegate to Profile.</param>
     /// <param name="frameworkInstance">The Framework Instance to pass to delegate.</param>
-    internal void ProfileAndInvoke(IFramework.OnUpdateDelegate? eventDelegate, IFramework frameworkInstance)
+    /// <param name="errorHandler">A function that is called with the exception, if one arrises.</param>
+    /// <param name="logHitch">Whether to detect and log a hitch or not.</param>
+    internal void ProfileAndInvoke(IFramework.OnUpdateDelegate? eventDelegate, IFramework frameworkInstance, Action<Exception, string>? errorHandler = null, bool logHitch = true)
     {
         // Individually invoke OnUpdate handlers and time them.
         foreach (var d in Delegate.EnumerateInvocationList(eventDelegate))
         {
-            var stopwatch = Stopwatch.StartNew();
+            var key = $"{d.Target}::{d.Method.Name}";
+            var startTime = Stopwatch.GetTimestamp();
+
             try
             {
                 d(frameworkInstance);
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Exception while dispatching Framework::Update event.");
+                if (errorHandler != null)
+                {
+                    errorHandler?.InvokeSafely(ex, key);
+                }
+                else
+                {
+                    Log.Error(ex, "Exception while dispatching Framework::Update event.");
+                }
             }
 
-            stopwatch.Stop();
+            var elapsedMilliseconds = Stopwatch.GetElapsedTime(startTime).TotalMilliseconds;
 
-            var key = $"{d.Target}::{d.Method.Name}";
-            this.NonUpdatedSubDelegates.Remove(key);
+            if (StatsEnabled)
+            {
+                this.NonUpdatedSubDelegates.Remove(key);
+                AddToStats(key, elapsedMilliseconds);
+            }
 
-            AddToStats(key, stopwatch.Elapsed.TotalMilliseconds);
+            if (logHitch && elapsedMilliseconds > this.configuration.FrameworkUpdateHitch)
+            {
+                var now = DateTime.UtcNow;
+                var cooldownTimeSpan = TimeSpan.FromSeconds(30);
+
+                var hasCooldown = this.HitchLogHistory.TryGetValue(key, out DateTime lastLogTimestamp);
+                if (!hasCooldown || (hasCooldown && now - lastLogTimestamp > cooldownTimeSpan))
+                {
+                    this.HitchLogHistory[key] = now;
+                    Serilog.Log.Warning("[HITCH] Long {Name} detected, {Total}ms > {Max}ms", key, elapsedMilliseconds, this.configuration.FrameworkUpdateHitch);
+                }
+
+                // Clean up old entries in HitchLogHistory
+                var threshold = now - cooldownTimeSpan;
+                foreach (var rmKey in this.HitchLogHistory.Where(kvp => kvp.Value < threshold).Select(kvp => kvp.Key).ToArray())
+                {
+                    this.HitchLogHistory.Remove(rmKey);
+                }
+            }
         }
     }
 
@@ -390,9 +425,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
 
         ThreadSafety.MarkMainThread();
 
-        this.hitchDetector.Start();
-
-        this.BeforeUpdate?.InvokeSafely(this);
+        this.ProfileAndInvoke(this.BeforeUpdate, this);
 
         try
         {
@@ -442,7 +475,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
             {
                 // Stat Tracking for Framework Updates
                 this.NonUpdatedSubDelegates = StatsHistory.Keys.ToList();
-                this.ProfileAndInvoke(this.Update, this);
+                this.ProfileAndInvoke(this.Update, this, null, false);
 
                 // Cleanup handlers that are no longer being called
                 foreach (var key in this.NonUpdatedSubDelegates)
@@ -465,8 +498,6 @@ internal sealed class Framework : IInternalDisposableService, IFramework
                 this.Update?.InvokeSafely(this);
             }
         }
-
-        this.hitchDetector.Stop();
     }
 }
 
@@ -480,6 +511,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
 #pragma warning restore SA1015
 internal class FrameworkPluginScoped : IInternalDisposableService, IFramework
 {
+    private readonly LocalPlugin plugin;
     private readonly PluginErrorHandler pluginErrorHandler;
 
     [ServiceManager.ServiceDependency]
@@ -488,10 +520,13 @@ internal class FrameworkPluginScoped : IInternalDisposableService, IFramework
     /// <summary>
     /// Initializes a new instance of the <see cref="FrameworkPluginScoped"/> class.
     /// </summary>
+    /// <param name="plugin">The plugin.</param>
     /// <param name="pluginErrorHandler">Error handler instance.</param>
-    internal FrameworkPluginScoped(PluginErrorHandler pluginErrorHandler)
+    internal FrameworkPluginScoped(LocalPlugin plugin, PluginErrorHandler pluginErrorHandler)
     {
+        this.plugin = plugin;
         this.pluginErrorHandler = pluginErrorHandler;
+
         this.frameworkService.Update += this.OnUpdateForward;
     }
 
@@ -582,13 +617,10 @@ internal class FrameworkPluginScoped : IInternalDisposableService, IFramework
 
     private void OnUpdateForward(IFramework framework)
     {
-        if (Framework.StatsEnabled && this.Update != null)
+        this.frameworkService.ProfileAndInvoke(this.Update, this, (ex, handlerName) =>
         {
-            this.frameworkService.ProfileAndInvoke(this.Update, framework);
-        }
-        else
-        {
-            this.pluginErrorHandler.InvokeAndCatch(this.Update, $"{nameof(IFramework)}::{nameof(IFramework.Update)}", framework);
-        }
+            Serilog.Log.Error(ex, "[{InternalName}] Exception in event handler {EventHandlerName}", this.plugin.InternalName, handlerName);
+            this.pluginErrorHandler.NotifyError();
+        });
     }
 }

--- a/Dalamud/Game/Framework.cs
+++ b/Dalamud/Game/Framework.cs
@@ -357,12 +357,12 @@ internal sealed class Framework : IInternalDisposableService, IFramework
     /// <param name="eventDelegate">The Delegate to Profile.</param>
     /// <param name="frameworkInstance">The Framework Instance to pass to delegate.</param>
     /// <param name="errorHandler">A function that is called with the exception, if one arrises.</param>
-    /// <param name="logHitch">Whether to detect and log a hitch or not.</param>
-    internal void ProfileAndInvoke(IFramework.OnUpdateDelegate? eventDelegate, IFramework frameworkInstance, Action<Exception, string>? errorHandler = null, bool logHitch = true)
+    internal void ProfileAndInvoke(IFramework.OnUpdateDelegate? eventDelegate, IFramework frameworkInstance, Action<Exception, string>? errorHandler = null)
     {
         // Individually invoke OnUpdate handlers and time them.
         foreach (var d in Delegate.EnumerateInvocationList(eventDelegate))
         {
+            var isScopedService = d.Method.DeclaringType == typeof(FrameworkPluginScoped); // ignore FrameworkPluginScoped.OnUpdateForward itself
             var key = $"{d.Target}::{d.Method.Name}";
             var startTime = Stopwatch.GetTimestamp();
 
@@ -376,7 +376,7 @@ internal sealed class Framework : IInternalDisposableService, IFramework
                 {
                     errorHandler?.InvokeSafely(ex, key);
                 }
-                else
+                else if (!isScopedService)
                 {
                     Log.Error(ex, "Exception while dispatching Framework::Update event.");
                 }
@@ -384,13 +384,13 @@ internal sealed class Framework : IInternalDisposableService, IFramework
 
             var elapsedMilliseconds = Stopwatch.GetElapsedTime(startTime).TotalMilliseconds;
 
-            if (StatsEnabled)
+            if (!isScopedService && StatsEnabled)
             {
                 this.NonUpdatedSubDelegates.Remove(key);
                 AddToStats(key, elapsedMilliseconds);
             }
 
-            if (logHitch && elapsedMilliseconds > this.configuration.FrameworkUpdateHitch)
+            if (!isScopedService && elapsedMilliseconds > this.configuration.FrameworkUpdateHitch)
             {
                 var now = DateTime.UtcNow;
                 var cooldownTimeSpan = TimeSpan.FromSeconds(30);
@@ -471,13 +471,17 @@ internal sealed class Framework : IInternalDisposableService, IFramework
         // Only call Update as long as we're in the actual Framework loop
         if (this.DispatchUpdateEvents)
         {
-            if (StatsEnabled && this.Update != null)
+            // Stat Tracking for Framework Updates
+            if (StatsEnabled)
             {
-                // Stat Tracking for Framework Updates
                 this.NonUpdatedSubDelegates = StatsHistory.Keys.ToList();
-                this.ProfileAndInvoke(this.Update, this, null, false);
+            }
 
-                // Cleanup handlers that are no longer being called
+            this.ProfileAndInvoke(this.Update, this);
+
+            // Cleanup handlers that are no longer being called
+            if (StatsEnabled)
+            {
                 foreach (var key in this.NonUpdatedSubDelegates)
                 {
                     if (key == nameof(this.FrameworkThreadTaskFactory))
@@ -492,10 +496,6 @@ internal sealed class Framework : IInternalDisposableService, IFramework
                         StatsHistory.Remove(key);
                     }
                 }
-            }
-            else
-            {
-                this.Update?.InvokeSafely(this);
             }
         }
     }

--- a/Dalamud/Utility/EventHandlerExtensions.cs
+++ b/Dalamud/Utility/EventHandlerExtensions.cs
@@ -112,27 +112,6 @@ internal static class EventHandlerExtensions
     }
 
     /// <summary>
-    /// Replacement for Invoke() on OnUpdateDelegate to catch exceptions that stop event propagation in case
-    /// of a thrown Exception inside an invocation.
-    /// </summary>
-    /// <param name="updateDelegate">The OnUpdateDelegate in question.</param>
-    /// <param name="framework">Framework to be passed on to OnUpdateDelegate.</param>
-    public static void InvokeSafely(this IFramework.OnUpdateDelegate? updateDelegate, Framework framework)
-    {
-        foreach (var action in Delegate.EnumerateInvocationList(updateDelegate))
-        {
-            try
-            {
-                action(framework);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Exception during raise of {handler}", action.Method);
-            }
-        }
-    }
-
-    /// <summary>
     /// Replacement for Invoke() on OnMenuOpenedDelegate to catch exceptions that stop event propagation in case
     /// of a thrown Exception inside an invocation.
     /// </summary>


### PR DESCRIPTION
Currently, `Framework.Update` hitches are detected and logged as a whole, not giving any information about which plugins `IFramework.Update` handler actually caused it. Similarly, the error handler does not log which function caused the error, instead it just mentions `IFramework.Update`:

<img width="1167" height="85" alt="Screenshot before changes" src="https://github.com/user-attachments/assets/5ba19cf3-3b7d-4a5f-ab16-7d96723a787d" />

This PR changes the internal code, so that hitches and errors are logged per-delegate:

<img width="1167" height="85" alt="Screenshot after changes" src="https://github.com/user-attachments/assets/dbeba859-d569-4bcb-b34e-483adaec9baf" />

The error notification is also still shown and stats are only recorded when the checkbox is ticked in the /xlstats window.

---

Code used for demonstration:

```cs
public class HitchTab : DebugTab, IDisposable
{
    private readonly IFramework _framework;
    private bool _doHitch;
    private bool _doError;

    public HitchTab(IFramework framework)
    {
        _framework = framework;
        _framework.Update += OnUpdate;
    }

    public void Dispose()
    {
        _framework.Update -= OnUpdate;
    }

    private void OnUpdate(IFramework framework)
    {
        if (_doHitch)
        {
            Thread.Sleep(500);
            _doHitch = false;
        }
        if (_doError)
        {
            _doError = false;
            throw new InvalidOperationException("This is a test exception.");
        }
    }

    public override void Draw()
    {
        _doHitch |= ImGui.Button("Hitch");
        _doError |= ImGui.Button("Error");
    }
}
```