### PR TITLE
[API16] Disposable Addon/AgentLifecycle listeners and IAddonEventHandles

### DIFF
--- a/Dalamud/Game/Addon/Events/AddonEventHandle.cs
+++ b/Dalamud/Game/Addon/Events/AddonEventHandle.cs
@@ -3,7 +3,7 @@ namespace Dalamud.Game.Addon.Events;
 /// <summary>
 /// Class that represents a addon event handle.
 /// </summary>
-public class AddonEventHandle : IAddonEventHandle
+internal class AddonEventHandle : IAddonEventHandle
 {
     /// <inheritdoc/>
     public uint ParamKey { get; init; }
@@ -16,4 +16,15 @@ public class AddonEventHandle : IAddonEventHandle
 
     /// <inheritdoc/>
     public Guid EventGuid { get; init; }
+
+    /// <summary>
+    /// Gets the EventController this handle is registered in.
+    /// </summary>
+    internal PluginEventController EventController { get; init; }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        this.EventController.RemoveEvent(this);
+    }
 }

--- a/Dalamud/Game/Addon/Events/AddonEventManager.cs
+++ b/Dalamud/Game/Addon/Events/AddonEventManager.cs
@@ -47,7 +47,7 @@ internal unsafe class AddonEventManager : IInternalDisposableService
 
         this.onUpdateCursor = Hook<AtkUnitManager.Delegates.UpdateCursor>.FromAddress(AtkUnitManager.Addresses.UpdateCursor.Value, this.UpdateCursorDetour);
 
-        this.finalizeEventListener = new AddonLifecycleEventListener(AddonEvent.PreFinalize, string.Empty, this.OnAddonFinalize);
+        this.finalizeEventListener = new AddonLifecycleEventListener(this.addonLifecycle, AddonEvent.PreFinalize, string.Empty, this.OnAddonFinalize);
         this.addonLifecycle.RegisterListener(this.finalizeEventListener);
 
         this.onUpdateCursor.Enable();

--- a/Dalamud/Game/Addon/Events/AddonEventManager.cs
+++ b/Dalamud/Game/Addon/Events/AddonEventManager.cs
@@ -75,18 +75,14 @@ internal unsafe class AddonEventManager : IInternalDisposableService
     /// <param name="eventType">The event type for this event.</param>
     /// <param name="eventDelegate">The delegate to call when event is triggered.</param>
     /// <returns>IAddonEventHandle used to remove the event.</returns>
-    internal IAddonEventHandle? AddEvent(Guid pluginId, nint atkUnitBase, nint atkResNode, AddonEventType eventType, IAddonEventManager.AddonEventDelegate eventDelegate)
+    internal IAddonEventHandle AddEvent(Guid pluginId, nint atkUnitBase, nint atkResNode, AddonEventType eventType, IAddonEventManager.AddonEventDelegate eventDelegate)
     {
-        if (this.pluginEventControllers.TryGetValue(pluginId, out var controller))
+        if (!this.pluginEventControllers.TryGetValue(pluginId, out var controller))
         {
-            return controller.AddEvent(atkUnitBase, atkResNode, eventType, eventDelegate);
-        }
-        else
-        {
-            Log.Verbose($"Unable to locate controller for {pluginId}. No event was added.");
+            this.pluginEventControllers.TryAdd(pluginId, controller = new PluginEventController());
         }
 
-        return null;
+        return controller.AddEvent(atkUnitBase, atkResNode, eventType, eventDelegate);
     }
 
     /// <summary>
@@ -232,7 +228,7 @@ internal class AddonEventManagerPluginScoped : IInternalDisposableService, IAddo
     }
 
     /// <inheritdoc/>
-    public IAddonEventHandle? AddEvent(nint atkUnitBase, nint atkResNode, AddonEventType eventType, IAddonEventManager.AddonEventDelegate eventDelegate)
+    public IAddonEventHandle AddEvent(nint atkUnitBase, nint atkResNode, AddonEventType eventType, IAddonEventManager.AddonEventDelegate eventDelegate)
         => this.eventManagerService.AddEvent(this.plugin.EffectiveWorkingPluginId, atkUnitBase, atkResNode, eventType, eventDelegate);
 
     /// <inheritdoc/>

