### PR TITLE
Add more information about active plugin changes to the event.

### DIFF
--- a/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
+++ b/Dalamud/Interface/Internal/Windows/PluginInstaller/PluginInstallerWindow.cs
@@ -1001,7 +1001,7 @@ internal class PluginInstallerWindow : Window, IDisposable
                                                        : Locs.ErrorModal_UpdaterFail(errorPluginCount);
 
                                 var hintInsert = errorPlugins
-                                                 .Aggregate(string.Empty, (current, pluginUpdateStatus) => $"{current}* {pluginUpdateStatus.InternalName} ({PluginUpdateStatus.LocalizeUpdateStatusKind(pluginUpdateStatus.Status)})\n")
+                                                 .Aggregate(string.Empty, (current, pluginUpdateStatus) => $"{current}* {pluginUpdateStatus.AffectedPlugin.InternalName} ({PluginUpdateStatus.LocalizeUpdateStatusKind(pluginUpdateStatus.Status)})\n")
                                                  .TrimEnd();
                                 errorMessage += Locs.ErrorModal_HintBlame(hintInsert);
 
@@ -2926,7 +2926,7 @@ internal class PluginInstallerWindow : Window, IDisposable
         var thisWasUpdated = false;
         if (this.updatedPlugins != null && !plugin.IsDev)
         {
-            var update = this.updatedPlugins.FirstOrDefault(update => update.InternalName == plugin.Manifest.InternalName);
+            var update = this.updatedPlugins.FirstOrDefault(update => update.AffectedPlugin.InternalName == plugin.Manifest.InternalName);
             if (update != null)
             {
                 if (update.Status == PluginUpdateStatus.StatusKind.Success)
@@ -4659,7 +4659,7 @@ internal class PluginInstallerWindow : Window, IDisposable
 
         public static string Notifications_UpdatesInstalled(List<PluginUpdateStatus> updates)
             => Loc.Localize("NotificationsUpdatesInstalled", "Updates for {0} of your plugins were installed.\n\n{1}")
-                  .Format(updates.Count, string.Join(", ", updates.Select(x => x.InternalName)));
+                  .Format(updates.Count, string.Join(", ", updates.Select(x => x.AffectedPlugin.InternalName)));
 
         public static string Notifications_PluginDisabledTitle => Loc.Localize("NotificationsPluginDisabledTitle", "Plugin disabled!");
 

--- a/Dalamud/Plugin/ActivePluginsChangedEventArgs.cs
+++ b/Dalamud/Plugin/ActivePluginsChangedEventArgs.cs
@@ -1,4 +1,7 @@
 using System.Collections.Generic;
+using System.Linq;
+
+using Dalamud.Plugin.Internal.Types;
 
 namespace Dalamud.Plugin;
 
@@ -10,16 +13,48 @@ public class ActivePluginsChangedEventArgs : EventArgs, IActivePluginsChangedEve
     /// with the specified parameters.
     /// </summary>
     /// <param name="kind">The kind of change that triggered the event.</param>
-    /// <param name="affectedInternalNames">The internal names of the plugins affected by the change.</param>
-    internal ActivePluginsChangedEventArgs(PluginListInvalidationKind kind, IEnumerable<string> affectedInternalNames)
+    /// <param name="affectedPlugins">The plugins affected by the change.</param>
+    internal ActivePluginsChangedEventArgs(PluginListInvalidationKind kind, IEnumerable<IActivePluginsChangedEventArgs.IAffectedPlugin> affectedPlugins)
     {
         this.Kind = kind;
-        this.AffectedInternalNames = affectedInternalNames;
+        this.AffectedPlugins = affectedPlugins;
     }
 
     /// <inheritdoc/>
     public PluginListInvalidationKind Kind { get; }
 
     /// <inheritdoc/>
-    public IEnumerable<string> AffectedInternalNames { get; }
+    public IEnumerable<string> AffectedInternalNames
+        => this.AffectedPlugins.Select(t => t.InternalName);
+
+    /// <inheritdoc/>
+    public IEnumerable<IActivePluginsChangedEventArgs.IAffectedPlugin> AffectedPlugins { get; }
+
+    /// <inheritdoc/>
+    internal sealed class AffectedPlugin(LocalPlugin plugin, Version? version) : IActivePluginsChangedEventArgs.IAffectedPlugin
+    {
+        /// <inheritdoc/>
+        public string Name { get; } = plugin.Name;
+
+        /// <inheritdoc/>
+        public string InternalName { get; } = plugin.InternalName;
+
+        /// <inheritdoc/>
+        public Version Version { get; } = version ?? plugin.EffectiveVersion;
+
+        /// <inheritdoc/>
+        public Guid WorkingPluginId { get; } = plugin.Manifest.WorkingPluginId;
+
+        /// <inheritdoc/>
+        public bool IsBanned { get; } = plugin.IsBanned;
+
+        /// <inheritdoc/>
+        public bool IsDev { get; } = plugin.IsDev;
+
+        /// <inheritdoc/>
+        public bool IsThirdParty { get; } = plugin.IsThirdParty;
+
+        /// <inheritdoc/>
+        public bool IsTesting { get; } = plugin.IsTesting;
+    }
 }

--- a/Dalamud/Plugin/DalamudPluginInterface.cs
+++ b/Dalamud/Plugin/DalamudPluginInterface.cs
@@ -110,6 +110,9 @@ internal sealed class DalamudPluginInterface : IDalamudPluginInterface, IDisposa
     public string InternalName => this.plugin.InternalName;
 
     /// <inheritdoc/>
+    public Guid WorkingPluginId => this.plugin.Manifest.WorkingPluginId;
+
+    /// <inheritdoc/>
     public IPluginManifest Manifest { get; }
 
     /// <inheritdoc/>

--- a/Dalamud/Plugin/IActivePluginsChangedEventArgs.cs
+++ b/Dalamud/Plugin/IActivePluginsChangedEventArgs.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 
+using Dalamud.Plugin.Internal.Types.Manifest;
+
 namespace Dalamud.Plugin;
 
 /// <summary>
@@ -7,6 +9,34 @@ namespace Dalamud.Plugin;
 /// </summary>
 public interface IActivePluginsChangedEventArgs
 {
+    /// <summary> Contains a subset of the data of <see cref="IExposedPlugin"/> that is available even if the plugin has been unloaded. </summary>
+    public interface IAffectedPlugin
+    {
+        /// <inheritdoc cref="IExposedPlugin.Name"/>
+        string Name { get; }
+
+        /// <inheritdoc cref="IExposedPlugin.InternalName"/>
+        string InternalName { get; }
+
+        /// <inheritdoc cref="IExposedPlugin.Version"/>
+        Version Version { get; }
+
+        /// <inheritdoc cref="ILocalPluginManifest.WorkingPluginId"/>
+        Guid WorkingPluginId { get; }
+
+        /// <inheritdoc cref="IExposedPlugin.IsBanned"/>
+        bool IsBanned { get; }
+
+        /// <inheritdoc cref="IExposedPlugin.IsDev"/>
+        bool IsDev { get; }
+
+        /// <inheritdoc cref="IExposedPlugin.IsThirdParty"/>
+        bool IsThirdParty { get; }
+
+        /// <inheritdoc cref="IExposedPlugin.IsTesting"/>
+        bool IsTesting { get; }
+    }
+
     /// <summary>
     /// Gets the invalidation kind that caused this event to be fired.
     /// </summary>
@@ -16,4 +46,9 @@ public interface IActivePluginsChangedEventArgs
     /// Gets the InternalNames of affected plugins.
     /// </summary>
     IEnumerable<string> AffectedInternalNames { get; }
+
+    /// <summary>
+    /// Gets the available information about affected plugins.
+    /// </summary>
+    IEnumerable<IAffectedPlugin> AffectedPlugins { get; }
 }

--- a/Dalamud/Plugin/IDalamudPluginInterface.cs
+++ b/Dalamud/Plugin/IDalamudPluginInterface.cs
@@ -70,6 +70,11 @@ public interface IDalamudPluginInterface : IServiceProvider
     /// </summary>
     string InternalName { get; }
 
+    /// <summary> 
+    /// Gets the unique working plugin ID set by Dalamud.
+    /// </summary>
+    Guid WorkingPluginId { get; }
+
     /// <summary>
     /// Gets the plugin's manifest.
     /// </summary>

--- a/Dalamud/Plugin/Internal/AutoUpdate/AutoUpdateManager.cs
+++ b/Dalamud/Plugin/Internal/AutoUpdate/AutoUpdateManager.cs
@@ -370,7 +370,7 @@ internal class AutoUpdateManager : IServiceType
 
             var failedPlugins = pluginStates
                                 .Where(x => x.Status != PluginUpdateStatus.StatusKind.Success)
-                                .Select(x => x.Name).ToList();
+                                .Select(x => x.AffectedPlugin.Name).ToList();
 
             notification.Content += "\n" + Locs.NotificationContentFailedPlugins(failedPlugins);
         }

