### PR TITLE
feat: add support for invalid VirtualKeys for plugin use

### DIFF
--- a/Dalamud/Game/ClientState/Keys/KeyState.cs
+++ b/Dalamud/Game/ClientState/Keys/KeyState.cs
@@ -42,12 +42,18 @@ internal class KeyState : IServiceType, IKeyState, IInternalDisposableService
     private static readonly ModuleLog Log = ModuleLog.Create<KeyState>();
     private readonly WndProcHookManager wndProcHookManager;
 
+    [ServiceManager.ServiceDependency]
+    private readonly Framework framework = Service<Framework>.Get();
+
     private readonly KeyStateAddressResolver addressResolver;
     private readonly IntPtr bufferBase;
     private readonly IntPtr indexBase;
 
     // Buffer to store the state of extended virtual keys that do not map to a in-game keycode.
     private readonly int[] extendedKeyState = new int[0x100];
+
+    // Stores the virtual key codes that have been pressed or released in the current frame.
+    private readonly HashSet<int> ephemeralKeys = [];
     private VirtualKey[]? validVirtualKeyCache;
 
     // Cache of valid virtual keys that do not map to a in-game keycode.
@@ -67,13 +73,16 @@ internal class KeyState : IServiceType, IKeyState, IInternalDisposableService
         this.wndProcHookManager = wndProcHookManager;
         this.wndProcHookManager.PreWndProc += this.OnPreWndProc;
 
+        // Clear ephemeral key states at the end of each frame
+        this.framework.Update += this.OnFrameworkUpdate;
+
         Log.Verbose($"Keyboard state buffer address {Util.DescribeAddress(this.bufferBase)}");
     }
 
     /// <inheritdoc/>
     public bool this[int vkCode]
     {
-        get => this.GetRawValue(vkCode) != 0;
+        get => (this.GetRawValue(vkCode) & (int)KeyStateFlags.Down) != 0;
         set => this.SetRawValue(vkCode, value ? 1 : 0);
     }
 
@@ -114,28 +123,42 @@ internal class KeyState : IServiceType, IKeyState, IInternalDisposableService
         => this.IsVirtualKeyValid((int)vkCode);
 
     /// <inheritdoc/>
+    public bool IsExtendedVirtualKeyValid(int vkCode)
+    {
+        var vk = (VirtualKey)vkCode;
+        return vkCode > 0 && vkCode < this.extendedKeyState.Length
+            && Enum.IsDefined(typeof(VirtualKey), vk)
+            && !IsExcludedKey(vk)
+            && !this.IsVirtualKeyValid(vkCode);
+    }
+
+    /// <inheritdoc/>
+    public bool IsExtendedVirtualKeyValid(VirtualKey vkCode)
+        => this.IsExtendedVirtualKeyValid((int)vkCode);
+
+    /// <inheritdoc/>
     public IEnumerable<VirtualKey> GetValidVirtualKeys()
         => this.validVirtualKeyCache ??= Enum.GetValues<VirtualKey>().Where(this.IsVirtualKeyValid).ToArray();
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public IEnumerable<VirtualKey> GetExtendedVirtualKeys()
-        => this.extendedVirtualKeyCache ??= [.. Enum.GetValues<VirtualKey>().Where(vk => vk != VirtualKey.NO_KEY && !this.IsVirtualKeyValid(vk))];
+        => this.extendedVirtualKeyCache ??= [.. Enum.GetValues<VirtualKey>().Where(this.IsExtendedVirtualKeyValid)];
 
     /// <inheritdoc/>
-    public bool TryGetSeVirtualKey(int vkCode, out SeVirtualKey? seVkCode)
+    public bool TryGetSeVirtualKey(int vkCode, out int seVkCode)
     {
         if (!this.IsVirtualKeyValid(vkCode))
         {
-            seVkCode = null;
+            seVkCode = 0;
             return false;
         }
 
-        seVkCode = (SeVirtualKey)this.ConvertVirtualKey(vkCode);
+        seVkCode = this.ConvertVirtualKey(vkCode);
         return true;
     }
 
     /// <inheritdoc/>
-    public bool TryGetSeVirtualKey(VirtualKey vkCode, out SeVirtualKey? seVkCode)
+    public bool TryGetSeVirtualKey(VirtualKey vkCode, out int seVkCode)
         => this.TryGetSeVirtualKey((int)vkCode, out seVkCode);
 
     /// <inheritdoc/>
@@ -147,21 +170,27 @@ internal class KeyState : IServiceType, IKeyState, IInternalDisposableService
         }
 
         Array.Clear(this.extendedKeyState);
+        this.ephemeralKeys.Clear();
     }
 
     /// <summary>
-    /// Unhooks the WndProc and clears the extended key state buffer.
+    /// Unhooks WndProc and Framework and clears the extended key state/ephemeral key buffer.
     /// </summary>