--- a/Dalamud/Game/Addon/Events/IAddonEventHandle.cs
+++ b/Dalamud/Game/Addon/Events/IAddonEventHandle.cs
@@ -3,7 +3,7 @@ namespace Dalamud.Game.Addon.Events;
 /// <summary>
 /// Interface representing the data used for managing AddonEvents.
 /// </summary>
-public interface IAddonEventHandle
+public interface IAddonEventHandle : IDisposable
 {
     /// <summary>
     /// Gets the param key associated with this event.

--- a/Dalamud/Game/Addon/Events/PluginEventController.cs
+++ b/Dalamud/Game/Addon/Events/PluginEventController.cs
@@ -47,6 +47,7 @@ internal unsafe class PluginEventController : IDisposable
 
         var eventHandle = new AddonEventHandle
         {
+            EventController = this,
             AddonName = addon->NameString,
             ParamKey = eventId,
             EventType = atkEventType,

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reactive.Disposables;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -272,29 +273,35 @@ internal class AddonLifecyclePluginScoped : IInternalDisposableService, IAddonLi
     }
 
     /// <inheritdoc/>
-    public void RegisterListener(AddonEvent eventType, IEnumerable<string> addonNames, IAddonLifecycle.AddonEventDelegate handler)
+    public IDisposable RegisterListener(AddonEvent eventType, IEnumerable<string> addonNames, IAddonLifecycle.AddonEventDelegate handler)
     {
+        var disposable = new CompositeDisposable();
+
         foreach (var addonName in addonNames)
         {
-            this.RegisterListener(eventType, addonName, handler);
+            disposable.Add(this.RegisterListener(eventType, addonName, handler));
         }
+
+        return disposable;
     }
 
     /// <inheritdoc/>
-    public void RegisterListener(AddonEvent eventType, string addonName, IAddonLifecycle.AddonEventDelegate handler)
+    public IDisposable RegisterListener(AddonEvent eventType, string addonName, IAddonLifecycle.AddonEventDelegate handler)
     {
-        var listener = new AddonLifecycleEventListener(eventType, addonName, handler);
+        var listener = new AddonLifecycleEventListener(this.addonLifecycleService, eventType, addonName, handler);
 
         using var scope = this.listenerLock.EnterScope();
 
         this.eventListeners.Add(listener);
         this.addonLifecycleService.RegisterListener(listener);
+
+        return listener;
     }
 
     /// <inheritdoc/>
-    public void RegisterListener(AddonEvent eventType, IAddonLifecycle.AddonEventDelegate handler)
+    public IDisposable RegisterListener(AddonEvent eventType, IAddonLifecycle.AddonEventDelegate handler)
     {
-        this.RegisterListener(eventType, string.Empty, handler);
+        return this.RegisterListener(eventType, string.Empty, handler);
     }
 
     /// <inheritdoc/>

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycleEventListener.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycleEventListener.cs
@@ -5,20 +5,27 @@ namespace Dalamud.Game.Addon.Lifecycle;
 /// <summary>
 /// This class is a helper for tracking and invoking listener delegates.
 /// </summary>
-internal class AddonLifecycleEventListener
+internal class AddonLifecycleEventListener : IDisposable
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AddonLifecycleEventListener"/> class.
     /// </summary>
+    /// <param name="service">The AddonLifecycle service.</param>
     /// <param name="eventType">Event type to listen for.</param>
     /// <param name="addonName">Addon name to listen for.</param>
     /// <param name="functionDelegate">Delegate to invoke.</param>
-    internal AddonLifecycleEventListener(AddonEvent eventType, string addonName, IAddonLifecycle.AddonEventDelegate functionDelegate)
+    internal AddonLifecycleEventListener(AddonLifecycle service, AddonEvent eventType, string addonName, IAddonLifecycle.AddonEventDelegate functionDelegate)
     {
+        this.Service = service;
         this.EventType = eventType;
         this.AddonName = addonName;
         this.FunctionDelegate = functionDelegate;
     }
+
+    /// <summary>
+    /// Gets the AddonLifecycle service.
+    /// </summary>
+    public AddonLifecycle Service { get; init; }
 
     /// <summary>
     /// Gets the name of the addon this listener is looking for.
@@ -40,4 +47,13 @@ internal class AddonLifecycleEventListener
     /// Gets or sets a value indicating whether the listener is requested to be cleared.
     /// </summary>
     internal bool IsRequestedToClear { get; set; }
+
+    /// <summary>
+    /// Unregisters the event listener from the AddonLifecycle service.
+    /// </summary>
+    public void Dispose()
+    {
+        if (!this.IsRequestedToClear)
+            this.Service.UnregisterListener(this);
+    }
 }