--- a/Dalamud/Plugin/Internal/PluginManager.cs
+++ b/Dalamud/Plugin/Internal/PluginManager.cs
@@ -312,7 +312,7 @@ internal class PluginManager : IInternalDisposableService
                     {
                         if (metadata.Status == PluginUpdateStatus.StatusKind.Success)
                         {
-                            chatGui.Print(Locs.DalamudPluginUpdateSuccessful(metadata.Name, metadata.Version));
+                            chatGui.Print(Locs.DalamudPluginUpdateSuccessful(metadata.AffectedPlugin.Name, metadata.AffectedPlugin.Version));
                         }
                         else
                         {
@@ -320,8 +320,8 @@ internal class PluginManager : IInternalDisposableService
                                 new XivChatEntry
                                 {
                                     Message = Locs.DalamudPluginUpdateFailed(
-                                        metadata.Name,
-                                        metadata.Version,
+                                        metadata.AffectedPlugin.Name,
+                                        metadata.AffectedPlugin.Version,
                                         PluginUpdateStatus.LocalizeUpdateStatusKind(metadata.Status)),
                                     Type = XivChatType.Urgent,
                                 });
@@ -970,7 +970,7 @@ internal class PluginManager : IInternalDisposableService
         this.NotifyInstalledPluginsChanged();
         this.NotifyPluginsForStateChange(
             autoUpdate ? PluginListInvalidationKind.AutoUpdate : PluginListInvalidationKind.Update,
-            updatedList.Select(x => x.InternalName));
+            updatedList.Select(x => x.AffectedPlugin));
 
         Log.Information("Plugin update OK. {UpdateCount} plugins updated", updatedList.Length);
 