-    public void Dispose()
+    public void DisposeService()
     {
         this.wndProcHookManager.PreWndProc -= this.OnPreWndProc;
+        this.framework.Update -= this.OnFrameworkUpdate;
         Array.Clear(this.extendedKeyState);
+        this.ephemeralKeys.Clear();
     }
 
     /// <summary>
-    /// Disposes this instance and its hooks.
+    /// Determines whether the given virtual key is excluded from extended key state tracking.
     /// </summary>
-    public void DisposeService() => this.Dispose();
+    /// <param name="key">The virtual key to check.</param>
+    /// <returns>True if the key is excluded, false otherwise.</returns>
+    private static bool IsExcludedKey(VirtualKey key)
+        => key is VirtualKey.LBUTTON or VirtualKey.RBUTTON or VirtualKey.NO_KEY;
 
     /// <summary>
     /// Converts a virtual key into the equivalent value that the game uses.
@@ -197,13 +226,67 @@ internal class KeyState : IServiceType, IKeyState, IInternalDisposableService
             return ref *(int*)(this.bufferBase + (4 * gameVkCode));
         }
 
-        if (vkCode >= 0 && vkCode < this.extendedKeyState.Length &&
-            Enum.IsDefined(typeof(VirtualKey), (VirtualKey)vkCode))
+        if (this.IsExtendedVirtualKeyValid(vkCode))
         {
             return ref this.extendedKeyState[vkCode];
         }
 
         throw new ArgumentException($"Keycode {vkCode} does not map to a valid VirtualKey. Refer to GetValidVirtualKeys() or GetExtendedVirtualKeys() for valid keycodes.", nameof(vkCode));
+    }
+
+    private void SetKeyDown(int vkCode, bool isRepeat)
+    {
+        ref var state = ref this.GetRefValue(vkCode);
+        var flags = KeyStateFlags.Down | (isRepeat ? KeyStateFlags.Held : KeyStateFlags.Pressed);
+        state = (int)flags;
+        this.ephemeralKeys.Add(vkCode);
+    }
+
+    private void SetKeyUp(int vkCode)
+    {
+        ref var state = ref this.GetRefValue(vkCode);
+        state = (int)KeyStateFlags.Released;
+        this.ephemeralKeys.Add(vkCode);
+    }
+
+    private void UpdateShiftStates()
+    {
+        // Get the current state of the left and right shift keys
+        var isLeftDown = (Windows.Win32.PInvoke.GetKeyState((int)VirtualKey.LSHIFT) & 0x8000) != 0;
+        var isRightDown = (Windows.Win32.PInvoke.GetKeyState((int)VirtualKey.RSHIFT) & 0x8000) != 0;
+
+        // Get the previous state of the left and right shift keys
+        var wasLeftDown = (this.GetRefValue((int)VirtualKey.LSHIFT) & (int)KeyStateFlags.Down) != 0;
+        var wasRightDown = (this.GetRefValue((int)VirtualKey.RSHIFT) & (int)KeyStateFlags.Down) != 0;
+
+        if (isLeftDown)
+            this.SetKeyDown((int)VirtualKey.LSHIFT, wasLeftDown);
+        else if (wasLeftDown)
+            this.SetKeyUp((int)VirtualKey.LSHIFT);
+
+        if (isRightDown)
+            this.SetKeyDown((int)VirtualKey.RSHIFT, wasRightDown);
+        else if (wasRightDown)
+            this.SetKeyUp((int)VirtualKey.RSHIFT);
+    }
+
+    private void OnFrameworkUpdate(IFramework framework)
+    {
+        if (this.ephemeralKeys.Count == 0) return;
+
+        foreach (var vkCode in this.ephemeralKeys)
+        {
+            ref var state = ref this.GetRefValue(vkCode);
+
+            // Clear one-frame ephemeral flags
+            state &= ~(int)(KeyStateFlags.Pressed | KeyStateFlags.Held);
+
+            // If the key was released, clear the down flag as well
+            state &= ~(int)KeyStateFlags.Released;
+        }
+
+        this.ephemeralKeys.RemoveWhere(vk => (this.GetRefValue(vk) & (int)(KeyStateFlags.Pressed |
+            KeyStateFlags.Released | KeyStateFlags.Held)) == 0);
     }
 
     /// <summary>