--- a/Dalamud/Game/Addon/Lifecycle/AddonLifecycleEventListener.cs
+++ b/Dalamud/Game/Addon/Lifecycle/AddonLifecycleEventListener.cs
@@ -10,7 +10,7 @@ internal class AddonLifecycleEventListener : IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="AddonLifecycleEventListener"/> class.
     /// </summary>
-    /// <param name="service">The AddonLifecycle service.</param>
+    /// <param name="service">The <see cref="AddonLifecycle"/> service.</param>
     /// <param name="eventType">Event type to listen for.</param>
     /// <param name="addonName">Addon name to listen for.</param>
     /// <param name="functionDelegate">Delegate to invoke.</param>
@@ -23,7 +23,7 @@ internal class AddonLifecycleEventListener : IDisposable
     }
 
     /// <summary>
-    /// Gets the AddonLifecycle service.
+    /// Gets the <see cref="AddonLifecycle"/> service.
     /// </summary>
     public AddonLifecycle Service { get; init; }
 
@@ -49,7 +49,7 @@ internal class AddonLifecycleEventListener : IDisposable
     internal bool IsRequestedToClear { get; set; }
 
     /// <summary>
-    /// Unregisters the event listener from the AddonLifecycle service.
+    /// Unregisters the event listener from the <see cref="AddonLifecycle"/> service.
     /// </summary>
     public void Dispose()
     {

--- a/Dalamud/Game/Agent/AgentLifecycle.cs
+++ b/Dalamud/Game/Agent/AgentLifecycle.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Disposables;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -327,29 +328,35 @@ internal class AgentLifecyclePluginScoped : IInternalDisposableService, IAgentLi
     }
 
     /// <inheritdoc/>
-    public void RegisterListener(AgentEvent eventType, IEnumerable<AgentId> agentIds, IAgentLifecycle.AgentEventDelegate handler)
+    public IDisposable RegisterListener(AgentEvent eventType, IEnumerable<AgentId> agentIds, IAgentLifecycle.AgentEventDelegate handler)
     {
+        var disposable = new CompositeDisposable();
+
         foreach (var agentId in agentIds)
         {
-            this.RegisterListener(eventType, agentId, handler);
+            disposable.Add(this.RegisterListener(eventType, agentId, handler));
         }
+
+        return disposable;
     }
 
     /// <inheritdoc/>
-    public void RegisterListener(AgentEvent eventType, AgentId agentId, IAgentLifecycle.AgentEventDelegate handler)
+    public IDisposable RegisterListener(AgentEvent eventType, AgentId agentId, IAgentLifecycle.AgentEventDelegate handler)
     {
-        var listener = new AgentLifecycleEventListener(eventType, agentId, handler);
+        var listener = new AgentLifecycleEventListener(this.agentLifecycleService, eventType, agentId, handler);
 
         using var scope = this.listenerLock.EnterScope();
 
         this.eventListeners.Add(listener);
         this.agentLifecycleService.RegisterListener(listener);
+
+        return listener;
     }
 
     /// <inheritdoc/>
