### PR TITLE
Only allow mainthread access of GameObject properties

### DIFF
--- a/Dalamud/Game/ClientState/Objects/Types/BattleChara.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/BattleChara.cs
@@ -1,4 +1,5 @@
 using Dalamud.Game.ClientState.Statuses;
+using Dalamud.Utility;
 
 namespace Dalamud.Game.ClientState.Objects.Types;
 
@@ -102,5 +103,12 @@ internal unsafe class BattleChara : Character, IBattleChara
     /// <summary>
     /// Gets the underlying structure.
     /// </summary>
-    protected internal new FFXIVClientStructs.FFXIV.Client.Game.Character.BattleChara* Struct => (FFXIVClientStructs.FFXIV.Client.Game.Character.BattleChara*)this.Address;
+    protected internal new FFXIVClientStructs.FFXIV.Client.Game.Character.BattleChara* Struct
+    {
+        get
+        {
+            ThreadSafety.AssertMainThread();
+            return (FFXIVClientStructs.FFXIV.Client.Game.Character.BattleChara*)this.Address;
+        }
+    }
 }

--- a/Dalamud/Game/ClientState/Objects/Types/BattleChara.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/BattleChara.cs
@@ -107,7 +107,7 @@ internal unsafe class BattleChara : Character, IBattleChara
     {
         get
         {
-            ThreadSafety.AssertMainThread();
+            ThreadSafety.DevModeAssertMainThread();
             return (FFXIVClientStructs.FFXIV.Client.Game.Character.BattleChara*)this.Address;
         }
     }

--- a/Dalamud/Game/ClientState/Objects/Types/Character.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/Character.cs
@@ -2,6 +2,7 @@ using Dalamud.Data;
 using Dalamud.Game.ClientState.Customize;
 using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Utility;
 
 using Lumina.Excel;
 using Lumina.Excel.Sheets;
@@ -222,6 +223,12 @@ internal unsafe class Character : GameObject, ICharacter
     /// <summary>
     /// Gets the underlying structure.
     /// </summary>
-    protected internal new FFXIVClientStructs.FFXIV.Client.Game.Character.Character* Struct =>
-        (FFXIVClientStructs.FFXIV.Client.Game.Character.Character*)this.Address;
+    protected internal new FFXIVClientStructs.FFXIV.Client.Game.Character.Character* Struct
+    {
+        get
+        {
+            ThreadSafety.AssertMainThread();
+            return (FFXIVClientStructs.FFXIV.Client.Game.Character.Character*)this.Address;
+        }
+    }
 }

--- a/Dalamud/Game/ClientState/Objects/Types/Character.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/Character.cs
@@ -227,7 +227,7 @@ internal unsafe class Character : GameObject, ICharacter
     {
         get
         {
-            ThreadSafety.AssertMainThread();
+            ThreadSafety.DevModeAssertMainThread();
             return (FFXIVClientStructs.FFXIV.Client.Game.Character.Character*)this.Address;
         }
     }

--- a/Dalamud/Game/ClientState/Objects/Types/GameObject.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/GameObject.cs
@@ -279,7 +279,7 @@ internal unsafe partial class GameObject : IGameObject
     {
         get
         {
-            ThreadSafety.AssertMainThread();
+            ThreadSafety.DevModeAssertMainThread();
             return (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)this.Address;
         }
     }

--- a/Dalamud/Game/ClientState/Objects/Types/GameObject.cs
+++ b/Dalamud/Game/ClientState/Objects/Types/GameObject.cs
@@ -185,8 +185,7 @@ internal partial class GameObject
         if (actor == null)
             return false;
 
-        var playerState = Service<PlayerState>.Get();
-        return playerState.IsLoaded == true;
+        return Service<PlayerState>.Get().IsLoaded;
     }
 
     /// <summary>
@@ -276,7 +275,14 @@ internal unsafe partial class GameObject : IGameObject
     /// <summary>
     /// Gets the underlying structure.
     /// </summary>
-    protected internal FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject* Struct => (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)this.Address;
+    protected internal FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject* Struct
+    {
+        get
+        {
+            ThreadSafety.AssertMainThread();
+            return (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)this.Address;
+        }
+    }
 
     /// <inheritdoc/>
     public override string ToString() => $"{this.GameObjectId:X}({this.Name.TextValue} - {this.ObjectKind}) at {this.Address:X}";