@@ -1009,13 +1009,10 @@ internal class PluginManager : IInternalDisposableService
         if (workingPluginId == Guid.Empty)
             throw new Exception("Existing plugin had no WorkingPluginId");
 
+        var version = metadata.UseTesting ? metadata.UpdateManifest.TestingAssemblyVersion : metadata.UpdateManifest.AssemblyVersion;
         var updateStatus = new PluginUpdateStatus
         {
-            InternalName = plugin.Manifest.InternalName,
-            Name = plugin.Manifest.Name,
-            Version = (metadata.UseTesting
-                           ? metadata.UpdateManifest.TestingAssemblyVersion
-                           : metadata.UpdateManifest.AssemblyVersion)!,
+            AffectedPlugin = new ActivePluginsChangedEventArgs.AffectedPlugin(plugin, version),
             Status = PluginUpdateStatus.StatusKind.Success,
             HasChangelog = !metadata.UpdateManifest.Changelog.IsNullOrWhitespace(),
         };
@@ -1224,8 +1221,8 @@ internal class PluginManager : IInternalDisposableService
     /// Notifies all plugins that the active plugins list changed.
     /// </summary>
     /// <param name="kind">The invalidation kind.</param>
-    /// <param name="affectedInternalNames">The affected plugins.</param>
-    public void NotifyPluginsForStateChange(PluginListInvalidationKind kind, IEnumerable<string> affectedInternalNames)
+    /// <param name="affectedPlugins">The affected plugins.</param>
+    public void NotifyPluginsForStateChange(PluginListInvalidationKind kind, IEnumerable<IActivePluginsChangedEventArgs.IAffectedPlugin> affectedPlugins)
     {
         using (this.pluginListLock.EnterScope())
         {
@@ -1234,8 +1231,7 @@ internal class PluginManager : IInternalDisposableService
                 if (!installedPlugin.IsLoaded || installedPlugin.DalamudInterface == null)
                     continue;
 
-                installedPlugin.DalamudInterface.NotifyActivePluginsChanged(
-                    new ActivePluginsChangedEventArgs(kind, affectedInternalNames));
+                installedPlugin.DalamudInterface.NotifyActivePluginsChanged(new ActivePluginsChangedEventArgs(kind, affectedPlugins));
             }
         }
     }