@@ -215,16 +298,60 @@ internal class KeyState : IServiceType, IKeyState, IInternalDisposableService
     {
         switch (args.Message)
         {
+            case WM.WM_MBUTTONDOWN:
+            case WM.WM_MBUTTONDBLCLK:
+                this.SetKeyDown((int)VirtualKey.MBUTTON, args.Message == WM.WM_MBUTTONDBLCLK);
+                break;
+            case WM.WM_MBUTTONUP:
+                this.SetKeyUp((int)VirtualKey.MBUTTON);
+                break;
+
+            case WM.WM_XBUTTONDOWN:
+            case WM.WM_XBUTTONDBLCLK:
+            {
+                var xButton = TerraFX.Interop.Windows.Windows.GET_XBUTTON_WPARAM(args.WParam) ==
+                    TerraFX.Interop.Windows.Windows.XBUTTON1 ? VirtualKey.XBUTTON1 : VirtualKey.XBUTTON2;
+                this.SetKeyDown((int)xButton, args.Message == WM.WM_XBUTTONDBLCLK);
+                break;
+            }
+
+            case WM.WM_XBUTTONUP:
+            {
+                var xButton = TerraFX.Interop.Windows.Windows.GET_XBUTTON_WPARAM(args.WParam) ==
+                    TerraFX.Interop.Windows.Windows.XBUTTON1 ? VirtualKey.XBUTTON1 : VirtualKey.XBUTTON2;
+                this.SetKeyUp((int)xButton);
+                break;
+            }
+
             case WM.WM_KEYDOWN:
             case WM.WM_SYSKEYDOWN:
             {
                 var vkCode = (int)args.WParam;
+                var isRepeat = (args.LParam & (1 << 30)) != 0;
 
-                // Only handle keys that are not valid in the game
-                if (vkCode >= 0 && vkCode < this.extendedKeyState.Length
-                    && !this.IsVirtualKeyValid(vkCode))
+                switch (vkCode)
                 {
-                    this.extendedKeyState[vkCode] = 1; // Set the extended key state to pressed
+                    // Process individual keys for Ctrl, Alt, and Shift for extended key state tracking
+                    case (int)VirtualKey.SHIFT:
+                        this.UpdateShiftStates();
+                        break;
+                    case (int)VirtualKey.CONTROL:
+                        var ctrlKey = (args.LParam & (1 << 24)) != 0 ? VirtualKey.RCONTROL : VirtualKey.LCONTROL;
+                        this.SetKeyDown((int)ctrlKey, isRepeat);
+                        break;
+                    case (int)VirtualKey.MENU: // Alt
+                        var altKey = (args.LParam & (1 << 24)) != 0 ? VirtualKey.RMENU : VirtualKey.LMENU;
+                        this.SetKeyDown((int)altKey, isRepeat);
+                        break;
+                    default:
+                        // Only handle keys that are not valid in the game
+                        if (vkCode >= 0 && vkCode < this.extendedKeyState.Length
+                            && !this.IsVirtualKeyValid(vkCode))
+                        {
+                            this.SetKeyDown(vkCode, isRepeat);
+                        }
+
+                        break;
                 }
 
                 break;
@@ -234,18 +361,45 @@ internal class KeyState : IServiceType, IKeyState, IInternalDisposableService
             case WM.WM_SYSKEYUP:
             {
                 var vkCode = (int)args.WParam;
-                if (vkCode >= 0 && vkCode < this.extendedKeyState.Length
-                    && !this.IsVirtualKeyValid(vkCode))
+
+                switch (vkCode)
                 {
-                    this.extendedKeyState[vkCode] = 0; // Set the extended key state to released
+                    case (int)VirtualKey.SHIFT:
+                        this.UpdateShiftStates();
+                        break;
+                    case (int)VirtualKey.CONTROL:
+                        var ctrlKey = (args.LParam & (1 << 24)) != 0 ? VirtualKey.RCONTROL : VirtualKey.LCONTROL;
+                        this.SetKeyUp((int)ctrlKey);
+                        break;
+                    case (int)VirtualKey.MENU: // Alt
+                        var altKey = (args.LParam & (1 << 24)) != 0 ? VirtualKey.RMENU : VirtualKey.LMENU;
+                        this.SetKeyUp((int)altKey);
+                        break;
+                    default:
+                        if (vkCode >= 0 && vkCode < this.extendedKeyState.Length
+                            && !this.IsVirtualKeyValid(vkCode))
+                        {
+                            this.SetKeyUp(vkCode);
+                        }
+
+                        break;
                 }
 
                 break;
             }
 
             case WM.WM_KILLFOCUS:
+                // Reset the state of modifier keys when the window loses focus
+                this.GetRefValue((int)VirtualKey.LSHIFT) = 0;
+                this.GetRefValue((int)VirtualKey.RSHIFT) = 0;
+                this.GetRefValue((int)VirtualKey.LCONTROL) = 0;
+                this.GetRefValue((int)VirtualKey.RCONTROL) = 0;
+                this.GetRefValue((int)VirtualKey.LMENU) = 0;
+                this.GetRefValue((int)VirtualKey.RMENU) = 0;
+
                 // Clear the extended key state when the window loses focus
                 Array.Clear(this.extendedKeyState);
+                this.ephemeralKeys.Clear();
                 break;
         }
     }

--- a/Dalamud/Game/ClientState/Keys/KeyState.cs
+++ b/Dalamud/Game/ClientState/Keys/KeyState.cs
@@ -2,11 +2,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 
+using Dalamud.Hooking.WndProcHook;
 using Dalamud.IoC;
 using Dalamud.IoC.Internal;
 using Dalamud.Logging.Internal;
 using Dalamud.Plugin.Services;
 using Dalamud.Utility;
+
+using FFXIVClientStructs.FFXIV.Client.System.Input;
+
+using TerraFX.Interop.Windows;
 
 namespace Dalamud.Game.ClientState.Keys;
 
@@ -27,7 +32,7 @@ namespace Dalamud.Game.ClientState.Keys;
 #pragma warning disable SA1015
 [ResolveVia<IKeyState>]
 #pragma warning restore SA1015
-internal class KeyState : IServiceType, IKeyState
+internal class KeyState : IServiceType, IKeyState, IInternalDisposableService
 {
     // The array is accessed in a way that this limit doesn't appear to exist
     // but there is other state data past this point, and keys beyond here aren't
@@ -35,14 +40,21 @@ internal class KeyState : IServiceType, IKeyState
     private const int MaxKeyCode = 0xF0;
 
     private static readonly ModuleLog Log = ModuleLog.Create<KeyState>();
+    private readonly WndProcHookManager wndProcHookManager;
 
     private readonly KeyStateAddressResolver addressResolver;
     private readonly IntPtr bufferBase;
     private readonly IntPtr indexBase;
+
+    // Buffer to store the state of extended virtual keys that do not map to a in-game keycode.
+    private readonly int[] extendedKeyState = new int[0x100];
     private VirtualKey[]? validVirtualKeyCache;
 
+    // Cache of valid virtual keys that do not map to a in-game keycode.
+    private VirtualKey[]? extendedVirtualKeyCache;
+
     [ServiceManager.ServiceConstructor]
-    private KeyState(TargetSigScanner sigScanner)
+    private KeyState(TargetSigScanner sigScanner, WndProcHookManager wndProcHookManager)
     {
         this.addressResolver = new KeyStateAddressResolver();
         this.addressResolver.Setup(sigScanner);
@@ -50,6 +62,10 @@ internal class KeyState : IServiceType, IKeyState
         var moduleBaseAddress = sigScanner.Module.BaseAddress;
         this.bufferBase = moduleBaseAddress + Marshal.ReadInt32(this.addressResolver.KeyboardState);
         this.indexBase = moduleBaseAddress + Marshal.ReadInt32(this.addressResolver.KeyboardStateIndexArray);
+
+        // Hook into the WndProc to track extended virtual key states
+        this.wndProcHookManager = wndProcHookManager;
+        this.wndProcHookManager.PreWndProc += this.OnPreWndProc;
 
         Log.Verbose($"Keyboard state buffer address {Util.DescribeAddress(this.bufferBase)}");
     }
@@ -101,6 +117,27 @@ internal class KeyState : IServiceType, IKeyState
     public IEnumerable<VirtualKey> GetValidVirtualKeys()
         => this.validVirtualKeyCache ??= Enum.GetValues<VirtualKey>().Where(this.IsVirtualKeyValid).ToArray();
 
+    /// <inheritdoc />
+    public IEnumerable<VirtualKey> GetExtendedVirtualKeys()
+        => this.extendedVirtualKeyCache ??= [.. Enum.GetValues<VirtualKey>().Where(vk => vk != VirtualKey.NO_KEY && !this.IsVirtualKeyValid(vk))];
+
+    /// <inheritdoc/>
+    public bool TryGetSeVirtualKey(int vkCode, out SeVirtualKey? seVkCode)
+    {
+        if (!this.IsVirtualKeyValid(vkCode))
+        {
+            seVkCode = null;
+            return false;
+        }
+
+        seVkCode = (SeVirtualKey)this.ConvertVirtualKey(vkCode);
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetSeVirtualKey(VirtualKey vkCode, out SeVirtualKey? seVkCode)
+        => this.TryGetSeVirtualKey((int)vkCode, out seVkCode);
+
     /// <inheritdoc/>
     public void ClearAll()
     {
@@ -108,7 +145,23 @@ internal class KeyState : IServiceType, IKeyState
         {
             this[vk] = false;
         }
+
+        Array.Clear(this.extendedKeyState);
     }
+
+    /// <summary>
+    /// Unhooks the WndProc and clears the extended key state buffer.
+    /// </summary>
+    public void Dispose()
+    {
+        this.wndProcHookManager.PreWndProc -= this.OnPreWndProc;
+        Array.Clear(this.extendedKeyState);
+    }
+
+    /// <summary>
+    /// Disposes this instance and its hooks.
+    /// </summary>
+    public void DisposeService() => this.Dispose();
 
     /// <summary>
     /// Converts a virtual key into the equivalent value that the game uses.
@@ -121,21 +174,79 @@ internal class KeyState : IServiceType, IKeyState
         if (vkCode <= 0 || vkCode >= MaxKeyCode)
             return 0;
 
+        // This is the game's internal virtual key value
         return *(byte*)(this.indexBase + vkCode);
     }
 
     /// <summary>
-    /// Gets the raw value from the key state array.
+    /// Gets the raw value from either the game's key state buffer or the extended key state array.
     /// </summary>
-    /// <param name="vkCode">Virtual key code.</param>
-    /// <returns>A reference to the indexed array.</returns>
+    /// <remarks>
+    /// The game only recognizes certain virtual keys as valid input. If the virtual key is not valid,
+    /// it will be stored in the extended key state array instead.
+    /// </remarks>
+    /// <param name="vkCode">The virtual key code to process.</param>
+    /// <returns>A reference to the indexed array from either the game's key state buffer or the extended
+    /// key state array.
+    /// </returns>
     private unsafe ref int GetRefValue(int vkCode)
     {
-        vkCode = this.ConvertVirtualKey(vkCode);
+        var gameVkCode = this.ConvertVirtualKey(vkCode);
+        if (gameVkCode != 0) // Return the game's key state buffer
+        {
+            return ref *(int*)(this.bufferBase + (4 * gameVkCode));
+        }
 
-        if (vkCode == 0)
-            throw new ArgumentException($"Keycode state is only valid for certain values. Reference GetValidVirtualKeys for help.");
+        if (vkCode >= 0 && vkCode < this.extendedKeyState.Length &&
+            Enum.IsDefined(typeof(VirtualKey), (VirtualKey)vkCode))
+        {
+            return ref this.extendedKeyState[vkCode];
+        }
 
-        return ref *(int*)(this.bufferBase + (4 * vkCode));
+        throw new ArgumentException($"Keycode {vkCode} does not map to a valid VirtualKey. Refer to GetValidVirtualKeys() or GetExtendedVirtualKeys() for valid keycodes.", nameof(vkCode));
+    }
+
+    /// <summary>
+    /// Processes WndProc messages to track the state of extended virtual keys that do not map to a
+    /// valid in-game keycode.
+    /// </summary>
+    /// <param name="args">The WndProc event arguments.</param>
+    private void OnPreWndProc(WndProcEventArgs args)
+    {
+        switch (args.Message)
+        {
+            case WM.WM_KEYDOWN:
+            case WM.WM_SYSKEYDOWN:
+            {
+                var vkCode = (int)args.WParam;
+
+                // Only handle keys that are not valid in the game
+                if (vkCode >= 0 && vkCode < this.extendedKeyState.Length
+                    && !this.IsVirtualKeyValid(vkCode))
+                {
+                    this.extendedKeyState[vkCode] = 1; // Set the extended key state to pressed
+                }
+
+                break;
+            }
+
+            case WM.WM_KEYUP:
+            case WM.WM_SYSKEYUP:
+            {
+                var vkCode = (int)args.WParam;
+                if (vkCode >= 0 && vkCode < this.extendedKeyState.Length
+                    && !this.IsVirtualKeyValid(vkCode))
+                {
+                    this.extendedKeyState[vkCode] = 0; // Set the extended key state to released
+                }
+
+                break;
+            }
+
+            case WM.WM_KILLFOCUS:
+                // Clear the extended key state when the window loses focus
+                Array.Clear(this.extendedKeyState);
+                break;
+        }
     }
 }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/KeyStateWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/KeyStateWidget.cs
@@ -6,6 +6,8 @@ using Dalamud.Game.ClientState.Keys;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility.Raii;
 
+using FFXIVClientStructs.FFXIV.Client.System.Input;
+
 namespace Dalamud.Interface.Internal.Windows.Data.Widgets;
 
 /// <summary>
@@ -49,6 +51,13 @@ internal class KeyStateWidget : IDataWindowWidget
         }
     }
 
