### PR TITLE
Add setting to toggle gamepad allowing windows to be closed

### DIFF
--- a/Dalamud/Configuration/Internal/DalamudConfiguration.cs
+++ b/Dalamud/Configuration/Internal/DalamudConfiguration.cs
@@ -283,6 +283,11 @@ internal sealed class DalamudConfiguration : IInternalDisposableService
     public bool IsGamepadNavigationEnabled { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether gamepads can close windows by hitting the right button.
+    /// </summary>
+    public bool IsGamepadClosingWindowsEnabled { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets a value indicating whether focus management is enabled.
     /// </summary>
     public bool IsFocusManagementEnabled { get; set; } = true;

--- a/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
+++ b/Dalamud/Interface/Internal/Windows/Settings/Tabs/SettingsTabLook.cs
@@ -145,6 +145,12 @@ internal sealed class SettingsTabLook : SettingsTab
             (v, c) => c.IsGamepadNavigationEnabled = v),
 
         new SettingsEntry<bool>(
+            LazyLoc.Localize("DalamudSettingToggleGamepadClosingWindows", "Allow closing windows via gamepad"),
+            LazyLoc.Localize("DalamudSettingToggleGamepadClosingWindowsHint", "This will allow focused windows to be closed using the gamepad face right button (B / Circle)."),
+            c => c.IsGamepadClosingWindowsEnabled,
+            (v, c) => c.IsGamepadClosingWindowsEnabled = v),
+
+        new SettingsEntry<bool>(
             LazyLoc.Localize("DalamudSettingToggleTsm", "Show title screen menu"),
             LazyLoc.Localize("DalamudSettingToggleTsmHint", "This will allow you to access certain Dalamud and Plugin functionality from the title screen.\nDisabling this will also hide the Dalamud version text on the title screen."),
             c => c.ShowTsm,

--- a/Dalamud/Interface/Windowing/WindowHost.cs
+++ b/Dalamud/Interface/Windowing/WindowHost.cs
@@ -119,6 +119,11 @@ public class WindowHost
         /// Do not draw non-critical animations.
         /// </summary>
         IsReducedMotion = 1 << 3,
+
+        /// <summary>
+        /// Allow the window to be closed with a gamepad.
+        /// </summary>
+        IsWindowClosableWithGamepad = 1 << 4,
     }
 
     /// <summary>
@@ -557,7 +562,11 @@ public class WindowHost
         }
 
         // Allow the window to be closed with a gamepad
-        if (ImGui.IsKeyPressed(ImGuiKey.GamepadFaceRight) && !this.Window.IsPinned && this.Window.IsFocused && ImGui.GetCurrentContext() is { NavId: 0, NavFocusScopeId: 0 })
+        if (internalDrawParams.Flags.HasFlag(WindowDrawFlags.IsWindowClosableWithGamepad) &&
+            ImGui.IsKeyPressed(ImGuiKey.GamepadFaceRight)
+            && !this.Window.IsPinned
+            && this.Window.IsFocused
+            && ImGui.GetCurrentContext() is { NavId: 0, NavFocusScopeId: 0 })
         {
             this.Window.IsOpen = false;
         }

--- a/Dalamud/Interface/Windowing/WindowSystem.cs
+++ b/Dalamud/Interface/Windowing/WindowSystem.cs
@@ -134,6 +134,9 @@ public class WindowSystem : IWindowSystem
         if (config?.ReduceMotions ?? false)
             flags |= WindowHost.WindowDrawFlags.IsReducedMotion;
 
+        if (config?.IsGamepadClosingWindowsEnabled ?? true)
+            flags |= WindowHost.WindowDrawFlags.IsWindowClosableWithGamepad;
+
         // Shallow clone the list of windows so that we can edit it without modifying it while the loop is iterating
         foreach (var window in this.windows.ToArray())
         {


### PR DESCRIPTION
Makes it configurable whether gamepads right button can close ImGui windows, just like it does for game windows.
I would like to wait for people to complain first, because I'm still of the opinion that this should be core behavior/mimic the games behavior.