--- a/Dalamud/Plugin/Internal/Types/LocalDevPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalDevPlugin.cs
@@ -55,6 +55,8 @@ internal sealed class LocalDevPlugin : LocalPlugin
             configuration.QueueSave();
         }
 
+        this.manifest.WorkingPluginId = this.devSettings.WorkingPluginId;
+
         if (this.AutomaticReload)
         {
             this.EnableReloading();
@@ -171,7 +173,10 @@ internal sealed class LocalDevPlugin : LocalPlugin
     {
         var manifestPath = LocalPluginManifest.GetManifestFile(this.DllFile);
         if (manifestPath.Exists)
+        {
             this.manifest = LocalPluginManifest.Load(manifestPath) ?? throw new Exception("Could not reload manifest.");
+            this.manifest.WorkingPluginId = this.devSettings.WorkingPluginId;
+        }
     }
 
     /// <inheritdoc/>

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -425,7 +425,7 @@ internal class LocalPlugin : IAsyncDisposable
             Log.Information("Finished loading {PluginName}", this.InternalName);
 
             var manager = Service<PluginManager>.Get();
-            manager.NotifyPluginsForStateChange(PluginListInvalidationKind.Loaded, [this.manifest.InternalName]);
+                manager.NotifyPluginsForStateChange(PluginListInvalidationKind.Loaded, [new ActivePluginsChangedEventArgs.AffectedPlugin(this, null)]);
         }
         catch (Exception ex)
         {
@@ -501,7 +501,7 @@ internal class LocalPlugin : IAsyncDisposable
             Log.Information("Finished unloading {PluginName}", this.InternalName);
 
             var manager = Service<PluginManager>.Get();
-            manager.NotifyPluginsForStateChange(PluginListInvalidationKind.Unloaded, [this.manifest.InternalName]);
+            manager.NotifyPluginsForStateChange(PluginListInvalidationKind.Unloaded, [new ActivePluginsChangedEventArgs.AffectedPlugin(this, null)]);
         }
         catch (Exception ex)
         {

--- a/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
+++ b/Dalamud/Plugin/Internal/Types/LocalPlugin.cs
@@ -425,7 +425,7 @@ internal class LocalPlugin : IAsyncDisposable
             Log.Information("Finished loading {PluginName}", this.InternalName);
 
             var manager = Service<PluginManager>.Get();
-                manager.NotifyPluginsForStateChange(PluginListInvalidationKind.Loaded, [new ActivePluginsChangedEventArgs.AffectedPlugin(this, null)]);
+            manager.NotifyPluginsForStateChange(PluginListInvalidationKind.Loaded, [new ActivePluginsChangedEventArgs.AffectedPlugin(this, null)]);
         }
         catch (Exception ex)
         {

--- a/Dalamud/Plugin/Internal/Types/PluginUpdateStatus.cs
+++ b/Dalamud/Plugin/Internal/Types/PluginUpdateStatus.cs
@@ -43,20 +43,8 @@ internal class PluginUpdateStatus
         Success,
     }
 
-    /// <summary>
-    /// Gets the plugin internal name.
-    /// </summary>
-    public string InternalName { get; init; } = null!;
-
-    /// <summary>
-    /// Gets the plugin name.
-    /// </summary>
-    public string Name { get; init; } = null!;
-
-    /// <summary>
-    /// Gets the plugin version.
-    /// </summary>
-    public Version Version { get; init; } = null!;
+    /// <summary> Gets data about the affected plugin. </summary>
+    public ActivePluginsChangedEventArgs.AffectedPlugin AffectedPlugin { get; init; } = null!;
 
     /// <summary>
     /// Gets or sets a value indicating the status of the update.


### PR DESCRIPTION
- I avoided to use IExposedPlugin since this contains data that does not make sense for a now-uninstalled plugin, and also references to objects that should only be available in a live plugin.
- So this creates most of the possibly relevant data and stores it without references, most importantly the WorkingPluginId, which is the only way to uniquely identify a plugin across its lifetime (due to dev plugins sharing internal names, possibly).