+    private static void DrawFlagCell(bool isActive)
+    {
+        ImGui.TableNextColumn();
+        var color = isActive ? ImGuiColors.SuccessForeground : ImGuiColors.DalamudOrange;
+        ImGui.TextColored(color, isActive ? "True" : "False");
+    }
+
     private void DrawKeyStateTable(string id, KeyState keyState, Func<IEnumerable<VirtualKey>> getKeys, bool isExtended = false)
     {
         if (isExtended)
@@ -66,7 +75,7 @@ internal class KeyStateWidget : IDataWindowWidget
 
         using var table = ImRaii.Table(
             id,
-            isExtended ? 4 : 5,
+            isExtended ? 7 : 8,
             ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.SizingFixedFit,
             new Vector2(-1, 300));
 
@@ -80,14 +89,17 @@ internal class KeyStateWidget : IDataWindowWidget
 
             ImGui.TableSetupColumn("Decimal", ImGuiTableColumnFlags.WidthFixed, 50);
             ImGui.TableSetupColumn("Hex", ImGuiTableColumnFlags.WidthFixed, 50);
-            ImGui.TableSetupColumn("State", ImGuiTableColumnFlags.WidthFixed, 70);
-
+            ImGui.TableSetupColumn("Down", ImGuiTableColumnFlags.WidthFixed, 45);
+            ImGui.TableSetupColumn("Pressed", ImGuiTableColumnFlags.WidthFixed, 60);
+            ImGui.TableSetupColumn("Held", ImGuiTableColumnFlags.WidthFixed, 45);
+            ImGui.TableSetupColumn("Released", ImGuiTableColumnFlags.WidthFixed, 60);
             ImGui.TableHeadersRow();
 
             foreach (var vkCode in getKeys())
             {
                 var code = (int)vkCode;
-                var isPressed = keyState[code];
+                var raw = keyState.GetRawValue(code);
+                var flags = (KeyStateFlags)raw;
 
                 ImGui.TableNextRow();
 
@@ -99,7 +111,8 @@ internal class KeyStateWidget : IDataWindowWidget
                     ImGui.TableNextColumn();
                     if (keyState.TryGetSeVirtualKey(code, out var seVirtualKey))
                     {
-                        ImGui.Text($"{seVirtualKey.ToString()} ({(int)seVirtualKey})");
+                        var seKey = (SeVirtualKey)seVirtualKey;
+                        ImGui.Text($"{seKey.ToString()} ({seVirtualKey})");
                     }
                     else
                     {
@@ -113,11 +126,10 @@ internal class KeyStateWidget : IDataWindowWidget
                 ImGui.TableNextColumn();
                 ImGui.Text($"0x{code:X2}");
 
-                ImGui.TableNextColumn();
-                using (ImRaii.PushColor(ImGuiCol.Text, isPressed ? ImGuiColors.SuccessForeground : ImGuiColors.DalamudOrange))
-                {
-                    ImGui.Text(isPressed ? "Pressed" : "Released");
-                }
+                DrawFlagCell(flags.HasFlag(KeyStateFlags.Down));
+                DrawFlagCell(flags.HasFlag(KeyStateFlags.Pressed));
+                DrawFlagCell(flags.HasFlag(KeyStateFlags.Held));
+                DrawFlagCell(flags.HasFlag(KeyStateFlags.Released));
             }
         }
     }