-    public void RegisterListener(AgentEvent eventType, IAgentLifecycle.AgentEventDelegate handler)
+    public IDisposable RegisterListener(AgentEvent eventType, IAgentLifecycle.AgentEventDelegate handler)
     {
-        this.RegisterListener(eventType, (AgentId)uint.MaxValue, handler);
+        return this.RegisterListener(eventType, (AgentId)uint.MaxValue, handler);
     }
 
     /// <inheritdoc/>

--- a/Dalamud/Game/Agent/AgentLifecycleEventListener.cs
+++ b/Dalamud/Game/Agent/AgentLifecycleEventListener.cs
@@ -5,20 +5,27 @@ namespace Dalamud.Game.Agent;
 /// <summary>
 /// This class is a helper for tracking and invoking listener delegates.
 /// </summary>
-public class AgentLifecycleEventListener
+internal class AgentLifecycleEventListener : IDisposable
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AgentLifecycleEventListener"/> class.
     /// </summary>
+    /// <param name="service">The <see cref="AgentLifecycle"/> service.</param>
     /// <param name="eventType">Event type to listen for.</param>
     /// <param name="agentId">Agent id to listen for.</param>
     /// <param name="functionDelegate">Delegate to invoke.</param>
-    internal AgentLifecycleEventListener(AgentEvent eventType, AgentId agentId, IAgentLifecycle.AgentEventDelegate functionDelegate)
+    internal AgentLifecycleEventListener(AgentLifecycle service, AgentEvent eventType, AgentId agentId, IAgentLifecycle.AgentEventDelegate functionDelegate)
     {
+        this.Service = service;
         this.EventType = eventType;
         this.AgentId = agentId;
         this.FunctionDelegate = functionDelegate;
     }
+
+    /// <summary>
+    /// Gets the <see cref="AgentLifecycle"/> service.
+    /// </summary>
+    public AgentLifecycle Service { get; init; }
 
     /// <summary>
     /// Gets the agentId of the agent this listener is looking for.
@@ -40,4 +47,13 @@ public class AgentLifecycleEventListener
     /// Gets or sets a value indicating whether the listener is requested to be cleared.
     /// </summary>
     internal bool IsRequestedToClear { get; set; }
+
+    /// <summary>
+    /// Unregisters the event listener from the <see cref="AgentLifecycle"/> service.
+    /// </summary>
+    public void Dispose()
+    {
+        if (!this.IsRequestedToClear)
+            this.Service.UnregisterListener(this);
+    }
 }