--- a/Dalamud/Game/ClientState/Party/PartyList.cs
+++ b/Dalamud/Game/ClientState/Party/PartyList.cs
@@ -43,7 +43,7 @@ internal sealed unsafe partial class PartyList : IServiceType, IPartyList
     public bool IsAlliance => this.GroupManagerStruct->MainGroup.AllianceFlags > 0;
 
     /// <inheritdoc/>
-    public unsafe nint GroupManagerAddress => (nint)CSGroupManager.Instance();
+    public nint GroupManagerAddress => (nint)CSGroupManager.Instance();
 
     /// <inheritdoc/>
     public nint GroupListAddress => (nint)Unsafe.AsPointer(ref this.GroupManagerStruct->MainGroup.PartyMembers[0]);
@@ -96,7 +96,7 @@ internal sealed unsafe partial class PartyList : IServiceType, IPartyList
         if (address == 0)
             return null;
 
-        return new PartyMember((CSPartyMember*)address);
+        return new PartyMember(address);
     }
 
     /// <inheritdoc/>

--- a/Dalamud/Game/ClientState/Party/PartyList.cs
+++ b/Dalamud/Game/ClientState/Party/PartyList.cs
@@ -117,7 +117,7 @@ internal sealed unsafe partial class PartyList : IServiceType, IPartyList
         if (address == 0)
             return null;
 
-        return new PartyMember((CSPartyMember*)address);
+        return new PartyMember(address);
     }
 }
 

--- a/Dalamud/Game/ClientState/Party/PartyMember.cs
+++ b/Dalamud/Game/ClientState/Party/PartyMember.cs
@@ -6,6 +6,7 @@ using Dalamud.Game.ClientState.Objects;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.ClientState.Statuses;
 using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Utility;
 
 using Lumina.Excel;
 
@@ -111,59 +112,71 @@ public interface IPartyMember : IEquatable<IPartyMember>
 /// <summary>
 /// This struct represents a party member in the group manager.
 /// </summary>
