### PR TITLE
Make IDtrBarEntry disposable

### DIFF
--- a/Dalamud/Game/Gui/Dtr/DtrBarEntry.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBarEntry.cs
@@ -64,7 +64,7 @@ public interface IReadOnlyDtrBarEntry
 /// <summary>
 /// Interface representing an entry in the server info bar.
 /// </summary>
-public interface IDtrBarEntry : IReadOnlyDtrBarEntry
+public interface IDtrBarEntry : IReadOnlyDtrBarEntry, IDisposable
 {
     /// <summary>
     /// Gets or sets the text of this entry.


### PR DESCRIPTION
It's already implemented (https://github.com/goatcorp/Dalamud/blob/master/Dalamud/Game/Gui/Dtr/DtrBarEntry.cs#L235), but the interface doesn't inherit from `IDisposable`.