--- a/Dalamud/Interface/Internal/Windows/Data/Widgets/KeyStateWidget.cs
+++ b/Dalamud/Interface/Internal/Windows/Data/Widgets/KeyStateWidget.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Numerics;
+
 using Dalamud.Bindings.ImGui;
 using Dalamud.Game.ClientState.Keys;
 using Dalamud.Interface.Colors;
@@ -30,25 +33,92 @@ internal class KeyStateWidget : IDataWindowWidget
     {
         var keyState = Service<KeyState>.Get();
 
-        // TODO: Use table instead of columns
-        ImGui.Columns(4);
-
-        var i = 0;
-        foreach (var vkCode in keyState.GetValidVirtualKeys())
+        using (ImRaii.Group())
         {
-            var code = (int)vkCode;
-            var value = keyState[code];
-
-            using (ImRaii.PushColor(ImGuiCol.Text, value ? ImGuiColors.SuccessForeground : ImGuiColors.ErrorForeground))
+            if (ImGui.CollapsingHeader("Game Keybinds"))
             {
-                ImGui.Text($"{vkCode} ({code})");
+                this.DrawKeyStateTable("##GameKeybinds", keyState, keyState.GetValidVirtualKeys);
             }
 
-            i++;
-            if (i % 24 == 0)
-                ImGui.NextColumn();
+            ImGui.Spacing();
+
+            if (ImGui.CollapsingHeader("Extended Keybinds"))
+            {
+                this.DrawKeyStateTable("##ExtendedKeybinds", keyState, keyState.GetExtendedVirtualKeys, true);
+            }
+        }
+    }
+
+    private void DrawKeyStateTable(string id, KeyState keyState, Func<IEnumerable<VirtualKey>> getKeys, bool isExtended = false)
+    {
+        if (isExtended)
+        {
+            using (ImRaii.PushFont(UiBuilder.IconFont))
+            {
+                ImGui.TextColored(ImGuiColors.DalamudYellow, FontAwesomeIcon.ExclamationTriangle.ToIconString());
+            }
+
+            ImGui.SameLine();
+            ImGui.Text("Extended keybinds cannot be used by the game, but are made available for plugin use.");
+
+            ImGui.Spacing();
         }
 
-        ImGui.Columns(1);
+        using var table = ImRaii.Table(
+            id,
+            isExtended ? 4 : 5,
+            ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.SizingFixedFit,
+            new Vector2(-1, 300));
+
+        if (table)
+        {
+            ImGui.TableSetupColumn("Virtual Key", ImGuiTableColumnFlags.WidthStretch);
+            if (!isExtended)
+            {
+                ImGui.TableSetupColumn("SeVirtualKey", ImGuiTableColumnFlags.WidthStretch);
+            }
+
+            ImGui.TableSetupColumn("Decimal", ImGuiTableColumnFlags.WidthFixed, 50);
+            ImGui.TableSetupColumn("Hex", ImGuiTableColumnFlags.WidthFixed, 50);
+            ImGui.TableSetupColumn("State", ImGuiTableColumnFlags.WidthFixed, 70);
+
+            ImGui.TableHeadersRow();
+
+            foreach (var vkCode in getKeys())
+            {
+                var code = (int)vkCode;
+                var isPressed = keyState[code];
+
+                ImGui.TableNextRow();
+
+                ImGui.TableNextColumn();
+                ImGui.Text(vkCode.ToString());
+
+                if (!isExtended)
+                {
+                    ImGui.TableNextColumn();
+                    if (keyState.TryGetSeVirtualKey(code, out var seVirtualKey))
+                    {
+                        ImGui.Text($"{seVirtualKey.ToString()} ({(int)seVirtualKey})");
+                    }
+                    else
+                    {
+                        ImGui.Text("-");
+                    }
+                }
+
+                ImGui.TableNextColumn();
+                ImGui.Text(code.ToString());
+
+                ImGui.TableNextColumn();
+                ImGui.Text($"0x{code:X2}");
+
+                ImGui.TableNextColumn();
+                using (ImRaii.PushColor(ImGuiCol.Text, isPressed ? ImGuiColors.SuccessForeground : ImGuiColors.DalamudOrange))
+                {
+                    ImGui.Text(isPressed ? "Pressed" : "Released");
+                }
+            }
+        }
     }
 }

