### PR TITLE
Enforce LF through .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 ###############################################################################
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
-* text=auto
+* text=auto eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.


### PR DESCRIPTION
We want `lf` as line endings, as set via .editorconfig

https://github.com/goatcorp/Dalamud/blob/6cf3e75421b0e8a0496d77393a3afb69c494fb71/.editorconfig#L7

but git seems to be doing its own thing (autocrlf), causing files to end up with mixed line endings.
Let's try enforcing `lf` via .gitattributes. Not sure if that helps, but it's worth a shot. 🤷‍♂️