--- a/Dalamud/Game/Gui/Dtr/DtrBar.cs
+++ b/Dalamud/Game/Gui/Dtr/DtrBar.cs
@@ -66,9 +66,9 @@ internal sealed unsafe class DtrBar : IInternalDisposableService, IDtrBar
     [ServiceManager.ServiceConstructor]
     private DtrBar()
     {
-        this.dtrPostDrawListener = new AddonLifecycleEventListener(AddonEvent.PostDraw, "_DTR", this.FixCollision);
-        this.dtrPostRequestedUpdateListener = new AddonLifecycleEventListener(AddonEvent.PostRequestedUpdate, "_DTR", this.FixCollision);
-        this.dtrPreFinalizeListener = new AddonLifecycleEventListener(AddonEvent.PreFinalize, "_DTR", this.PreFinalize);
+        this.dtrPostDrawListener = new AddonLifecycleEventListener(this.addonLifecycle, AddonEvent.PostDraw, "_DTR", this.FixCollision);
+        this.dtrPostRequestedUpdateListener = new AddonLifecycleEventListener(this.addonLifecycle, AddonEvent.PostRequestedUpdate, "_DTR", this.FixCollision);
+        this.dtrPreFinalizeListener = new AddonLifecycleEventListener(this.addonLifecycle, AddonEvent.PreFinalize, "_DTR", this.PreFinalize);
 
         this.addonLifecycle.RegisterListener(this.dtrPostDrawListener);
         this.addonLifecycle.RegisterListener(this.dtrPostRequestedUpdateListener);

--- a/Dalamud/Game/Internal/LobbyProfileHandler.cs
+++ b/Dalamud/Game/Internal/LobbyProfileHandler.cs
@@ -40,7 +40,7 @@ internal sealed unsafe class LobbyProfileHandler : IInternalDisposableService
     [ServiceManager.ServiceConstructor]
     private LobbyProfileHandler()
     {
-        this.agentLobbyPreEventListener = new AgentLifecycleEventListener(AgentEvent.PreReceiveEvent, Agent.AgentId.Lobby, this.AgentLobbyPreReceiveEvent);
+        this.agentLobbyPreEventListener = new AgentLifecycleEventListener(this.agentLifecycle, AgentEvent.PreReceiveEvent, Agent.AgentId.Lobby, this.AgentLobbyPreReceiveEvent);
         this.agentLifecycle.RegisterListener(this.agentLobbyPreEventListener);
     }
 

--- a/Dalamud/Game/Internal/TitleScreenVersionInfo.cs
+++ b/Dalamud/Game/Internal/TitleScreenVersionInfo.cs
@@ -38,7 +38,7 @@ internal sealed unsafe class TitleScreenVersionInfo : IInternalDisposableService
     [ServiceManager.ServiceConstructor]
     private TitleScreenVersionInfo()
     {
-        this.versionStringListener = new AddonLifecycleEventListener(AddonEvent.PreDraw, "_TitleRevision", this.OnVersionStringDraw);
+        this.versionStringListener = new AddonLifecycleEventListener(this.addonLifecycle, AddonEvent.PreDraw, "_TitleRevision", this.OnVersionStringDraw);
 
         this.addonLifecycle.RegisterListener(this.versionStringListener);
     }

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/AddonLifecycleSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/AddonLifecycleSelfTestStep.cs
@@ -12,9 +12,8 @@ namespace Dalamud.Interface.Internal.Windows.SelfTest.Steps;
 /// </summary>
 internal class AddonLifecycleSelfTestStep : ISelfTestStep
 {
-    private readonly List<AddonLifecycleEventListener> listeners;
-
     private AddonLifecycle? service;
+    private List<AddonLifecycleEventListener>? listeners;
     private TestStep currentStep = TestStep.CharacterRefresh;
     private bool listenersRegistered;
 
@@ -23,15 +22,6 @@ internal class AddonLifecycleSelfTestStep : ISelfTestStep
     /// </summary>
     public AddonLifecycleSelfTestStep()
     {
-        this.listeners =
-        [
-            new(AddonEvent.PostSetup, "Character", this.PostSetup),
-            new(AddonEvent.PostUpdate, "Character", this.PostUpdate),
-            new(AddonEvent.PostDraw, "Character", this.PostDraw),
-            new(AddonEvent.PostRefresh, "Character", this.PostRefresh),
-            new(AddonEvent.PostRequestedUpdate, "Character", this.PostRequestedUpdate),
-            new(AddonEvent.PreFinalize, "Character", this.PreFinalize),
-        ];
     }
 
     private enum TestStep
@@ -56,6 +46,16 @@ internal class AddonLifecycleSelfTestStep : ISelfTestStep
 
         if (!this.listenersRegistered)
         {
+            this.listeners =
+            [
+                new(this.service, AddonEvent.PostSetup, "Character", this.PostSetup),
+                new(this.service, AddonEvent.PostUpdate, "Character", this.PostUpdate),
+                new(this.service, AddonEvent.PostDraw, "Character", this.PostDraw),
+                new(this.service, AddonEvent.PostRefresh, "Character", this.PostRefresh),
+                new(this.service, AddonEvent.PostRequestedUpdate, "Character", this.PostRequestedUpdate),
+                new(this.service, AddonEvent.PreFinalize, "Character", this.PreFinalize),
+            ];
+
             foreach (var listener in this.listeners)
             {
                 this.service.RegisterListener(listener);
@@ -100,6 +100,9 @@ internal class AddonLifecycleSelfTestStep : ISelfTestStep
         {
             this.service?.UnregisterListener(listener);
         }
+
+        this.listeners = null;
+        this.listenersRegistered = false;
     }
 
     private void PostSetup(AddonEvent eventType, AddonArgs addonInfo)

--- a/Dalamud/Interface/Internal/Windows/SelfTest/Steps/AgentLifecycleSelfTestStep.cs
+++ b/Dalamud/Interface/Internal/Windows/SelfTest/Steps/AgentLifecycleSelfTestStep.cs
@@ -12,9 +12,8 @@ namespace Dalamud.Interface.Internal.Windows.SelfTest.Steps;
 /// </summary>
 internal class AgentLifecycleSelfTestStep : ISelfTestStep
 {
-    private readonly List<AgentLifecycleEventListener> listeners;
-
     private AgentLifecycle? service;
+    private List<AgentLifecycleEventListener>? listeners;
     private TestStep currentStep = TestStep.ReceiveEvent;
     private bool listenersRegistered;
 
@@ -23,12 +22,6 @@ internal class AgentLifecycleSelfTestStep : ISelfTestStep
     /// </summary>
     public AgentLifecycleSelfTestStep()
     {
-        this.listeners =
-        [
-            // ReceiveEvent is gonna be what is most commonly used, and is the easiest to test
-            // Other events require performing actions that may be considered unreasonable for a test, such as switching job/changing level
-            new AgentLifecycleEventListener(AgentEvent.PreReceiveEvent, AgentId.ConfigCharacter, this.PreReceiveEvent),
-        ];
     }
 
     private enum TestStep
@@ -48,6 +41,13 @@ internal class AgentLifecycleSelfTestStep : ISelfTestStep
 
         if (!this.listenersRegistered)
         {
+            this.listeners =
+            [
+                // ReceiveEvent is gonna be what is most commonly used, and is the easiest to test
+                // Other events require performing actions that may be considered unreasonable for a test, such as switching job/changing level
+                new AgentLifecycleEventListener(this.service, AgentEvent.PreReceiveEvent, AgentId.ConfigCharacter, this.PreReceiveEvent),
+            ];
+
             foreach (var listener in this.listeners)
             {
                 this.service.RegisterListener(listener);
@@ -78,6 +78,9 @@ internal class AgentLifecycleSelfTestStep : ISelfTestStep
         {
             this.service?.UnregisterListener(listener);
         }
+
+        this.listeners = null;
+        this.listenersRegistered = false;
     }
 
     private void PreReceiveEvent(AgentEvent type, AgentArgs args)

--- a/Dalamud/Plugin/Services/IAddonEventManager.cs
+++ b/Dalamud/Plugin/Services/IAddonEventManager.cs
@@ -23,7 +23,7 @@ public interface IAddonEventManager : IDalamudService
     /// <param name="eventType">The event type for this event.</param>
     /// <param name="eventDelegate">The handler to call when event is triggered.</param>
     /// <returns>IAddonEventHandle used to remove the event. Null if no event was added.</returns>
-    IAddonEventHandle? AddEvent(nint atkUnitBase, nint atkResNode, AddonEventType eventType, AddonEventDelegate eventDelegate);
+    IAddonEventHandle AddEvent(nint atkUnitBase, nint atkResNode, AddonEventType eventType, AddonEventDelegate eventDelegate);
 
     /// <summary>
     /// Unregisters an event handler with the specified event id and event type.

--- a/Dalamud/Plugin/Services/IAddonLifecycle.cs
+++ b/Dalamud/Plugin/Services/IAddonLifecycle.cs
@@ -24,7 +24,8 @@ public interface IAddonLifecycle : IDalamudService
     /// <param name="eventType">Event type to trigger on.</param>
     /// <param name="addonNames">Addon names that will trigger the handler to be invoked.</param>
     /// <param name="handler">The handler to invoke.</param>
-    void RegisterListener(AddonEvent eventType, IEnumerable<string> addonNames, AddonEventDelegate handler);
+    /// <returns>An <see cref="IDisposable"/> that automatically unregisters the listener when disposed.</returns>
+    IDisposable RegisterListener(AddonEvent eventType, IEnumerable<string> addonNames, AddonEventDelegate handler);
 
     /// <summary>
     /// Register a listener that will trigger on the specified event only for the specified addon.
@@ -32,14 +33,16 @@ public interface IAddonLifecycle : IDalamudService
     /// <param name="eventType">Event type to trigger on.</param>
     /// <param name="addonName">The addon name that will trigger the handler to be invoked.</param>
     /// <param name="handler">The handler to invoke.</param>
-    void RegisterListener(AddonEvent eventType, string addonName, AddonEventDelegate handler);
+    /// <returns>An <see cref="IDisposable"/> that automatically unregisters the listener when disposed.</returns>
+    IDisposable RegisterListener(AddonEvent eventType, string addonName, AddonEventDelegate handler);
 
     /// <summary>
     /// Register a listener that will trigger on the specified event for any addon.
     /// </summary>
     /// <param name="eventType">Event type to trigger on.</param>
     /// <param name="handler">The handler to invoke.</param>
-    void RegisterListener(AddonEvent eventType, AddonEventDelegate handler);
+    /// <returns>An <see cref="IDisposable"/> that automatically unregisters the listener when disposed.</returns>
+    IDisposable RegisterListener(AddonEvent eventType, AddonEventDelegate handler);
 
     /// <summary>
     /// Unregister listener from specified event type and specified addon names.

--- a/Dalamud/Plugin/Services/IAgentLifecycle.cs
+++ b/Dalamud/Plugin/Services/IAgentLifecycle.cs
@@ -24,7 +24,8 @@ public interface IAgentLifecycle : IDalamudService
     /// <param name="eventType">Event type to trigger on.</param>
     /// <param name="agentIds">Agent IDs that will trigger the handler to be invoked.</param>
     /// <param name="handler">The handler to invoke.</param>
-    void RegisterListener(AgentEvent eventType, IEnumerable<AgentId> agentIds, AgentEventDelegate handler);
+    /// <returns>An <see cref="IDisposable"/> that automatically unregisters the listener when disposed.</returns>
+    IDisposable RegisterListener(AgentEvent eventType, IEnumerable<AgentId> agentIds, AgentEventDelegate handler);
 
     /// <summary>
     /// Register a listener that will trigger on the specified event only for the specified agent.
@@ -32,14 +33,16 @@ public interface IAgentLifecycle : IDalamudService
     /// <param name="eventType">Event type to trigger on.</param>
     /// <param name="agentId">The agent ID that will trigger the handler to be invoked.</param>
     /// <param name="handler">The handler to invoke.</param>
-    void RegisterListener(AgentEvent eventType, AgentId agentId, AgentEventDelegate handler);
+    /// <returns>An <see cref="IDisposable"/> that automatically unregisters the listener when disposed.</returns>
+    IDisposable RegisterListener(AgentEvent eventType, AgentId agentId, AgentEventDelegate handler);
 
     /// <summary>
     /// Register a listener that will trigger on the specified event for any agent.
     /// </summary>
     /// <param name="eventType">Event type to trigger on.</param>
     /// <param name="handler">The handler to invoke.</param>
-    void RegisterListener(AgentEvent eventType, AgentEventDelegate handler);
+    /// <returns>An <see cref="IDisposable"/> that automatically unregisters the listener when disposed.</returns>
+    IDisposable RegisterListener(AgentEvent eventType, AgentEventDelegate handler);
 
     /// <summary>
     /// Unregister listener from specified event type and specified agent IDs.


### PR DESCRIPTION
Makes it easy to shove subscriptions into a `CompositeDisposable` or similar and have it unregister them all on dispose.