--- a/Dalamud/Plugin/Services/IKeyState.cs
+++ b/Dalamud/Plugin/Services/IKeyState.cs
@@ -2,8 +2,6 @@ using System.Collections.Generic;
 
 using Dalamud.Game.ClientState.Keys;
 
-using FFXIVClientStructs.FFXIV.Client.System.Input;
-
 namespace Dalamud.Plugin.Services;
 
 /// <summary>
@@ -66,15 +64,25 @@ public interface IKeyState : IDalamudService
     bool IsVirtualKeyValid(VirtualKey vkCode);
 
     /// <summary>
-    /// Attempts to get the SeVirtualKey equivalent of a given virtual key code.
+    /// Gets a value indicating whether the given VirtualKey code is regarded as a valid extended key by Dalamud.
+    /// </summary>
+    /// <param name="vkCode">Virtual key code.</param>
+    /// <returns>If the code is a valid extended key.</returns>
+    bool IsExtendedVirtualKeyValid(int vkCode);
+
+    /// <inheritdoc cref="IsExtendedVirtualKeyValid(int)"/>
+    bool IsExtendedVirtualKeyValid(VirtualKey vkCode);
+
+    /// <summary>
+    /// Attempts to get the game's virtual key code equivalent of a given virtual key code.
     /// </summary>
     /// <param name="vkCode">The virtual key code to convert.</param>