-/// <param name="ptr">A pointer to the PartyMember.</param>
-internal readonly unsafe struct PartyMember(CSPartyMember* ptr) : IPartyMember
+/// <param name="address">A pointer to the PartyMember.</param>
+internal readonly unsafe struct PartyMember(nint address) : IPartyMember
 {
     /// <inheritdoc/>
-    public nint Address => (nint)ptr;
+    public nint Address => address;
 
     /// <inheritdoc/>
-    public StatusList Statuses => new(&ptr->StatusManager);
+    public StatusList Statuses => new(&this.Struct->StatusManager);
 
     /// <inheritdoc/>
-    public Vector3 Position => ptr->Position;
+    public Vector3 Position => this.Struct->Position;
 
     /// <inheritdoc/>
-    public ulong ContentId => ptr->ContentId;
+    public ulong ContentId => this.Struct->ContentId;
 
     /// <inheritdoc/>
-    public uint ObjectId => ptr->EntityId;
+    public uint ObjectId => this.Struct->EntityId;
 
     /// <inheritdoc/>
-    public uint EntityId => ptr->EntityId;
+    public uint EntityId => this.Struct->EntityId;
 
     /// <inheritdoc/>
     public IGameObject? GameObject => Service<ObjectTable>.Get().SearchById(this.EntityId);
 
     /// <inheritdoc/>
-    public uint CurrentHP => ptr->CurrentHP;
+    public uint CurrentHP => this.Struct->CurrentHP;
 
     /// <inheritdoc/>
-    public uint MaxHP => ptr->MaxHP;
+    public uint MaxHP => this.Struct->MaxHP;
 
     /// <inheritdoc/>
-    public ushort CurrentMP => ptr->CurrentMP;
+    public ushort CurrentMP => this.Struct->CurrentMP;
 
     /// <inheritdoc/>
-    public ushort MaxMP => ptr->MaxMP;
+    public ushort MaxMP => this.Struct->MaxMP;
 
     /// <inheritdoc/>
-    public RowRef<Lumina.Excel.Sheets.TerritoryType> Territory => LuminaUtils.CreateRef<Lumina.Excel.Sheets.TerritoryType>(ptr->TerritoryType);
+    public RowRef<Lumina.Excel.Sheets.TerritoryType> Territory => LuminaUtils.CreateRef<Lumina.Excel.Sheets.TerritoryType>(this.Struct->TerritoryType);
 
     /// <inheritdoc/>
-    public RowRef<Lumina.Excel.Sheets.World> World => LuminaUtils.CreateRef<Lumina.Excel.Sheets.World>(ptr->HomeWorld);
+    public RowRef<Lumina.Excel.Sheets.World> World => LuminaUtils.CreateRef<Lumina.Excel.Sheets.World>(this.Struct->HomeWorld);
 
     /// <inheritdoc/>
-    public SeString Name => SeString.Parse(ptr->Name);
+    public SeString Name => SeString.Parse(this.Struct->Name);
 
     /// <inheritdoc/>
-    public byte Sex => ptr->Sex;
+    public byte Sex => this.Struct->Sex;
 
     /// <inheritdoc/>
-    public RowRef<Lumina.Excel.Sheets.ClassJob> ClassJob => LuminaUtils.CreateRef<Lumina.Excel.Sheets.ClassJob>(ptr->ClassJob);
+    public RowRef<Lumina.Excel.Sheets.ClassJob> ClassJob => LuminaUtils.CreateRef<Lumina.Excel.Sheets.ClassJob>(this.Struct->ClassJob);
 
     /// <inheritdoc/>
-    public byte Level => ptr->Level;
+    public byte Level => this.Struct->Level;
+
+    /// <summary>
+    /// Gets the underlying structure.
+    /// </summary>
+    internal CSPartyMember* Struct
+    {
+        get
+        {
+            ThreadSafety.AssertMainThread();
+            return (CSPartyMember*)address;
+        }
+    }
 
     public static bool operator ==(PartyMember x, PartyMember y) => x.Equals(y);
 

--- a/Dalamud/Game/ClientState/Party/PartyMember.cs
+++ b/Dalamud/Game/ClientState/Party/PartyMember.cs
@@ -173,7 +173,7 @@ internal readonly unsafe struct PartyMember(nint address) : IPartyMember
     {
         get
         {
-            ThreadSafety.AssertMainThread();
+            ThreadSafety.DevModeAssertMainThread();
             return (CSPartyMember*)address;
         }
     }

--- a/Dalamud/Game/ClientState/Statuses/Status.cs
+++ b/Dalamud/Game/ClientState/Statuses/Status.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using Dalamud.Data;
 using Dalamud.Game.ClientState.Objects;
 using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Utility;
 
 using Lumina.Excel;
 
@@ -57,29 +58,41 @@ public interface IStatus : IEquatable<IStatus>
 /// <summary>
 /// This struct represents a status effect an actor is afflicted by.
 /// </summary>
-/// <param name="ptr">A pointer to the Status.</param>
-internal readonly unsafe struct Status(CSStatus* ptr) : IStatus
+/// <param name="address">A pointer to the Status.</param>
+internal readonly unsafe struct Status(nint address) : IStatus
 {
     /// <inheritdoc/>
-    public nint Address => (nint)ptr;
+    public nint Address => address;
 
     /// <inheritdoc/>
-    public uint StatusId => ptr->StatusId;
+    public uint StatusId => this.Struct->StatusId;
 
     /// <inheritdoc/>
-    public RowRef<Lumina.Excel.Sheets.Status> GameData => LuminaUtils.CreateRef<Lumina.Excel.Sheets.Status>(ptr->StatusId);
+    public RowRef<Lumina.Excel.Sheets.Status> GameData => LuminaUtils.CreateRef<Lumina.Excel.Sheets.Status>(this.Struct->StatusId);
 
     /// <inheritdoc/>
-    public ushort Param => ptr->Param;
+    public ushort Param => this.Struct->Param;
 
     /// <inheritdoc/>
-    public float RemainingTime => ptr->RemainingTime;
+    public float RemainingTime => this.Struct->RemainingTime;
 
     /// <inheritdoc/>
-    public uint SourceId => ptr->SourceObject.ObjectId;
+    public uint SourceId => this.Struct->SourceObject.ObjectId;
 
     /// <inheritdoc/>
     public IGameObject? SourceObject => Service<ObjectTable>.Get().SearchById(this.SourceId);
+
+    /// <summary>
+    /// Gets the underlying structure.
+    /// </summary>
+    internal CSStatus* Struct
+    {
+        get
+        {
+            ThreadSafety.AssertMainThread();
+            return (CSStatus*)address;
+        }
+    }
 
     public static bool operator ==(Status x, Status y) => x.Equals(y);
 

--- a/Dalamud/Game/ClientState/Statuses/Status.cs
+++ b/Dalamud/Game/ClientState/Statuses/Status.cs
@@ -89,7 +89,7 @@ internal readonly unsafe struct Status(nint address) : IStatus
     {
         get
         {
-            ThreadSafety.AssertMainThread();
+            ThreadSafety.DevModeAssertMainThread();
             return (CSStatus*)address;
         }
     }

--- a/Dalamud/Game/ClientState/Statuses/StatusList.cs
+++ b/Dalamud/Game/ClientState/Statuses/StatusList.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 using Dalamud.Game.Player;
+using Dalamud.Utility;
 
 using CSStatus = FFXIVClientStructs.FFXIV.Client.Game.Status;
 using CSStatusManager = FFXIVClientStructs.FFXIV.Client.Game.StatusManager;
@@ -27,7 +28,7 @@ public sealed unsafe partial class StatusList
     /// Initializes a new instance of the <see cref="StatusList"/> class.
     /// </summary>
     /// <param name="pointer">Pointer to the status list.</param>
-    internal unsafe StatusList(void* pointer)
+    internal StatusList(void* pointer)
         : this((nint)pointer)
     {
     }
@@ -42,7 +43,14 @@ public sealed unsafe partial class StatusList
     /// </summary>
     public int Length => this.Struct->NumValidStatuses;
 
-    private CSStatusManager* Struct => (CSStatusManager*)this.Address;
+    private CSStatusManager* Struct
+    {
+        get
+        {
+            ThreadSafety.AssertMainThread();
+            return (CSStatusManager*)this.Address;
+        }
+    }
 
     /// <summary>
     /// Get a status effect at the specified index.

--- a/Dalamud/Game/ClientState/Statuses/StatusList.cs
+++ b/Dalamud/Game/ClientState/Statuses/StatusList.cs
@@ -106,7 +106,7 @@ public sealed unsafe partial class StatusList
         if (address == 0)
             return null;
 
-        return new Status((CSStatus*)address);
+        return new Status(address);
     }
 
     /// <summary>

--- a/Dalamud/Utility/ThreadSafety.cs
+++ b/Dalamud/Utility/ThreadSafety.cs
@@ -1,5 +1,7 @@
 using System.Runtime.CompilerServices;
 
+using Dalamud.Configuration.Internal;
+
 namespace Dalamud.Utility;
 
 /// <summary>
@@ -49,6 +51,21 @@ public static class ThreadSafety
 #if DEBUG
         AssertMainThread();
 #endif
+    }
+
+    /// <summary>
+    /// Throws an exception when the current thread is not the main thread and DevMode is enabled.
+    /// </summary>
+    /// <param name="message">The message to be passed into the exception, if one is to be thrown.</param>
+    /// <exception cref="InvalidOperationException">Thrown when the current thread is not the main thread.</exception>
+    [Api16ToDo("Replace all calls with AssertMainThread")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void DevModeAssertMainThread(string? message = null)
+    {
+        if (!threadStaticIsMainThread && Service<DalamudConfiguration>.Get().DevMode == true)
+        {
+            throw new InvalidOperationException(message ?? "Not on main thread!");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Safeguarding the ObjectTable wasn't enough, since plugins can cache the LocalPlayer's IPlayerCharacter object and can still access its properties in a different thread.

Not sure if this should be API16 or if we want plugins to get thrown in the face now.

See also internal channel, where access to the Name causes a crash now due to the change in #2919:
https://discord.com/channels/581875019861328007/837808848718004245/1548038060518670429