-    /// <param name="seVkCode">The resulting SeVirtualKey, if the conversion is successful.</param>
-    /// <returns>Whether the virtual key code has a valid SeVirtualKey equivalent.</returns>
-    bool TryGetSeVirtualKey(int vkCode, out SeVirtualKey? seVkCode);
+    /// <param name="seVkCode">The resulting game's virtual key code, if the conversion is successful.</param>
+    /// <returns>Whether the virtual key code has a valid game's virtual key code equivalent.</returns>
+    bool TryGetSeVirtualKey(int vkCode, out int seVkCode);
 
-    /// <inheritdoc cref="TryGetSeVirtualKey(int, out SeVirtualKey?)"/>
-    bool TryGetSeVirtualKey(VirtualKey vkCode, out SeVirtualKey? seVkCode);
+    /// <inheritdoc cref="TryGetSeVirtualKey(int, out int)"/>
+    bool TryGetSeVirtualKey(VirtualKey vkCode, out int seVkCode);
 
     /// <summary>
     /// Gets an array of virtual keys the game considers valid input.

--- a/Dalamud/Plugin/Services/IKeyState.cs
+++ b/Dalamud/Plugin/Services/IKeyState.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 
 using Dalamud.Game.ClientState.Keys;
 
+using FFXIVClientStructs.FFXIV.Client.System.Input;
+
 namespace Dalamud.Plugin.Services;
 
 /// <summary>
@@ -23,7 +25,7 @@ public interface IKeyState : IDalamudService
     /// </summary>
     /// <param name="vkCode">The virtual key to change.</param>
     /// <returns>Whether the specified key is currently pressed.</returns>
-    /// <exception cref="ArgumentException">If the vkCode is not valid. Refer to <see cref="IsVirtualKeyValid(int)"/> or <see cref="GetValidVirtualKeys"/>.</exception>
+    /// <exception cref="ArgumentException">If the vkCode is not valid. Refer to <see cref="IsVirtualKeyValid(int)"/> or <see cref="GetValidVirtualKeys"/> or <see cref="GetExtendedVirtualKeys"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">If the set value is non-zero.</exception>
     bool this[int vkCode] { get; set; }
 
@@ -35,7 +37,7 @@ public interface IKeyState : IDalamudService
     /// </summary>
     /// <param name="vkCode">The virtual key to change.</param>
     /// <returns>The raw value stored in the index array.</returns>
-    /// <exception cref="ArgumentException">If the vkCode is not valid. Refer to <see cref="IsVirtualKeyValid(int)"/> or <see cref="GetValidVirtualKeys"/>.</exception>
+    /// <exception cref="ArgumentException">If the vkCode is not valid. Refer to <see cref="IsVirtualKeyValid(int)"/> or <see cref="GetValidVirtualKeys"/> or <see cref="GetExtendedVirtualKeys"/>.</exception>
     int GetRawValue(int vkCode);
 
     /// <inheritdoc cref="GetRawValue(int)"/>
@@ -46,7 +48,7 @@ public interface IKeyState : IDalamudService
     /// </summary>
     /// <param name="vkCode">The virtual key to change.</param>
     /// <param name="value">The raw value to set in the index array.</param>
-    /// <exception cref="ArgumentException">If the vkCode is not valid. Refer to <see cref="IsVirtualKeyValid(int)"/> or <see cref="GetValidVirtualKeys"/>.</exception>
+    /// <exception cref="ArgumentException">If the vkCode is not valid. Refer to <see cref="IsVirtualKeyValid(int)"/> or <see cref="GetValidVirtualKeys"/> or <see cref="GetExtendedVirtualKeys"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">If the set value is non-zero.</exception>
     void SetRawValue(int vkCode, int value);
 
@@ -64,10 +66,27 @@ public interface IKeyState : IDalamudService
     bool IsVirtualKeyValid(VirtualKey vkCode);
 
     /// <summary>
+    /// Attempts to get the SeVirtualKey equivalent of a given virtual key code.
+    /// </summary>
+    /// <param name="vkCode">The virtual key code to convert.</param>
+    /// <param name="seVkCode">The resulting SeVirtualKey, if the conversion is successful.</param>
+    /// <returns>Whether the virtual key code has a valid SeVirtualKey equivalent.</returns>
+    bool TryGetSeVirtualKey(int vkCode, out SeVirtualKey? seVkCode);
+
+    /// <inheritdoc cref="TryGetSeVirtualKey(int, out SeVirtualKey?)"/>
+    bool TryGetSeVirtualKey(VirtualKey vkCode, out SeVirtualKey? seVkCode);
+
+    /// <summary>
     /// Gets an array of virtual keys the game considers valid input.
     /// </summary>
     /// <returns>An array of valid virtual keys.</returns>
     IEnumerable<VirtualKey> GetValidVirtualKeys();
+
+    /// <summary>
+    /// Gets an array of virtual keys the game considers invalid input, but are tracked by Dalamud for plugin use.
+    /// </summary>
+    /// <returns>An array of extended virtual keys.</returns>
+    IEnumerable<VirtualKey> GetExtendedVirtualKeys();
 
     /// <summary>
     /// Clears the pressed state for all keys.


### PR DESCRIPTION
This PR does the following:
1. Handles keys that are not supported by XIV for plugin use only (F13-F24 among a few others).
    > This is done by attaching *WndProcHookManager* to **KeyState** and making a event function called `OnPreWndProc` that handles the key state of keys not supported by XIV. In addition a cache and buffer was made to handle input processing and key gathering as well as returning the ref value for *GetRefValue*.

3. Rewrote the KeyState widget into two tables that are structured as:

    ## Game Keybinds
     | Virtual Key | SeVirtualKey | Decimal | Hex | State |
     | :-----------: | :------------: | :--------: | :---: | :-----: | 
     | RETURN | RETURN (13) | 13 | 0x0D | Released |
     | HOME | HOME (36) | 36 | 0x24 | Pressed |
       
    ## Extended Keybinds
     | Virtual Key | Decimal | Hex | State |
     | :-----------: | :--------: | :---: | :-----: | 
     | F13 | 124 | 0x7C | Released |
     | F24 | 135 | 0x87 | Pressed |

4. Added `TryGetSeVirtualKey` to obtain the *SeVirtualKey* equivalent of a *VirtualKey* in `IKeyState`.
5. Added `GetExtendedVirtualKeys` to return all *VirtualKey*'s that are not supported by the game in `IKeyState`.